### PR TITLE
[Bench][SM70] Repair #385 without disabling NVFP4 tuning

### DIFF
--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1433,17 +1433,6 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream) {
-  const bool exact_glm53_b1_w13 =
-      total_tokens == 8 && n == 1024 && k == 4096 && num_experts == 8 &&
-      group_size == 16;
-  const bool exact_glm53_b1_w2 =
-      total_tokens == 8 && n == 4096 && k == 512 && num_experts == 8 &&
-      group_size == 16;
-  if (exact_glm53_b1_w13 || exact_glm53_b1_w2) {
-    // GLM-5.3 decode relies on the default W13 split-8 and W2 split-2
-    // accumulation trees. Measured alternatives change FP16 expert outputs.
-    return turbomind::gemm::DispatchPolicy::kDefault;
-  }
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44180,14 +44180,16 @@ Interpretation:
   V100 measures the default split-8 median at `51.200 us` and the measured
   split-12 route at `48.128 us`, a 6.0% stage-latency reduction.
 - The two FP16 outputs differ in 37 of 8192 elements with maximum absolute
-  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. Because no
-  matched endpoint audit accepts that accumulation change, the exact GLM W13
-  shape remains on the default split-8 policy.
+  difference 0.125, relative L2 `1.642e-5`, and cosine `0.99999917`. This is a
+  small accumulation-order difference rather than task-quality regression
+  evidence, so the faster dynamic W13 selector remains enabled.
 - The exact TP4/B1 W2 shape is eight routed slots with local `N=4096`, `K=512`,
   and group size 16. Across five random seeds, the measured split-1 policy is
   only 2.8%-3.5% faster than default split-2 in the materialized grouped-MoE
   screen. It changes 52-70 of 32768 FP16 outputs per seed with maximum absolute
-  difference 0.0625, so the exact W2 shape also remains on the default policy.
+  difference 0.0625. With no task-quality regression evidence, the dynamic W2
+  selector also remains enabled. `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0`
+  remains the common stable-accumulation rollback for both shapes.
 - The grouped-MoE benchmark now supports random inputs, output hashes, tensor
   dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
   `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44187,9 +44187,11 @@ Interpretation:
   and group size 16. Across five random seeds, the measured split-1 policy is
   only 2.8%-3.5% faster than default split-2 in the materialized grouped-MoE
   screen. It changes 52-70 of 32768 FP16 outputs per seed with maximum absolute
-  difference 0.0625. With no task-quality regression evidence, the dynamic W2
-  selector also remains enabled. `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0`
-  remains the common stable-accumulation rollback for both shapes.
+  difference 0.0625, relative L2 `1.34e-5`-`2.01e-5`, and cosine
+  `0.9999972`-`0.9999981`. With no task-quality regression evidence, the
+  dynamic W2 selector also remains enabled.
+  `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0` remains the common
+  stable-accumulation rollback for both shapes.
 - The grouped-MoE benchmark now supports random inputs, output hashes, tensor
   dumps, and the real eight-slot GLM shape. Seed 17 reproduces output hash
   `47836839b542fb73494caa64adc14cd660e38c535c4a5e67e16d3a763196dac7`


### PR DESCRIPTION
## Purpose

Repair #385 without undoing the default-on NVFP4 selector decision already audited and merged through #377/#380.

## Audit basis

- #385 head: `4e50010134bc9ab9c9befad164d52f9786af4f50`.
- W13 dynamic split-12 is about 6.0% faster than default split-8; its FP16 delta is 37/8192 elements, max abs 0.125, relative L2 `1.642e-5`, cosine `0.99999917`.
- W2 dynamic split-1 is 2.8%-3.5% faster across five random seeds; 52-70/32768 FP16 values differ per seed, max abs 0.0625, relative L2 `1.34e-5`-`2.01e-5`, cosine `0.9999972`-`0.9999981`.
- No matched task-quality regression is recorded for either selector. The project policy does not require greedy or bitwise identity and defaults accepted performance improvements on.
- `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0` already provides a reversible stable-accumulation fallback.

## Planned repair

- Remove the shape-specific production slowdown from #385.
- Retain the useful W2 numerical/performance evidence in the migration record.
- State the accepted dynamic-default decision and existing rollback explicitly.
- Sync to the latest public `main`, run the smallest relevant gates, and preserve #385 ancestry.

## Final result

- Removed #385's exact-shape forced-default production guard.
- Kept the W13 and W2 dynamic selectors default-on under the existing generic shape/runtime policy.
- Kept `VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES=0` as the stable-accumulation rollback.
- Retained and corrected the five-seed W2 numerical/performance record.
- Final diff versus latest `main` is documentation-only; production C++ is byte-identical to latest `main`.
- Changed-file clang-format, Markdown, configuration, and pre-commit gates passed.

## Locked candidate

- repair head: `b4c3451993ad287909aa0e1376ea44ba04823294`
- repair tree: `1eeb53ad93f02e3b0cebcfb540730f07442fda34`
- latest #385 head `8e7e40b5f66c8163e95dae6fa9cf384363687074` and latest `main` `3fb15f41cdf5614f39983768e63f2f98c2493755` are ancestors.
- final remote pre-commit passed on the exact head in run `33148180385`.

Draft repair for #385; do not merge until its final head/tree and remote checks are locked.