### PR TITLE
[Bugfix][QSA] Keep compressed block tables in physical-page units

### DIFF
--- a/tests/v1/core/test_qwen4_exp_kv_cache.py
+++ b/tests/v1/core/test_qwen4_exp_kv_cache.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.models.qwen4_exp.common.qsa_cache import QSAStateBackend
@@ -40,7 +41,11 @@ def _vllm_config():
     return SimpleNamespace(
         model_config=_ModelConfig(),
         parallel_config=SimpleNamespace(pipeline_parallel_size=1),
-        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        scheduler_config=SimpleNamespace(
+            disable_hybrid_kv_cache_manager=False,
+            max_num_batched_tokens=8192,
+            max_num_seqs=2,
+        ),
         cache_config=SimpleNamespace(
             num_gpu_blocks_override=None,
             mamba_cache_mode="none",
@@ -212,3 +217,53 @@ def test_qwen4_exp_compressed_qsa_reshape_uses_storage_block_size() -> None:
 
     assert caches["compressed"].shape == (num_blocks, 4, 1, 128)
     assert caches["compressed"].untyped_storage().data_ptr() == raw.data_ptr()
+
+
+@pytest.mark.skip_global_cleanup
+def test_qwen4_exp_qsa_metadata_canonicalizes_expanded_block_table() -> None:
+    spec = MLAAttentionSpec(
+        block_size=784,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float16,
+        compress_ratio=8,
+    )
+    group = AttentionGroup(
+        QSAStateBackend,
+        ["compressed"],
+        spec,
+        kv_cache_group_id=0,
+    )
+    group.create_metadata_builders(
+        _vllm_config(), torch.device("cpu"), kernel_block_size=16
+    )
+    builder = group.get_metadata_builder()
+
+    # The QSA builder must retain the actual 98-row cache page rather than the
+    # generic 32-row paged-MQA virtualization used by other compressed backends.
+    assert builder.kv_cache_spec.block_size == 784
+    assert builder.kv_cache_spec.storage_block_size == 98
+
+    expansion = 784 // 16
+    # The legacy block-table path pads 11 physical pages to 16 for its
+    # 128-token alignment. The persistent QSA buffer must cover that width as
+    # well as the unpadded V2 table.
+    physical_pages = torch.arange(16, dtype=torch.int32).mul(3).add(7)
+    expanded = (
+        physical_pages[:, None] * expansion + torch.arange(expansion, dtype=torch.int32)
+    ).reshape(1, -1)
+
+    canonical = builder._canonical_block_table(expanded)
+    first_ptr = canonical.data_ptr()
+    assert torch.equal(canonical, physical_pages[None])
+
+    physical_pages.add_(5)
+    expanded.copy_(
+        (
+            physical_pages[:, None] * expansion
+            + torch.arange(expansion, dtype=torch.int32)
+        ).reshape(1, -1)
+    )
+    canonical = builder._canonical_block_table(expanded)
+    assert canonical.data_ptr() == first_ptr
+    assert torch.equal(canonical, physical_pages[None])

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -567,6 +567,8 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
     """Build QSA metadata from vLLM's cache-group-specific common metadata."""
 
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    requires_block_table_width: ClassVar[bool] = True
+    uses_physical_block_table: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -574,6 +576,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
         layer_names: list[str],
         vllm_config: VllmConfig,
         device: torch.device,
+        block_table_width: int,
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         self.is_circular_buffer = isinstance(kv_cache_spec, CircularBufferSpec)
@@ -594,6 +597,16 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
         )
         max_requests = vllm_config.scheduler_config.max_num_seqs
         self.request_capacity = max_requests
+        if isinstance(kv_cache_spec, MLAAttentionSpec) and self.compress_ratio != 1:
+            self.block_table_buffer = torch.empty(
+                (max_requests, block_table_width),
+                dtype=torch.int32,
+                device=device,
+            )
+        else:
+            self.block_table_buffer = torch.empty(
+                (0, 0), dtype=torch.int32, device=device
+            )
         if not self.is_circular_buffer and self.compress_ratio != 1:
             max_k_work = (
                 max_tokens + (self.compress_ratio - 1) * max_requests
@@ -606,6 +619,53 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
                 0, 2, dtype=torch.int32, device=device
             )
 
+    def _canonical_block_table(self, block_table: torch.Tensor) -> torch.Tensor:
+        """Return physical QSA page IDs in a pointer-stable buffer.
+
+        A hybrid KV group exposes one common block table in units of its
+        smallest attention kernel block. For example, a 784-token scheduler
+        block with a 16-token main-attention kernel appears as 49 consecutive
+        entries whose values are ``physical_block * 49 + sub_block``. QSA's
+        compressed cache stores that same scheduler block as one physical
+        98-row page, so it must consume one canonical page ID rather than the
+        expanded main-attention entries.
+        """
+
+        if not self.block_table_buffer.numel():
+            return block_table
+        kernel_block_size = getattr(
+            self, "kernel_block_size", self.kv_cache_spec.block_size
+        )
+        if self.kv_cache_spec.block_size % kernel_block_size:
+            raise RuntimeError(
+                "QSA scheduler block size must be divisible by the KV-group "
+                "kernel block size"
+            )
+        expansion = self.kv_cache_spec.block_size // kernel_block_size
+        if expansion == 1:
+            return block_table
+        if block_table.shape[1] % expansion:
+            raise RuntimeError(
+                "QSA common block-table width does not match its virtual "
+                "kernel-block expansion"
+            )
+        rows = block_table.shape[0]
+        columns = block_table.shape[1] // expansion
+        if (
+            rows > self.block_table_buffer.shape[0]
+            or columns > (self.block_table_buffer.shape[1])
+        ):
+            raise RuntimeError("QSA canonical block-table buffer is too small")
+        canonical = self.block_table_buffer[:rows, :columns]
+        expanded_first = block_table[:, : columns * expansion : expansion]
+        torch.div(
+            expanded_first,
+            expansion,
+            rounding_mode="floor",
+            out=canonical,
+        )
+        return canonical
+
     def build(
         self,
         common_prefix_len: int,
@@ -614,6 +674,9 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
     ) -> QSAForwardMetadata:
         del common_prefix_len, fast_build
         num_tokens = common_attn_metadata.num_actual_tokens
+        block_table = self._canonical_block_table(
+            common_attn_metadata.block_table_tensor
+        )
         build_k_work = not self.is_circular_buffer and self.compress_ratio != 1
         k_work_metadata = self.k_work_metadata_buffer
         request_capacity = None
@@ -625,7 +688,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
             ) // self.compress_ratio
             k_work_metadata = self.k_work_metadata_buffer[:max_num_work]
         token_to_req, logical_positions, slot_mapping = build_qsa_metadata(
-            common_attn_metadata,
+            common_attn_metadata.replace(block_table_tensor=block_table),
             self.token_to_req_buffer,
             self.logical_positions_buffer,
             self.slot_mapping_buffer,
@@ -638,7 +701,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
             request_capacity=request_capacity,
         )
         return QSAForwardMetadata(
-            block_table=common_attn_metadata.block_table_tensor,
+            block_table=block_table,
             slot_mapping=slot_mapping,
             seq_lens=common_attn_metadata.seq_lens,
             query_start_loc=common_attn_metadata.query_start_loc,
@@ -690,10 +753,6 @@ class QSAStateBackend(AttentionBackend):
         if num_kv_heads != 1:
             raise ValueError("QSA side caches require exactly one KV head")
         return (num_blocks, block_size, num_kv_heads, head_size)
-
-    @classmethod
-    def indexes_kv_by_block_stride(cls) -> bool:
-        return True
 
     @staticmethod
     def get_kv_cache_stride_order(

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -571,6 +571,10 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     # metadata
     supports_update_block_table: bool = False
     requires_block_table_width: ClassVar[bool] = False
+    # Whether this builder consumes scheduler-level physical block IDs rather
+    # than the cache group's virtual kernel-block IDs. Compressed-cache builders
+    # that set this retain the original logical/storage block geometry.
+    uses_physical_block_table: ClassVar[bool] = False
 
     @abstractmethod
     def __init__(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -371,7 +371,13 @@ class AttentionGroup:
         kernel_block_size: int | None = None,
         num_metadata_builders: int = 1,
     ):
-        if kernel_block_size is None:
+        builder_cls = self.backend.get_builder_cls()
+        uses_physical_block_table = (
+            isinstance(self.kv_cache_spec, AttentionSpec)
+            and self.kv_cache_spec.storage_block_size != self.kv_cache_spec.block_size
+            and builder_cls.uses_physical_block_table
+        )
+        if kernel_block_size is None or (uses_physical_block_table):
             kv_cache_spec_builder = self.kv_cache_spec
         elif (
             isinstance(self.kv_cache_spec, AttentionSpec)
@@ -387,14 +393,20 @@ class AttentionGroup:
             kv_cache_spec_builder = self.kv_cache_spec.copy_with_new_block_size(
                 kernel_block_size
             )
-        builder_cls = self.backend.get_builder_cls()
         builder_kwargs = {}
         if builder_cls.requires_block_table_width:
             max_num_blocks = self.kv_cache_spec.max_num_blocks_per_req(
                 vllm_config, vllm_config.model_config.max_model_len
             )
+            metadata_block_size = (
+                self.kv_cache_spec.block_size
+                if uses_physical_block_table
+                else kernel_block_size
+            )
             builder_kwargs["block_table_width"] = get_block_table_width(
-                max_num_blocks, self.kv_cache_spec.block_size, kernel_block_size
+                max_num_blocks,
+                self.kv_cache_spec.block_size,
+                metadata_block_size,
             )
         self.metadata_builders = [
             builder_cls(


### PR DESCRIPTION
## Purpose

Fix Qwen4Exp QSA compressed-cache metadata when a hybrid KV group uses different scheduler, attention-kernel, and compressed-storage block sizes.

For the observed `784 / 16 / 98` geometry, the common block table expands each scheduler block into 49 virtual kernel-block IDs. The QSA scorer indexes a cache whose first dimension is the physical compressed page, so consuming those expanded IDs can leave the graph-replayed score buffer at `-inf`.

This change:

- adds an opt-in metadata-builder contract for backends that consume scheduler-level physical block IDs;
- keeps QSA's original logical/storage cache geometry instead of applying the generic compressed-backend virtualization;
- canonicalizes the expanded common block table to physical QSA page IDs in an address-stable device buffer; and
- covers the `784 / 16 / 98` conversion, padded table width, and pointer stability across updates.

This PR intentionally does not change `persistent_topk` or QSA boundary-tie semantics. Deterministic top-k membership remains a separate follow-up.

## Test Plan

- Run the focused CPU unit test for expanded-to-physical QSA block-table conversion.
- Run Ruff check/format and `git diff --check` on all changed files.
- On 4 x V100 32 GiB, compare a 16,383-token natural archive prompt under FULL+PIECEWISE graph replay and the PIECEWISE control path.
- For all 12 QSA layers, compare the live score region, cutoff, selected block set, and canonical expanded selection at decode step 1.

## Test Result

- Focused unit test: `1 passed`.
- Ruff check: passed; Ruff format check: passed; `git diff --check`: passed.
- FULL graph natural-text probe:
  - all 4,096 live scores were finite in all 12 QSA layers;
  - all 12 cutoffs were finite;
  - every top-512 set contained 512 unique blocks and spanned block IDs `0..4095`;
  - 292 to 434 selected blocks per layer were above block 511, rather than the prior lowest-block degeneration.
- FULL versus PIECEWISE decode step 1:
  - live scores were bit-exact in 12/12 layers;
  - cutoffs were bit-exact in 12/12 layers;
  - selected block sets were exact in 12/12 layers; and
  - canonical expanded selections were bit-exact in 12/12 layers.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

