### PR TITLE
[KV Cache] Zero compressed attention storage pages

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -12,13 +12,117 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm.v1.kv_cache_interface import MambaSpec
-from vllm.v1.worker.utils import KVBlockZeroer, _infer_segment_block_strides
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+)
+from vllm.v1.worker.utils import (
+    KVBlockZeroer,
+    _infer_segment_block_strides,
+    _resolve_zeroer_kernel_layout,
+)
 
 CELL_ELS = 8  # int32 elements zeroed per (block, segment)
 CELL_BYTES = CELL_ELS * 4
 N_LAYERS = 3  # -> n_segs = 3 interleaved segments
 N_BLOCKS = 4
+
+
+class _BlockFirstAttentionBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs) -> int:
+        return 0
+
+
+@pytest.mark.parametrize(
+    ("spec", "group_kernel_bs", "expected"),
+    [
+        (
+            FullAttentionSpec(
+                block_size=784,
+                num_kv_heads=1,
+                head_size=128,
+                dtype=torch.bfloat16,
+            ),
+            16,
+            (16, 49),
+        ),
+        (
+            MLAAttentionSpec(
+                block_size=784,
+                num_kv_heads=1,
+                head_size=128,
+                dtype=torch.bfloat16,
+                compress_ratio=8,
+            ),
+            16,
+            (98, 1),
+        ),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_resolve_zeroer_kernel_layout(
+    spec: FullAttentionSpec,
+    group_kernel_bs: int,
+    expected: tuple[int, int],
+) -> None:
+    assert _resolve_zeroer_kernel_layout(spec, group_kernel_bs) == expected
+
+
+@pytest.mark.skip_global_cleanup
+def test_resolve_zeroer_kernel_layout_rejects_nondivisible_size() -> None:
+    spec = FullAttentionSpec(
+        block_size=784,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    with pytest.raises(ValueError, match="must be divisible"):
+        _resolve_zeroer_kernel_layout(spec, 30)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_zero_block_ids_compressed_attention_storage_page() -> None:
+    device = torch.device("cuda")
+    num_blocks = 8
+    spec = MLAAttentionSpec(
+        block_size=8,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.bfloat16,
+        compress_ratio=2,
+    )
+    kv = torch.ones(
+        (num_blocks, spec.storage_block_size, 1, spec.head_size),
+        dtype=spec.dtype,
+        device=device,
+    )
+    layer_name = "qsa.compressed"
+    group = SimpleNamespace(
+        kv_cache_spec=spec,
+        kv_cache_group_id=0,
+        layer_names=[layer_name],
+        backend=_BlockFirstAttentionBackend,
+    )
+    static_forward_context = {layer_name: SimpleNamespace(kv_cache=kv)}
+
+    zeroer = KVBlockZeroer(device, pin_memory=False)
+    zeroer.init_meta(
+        [group],
+        kernel_block_sizes=[2],
+        cache_dtype="auto",
+        runner_only_attn_layers=set(),
+        static_forward_context=static_forward_context,
+    )
+
+    target = 1
+    zeroer.zero_block_ids([target])
+    torch.accelerator.synchronize()
+
+    pages = kv.view(num_blocks, -1)
+    zeroed = {index for index in range(num_blocks) if bool((pages[index] == 0).all())}
+    assert zeroed == {target}
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -38,6 +38,31 @@ from vllm.v1.worker.block_table import get_block_table_width
 logger = init_logger(__name__)
 
 
+def _resolve_zeroer_kernel_layout(
+    spec: FullAttentionSpec,
+    group_kernel_block_size: int,
+) -> tuple[int, int]:
+    """Return the physical kernel block size and virtual-block ratio.
+
+    Compressed attention specs store fewer rows than their logical scheduler
+    block size. Their cache view is shaped with ``storage_block_size`` as one
+    physical page, so zeroing must mirror that layout instead of multiplying
+    the page span by the logical compression ratio a second time.
+    """
+    storage_block_size = spec.storage_block_size
+    kernel_block_size = (
+        storage_block_size
+        if storage_block_size != spec.block_size
+        else group_kernel_block_size
+    )
+    if storage_block_size % kernel_block_size:
+        raise ValueError(
+            "KV storage block size must be divisible by its kernel block size: "
+            f"{storage_block_size} vs {kernel_block_size}."
+        )
+    return kernel_block_size, storage_block_size // kernel_block_size
+
+
 def compressed_kernel_block_size(spec: AttentionSpec) -> int:
     storage = spec.storage_block_size
     max_page = max(PAGED_MQA_PAGE_SIZES)
@@ -195,8 +220,10 @@ class KVBlockZeroer:
                 if isinstance(spec, FullAttentionSpec):
                     if not isinstance(kv, torch.Tensor):
                         continue
-                    kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
-                    ratio = spec.block_size // kernel_bs
+                    kernel_bs, ratio = _resolve_zeroer_kernel_layout(
+                        spec,
+                        kernel_block_sizes[group.kv_cache_group_id],
+                    )
                     block_dim = group.backend.get_kv_cache_block_dim(
                         kernel_bs,
                         spec.num_kv_heads,


### PR DESCRIPTION
## Summary

- derive the zeroer's physical attention page layout from `storage_block_size`
- keep the existing virtual-block split for ordinary full attention pages
- cover ordinary and compressed layouts with real cache specs and a CUDA page-zeroing test

## Problem

Compressed attention exposes a logical scheduler block that is larger than its
physical cache page. For example, Qwen3.8 Flash Next uses a logical block size
of 784 and a compression ratio of 8, so its compressed QSA cache stores 98 rows
per physical page.

`KVBlockZeroer` previously formed its virtual-page ratio from the logical block
size and the group's kernel block size. For a compressed cache this multiplied
the physical span by the compression ratio again, so a reused block could clear
the wrong physical range instead of exactly one compressed storage page.

## Fix

Resolve the physical kernel block size and virtual-page ratio from the cache
spec before deriving segment spans:

- ordinary attention: keep the group kernel block size and its existing ratio
- compressed attention: use `storage_block_size` as one physical page with ratio 1
- reject layouts whose storage block is not divisible by the selected kernel block

## Validation

- `3 passed, 1 skipped` for the focused controller test selection (CUDA test skipped there)
- Ruff check and format check pass for both changed files
- CUDA smoke on a Tesla V100-PCIE-32GB:
  - ordinary layout: `(16, 49)`
  - compressed layout: `(98, 1)`
  - zeroing block 1 clears only physical page 1
- Qwen3.8 Flash Next 125B NVFP4, TP4 on 4x V100 completed model load,
  4 GiB/GPU KV-cache initialization, PIECEWISE+FULL CUDA Graph capture, and
  1K/4K generation with the equivalent patch before rebasing onto current main
