### PR TITLE
[Bench][SM70] Record GLM NVFP4 selector quality audit

### DIFF
--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,12 +1433,10 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
-  const bool exact_glm53_b1_w13 =
-      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
-      group_size == 16;
-  const bool exact_glm53_b1_w2 =
-      total_tokens == 8 && n == 4096 && k == 512 && num_experts == 8 &&
-      group_size == 16;
+  const bool exact_glm53_b1_w13 = total_tokens == 8 && n == 1024 && k == 4096 &&
+                                  num_experts == 8 && group_size == 16;
+  const bool exact_glm53_b1_w2 = total_tokens == 8 && n == 4096 && k == 512 &&
+                                 num_experts == 8 && group_size == 16;
   if (exact_glm53_b1_w13 || exact_glm53_b1_w2) {
     // GLM-5.3 decode relies on the default W13 split-8 and W2 split-2
     // accumulation trees. Measured alternatives change FP16 expert outputs.

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,6 +1433,17 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
+  const bool exact_glm53_b1_w13 =
+      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
+      group_size == 16;
+  const bool exact_glm53_b1_w2 =
+      total_tokens == 8 && n == 4096 && k == 512 && num_experts == 8 &&
+      group_size == 16;
+  if (exact_glm53_b1_w13 || exact_glm53_b1_w2) {
+    // GLM-5.3 decode relies on the default W13 split-8 and W2 split-2
+    // accumulation trees. Measured alternatives change FP16 expert outputs.
+    return turbomind::gemm::DispatchPolicy::kDefault;
+  }
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,17 +1433,6 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
-  const bool exact_glm53_b1_w13 =
-      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
-      group_size == 16;
-  const bool exact_glm53_b1_w2 =
-      total_tokens == 8 && n == 4096 && k == 512 && num_experts == 8 &&
-      group_size == 16;
-  if (exact_glm53_b1_w13 || exact_glm53_b1_w2) {
-    // GLM-5.3 decode relies on the default W13 split-8 and W2 split-2
-    // accumulation trees. Measured alternatives change FP16 expert outputs.
-    return turbomind::gemm::DispatchPolicy::kDefault;
-  }
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44180,15 +44180,21 @@ Interpretation:
   V100 measures the default split-8 median at `51.200 us` and the measured
   split-12 route at `48.128 us`, a 6.0% stage-latency reduction.
 - The two FP16 outputs differ in 37 of 8192 elements with maximum absolute
-  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. This is a
-  small accumulation-order difference, not task-quality evidence. The faster
-  measured selector remains enabled while matched endpoint quality is still
-  collected; no model-identity gate or default-split override is added.
+  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. Because no
+  matched endpoint audit accepts that accumulation change, the exact GLM W13
+  shape remains on the default split-8 policy.
+- The exact TP4/B1 W2 shape is eight routed slots with local `N=4096`, `K=512`,
+  and group size 16. Across five random seeds, the measured split-1 policy is
+  only 2.8%-3.5% faster than default split-2 in the materialized grouped-MoE
+  screen. It changes 52-70 of 32768 FP16 outputs per seed with maximum absolute
+  difference 0.0625, so the exact W2 shape also remains on the default policy.
 - The grouped-MoE benchmark now supports random inputs, output hashes, tensor
   dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
   `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`
-  across repeated runs. A separate FP16 Dense/Indexer candidate screen remains
-  benchmark-only and does not alter production dispatch.
+  across repeated runs. The W2 audit evidence is rooted at
+  `/data/minimax-h3/task-cache/glm53-nvfp4-sm70-20260827/`
+  `nvfp4_selector_main_20260828/`. A separate FP16 Dense/Indexer candidate
+  screen remains benchmark-only and does not alter production dispatch.
 
 ## 2026-08-28 Qwen3.8 QSA page4 XQA prefill audit
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44180,14 +44180,16 @@ Interpretation:
   V100 measures the default split-8 median at `51.200 us` and the measured
   split-12 route at `48.128 us`, a 6.0% stage-latency reduction.
 - The two FP16 outputs differ in 37 of 8192 elements with maximum absolute
-  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. Because no
-  matched endpoint audit accepts that accumulation change, the exact GLM W13
-  shape remains on the default split-8 policy.
+  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. This is a
+  small accumulation-order difference rather than task-quality regression
+  evidence, so the faster dynamic W13 selector remains enabled.
 - The exact TP4/B1 W2 shape is eight routed slots with local `N=4096`, `K=512`,
   and group size 16. Across five random seeds, the measured split-1 policy is
   only 2.8%-3.5% faster than default split-2 in the materialized grouped-MoE
   screen. It changes 52-70 of 32768 FP16 outputs per seed with maximum absolute
-  difference 0.0625, so the exact W2 shape also remains on the default policy.
+  difference 0.0625. With no task-quality regression evidence, the dynamic W2
+  selector also remains enabled. `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0`
+  remains the common stable-accumulation rollback for both shapes.
 - The grouped-MoE benchmark now supports random inputs, output hashes, tensor
   dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
   `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44187,9 +44187,11 @@ Interpretation:
   and group size 16. Across five random seeds, the measured split-1 policy is
   only 2.8%-3.5% faster than default split-2 in the materialized grouped-MoE
   screen. It changes 52-70 of 32768 FP16 outputs per seed with maximum absolute
-  difference 0.0625. With no task-quality regression evidence, the dynamic W2
-  selector also remains enabled. `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0`
-  remains the common stable-accumulation rollback for both shapes.
+  difference 0.0625, relative L2 `1.34e-5`-`2.01e-5`, and cosine
+  `0.9999972`-`0.9999981`. With no task-quality regression evidence, the
+  dynamic W2 selector also remains enabled.
+  `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0` remains the common
+  stable-accumulation rollback for both shapes.
 - The grouped-MoE benchmark now supports random inputs, output hashes, tensor
   dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
   `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`


### PR DESCRIPTION
## Purpose

Record the latest GLM NVFP4 grouped-MoE selector quality audit while preserving the default-on performance policy already accepted through #377/#380.

## Decision

- Keep dynamic W13 and W2 selection enabled by default.
- Do not require FP16 bitwise or greedy identity when aggregate quality has not regressed.
- Keep `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0` as the stable-accumulation rollback.
- Do not add model/checkpoint identity gates.

## Evidence

- W13: dynamic split-12 is about 6.0% faster than default split-8; 37/8192 FP16 elements differ, max abs 0.125, relative L2 `1.642e-5`, cosine `0.99999917`.
- W2 across five random seeds: dynamic split-1 is 2.8%-3.5% faster; 52-70/32768 elements differ, max abs 0.0625, relative L2 `1.34e-5`-`2.01e-5`, cosine `0.9999972`-`0.9999981`.
- No matched task-quality regression is recorded for either selector.
- Evidence root: `/data/minimax-h3/task-cache/glm53-nvfp4-sm70-20260827/nvfp4_selector_main_20260828/`.

## Final changes and validation

- The original forced-default production guard was removed by repair #386.
- Final diff versus current `main` is documentation-only; production C++ is byte-identical to `main`.
- Changed-file clang-format, Markdown, configuration, and local pre-commit gates passed.
- Repair head `b4c3451993ad287909aa0e1376ea44ba04823294` passed full GitHub pre-commit.
- Full end-to-end testing was intentionally skipped; the decision uses the existing exact operator evidence and the requested source-audit scope.

## Locked candidate

- final head: `2a5e2f5b377538d1f1af4d24e466f41df8a076f8`
- final tree: `1eeb53ad93f02e3b0cebcfb540730f07442fda34`
- current `main` `3fb15f41cdf5614f39983768e63f2f98c2493755` is an ancestor.
- final GitHub pre-commit on the merged original head: passed (run `33148448986`).

AI assistance was used. The source diff, tensor deltas, performance evidence, and final tree were reviewed before admission.