### PR TITLE
[Bench][SM70] Add GLM NVFP4 quality and performance screens

### DIFF
--- a/benchmarks/benchmark_sm70_nvfp4_gemm_micro.py
+++ b/benchmarks/benchmark_sm70_nvfp4_gemm_micro.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import os
 import statistics
@@ -57,13 +58,43 @@ def _require_sm70(device: torch.device) -> None:
         raise RuntimeError(f"Expected SM70, got sm_{capability[0]}{capability[1]}.")
 
 
-def _make_input(m: int, k: int, device: torch.device) -> torch.Tensor:
+def _make_input(
+    m: int,
+    k: int,
+    device: torch.device,
+    *,
+    data_pattern: str,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    if data_pattern == "random":
+        return torch.randn(
+            (m, k),
+            dtype=torch.float16,
+            device=device,
+            generator=generator,
+        )
     values = torch.arange(m * k, device=device, dtype=torch.int32)
     values = ((values % 1024).to(torch.float32) / 512.0) - 1.0
     return values.reshape(m, k).to(torch.float16)
 
 
-def _make_qweight(k: int, n: int, device: torch.device) -> torch.Tensor:
+def _make_qweight(
+    k: int,
+    n: int,
+    device: torch.device,
+    *,
+    data_pattern: str,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    if data_pattern == "random":
+        return torch.randint(
+            0,
+            16,
+            (k, n),
+            dtype=torch.uint8,
+            device=device,
+            generator=generator,
+        )
     values = torch.arange(k * n, device=device, dtype=torch.int32)
     return (values.reshape(k, n) & 15).to(torch.uint8).contiguous()
 
@@ -82,8 +113,27 @@ def _pack_qweight_u4(qweight: torch.Tensor) -> torch.Tensor:
     return packed.contiguous()
 
 
-def _make_scales(k: int, n: int, group_size: int, device: torch.device) -> torch.Tensor:
+def _make_scales(
+    k: int,
+    n: int,
+    group_size: int,
+    device: torch.device,
+    *,
+    data_pattern: str,
+    generator: torch.Generator,
+) -> torch.Tensor:
     groups = k // group_size
+    if data_pattern == "random":
+        return (
+            torch.rand(
+                (groups, n),
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+            )
+            * 0.9921875
+            + 0.0078125
+        ).to(torch.float16)
     values = torch.arange(groups * n, device=device, dtype=torch.int32)
     values = ((values % 127).to(torch.float32) + 1.0) / 128.0
     return values.reshape(groups, n).to(torch.float16).contiguous()
@@ -163,12 +213,35 @@ def _run_case(
     mode: str,
     gemv_split_k: int,
     gated_silu: bool,
+    num_experts: int,
+    tensor_out: Path | None,
+    data_pattern: str,
+    generator: torch.Generator,
 ) -> dict[str, Any]:
     if case.k % group_size != 0:
         raise ValueError(f"{case.label}: K={case.k} not divisible by {group_size}.")
-    qweight = _make_qweight(case.k, case.n, device)
-    scales = _make_scales(case.k, case.n, group_size, device)
-    x = _make_input(case.m, case.k, device)
+    qweight = _make_qweight(
+        case.k,
+        case.n,
+        device,
+        data_pattern=data_pattern,
+        generator=generator,
+    )
+    scales = _make_scales(
+        case.k,
+        case.n,
+        group_size,
+        device,
+        data_pattern=data_pattern,
+        generator=generator,
+    )
+    x = _make_input(
+        case.m,
+        case.k,
+        device,
+        data_pattern=data_pattern,
+        generator=generator,
+    )
     if gated_silu and case.n % 2 != 0:
         raise ValueError(f"{case.label}: gated-SiLU requires even N, got {case.n}.")
     output_size = case.n // 2 if gated_silu else case.n
@@ -183,6 +256,12 @@ def _run_case(
     dense_weight = None
     qweight_packed = None
     partials = None
+    grouped_weights = None
+    grouped_scales = None
+    ptrs_w = None
+    ptrs_s = None
+    expert_offsets = None
+    expert_ids = None
     if mode == "gemm":
         tm_weight, tm_scales, meta = ops.nvfp4_sm70_prepare(
             qweight, scales, group_size, gated_silu
@@ -214,6 +293,40 @@ def _run_case(
             0.0,
             False,
             gated_silu,
+        )
+    elif mode == "grouped-moe":
+        if gated_silu:
+            raise ValueError("grouped-moe selector screens require --gated-silu off.")
+        if num_experts <= 0 or case.m != num_experts:
+            raise ValueError("grouped-moe M must equal --num-experts.")
+        tm_weight, tm_scales, meta = ops.nvfp4_sm70_prepare(
+            qweight, scales, group_size, False
+        )
+        k_ld = int(meta[0].item())
+        q_ld = int(meta[1].item())
+        grouped_weights = tm_weight.unsqueeze(0).repeat(num_experts, 1, 1)
+        grouped_scales = tm_scales.unsqueeze(0).repeat(num_experts, 1, 1)
+        ptrs_w, ptrs_s = ops.awq_moe_build_strided_ptrs(
+            grouped_weights,
+            grouped_scales,
+            k_ld,
+            q_ld,
+            num_experts,
+        )
+        expert_offsets = torch.arange(num_experts + 1, dtype=torch.int32, device=device)
+        expert_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
+        run = partial(
+            ops.nvfp4_moe_dense_stage_sm70_out,
+            out,
+            x,
+            expert_offsets,
+            expert_ids,
+            ptrs_w,
+            ptrs_s,
+            num_experts,
+            case.k,
+            case.n,
+            group_size,
         )
     elif mode in ("raw-gemv", "raw-gemv-warp", "raw-gemv-h2"):
         if case.m != 1:
@@ -268,6 +381,13 @@ def _run_case(
         raise ValueError(f"Unsupported mode: {mode}")
 
     timing = _time_cuda_call(run, device, warmup, iters, use_cuda_graph)
+    output_cpu = out.detach().contiguous().cpu()
+    output_sha256 = hashlib.sha256(
+        output_cpu.view(torch.uint8).numpy().tobytes()
+    ).hexdigest()
+    if tensor_out is not None:
+        tensor_out.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(output_cpu, tensor_out)
     weighted_mean_ms = float(case.count) * timing["mean_us"] / 1000.0
     row = {
         "mode": mode,
@@ -278,6 +398,7 @@ def _run_case(
         "k": case.k,
         "group_size": group_size,
         "gated_silu": gated_silu,
+        "num_experts": num_experts if mode == "grouped-moe" else 1,
         "gemv_split_k": gemv_split_k if mode in ("raw-gemv", "raw-gemv-h2") else 0,
         "k_ld": k_ld,
         "q_ld": q_ld,
@@ -293,12 +414,18 @@ def _run_case(
                     else (
                         f"qpn4_prefill_{case.m}x{case.n}x{case.k}"
                         if mode == "qpn4-prefill"
-                        else f"sm70_f16_nvfp4k{group_size}_f16_tnt_fff_"
-                        f"{case.m}x{case.n}x{case.k}_1"
+                        else (
+                            f"grouped_moe_e{num_experts}_{case.m}x{case.n}x{case.k}"
+                            if mode == "grouped-moe"
+                            else f"sm70_f16_nvfp4k{group_size}_f16_tnt_fff_"
+                            f"{case.m}x{case.n}x{case.k}_1"
+                        )
                     )
                 )
             )
         ),
+        "output_sha256": output_sha256,
+        "tensor_out": str(tensor_out) if tensor_out is not None else None,
         **timing,
         "weighted_mean_ms": weighted_mean_ms,
     }
@@ -312,6 +439,12 @@ def _run_case(
         dense_weight,
         qweight_packed,
         partials,
+        grouped_weights,
+        grouped_scales,
+        ptrs_w,
+        ptrs_s,
+        expert_offsets,
+        expert_ids,
         x,
         out,
     )
@@ -330,10 +463,13 @@ def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "k",
         "group_size",
         "gated_silu",
+        "num_experts",
         "gemv_split_k",
         "k_ld",
         "q_ld",
         "desc_hint",
+        "output_sha256",
+        "tensor_out",
         "mean_us",
         "min_us",
         "p50_us",
@@ -355,6 +491,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--m", type=int, default=1)
     parser.add_argument("--warmup", type=int, default=30)
     parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--data-pattern",
+        choices=("periodic", "random"),
+        default="periodic",
+        help="Synthetic tensor pattern; random is intended for numerical A/B gates.",
+    )
     parser.add_argument(
         "--cuda-graph",
         action="store_true",
@@ -364,6 +507,7 @@ def _parse_args() -> argparse.Namespace:
         "--mode",
         choices=(
             "gemm",
+            "grouped-moe",
             "qpn4-prefill",
             "raw-gemv",
             "raw-gemv-warp",
@@ -377,6 +521,7 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fuse gate/up SiLU and emit N/2 output columns.",
     )
+    parser.add_argument("--num-experts", type=int, default=8)
     parser.add_argument(
         "--gemv-split-k",
         type=int,
@@ -391,6 +536,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--json-out", type=Path)
     parser.add_argument("--csv-out", type=Path)
+    parser.add_argument(
+        "--tensor-out",
+        type=Path,
+        help="Save the exact output tensor; requires exactly one --case.",
+    )
     return parser.parse_args()
 
 
@@ -413,6 +563,10 @@ def main() -> int:
         ]
         if missing_qpn4_ops:
             raise RuntimeError(f"Missing QPN4 operators: {missing_qpn4_ops}.")
+    if args.mode == "grouped-moe" and not hasattr(
+        torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"
+    ):
+        raise RuntimeError("Missing _C::nvfp4_moe_dense_stage_sm70_out.")
     if args.mode == "raw-gemv" and not hasattr(torch.ops._C, "nvfp4_gemv_sm70_raw_out"):
         raise RuntimeError("Missing _C::nvfp4_gemv_sm70_raw_out.")
     if args.mode == "raw-gemv-warp" and not hasattr(
@@ -429,6 +583,9 @@ def main() -> int:
         if args.case
         else _default_cases(args.m)
     )
+    if args.tensor_out is not None and len(cases) != 1:
+        raise ValueError("--tensor-out requires exactly one benchmark case.")
+    generator = torch.Generator(device=device).manual_seed(args.seed)
     rows = [
         _run_case(
             ops=ops,
@@ -441,6 +598,10 @@ def main() -> int:
             mode=args.mode,
             gemv_split_k=args.gemv_split_k,
             gated_silu=args.gated_silu,
+            num_experts=args.num_experts,
+            tensor_out=args.tensor_out,
+            data_pattern=args.data_pattern,
+            generator=generator,
         )
         for case in cases
     ]
@@ -454,6 +615,7 @@ def main() -> int:
         "torch_version": torch.__version__,
         "cuda_version": torch.version.cuda,
         "group_size": args.group_size,
+        "num_experts": args.num_experts if args.mode == "grouped-moe" else 1,
         "mode": args.mode,
         "gated_silu": args.gated_silu,
         "gemv_split_k": (
@@ -462,6 +624,8 @@ def main() -> int:
         "warmup": args.warmup,
         "iters": args.iters,
         "cuda_graph": args.cuda_graph,
+        "data_pattern": args.data_pattern,
+        "seed": args.seed,
         "total_weighted_mean_ms": total_ms,
         "stage1_target_ms": 10.0,
         "cases": rows,

--- a/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
+++ b/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
@@ -17,7 +17,6 @@ from typing import Any
 
 import torch
 
-from vllm import _sm70_ops as sm70_ops
 from vllm.triton_utils import tl, triton
 
 _SM70_GLM53_FP16_GEMV_CONFIGS: dict[tuple[int, int], tuple[int, int]] = {
@@ -47,14 +46,8 @@ def _sm70_glm53_fp16_gemv_kernel(
     offsets = tl.arange(0, BLOCK_K)
     acc = 0.0
     for block_start in tl.static_range(0, K, BLOCK_K):
-        x = tl.load(
-            x_ptr + block_start + offsets,
-            eviction_policy="evict_last",
-        ).to(tl.float32)
-        weight = tl.load(
-            weight_ptr + row * K + block_start + offsets,
-            eviction_policy="evict_first",
-        ).to(tl.float32)
+        x = tl.load(x_ptr + block_start + offsets).to(tl.float32)
+        weight = tl.load(weight_ptr + row * K + block_start + offsets).to(tl.float32)
         acc += tl.sum(x * weight, axis=0)
     tl.store(out_ptr + row, acc)
 
@@ -112,14 +105,14 @@ def _measure_graph_us(
 ) -> float:
     for _ in range(warmups):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         launch()
     for _ in range(warmups):
         graph.replay()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
@@ -193,6 +186,8 @@ def _benchmark_turbomind(
     warmups: int,
     repeats: int,
 ) -> dict[str, Any]:
+    from vllm import _sm70_ops as sm70_ops
+
     prepared_weight, meta = sm70_ops.sm70_f16_prepare(weight)
     k_ld = int(meta[0].item())
     out = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)

--- a/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
+++ b/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Screen GLM-5.3 FP16 decode GEMV candidates on SM70.
+
+Microbenchmark error bounds are diagnostic only. A candidate is not accepted
+until the real-model logits and output-quality gates pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+from vllm.triton_utils import tl, triton
+
+_SM70_GLM53_FP16_GEMV_CONFIGS: dict[tuple[int, int], tuple[int, int]] = {
+    (6416, 4096): (1024, 2),  # KDA fused q/k/v/b/f_a/g_a
+    (4096, 2048): (1024, 4),  # KDA output projection
+    (6144, 4096): (1024, 2),  # dense MLP gate/up
+    (4096, 3072): (1024, 2),  # dense MLP down
+    (1024, 4096): (1024, 4),  # shared-expert gate/up
+    (2048, 4096): (1024, 2),  # MLA fused q/kv A projection
+    (4096, 1536): (512, 4),  # MLA/indexer B projection
+    (4096, 4096): (1024, 4),  # MLA output projection
+    (32, 4096): (1024, 4),  # indexer weights
+    (128, 4096): (1024, 4),  # indexer key projection
+    (1024, 1536): (512, 4),  # TP-sharded indexer query B
+}
+
+
+@triton.jit
+def _sm70_glm53_fp16_gemv_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = 0.0
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        x = tl.load(
+            x_ptr + block_start + offsets,
+            eviction_policy="evict_last",
+        ).to(tl.float32)
+        weight = tl.load(
+            weight_ptr + row * K + block_start + offsets,
+            eviction_policy="evict_first",
+        ).to(tl.float32)
+        acc += tl.sum(x * weight, axis=0)
+    tl.store(out_ptr + row, acc)
+
+
+@triton.jit
+def _sm70_glm53_fp16_gemv_evict_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = 0.0
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        x = tl.load(
+            x_ptr + block_start + offsets,
+            eviction_policy="evict_last",
+        ).to(tl.float32)
+        weight = tl.load(
+            weight_ptr + row * K + block_start + offsets,
+            eviction_policy="evict_first",
+        ).to(tl.float32)
+        acc += tl.sum(x * weight, axis=0)
+    tl.store(out_ptr + row, acc)
+
+
+@triton.jit
+def _sm70_glm53_fp16_gemv_cg_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = 0.0
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        x = tl.load(
+            x_ptr + block_start + offsets,
+            cache_modifier=".ca",
+        ).to(tl.float32)
+        weight = tl.load(
+            weight_ptr + row * K + block_start + offsets,
+            cache_modifier=".cg",
+        ).to(tl.float32)
+        acc += tl.sum(x * weight, axis=0)
+    tl.store(out_ptr + row, acc)
+
+
+def _measure_graph_us(
+    launch: Callable[[], None], *, warmups: int, repeats: int
+) -> float:
+    for _ in range(warmups):
+        launch()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+    for _ in range(warmups):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / repeats
+
+
+def _benchmark_kernel(
+    name: str,
+    kernel: Any,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    reference: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    block_k: int,
+    num_warps: int,
+    warmups: int,
+    repeats: int,
+) -> dict[str, Any]:
+    n, k = weight.shape
+    out = torch.empty((1, n), dtype=x.dtype, device=x.device)
+
+    def launch() -> None:
+        kernel[(n,)](
+            x,
+            weight,
+            out,
+            K=k,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+        )
+
+    latency_us = _measure_graph_us(launch, warmups=warmups, repeats=repeats)
+    error = out.float() - reference.float()
+    fp32_error = out.float() - fp32_reference
+    cublas_fp32_error = reference.float() - fp32_reference
+    traffic_bytes = 2 * (weight.numel() + x.numel() + out.numel())
+    return {
+        "kernel": name,
+        "latency_us": latency_us,
+        "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+        "exact_equal": torch.equal(out, reference),
+        "output_sha256": hashlib.sha256(
+            out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        ).hexdigest(),
+        "max_abs_error": error.abs().max().item(),
+        "relative_l2_error": (error.norm() / reference.float().norm()).item(),
+        "cosine_similarity": torch.nn.functional.cosine_similarity(
+            out.float(), reference.float()
+        ).item(),
+        "fp32_reference_relative_l2_error": (
+            fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+        "cublas_fp16_fp32_reference_relative_l2_error": (
+            cublas_fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+    }
+
+
+def _benchmark_turbomind(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    reference: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    warmups: int,
+    repeats: int,
+) -> dict[str, Any]:
+    prepared_weight, meta = sm70_ops.sm70_f16_prepare(weight)
+    k_ld = int(meta[0].item())
+    out = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)
+
+    def launch() -> None:
+        sm70_ops.sm70_f16_gemm_out(out, x, prepared_weight, k_ld, False)
+
+    latency_us = _measure_graph_us(launch, warmups=warmups, repeats=repeats)
+    error = out.float() - reference.float()
+    fp32_error = out.float() - fp32_reference
+    cublas_fp32_error = reference.float() - fp32_reference
+    traffic_bytes = 2 * (weight.numel() + x.numel() + out.numel())
+    return {
+        "kernel": "turbomind_f16_tensorcore",
+        "latency_us": latency_us,
+        "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+        "exact_equal": torch.equal(out, reference),
+        "output_sha256": hashlib.sha256(
+            out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        ).hexdigest(),
+        "max_abs_error": error.abs().max().item(),
+        "relative_l2_error": (error.norm() / reference.float().norm()).item(),
+        "cosine_similarity": torch.nn.functional.cosine_similarity(
+            out.float(), reference.float()
+        ).item(),
+        "fp32_reference_relative_l2_error": (
+            fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+        "cublas_fp16_fp32_reference_relative_l2_error": (
+            cublas_fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+    }
+
+
+def _benchmark_padded_cublas_gemm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    reference: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    padded_m: int,
+    warmups: int,
+    repeats: int,
+) -> dict[str, Any]:
+    padded_x = torch.zeros((padded_m, x.shape[1]), dtype=x.dtype, device=x.device)
+    padded_x[0].copy_(x[0])
+    padded_out = torch.empty(
+        (padded_m, weight.shape[0]), dtype=x.dtype, device=x.device
+    )
+    weight_t = weight.t()
+
+    def launch() -> None:
+        torch.mm(padded_x, weight_t, out=padded_out)
+
+    latency_us = _measure_graph_us(launch, warmups=warmups, repeats=repeats)
+    out = padded_out[:1]
+    error = out.float() - reference.float()
+    fp32_error = out.float() - fp32_reference
+    cublas_fp32_error = reference.float() - fp32_reference
+    traffic_bytes = 2 * (weight.numel() + padded_x.numel() + padded_out.numel())
+    return {
+        "kernel": f"cublas_gemm_m{padded_m}",
+        "latency_us": latency_us,
+        "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+        "exact_equal": torch.equal(out, reference),
+        "output_sha256": hashlib.sha256(
+            out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        ).hexdigest(),
+        "max_abs_error": error.abs().max().item(),
+        "relative_l2_error": (error.norm() / reference.float().norm()).item(),
+        "cosine_similarity": torch.nn.functional.cosine_similarity(
+            out.float(), reference.float()
+        ).item(),
+        "fp32_reference_relative_l2_error": (
+            fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+        "cublas_fp16_fp32_reference_relative_l2_error": (
+            cublas_fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+    }
+
+
+def _benchmark_indexer_fp32_paths(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    warmups: int,
+    repeats: int,
+) -> list[dict[str, Any]]:
+    weight_fp32_t = weight.t().contiguous().float()
+    weight_t = weight.t()
+    current_out = torch.empty(
+        (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
+    )
+    fp16_out = torch.empty_like(current_out)
+
+    def current_launch() -> None:
+        torch.mm(x.float(), weight_fp32_t, out=current_out)
+
+    def fp16_launch() -> None:
+        torch.mm(x, weight_t, out_dtype=torch.float32, out=fp16_out)
+
+    current_us = _measure_graph_us(current_launch, warmups=warmups, repeats=repeats)
+    fp16_us = _measure_graph_us(fp16_launch, warmups=warmups, repeats=repeats)
+    rows = []
+    for name, out, latency_us, traffic_bytes in (
+        (
+            "indexer_current_fp32_cast_mm",
+            current_out,
+            current_us,
+            4 * weight.numel() + 6 * x.numel() + 4 * current_out.numel(),
+        ),
+        (
+            "indexer_fp16_mm_out_fp32",
+            fp16_out,
+            fp16_us,
+            2 * (weight.numel() + x.numel()) + 4 * fp16_out.numel(),
+        ),
+    ):
+        error = out - fp32_reference
+        rows.append(
+            {
+                "kernel": name,
+                "latency_us": latency_us,
+                "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+                "exact_equal": torch.equal(out, fp32_reference),
+                "output_sha256": hashlib.sha256(
+                    out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+                ).hexdigest(),
+                "max_abs_error": error.abs().max().item(),
+                "relative_l2_error": (error.norm() / fp32_reference.norm()).item(),
+                "cosine_similarity": torch.nn.functional.cosine_similarity(
+                    out, fp32_reference
+                ).item(),
+                "fp32_reference_relative_l2_error": (
+                    error.norm() / fp32_reference.norm()
+                ).item(),
+                "cublas_fp16_fp32_reference_relative_l2_error": None,
+            }
+        )
+    rows[1]["exact_equal_current_fp32_path"] = torch.equal(fp16_out, current_out)
+    rows[1]["max_abs_error_vs_current_fp32_path"] = (
+        (fp16_out - current_out).abs().max().item()
+    )
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmups", type=int, default=50)
+    parser.add_argument("--repeats", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--out", type=str)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("This benchmark requires an NVIDIA SM70 GPU.")
+    torch.manual_seed(args.seed)
+    rows: list[dict[str, Any]] = []
+    candidates = (
+        ("base", _sm70_glm53_fp16_gemv_kernel),
+        ("evict", _sm70_glm53_fp16_gemv_evict_kernel),
+        ("cg", _sm70_glm53_fp16_gemv_cg_kernel),
+    )
+    for (n, k), (block_k, num_warps) in _SM70_GLM53_FP16_GEMV_CONFIGS.items():
+        x = torch.randn((1, k), dtype=torch.float16, device="cuda")
+        weight = torch.randn((n, k), dtype=torch.float16, device="cuda")
+        reference = torch.nn.functional.linear(x, weight)
+        fp32_reference = torch.nn.functional.linear(x.float(), weight.float())
+        for name, kernel in candidates:
+            try:
+                result = _benchmark_kernel(
+                    name,
+                    kernel,
+                    x,
+                    weight,
+                    reference,
+                    fp32_reference,
+                    block_k=block_k,
+                    num_warps=num_warps,
+                    warmups=args.warmups,
+                    repeats=args.repeats,
+                )
+            except Exception as exc:
+                result = {"kernel": name, "error": f"{type(exc).__name__}: {exc}"}
+            rows.append(
+                {
+                    "shape": [n, k],
+                    "block_k": block_k,
+                    "num_warps": num_warps,
+                    **result,
+                }
+            )
+        try:
+            result = _benchmark_turbomind(
+                x,
+                weight,
+                reference,
+                fp32_reference,
+                warmups=args.warmups,
+                repeats=args.repeats,
+            )
+        except Exception as exc:
+            result = {
+                "kernel": "turbomind_f16_tensorcore",
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        rows.append(
+            {
+                "shape": [n, k],
+                "block_k": None,
+                "num_warps": None,
+                **result,
+            }
+        )
+        for padded_m in (1, 2, 4, 8, 16):
+            try:
+                result = _benchmark_padded_cublas_gemm(
+                    x,
+                    weight,
+                    reference,
+                    fp32_reference,
+                    padded_m=padded_m,
+                    warmups=args.warmups,
+                    repeats=args.repeats,
+                )
+            except Exception as exc:
+                result = {
+                    "kernel": f"cublas_gemm_m{padded_m}",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            rows.append(
+                {
+                    "shape": [n, k],
+                    "block_k": None,
+                    "num_warps": None,
+                    **result,
+                }
+            )
+        if (n, k) == (32, 4096):
+            try:
+                indexer_results = _benchmark_indexer_fp32_paths(
+                    x,
+                    weight,
+                    fp32_reference,
+                    warmups=args.warmups,
+                    repeats=args.repeats,
+                )
+            except Exception as exc:
+                indexer_results = [
+                    {
+                        "kernel": "indexer_fp32_paths",
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                ]
+            rows.extend(
+                {
+                    "shape": [n, k],
+                    "block_k": None,
+                    "num_warps": None,
+                    **result,
+                }
+                for result in indexer_results
+            )
+
+    report = {
+        "device": torch.cuda.get_device_name(),
+        "capability": list(torch.cuda.get_device_capability()),
+        "dtype": "float16",
+        "accumulation": "float32",
+        "warmups": args.warmups,
+        "repeats": args.repeats,
+        "rows": rows,
+    }
+    payload = json.dumps(report, indent=2)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as output_file:
+            output_file.write(payload + "\n")
+    print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,14 +1433,6 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
-  const bool exact_glm53_b1_w13 =
-      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
-      group_size == 16;
-  if (exact_glm53_b1_w13) {
-    // GLM-5.3 decode relies on the default split-8 accumulation tree. The
-    // measured split-12 candidate changes FP16 expert outputs.
-    return turbomind::gemm::DispatchPolicy::kDefault;
-  }
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,6 +1433,14 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
+  const bool exact_glm53_b1_w13 =
+      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
+      group_size == 16;
+  if (exact_glm53_b1_w13) {
+    // GLM-5.3 decode relies on the default split-8 accumulation tree. The
+    // measured split-12 candidate changes FP16 expert outputs.
+    return turbomind::gemm::DispatchPolicy::kDefault;
+  }
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44172,3 +44172,20 @@ Interpretation:
   `docs/design/sm70_dflash2_quality_audit.md`. Do not cite acceptance length as
   intelligence: it explains throughput, while official executable scores and
   natural termination are the quality gates.
+
+## 2026-08-28 GLM-5.3 NVFP4 selector audit
+
+- The exact TP4/B1 grouped W13 shape is eight routed slots with local
+  `N=1024`, `K=4096`, and group size 16. A same-GPU random-data screen on one
+  V100 measures the default split-8 median at `51.200 us` and the measured
+  split-12 route at `48.128 us`, a 6.0% stage-latency reduction.
+- The two FP16 outputs differ in 37 of 8192 elements with maximum absolute
+  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. This is a
+  small accumulation-order difference, not task-quality evidence. The faster
+  measured selector remains enabled while matched endpoint quality is still
+  collected; no model-identity gate or default-split override is added.
+- The grouped-MoE benchmark now supports random inputs, output hashes, tensor
+  dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
+  `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`
+  across repeated runs. A separate FP16 Dense/Indexer candidate screen remains
+  benchmark-only and does not alter production dispatch.


### PR DESCRIPTION
## Purpose

Add reproducible SM70 screens for GLM-5.3 NVFP4 grouped-MoE and FP16 Dense/Indexer candidates while keeping the faster dynamic W13 selector enabled on current `main`.

## Changes

- Extend the NVFP4 microbenchmark with grouped-MoE, random-data, output-hash, and tensor-dump gates.
- Add a self-contained GLM FP16 Dense/Indexer candidate benchmark; it does not alter production dispatch.
- Correct the benchmark candidate definitions, use the accelerator-neutral synchronization API, and allow clean-source CLI help without a built native extension.
- Record the locked V100 selector audit in the SM70 migration control document.
- Remove the original production C++ forced split-8 fallback: the audited dynamic selector remains default-on.

## Test Plan

- Run focused GLM ModelOpt NVFP4 unit tests.
- Run changed-file and full remote pre-commit gates.
- Compile and smoke both benchmark CLIs from a clean checkout.
- Measure the exact grouped W13 shape on V100 and compare output quality and repeatability.

## Test Result

- Full remote pre-commit: passed.
- Focused GLM ModelOpt NVFP4 tests: `8 passed`.
- Clean-source benchmark `--help` and Python compile: passed.
- Exact grouped W13 V100 measurement, seed 17:
  - default split-8 median: `51.200 us`
  - dynamic selector median: `48.128 us` (about `6.0%` faster)
  - changed FP16 elements: `37 / 8192`
  - max abs: `0.125`
  - relative L2: `1.642256e-5`
  - cosine: `0.9999991655`
  - repeated dynamic output hash: identical
- Corrected FP16 N32/K4096 candidate smoke completed on V100; outputs were exact for the tested input.

## Decision

The small accumulation-order difference does not justify a production slowdown under the project quality policy. This PR therefore keeps the faster dynamic selector and contributes only benchmark/quality tooling plus the migration record.

Repair chain: #380.