### PR TITLE
[Kernel][SM70] Add q32 lookup-augmented DFlash2 verification

### DIFF
--- a/benchmarks/benchmark_sm70_dflash2_iterative_chat.py
+++ b/benchmarks/benchmark_sm70_dflash2_iterative_chat.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark cumulative coding chats through an OpenAI-compatible endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+SPEC_METRICS = (
+    "vllm:spec_decode_num_drafts",
+    "vllm:spec_decode_num_draft_tokens",
+    "vllm:spec_decode_num_accepted_tokens",
+)
+
+DIRECT_CODING_SYSTEM_PROMPT = (
+    "You are editing a single-file Python application in a benchmark. "
+    "No tools, filesystem, shell, or external project are available. Never emit "
+    "tool calls and never ask to inspect files. Answer each request directly. "
+    "When asked to build or update app.py, emit the complete current app.py in "
+    "one Python code block so later turns can modify the text from conversation "
+    "history."
+)
+
+
+def _load_prompts(path: Path) -> list[dict[str, str]]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("--prompts-json must contain a non-empty JSON list")
+    prompts: list[dict[str, str]] = []
+    for index, item in enumerate(raw):
+        if isinstance(item, str):
+            prompts.append({"label": f"turn-{index + 1:02d}", "prompt": item})
+        elif isinstance(item, dict) and isinstance(item.get("prompt"), str):
+            prompts.append(
+                {
+                    "label": str(item.get("label") or f"turn-{index + 1:02d}"),
+                    "prompt": item["prompt"],
+                }
+            )
+        else:
+            raise TypeError(f"invalid prompt record at index {index}: {item!r}")
+    return prompts
+
+
+def _get_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read())
+
+
+def _metric_snapshot(base_url: str) -> dict[str, float]:
+    try:
+        with urllib.request.urlopen(f"{base_url}/metrics", timeout=10.0) as response:
+            text = response.read().decode()
+    except Exception:
+        return {}
+    totals = {name: 0.0 for name in SPEC_METRICS}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        metric_name = line.split("{", 1)[0].split(" ", 1)[0]
+        for name in SPEC_METRICS:
+            if metric_name in (name, f"{name}_total"):
+                with contextlib.suppress(ValueError):
+                    totals[name] += float(line.rsplit(None, 1)[-1])
+    return totals
+
+
+def _metric_delta(
+    before: dict[str, float], after: dict[str, float]
+) -> dict[str, float]:
+    return {name: after.get(name, 0.0) - before.get(name, 0.0) for name in SPEC_METRICS}
+
+
+def _stream_turn(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, str]],
+    *,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    timeout: float,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    request = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    started = time.perf_counter()
+    first_token_at: float | None = None
+    finished_at = started
+    text_parts: list[str] = []
+    usage: dict[str, Any] = {}
+    finish_reason: str | None = None
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        for raw_line in response:
+            line = raw_line.decode().strip()
+            if not line.startswith("data: "):
+                continue
+            body = line[6:]
+            if body == "[DONE]":
+                break
+            event = json.loads(body)
+            if event.get("usage"):
+                usage = event["usage"]
+            for choice in event.get("choices") or []:
+                delta = choice.get("delta") or {}
+                content = delta.get("content") or ""
+                if content:
+                    if first_token_at is None:
+                        first_token_at = time.perf_counter()
+                    text_parts.append(content)
+                if choice.get("finish_reason") is not None:
+                    finish_reason = choice["finish_reason"]
+            finished_at = time.perf_counter()
+    if first_token_at is None:
+        first_token_at = finished_at
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    decode_seconds = max(finished_at - first_token_at, 1e-9)
+    return {
+        "text": "".join(text_parts),
+        "usage": usage,
+        "finish_reason": finish_reason,
+        "ttft_seconds": first_token_at - started,
+        "decode_seconds": decode_seconds,
+        "wall_seconds": finished_at - started,
+        "steady_decode_tps": (
+            max(completion_tokens - 1, 0) / decode_seconds if completion_tokens else 0.0
+        ),
+    }
+
+
+def _write_result(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(result, ensure_ascii=False, indent=2))
+    temporary.replace(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:18020")
+    parser.add_argument("--model")
+    parser.add_argument("--prompts-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--max-turns", type=int, default=0)
+    parser.add_argument("--max-tokens", type=int, default=512)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=1)
+    parser.add_argument(
+        "--system-prompt",
+        default=DIRECT_CODING_SYSTEM_PROMPT,
+        help="System contract. Pass an empty string to omit the system message.",
+    )
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    args = parser.parse_args()
+
+    prompts = _load_prompts(args.prompts_json)
+    if args.max_turns > 0:
+        prompts = prompts[: args.max_turns]
+    models = _get_json(f"{args.base_url}/v1/models").get("data") or []
+    model = args.model or (models[0].get("id") if models else None)
+    if not model:
+        raise RuntimeError("could not resolve the served model ID")
+
+    result: dict[str, Any] = {
+        "base_url": args.base_url,
+        "model": model,
+        "prompts_json": str(args.prompts_json),
+        "settings": {
+            "max_tokens": args.max_tokens,
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "system_prompt": args.system_prompt,
+        },
+        "records": [],
+    }
+    messages: list[dict[str, str]] = []
+    if args.system_prompt:
+        messages.append({"role": "system", "content": args.system_prompt})
+    for index, prompt in enumerate(prompts):
+        messages.append({"role": "user", "content": prompt["prompt"]})
+        before = _metric_snapshot(args.base_url)
+        turn = _stream_turn(
+            args.base_url,
+            model,
+            messages,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            top_k=args.top_k,
+            timeout=args.timeout,
+        )
+        after = _metric_snapshot(args.base_url)
+        delta = _metric_delta(before, after)
+        drafts = delta["vllm:spec_decode_num_drafts"]
+        accepted = delta["vllm:spec_decode_num_accepted_tokens"]
+        draft_tokens = delta["vllm:spec_decode_num_draft_tokens"]
+        turn["spec_decoding"] = {
+            "num_drafts": drafts,
+            "num_draft_tokens": draft_tokens,
+            "num_accepted_tokens": accepted,
+            "mean_acceptance_length": 1.0 + accepted / drafts if drafts else None,
+            "draft_acceptance_rate": accepted / draft_tokens if draft_tokens else None,
+        }
+        record = {"index": index + 1, "label": prompt["label"], **turn}
+        result["records"].append(record)
+        messages.append({"role": "assistant", "content": turn["text"]})
+        _write_result(args.out, result)
+        usage = turn["usage"]
+        print(
+            f"turn={index + 1:02d} label={prompt['label']!r} "
+            f"prompt={usage.get('prompt_tokens', 0)} "
+            f"output={usage.get('completion_tokens', 0)} "
+            f"decode={turn['steady_decode_tps']:.2f} tok/s "
+            f"accept={turn['spec_decoding']['mean_acceptance_length']}",
+            flush=True,
+        )
+
+    records = result["records"]
+    output_tokens = sum(int(r["usage"].get("completion_tokens") or 0) for r in records)
+    decode_tokens = sum(
+        max(int(r["usage"].get("completion_tokens") or 0) - 1, 0) for r in records
+    )
+    decode_seconds = sum(float(r["decode_seconds"]) for r in records)
+    drafts = sum(float(r["spec_decoding"]["num_drafts"]) for r in records)
+    accepted = sum(float(r["spec_decoding"]["num_accepted_tokens"]) for r in records)
+    result["aggregate"] = {
+        "turns": len(records),
+        "output_tokens": output_tokens,
+        "steady_decode_tps": decode_tokens / decode_seconds if decode_seconds else 0.0,
+        "mean_acceptance_length": 1.0 + accepted / drafts if drafts else None,
+        "total_wall_seconds": sum(float(r["wall_seconds"]) for r in records),
+    }
+    _write_result(args.out, result)
+    print(json.dumps(result["aggregate"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_dflash2_lookup.py
+++ b/benchmarks/kernels/benchmark_dflash2_lookup.py
@@ -8,8 +8,13 @@ from collections.abc import Callable
 
 import torch
 
+from vllm.triton_utils import triton
 from vllm.v1.worker.gpu.buffer_utils import UvaBuffer
-from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import fuse_draft, suffix_lookup
+from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
+    _point_mass_draft_logits_kernel,
+    fuse_draft,
+    suffix_lookup,
+)
 
 
 def _time_ms(fn: Callable[[], None], repeats: int, warmup: int) -> float:
@@ -29,8 +34,8 @@ def _time_ms(fn: Callable[[], None], repeats: int, warmup: int) -> float:
 def _make_history(batch_size: int, context_len: int) -> UvaBuffer:
     history = UvaBuffer((batch_size, context_len + 32), torch.int32)
     history.cpu.random_(1000, 200000)
-    suffix = torch.arange(700001, 700013, dtype=torch.int32)
-    continuation = torch.arange(800001, 800016, dtype=torch.int32)
+    suffix = torch.arange(220001, 220013, dtype=torch.int32)
+    continuation = torch.arange(230001, 230016, dtype=torch.int32)
     match_start = max(0, context_len // 2 - suffix.numel())
     for row in range(batch_size):
         history.cpu[row, match_start : match_start + suffix.numel()].copy_(suffix)
@@ -51,7 +56,7 @@ def _benchmark_case(
     warmup: int,
 ) -> dict[str, float | int]:
     device = torch.device("cuda")
-    k, draft_block = 15, 7
+    k, draft_block, top_k, vocab_size = 15, 7, 16, 248320
     history = _make_history(batch_size, context_len)
     total_len = torch.full((batch_size,), context_len, dtype=torch.int32, device=device)
     idx_mapping = torch.arange(
@@ -67,6 +72,18 @@ def _benchmark_case(
     use = torch.zeros((batch_size, k), dtype=torch.int32, device=device)
     hits = torch.zeros((), dtype=torch.int64, device=device)
     take_flags = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    cached_ids = torch.arange(top_k, dtype=torch.int64, device=device).view(1, 1, top_k)
+    cached_ids = cached_ids.expand(batch_size, k, top_k).clone()
+    cached_scores = torch.zeros(
+        (batch_size, k, top_k), dtype=torch.float32, device=device
+    )
+    draft_logits = torch.full(
+        (batch_size, k, vocab_size),
+        -float("inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    draft_logits.scatter_(2, cached_ids, cached_scores)
 
     def lookup_only() -> None:
         suffix_lookup(
@@ -106,7 +123,33 @@ def _benchmark_case(
             take_flags=take_flags,
         )
 
+    def draftless_chain() -> None:
+        lookup_tokens.zero_()
+        lookup_only()
+        drafted.copy_(lookup_tokens)
+        use.fill_(1)
+        _point_mass_draft_logits_kernel[(batch_size * k,)](
+            draft_logits,
+            cached_ids,
+            cached_scores,
+            drafted,
+            drafted.stride(0),
+            use,
+            idx_mapping,
+            draft_block,
+            cached_ids.stride(0),
+            cached_ids.stride(1),
+            draft_logits.stride(0),
+            draft_logits.stride(1),
+            num_steps=k,
+            top_k=top_k,
+            BLOCK_K=triton.next_power_of_2(top_k),
+            CACHE_SCORES=True,
+            num_warps=1,
+        )
+
     eager_ms = _time_ms(lookup_and_fuse, repeats, warmup)
+    chain_eager_ms = _time_ms(draftless_chain, repeats, warmup)
     graph = torch.cuda.CUDAGraph()
     capture_stream = torch.cuda.Stream()
     capture_stream.wait_stream(torch.cuda.current_stream())
@@ -127,6 +170,7 @@ def _benchmark_case(
         "context_len": context_len,
         "uva_lookup_fuse_eager_ms": eager_ms,
         "uva_lookup_fuse_graph_ms": graph_ms,
+        "uva_draftless_chain_eager_ms": chain_eager_ms,
     }
 
 

--- a/benchmarks/kernels/benchmark_sm70_dflash2_grouped_verify.py
+++ b/benchmarks/kernels/benchmark_sm70_dflash2_grouped_verify.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Microbenchmark the SM70 q8/q16 grouped DFlash2 verifier."""
+"""Microbenchmark the SM70 q8/q16/q32 grouped DFlash2 verifier."""
 
 from __future__ import annotations
 
@@ -61,7 +61,7 @@ def _capture(fn: Callable[[], object]) -> torch.cuda.CUDAGraph:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--query-lens", type=int, nargs="+", default=[8, 16])
+    parser.add_argument("--query-lens", type=int, nargs="+", default=[8, 16, 32])
     parser.add_argument(
         "--prefix-lens", type=int, nargs="+", default=[1024, 32768, 128000]
     )

--- a/docs/design/sm70_dflash2_drafter_free_chain.md
+++ b/docs/design/sm70_dflash2_drafter_free_chain.md
@@ -1,0 +1,109 @@
+# SM70 DFlash2 drafter-free lookup chains
+
+## Scope and provenance
+
+This change adds the second-stage drafter-free chain on top of the existing
+lookup-augmented DFlash2 (LABD) path. It is adapted from the Apache-2.0
+implementations in
+[`syv-ai/qwen38-27b-rtx3090`](https://github.com/syv-ai/qwen38-27b-rtx3090)
+revision `69ba4d0688c6ae76cb9d3c4a5c3b36445e1b040c` and
+[`Dmtrii-tesla/dflash2-ngram-vllm`](https://github.com/Dmtrii-tesla/dflash2-ngram-vllm)
+revision `8fb3a6044158fd74c096b3cb1b274edbe4b490c6`.
+
+The feature is opt-in (`VLLM_DFLASH2_CHAIN=1`) and requires the existing LABD
+contract: DFlash2 emits its checkpoint-native seven-token block while lookup
+may fill a target verifier wider than the checkpoint. The default gate is
+greedy, B1, DP1, text-only traffic. Sampled requests retain the neural drafter;
+upstream measured a regression when a point-mass context proposal displaced a
+distribution-aware neural proposal at nonzero temperature.
+
+## Runtime design
+
+- The chain controller runs once per scheduler step outside CUDA Graph
+  capture. Entry uses the previous normal step's raw suffix-match length, read
+  asynchronously through pinned memory. It does not use the valid continuation
+  count, which is clamped to the verifier width and cannot prove a long match.
+- An active chain still stages target hidden states, prepares slot mappings,
+  and materializes draft context KV. It skips only the DFlash2 query/selector
+  graph. This keeps the draft cache warm and makes the first post-chain neural
+  proposal valid.
+- A full verifier block comes from request history. Every row is rewritten to
+  a point mass on its proposed token. Missing continuation positions are
+  cleared to token zero rather than retaining stale proposals.
+- The first rejected token exits the chain. One intervening neural step is
+  required before re-entry so stale pinned evidence cannot immediately reopen
+  it.
+- While active, the scheduler is pinned to the full q16 graph. Normal traffic
+  keeps the existing adaptive q8/q16 policy.
+
+This preserves target verification and does not introduce a direct-output or
+unverified path. It also deliberately does not replace the SM70 compact top20
+sampler, sparse rejection sampler, Flash-V100 grouped verifier, prefix cache,
+or Mamba-align policy.
+
+## Validation and measured boundary
+
+The targeted DFlash2 suite passes `128` tests. It covers controller
+entry/hold/reject/cooldown, stale-buffer clearing, full-width point masses,
+environment defaults, routing, and lookup CUDA behavior. The full-vocabulary
+draftless lookup microbenchmark on V100 reports:
+
+| Context | LABD graph | Drafter-free eager proposal |
+| ---: | ---: | ---: |
+| 1K | 0.0099 ms | 0.1069 ms |
+| 32K | 0.1245 ms | 0.1322 ms |
+| 128K | 0.4651 ms | 0.4714 ms |
+
+The paired end-to-end contract uses the production NVFP4 target, official
+BF16 DFlash2 draft, TP4 V100, FP8 E5M2 target KV, FP16 draft KV, Flash-V100,
+CUDA Graphs, prefix caching, Mamba align, 4,096 scheduler tokens, q15 adaptive
+LABD, and greedy target sampling. Both arms use separate compilation caches.
+
+| Request | Chain off | Chain on | Interpretable result |
+| --- | ---: | ---: | --- |
+| ordinary text | 139.63 tok/s | 156.60 tok/s | not attributable: output diverges at token 123 and the chain never engages |
+| repeated-context copy | 359.76 tok/s | 363.69 tok/s | +1.09%; all 512 output token IDs are identical |
+
+The copy request takes 36 speculative rounds in both arms, with mean
+acceptance length `14.222`. The chain engages on about 25 rounds. The observed
+decode-time reduction is about `14.9 ms`, or `0.59 ms` per engaged round. This
+is the actual remaining neural-query cost on the TP4 path; the target-hidden
+projection and draft context-KV maintenance intentionally remain.
+
+The result also explains why the upstream headline must not be generalized.
+Its `381 tok/s` number is a 25K-context verbatim-document task at `14.97`
+tokens per round, not ordinary chat. That implies about `39.3 ms` per q16
+round. The local copy arm is about `39.5 ms` per round before chaining, so its
+q16 target-verification service is already in the same range. The shorter
+local prompt needs more q8/transition rounds and reaches `14.22`, which is the
+larger gap to the headline. Upstream's separate `+7%` chain result was measured
+on q7 with a single-card drafter; a four-way sharded drafter leaves less query
+work to remove.
+
+Artifacts are rooted at
+`/data/minimax-h3/task-cache/v100-dflash2-labd-chain-20260828/`:
+
+- `chain-overhead-sm70.json` is the lookup/proposal microbenchmark;
+- `control-v2-greedy-q15-o512.json` is the chain-off end-to-end arm;
+- `candidate-v1-greedy-q15-o512.json` is the chain-on arm.
+
+## Next gates
+
+1. Reproduce the upstream frozen 20K/25K six-task LABD workload instead of
+   treating a 417-token repeated phrase as a document benchmark. Report q8/q16
+   rounds, chain engagement, tokens per round, and pure decode separately.
+2. Capture a graph-node/NVTX trace and split the remaining draft stage into
+   target-hidden projection, input/slot preparation, context-KV projection and
+   insertion, and query/selector graph. A larger chain win requires moving
+   cache maintenance off the critical path; merely skipping the already-small
+   TP4 query graph cannot supply it.
+3. Evaluate an event-ordered maintenance stream only if the trace shows useful
+   overlap with target verification. The draft cache must be complete before
+   re-entering the neural path, and output tokens plus post-chain acceptance
+   must match the warm-cache control.
+4. Run B1/B2/B4 distinct-prefix and shared-prefix concurrency ladders. Report
+   per-stream decode, aggregate decode, milliseconds per forward, resident
+   requests, KV occupancy, and preemptions. Drafter-free chaining remains B1;
+   batching and hybrid recurrent-state capacity are separate optimization
+   problems.
+

--- a/docs/design/sm70_dflash2_drafter_free_chain.md
+++ b/docs/design/sm70_dflash2_drafter_free_chain.md
@@ -33,13 +33,36 @@ distribution-aware neural proposal at nonzero temperature.
 - The first rejected token exits the chain. One intervening neural step is
   required before re-entry so stale pinned evidence cannot immediately reopen
   it.
-- While active, the scheduler is pinned to the full q16 graph. Normal traffic
-  keeps the existing adaptive q8/q16 policy.
+- While active, the scheduler is pinned to the full target-verification graph.
+  The original q15 contract uses q16; the current q31 contract uses q32 while
+  the checkpoint still emits only seven neural drafts. Normal traffic keeps
+  the existing adaptive q8/full-width policy.
 
 This preserves target verification and does not introduce a direct-output or
 unverified path. It also deliberately does not replace the SM70 compact top20
 sampler, sparse rejection sampler, Flash-V100 grouped verifier, prefix cache,
 or Mamba-align policy.
+
+### Native q32 target verifier
+
+The q31 LABD contract originally fell through to the generic XQA verifier. The
+SM70 grouped verifier now has an exact q32 specialization for the production
+`Hq=6`, `Hkv=1`, `D=256`, E5M2 paged-KV shape:
+
+- three two-head CTA groups retain 64 query rows per CTA;
+- 27 context splits launch 81 CTAs, keeping one wave available across V100's
+  80 SMs;
+- the stream-local Graph workspace is `27 x 32 x 6 x 256` FP16 outputs plus
+  FP32 LSE, and the dynamic shared-memory contract stays within V100's 96-KiB
+  opt-in limit;
+- every proposed row is still evaluated by target attention and combined with
+  online-softmax LSE. There is no direct-output or skipped-verification path.
+
+Admission is limited to a seven-token DFlash2 checkpoint with target draft
+widths 7, 15, or 31. Other widths and cache layouts retain their old backend.
+At the q32 production page size 3,776, the isolated kernel is `2.71x` faster
+than the row-wise baseline at 1K context and `3.90x` at 32K. Maximum absolute
+error against the existing FP32 oracle is `1.53e-5`.
 
 ## Validation and measured boundary
 
@@ -47,6 +70,11 @@ The targeted DFlash2 suite passes `128` tests. It covers controller
 entry/hold/reject/cooldown, stale-buffer clearing, full-width point masses,
 environment defaults, routing, and lookup CUDA behavior. The full-vocabulary
 draftless lookup microbenchmark on V100 reports:
+
+After the TP-lifetime repair, the two focused DFlash2 files rerun as
+`109 passed, 15 skipped`; eight controller/lifetime tests pass when selected
+alone. The q32 kernel and backend-policy suites pass 29 GPU numerical/Graph
+cases and eight policy cases.
 
 | Context | LABD graph | Drafter-free eager proposal |
 | ---: | ---: | ---: |
@@ -62,7 +90,8 @@ LABD, and greedy target sampling. Both arms use separate compilation caches.
 | Request | Chain off | Chain on | Interpretable result |
 | --- | ---: | ---: | --- |
 | ordinary text | 139.63 tok/s | 156.60 tok/s | not attributable: output diverges at token 123 and the chain never engages |
-| repeated-context copy | 359.76 tok/s | 363.69 tok/s | +1.09%; all 512 output token IDs are identical |
+| short repeated-context copy, q16 | 359.76 tok/s | 363.69 tok/s | +1.09%; all 512 output token IDs are identical |
+| frozen syv 25K document, q32 | 337.107 tok/s | **359.770 tok/s** | **+6.72%**; all 512 output tokens and text SHA are identical |
 
 The copy request takes 36 speculative rounds in both arms, with mean
 acceptance length `14.222`. The chain engages on about 25 rounds. The observed
@@ -76,9 +105,37 @@ tokens per round, not ordinary chat. That implies about `39.3 ms` per q16
 round. The local copy arm is about `39.5 ms` per round before chaining, so its
 q16 target-verification service is already in the same range. The shorter
 local prompt needs more q8/transition rounds and reaches `14.22`, which is the
-larger gap to the headline. Upstream's separate `+7%` chain result was measured
-on q7 with a single-card drafter; a four-way sharded drafter leaves less query
-work to remove.
+larger gap to the headline. The frozen upstream-style 25K rerun closes that
+uncertainty. It keeps the same 512-token output SHA256
+`7d69c86ce0b10ca95d40ce33cbce8d798d9a215a8fbf2b4b9b4dc849a6dda55c`,
+the same 28 rounds, 497 accepted draft tokens, and mean acceptance length
+`18.75`. Pure decode moves from `1.51584` to `1.42035 s`. This reproduces the
+upstream chain's roughly seven-percent workload-specific gain on TP4 V100.
+Cold-request wall time remains prefill dominated (`9.336 -> 9.391 s`) and is
+not credited as an end-to-end win. Repeating the identical cached prefix gives
+`1.114 s` TTFT, `359.37 tok/s` decode, and `2.535 s` total wall time.
+
+The first TP4 implementation also exposed a correctness race after a chain
+ended. Request-state slots were used as controller identities even though the
+scheduler reuses them across requests, and TP ranks independently queried D2H
+event readiness before deciding whether to skip the neural draft graph. That
+could make only a subset of ranks enter the drafter-free collective sequence
+and eventually feed an invalid token ID to the selector. The retained fix:
+
+- keys every pending lookup/rejection verdict by stable request ID rather than
+  a reusable slot index;
+- fences a pending entry/rejection event before a host branch so every TP rank
+  selects the same collective sequence;
+- tags rejection feedback with the proposal that produced it, preventing the
+  normal proposal that admitted a chain from immediately terminating its first
+  drafter-free step.
+
+No token-ID clamp or selector-bound weakening is used. The cleaned route runs
+the complete 18-turn iterative coding stress (`8,325` generated tokens) with
+no assert or HTTP 500; mean acceptance length is `7.513`. This is a lifetime
+and stability gate, not a scored coding-quality result. Chain remains opt-in
+and greedy-only; production sampling, tools, and structured outputs keep the
+neural drafter and the previously accepted quality path.
 
 Artifacts are rooted at
 `/data/minimax-h3/task-cache/v100-dflash2-labd-chain-20260828/`:
@@ -86,12 +143,21 @@ Artifacts are rooted at
 - `chain-overhead-sm70.json` is the lookup/proposal microbenchmark;
 - `control-v2-greedy-q15-o512.json` is the chain-off end-to-end arm;
 - `candidate-v1-greedy-q15-o512.json` is the chain-on arm.
+- `results/q31-grouped-syv-labd-copy25k-o512.json` is the frozen q32 chain-off
+  25K document control;
+- `results/q31-chain-exact-q32-qpn2-clean-syv-copy25k-o512.json` is the matched
+  cold chain-on result;
+- `results/q31-chain-exact-q32-qpn2-clean-syv-copy25k-prefixhit-o512.json` is
+  the identical-prefix rerun;
+- `results/q31-chain-exact-q32-qpn2-clean-iterative18-o512.json` is the cleaned
+  cross-request lifetime stress.
 
 ## Next gates
 
-1. Reproduce the upstream frozen 20K/25K six-task LABD workload instead of
-   treating a 417-token repeated phrase as a document benchmark. Report q8/q16
-   rounds, chain engagement, tokens per round, and pure decode separately.
+1. Extend the frozen 25K document control from verbatim reproduction to the
+   upstream six-task LABD matrix. Report q8/q32 rounds, chain engagement,
+   tokens per round, and pure decode separately; ordinary prose may not
+   regress.
 2. Capture a graph-node/NVTX trace and split the remaining draft stage into
    target-hidden projection, input/slot preparation, context-KV projection and
    insertion, and query/selector graph. A larger chain win requires moving
@@ -106,4 +172,3 @@ Artifacts are rooted at
    requests, KV occupancy, and preemptions. Drafter-free chaining remains B1;
    batching and hybrid recurrent-state capacity are separate optimization
    problems.
-

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44172,3 +44172,24 @@ Interpretation:
   `docs/design/sm70_dflash2_quality_audit.md`. Do not cite acceptance length as
   intelligence: it explains throughput, while official executable scores and
   natural termination are the quality gates.
+
+## 2026-08-28 DFlash2 drafter-free lookup chain
+
+- Public integration starts from `onecat/main` in isolated worktree
+  `v100-dflash2-labd-chain-20260828-031506`. The opt-in chain keeps the existing
+  LABD q8/q16 scheduler and all target verification, but skips the neural
+  DFlash2 query/selector graph while a greedy B1 request continuously copies
+  its own context. The first rejection exits to a normal DFlash2 step.
+- The targeted DFlash2 suite passes `128` tests. A paired TP4 V100 copy request
+  is token-identical for all 512 output tokens and moves `359.76 -> 363.69
+  token/s` (`+1.09%`). About 25 of 36 rounds chain; measured saving is roughly
+  `0.59 ms` per engaged round. The ordinary request never chains and diverges
+  at a near tie, so its apparent throughput movement is not attributed to the
+  feature.
+- The upstream `381 token/s` result is a 25K verbatim-document workload at
+  `14.97` tokens per q16 round, not a universal chat rate. Its implied q16
+  round cost is about `39.3 ms`, essentially the local control's `39.5 ms`.
+  The remaining gap in the current short sample is acceptance/transition
+  behavior, not a missing 30% verifier kernel speedup.
+- Full provenance, contracts, artifacts, and the next trace/concurrency gates
+  are recorded in `docs/design/sm70_dflash2_drafter_free_chain.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44193,3 +44193,20 @@ Interpretation:
   behavior, not a missing 30% verifier kernel speedup.
 - Full provenance, contracts, artifacts, and the next trace/concurrency gates
   are recorded in `docs/design/sm70_dflash2_drafter_free_chain.md`.
+- The q31 LABD continuation now has a native exact q32 grouped Flash-V100
+  verifier. At production page 3,776 it is `2.71x/3.90x` faster than the
+  row-wise baseline at 1K/32K context and stays within `1.53e-5` maximum
+  absolute error. The frozen syv 25K document moves from q16
+  `222.734 tok/s` to q32 `337.107 tok/s` (`+51.35%`) before chain, with the
+  same output.
+- A TP4 selector crash was traced to reused request-slot controller keys and
+  rank-local asynchronous event readiness. Pending controller state now keys
+  on request ID, rejection feedback is tagged by proposal origin, and TP ranks
+  fence the event before choosing a drafter-free collective sequence. No
+  selector clamp was added. The cleaned chain completes an 18-turn/8,325-token
+  iterative stress without an assert or HTTP 500.
+- On the frozen 25K verbatim task, cleaned chain-on keeps all 512 output tokens,
+  mean acceptance `18.75`, and text SHA256 unchanged while pure decode moves
+  `337.107 -> 359.770 tok/s` (`+6.72%`). Cold wall time is prefill dominated;
+  an identical-prefix rerun records `1.114 s` TTFT and `2.535 s` total. Chain
+  remains opt-in and greedy-only rather than a universal chat default.

--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -517,12 +517,12 @@ def _get_grouped_verify_workspace(q: torch.Tensor) -> _GroupedVerifyWorkspace:
     if workspace is None:
         workspace = _GroupedVerifyWorkspace(
             partial_out=torch.empty(
-                (80, 8, 6, 256),
+                (27 * 32, 6, 256),
                 dtype=torch.float16,
                 device=q.device,
             ),
             partial_lse=torch.empty(
-                (80, 8, 6),
+                (27 * 32, 6),
                 dtype=torch.float32,
                 device=q.device,
             ),
@@ -1036,12 +1036,13 @@ def flash_attn_grouped_verify_paged(
     v_scale: float = 1.0,
     one_pass: bool = False,
 ) -> torch.Tensor:
-    """Exact grouped q8/q16 H6/D256 DFlash2 verifier for SM70.
+    """Exact grouped q8/q16/q32 H6/D256 DFlash2 verifier for SM70.
 
     The native entry keeps all causal verifier rows together and reuses each
     paged-KV scan across a packed GQA group. q8 uses one six-head group and q16
-    uses two three-head groups, retaining 48 rows per CTA and the same workspace
-    byte count. Workspaces are stream-local and CUDA-graph safe.
+    uses two three-head groups, retaining 48 rows per CTA. q32 uses three
+    two-head groups with 64 rows per CTA. Workspaces are stream-local and
+    CUDA-graph safe.
     """
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
@@ -1050,12 +1051,19 @@ def flash_attn_grouped_verify_paged(
     seq_lens = maybe_contiguous(seq_lens)
     out = maybe_contiguous(out)
     workspace = _get_grouped_verify_workspace(q)
-    if q.shape[0] > 8:
-        partial_out = workspace.partial_out.view(40, 16, 6, 256)
-        partial_lse = workspace.partial_lse.view(40, 16, 6)
+    if q.shape[0] > 16:
+        splits, max_query_tokens = 27, 32
+    elif q.shape[0] > 8:
+        splits, max_query_tokens = 40, 16
     else:
-        partial_out = workspace.partial_out
-        partial_lse = workspace.partial_lse
+        splits, max_query_tokens = 80, 8
+    workspace_rows = splits * max_query_tokens
+    partial_out = workspace.partial_out[:workspace_rows].view(
+        splits, max_query_tokens, 6, 256
+    )
+    partial_lse = workspace.partial_lse[:workspace_rows].view(
+        splits, max_query_tokens, 6
+    )
     return flash_attn_v100_cuda.grouped_verify_paged_fwd(
         q,
         k_cache,

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -1777,16 +1777,17 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
 // It remains a numerical oracle for the production one-pass register-rescale
 // variant, which loads K once and preserves the same online-softmax/PV result.
 //
-// The verifier shape has one KV head and six query heads. Keep each CTA at 48
-// rows for both supported widths: q8 packs six heads in one CTA, while q16
-// packs three heads in each of two CTAs. The q16 route halves the number of
-// context splits, preserving eighty CTAs and the q8 workspace byte count.
+// The verifier shape has one KV head and six query heads. Keep each q8/q16 CTA
+// at 48 rows: q8 packs six heads in one CTA, while q16 packs three heads in
+// each of two CTAs. q32 uses 64 rows (two heads per CTA) and three head groups.
+// Its 27 context splits launch 81 CTAs, preserving one wave across V100's 80
+// SMs without reloading K/V independently for all 32 verifier rows.
 constexpr int kGroupedVerifyQ8MaxQ = 8;
 constexpr int kGroupedVerifyQ16MaxQ = 16;
-constexpr int kGroupedVerifyMaxSupportedQ = kGroupedVerifyQ16MaxQ;
+constexpr int kGroupedVerifyQ32MaxQ = 32;
+constexpr int kGroupedVerifyMaxSupportedQ = kGroupedVerifyQ32MaxQ;
 constexpr int kGroupedVerifyHeads = 6;
 constexpr int kGroupedVerifyHeadDim = 256;
-constexpr int kGroupedVerifyRows = 48;
 constexpr int kGroupedVerifyBlockN = 32;
 constexpr int kGroupedVerifyQStride = 264;
 constexpr int kGroupedVerifyKVStride = 264;
@@ -1797,8 +1798,8 @@ constexpr int kGroupedVerifyPageIdsCapacity = 16;
 // each of V100's eighty SMs. Short sequences still reduce active_splits using
 // kGroupedVerifyMinTokensPerSplit inside the captured graph.
 constexpr int kGroupedVerifyQ8Splits = 80;
-constexpr int kGroupedVerifyWorkspaceRows =
-    kGroupedVerifyQ8MaxQ * kGroupedVerifyQ8Splits;
+constexpr int kGroupedVerifyQ16Splits = 40;
+constexpr int kGroupedVerifyQ32Splits = 27;
 // A packed CTA replaces two 256-thread head-group CTAs and can occupy only one
 // SM. Use 64-token chunks to expose enough short-context parallelism without
 // paying one split reduction per N32 tile; longer contexts saturate at the
@@ -1809,49 +1810,56 @@ constexpr int kGroupedVerifySingleQueryMinTokensPerSplit = 128;
 constexpr int kGroupedVerifyShortContextMaxTokens = 128;
 constexpr int kGroupedVerifyThreads = 512;
 constexpr int kGroupedVerifyWarps = kGroupedVerifyThreads / kWarpSize;
-constexpr int kGroupedVerifyQKWarps =
-    (kGroupedVerifyRows / 16) * (kGroupedVerifyBlockN / 16);
-constexpr int kGroupedVerifyOutputTiles =
-    (kGroupedVerifyRows / 16) * (kGroupedVerifyHeadDim / 16);
-constexpr int kGroupedVerifyOutputTilesPerWarp =
-    kGroupedVerifyOutputTiles / kGroupedVerifyWarps;
 
 template <int MAX_QUERY_TOKENS>
 struct GroupedVerifyTraits {
   static_assert(MAX_QUERY_TOKENS == kGroupedVerifyQ8MaxQ ||
-                    MAX_QUERY_TOKENS == kGroupedVerifyQ16MaxQ,
-                "grouped verifier supports q8 and q16 workspaces only");
-  static constexpr int kHeadsPerCta = kGroupedVerifyRows / MAX_QUERY_TOKENS;
+                    MAX_QUERY_TOKENS == kGroupedVerifyQ16MaxQ ||
+                    MAX_QUERY_TOKENS == kGroupedVerifyQ32MaxQ,
+                "grouped verifier supports q8, q16, and q32 workspaces only");
+  static constexpr int kRows =
+      MAX_QUERY_TOKENS == kGroupedVerifyQ32MaxQ ? 64 : 48;
+  static constexpr int kHeadsPerCta = kRows / MAX_QUERY_TOKENS;
   static constexpr int kHeadGroups = kGroupedVerifyHeads / kHeadsPerCta;
-  static constexpr int kSplits = kGroupedVerifyWorkspaceRows / MAX_QUERY_TOKENS;
-  static_assert(MAX_QUERY_TOKENS * kHeadsPerCta == kGroupedVerifyRows,
-                "grouped verifier CTA must retain 48 rows");
+  static constexpr int kSplits =
+      MAX_QUERY_TOKENS == kGroupedVerifyQ8MaxQ
+          ? kGroupedVerifyQ8Splits
+          : (MAX_QUERY_TOKENS == kGroupedVerifyQ16MaxQ
+                 ? kGroupedVerifyQ16Splits
+                 : kGroupedVerifyQ32Splits);
+  static constexpr int kOutputTiles =
+      (kRows / 16) * (kGroupedVerifyHeadDim / 16);
+  static constexpr int kOutputTilesPerWarp =
+      kOutputTiles / kGroupedVerifyWarps;
+  static_assert(MAX_QUERY_TOKENS * kHeadsPerCta == kRows,
+                "grouped verifier CTA rows must contain whole query heads");
   static_assert(kGroupedVerifyHeads % kHeadsPerCta == 0,
                 "query heads must divide evenly across grouped CTAs");
-  static_assert(kSplits * MAX_QUERY_TOKENS == kGroupedVerifyWorkspaceRows,
-                "q8 and q16 workspaces must have equal element counts");
+  static_assert(kOutputTiles % kGroupedVerifyWarps == 0,
+                "output tiles must divide evenly across warps");
 };
 
+template <int ROWS>
 struct alignas(256) GroupedVerifySmem {
   union {
     struct {
-      alignas(16) __half q[kGroupedVerifyRows * kGroupedVerifyQStride];
+      alignas(16) __half q[ROWS * kGroupedVerifyQStride];
       alignas(16) __half kv[kGroupedVerifyBlockN * kGroupedVerifyKVStride];
-      alignas(16) float scores[kGroupedVerifyRows * kGroupedVerifyScoreStride];
-      alignas(16) __half probs[kGroupedVerifyRows * kGroupedVerifyProbStride];
+      alignas(16) float scores[ROWS * kGroupedVerifyScoreStride];
+      alignas(16) __half probs[ROWS * kGroupedVerifyProbStride];
     } compute;
-    alignas(16) float output[kGroupedVerifyRows * kGroupedVerifyHeadDim];
+    alignas(16) float output[ROWS * kGroupedVerifyHeadDim];
   } storage;
-  alignas(16) float row_max[kGroupedVerifyRows];
-  alignas(16) float row_sum[kGroupedVerifyRows];
-  alignas(16) float row_scale[kGroupedVerifyRows];
+  alignas(16) float row_max[ROWS];
+  alignas(16) float row_sum[ROWS];
+  alignas(16) float row_scale[ROWS];
   alignas(16) int page_ids[kGroupedVerifyPageIdsCapacity];
 };
 
-static_assert(sizeof(GroupedVerifySmem) <= 64 * 1024,
-              "packed grouped verifier must fit Volta's 64 KiB opt-in budget");
-static_assert(kGroupedVerifyOutputTiles % kGroupedVerifyWarps == 0,
-              "output tiles must divide evenly across warps");
+static_assert(sizeof(GroupedVerifySmem<48>) <= 64 * 1024,
+              "q8/q16 verifier must fit Volta's 64 KiB opt-in budget");
+static_assert(sizeof(GroupedVerifySmem<64>) <= 96 * 1024,
+              "q32 verifier must fit Volta's 96 KiB opt-in budget");
 
 template <int MAX_QUERY_TOKENS, bool SINGLE_QUERY>
 __device__ __forceinline__ int grouped_verify_active_splits(
@@ -1869,11 +1877,14 @@ __device__ __forceinline__ int grouped_verify_active_splits(
   return total_kv <= kGroupedVerifyShortContextMaxTokens ? 1 : active_splits;
 }
 
+template <int ROWS>
 __device__ __forceinline__ void grouped_verify_qk(
     const __half* __restrict__ shared_q, const __half* __restrict__ shared_k,
     float* __restrict__ shared_scores, const float qk_scale) {
   const int warp_id = threadIdx.x / kWarpSize;
-  if (warp_id >= kGroupedVerifyQKWarps) {
+  constexpr int kQKWarps =
+      (ROWS / 16) * (kGroupedVerifyBlockN / 16);
+  if (warp_id >= kQKWarps) {
     return;
   }
 
@@ -1973,8 +1984,9 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   const int lane_id = tid % kWarpSize;
 
   extern __shared__ char grouped_verify_smem_raw[];
-  GroupedVerifySmem& smem =
-      *reinterpret_cast<GroupedVerifySmem*>(grouped_verify_smem_raw);
+  GroupedVerifySmem<Traits::kRows>& smem =
+      *reinterpret_cast<GroupedVerifySmem<Traits::kRows>*>(
+          grouped_verify_smem_raw);
   __half* shared_q = smem.storage.compute.q;
   __half* shared_kv = smem.storage.compute.kv;
   float* shared_scores = smem.storage.compute.scores;
@@ -2006,7 +2018,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   constexpr int kSharedQVecsPerRow = kGroupedVerifyQStride / 8;
   const uint4* q_vec = reinterpret_cast<const uint4*>(q);
   uint4* shared_q_vec = reinterpret_cast<uint4*>(shared_q);
-  for (int idx = tid; idx < kGroupedVerifyRows * kVecsPerRow;
+  for (int idx = tid; idx < Traits::kRows * kVecsPerRow;
        idx += kGroupedVerifyThreads) {
     const int row = idx / kVecsPerRow;
     const int vec_col = idx % kVecsPerRow;
@@ -2021,7 +2033,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
       shared_q_vec[row * kSharedQVecsPerRow + vec_col] = make_uint4(0, 0, 0, 0);
     }
   }
-  if (tid < kGroupedVerifyRows) {
+  if (tid < Traits::kRows) {
     smem.row_max[tid] = kXQANegInf;
     smem.row_sum[tid] = 0.0f;
     smem.row_scale[tid] = 1.0f;
@@ -2033,9 +2045,9 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   constexpr int kSharedStrideVec = kGroupedVerifyKVStride / 8;
 
   volta::fragment<volta::accumulator, 16, 16, 16, float>
-      output_fragments[kGroupedVerifyOutputTilesPerWarp];
+      output_fragments[Traits::kOutputTilesPerWarp];
 #pragma unroll
-  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+  for (int fragment_idx = 0; fragment_idx < Traits::kOutputTilesPerWarp;
        ++fragment_idx) {
     volta::fill_fragment(output_fragments[fragment_idx], 0.0f);
   }
@@ -2063,11 +2075,12 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
       }
       __syncthreads();
 
-      grouped_verify_qk(shared_q, shared_kv, shared_scores, qk_scale);
+      grouped_verify_qk<Traits::kRows>(shared_q, shared_kv, shared_scores,
+                                       qk_scale);
       __syncthreads();
 
 #pragma unroll
-      for (int row = warp_id; row < kGroupedVerifyRows;
+      for (int row = warp_id; row < Traits::kRows;
            row += kGroupedVerifyWarps) {
         const int token_idx = row / Traits::kHeadsPerCta;
         const int local_head = row % Traits::kHeadsPerCta;
@@ -2121,11 +2134,12 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
     }
     __syncthreads();
 
-    grouped_verify_qk(shared_q, shared_kv, shared_scores, qk_scale);
+    grouped_verify_qk<Traits::kRows>(shared_q, shared_kv, shared_scores,
+                                     qk_scale);
     __syncthreads();
 
     if constexpr (TWO_PASS) {
-      for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyBlockN;
+      for (int idx = tid; idx < Traits::kRows * kGroupedVerifyBlockN;
            idx += kGroupedVerifyThreads) {
         const int row = idx / kGroupedVerifyBlockN;
         const int col = idx % kGroupedVerifyBlockN;
@@ -2149,7 +2163,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
       __syncthreads();
     } else {
 #pragma unroll
-      for (int row = warp_id; row < kGroupedVerifyRows;
+      for (int row = warp_id; row < Traits::kRows;
            row += kGroupedVerifyWarps) {
         const int token_idx = row / Traits::kHeadsPerCta;
         const int local_head = row % Traits::kHeadsPerCta;
@@ -2184,7 +2198,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
       __syncthreads();
 #pragma unroll
       for (int fragment_idx = 0;
-           fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+           fragment_idx < Traits::kOutputTilesPerWarp; ++fragment_idx) {
         const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
         const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
         grouped_verify_scale_output_fragment(output_fragments[fragment_idx],
@@ -2206,7 +2220,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
     __syncthreads();
 
 #pragma unroll
-    for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+    for (int fragment_idx = 0; fragment_idx < Traits::kOutputTilesPerWarp;
          ++fragment_idx) {
       const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
       const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
@@ -2237,7 +2251,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   __syncthreads();
   float* shared_output = smem.storage.output;
 #pragma unroll
-  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+  for (int fragment_idx = 0; fragment_idx < Traits::kOutputTilesPerWarp;
        ++fragment_idx) {
     const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
     const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
@@ -2249,7 +2263,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   }
   __syncthreads();
 
-  for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyHeadDim;
+  for (int idx = tid; idx < Traits::kRows * kGroupedVerifyHeadDim;
        idx += kGroupedVerifyThreads) {
     const int row = idx / kGroupedVerifyHeadDim;
     const int d = idx % kGroupedVerifyHeadDim;
@@ -2268,7 +2282,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
       partial_out[output_idx] = __float2half_rn(shared_output[idx] * scale);
     }
   }
-  if (tid < kGroupedVerifyRows) {
+  if (tid < Traits::kRows) {
     const int token_idx = tid / Traits::kHeadsPerCta;
     const int local_head = tid % Traits::kHeadsPerCta;
     const int head_idx = head_start + local_head;
@@ -3542,12 +3556,19 @@ at::Tensor flash_attention_grouped_verify_paged(
                   q.size(0) <= kGroupedVerifyMaxSupportedQ &&
                   q.size(1) == kGroupedVerifyHeads &&
                   q.size(2) == kGroupedVerifyHeadDim,
-              "grouped verify q must have shape [1..16, 6, 256]");
-  const bool wide_query = q.size(0) > kGroupedVerifyQ8MaxQ;
+              "grouped verify q must have shape [1..32, 6, 256]");
+  const bool q32_query = q.size(0) > kGroupedVerifyQ16MaxQ;
+  const bool q16_query = q.size(0) > kGroupedVerifyQ8MaxQ && !q32_query;
   const int max_query_tokens =
-      wide_query ? kGroupedVerifyQ16MaxQ : kGroupedVerifyQ8MaxQ;
-  const int grouped_splits = kGroupedVerifyWorkspaceRows / max_query_tokens;
-  const int heads_per_cta = kGroupedVerifyRows / max_query_tokens;
+      q32_query ? kGroupedVerifyQ32MaxQ
+                : (q16_query ? kGroupedVerifyQ16MaxQ
+                             : kGroupedVerifyQ8MaxQ);
+  const int grouped_splits =
+      q32_query ? kGroupedVerifyQ32Splits
+                : (q16_query ? kGroupedVerifyQ16Splits
+                             : kGroupedVerifyQ8Splits);
+  const int grouped_rows = q32_query ? 64 : 48;
+  const int heads_per_cta = grouped_rows / max_query_tokens;
   const int head_groups = kGroupedVerifyHeads / heads_per_cta;
   TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4 &&
                   k_cache.sizes() == v_cache.sizes() && k_cache.size(1) > 0 &&
@@ -3570,11 +3591,12 @@ at::Tensor flash_attention_grouped_verify_paged(
                   at::IntArrayRef({grouped_splits, max_query_tokens,
                                    kGroupedVerifyHeads, kGroupedVerifyHeadDim}),
               "partial_out must have shape [80, 8, 6, 256] or "
-              "[40, 16, 6, 256]");
+              "[40, 16, 6, 256] or [27, 32, 6, 256]");
   TORCH_CHECK(
       partial_lse.sizes() == at::IntArrayRef({grouped_splits, max_query_tokens,
                                               kGroupedVerifyHeads}),
-      "partial_lse must have shape [80, 8, 6] or [40, 16, 6]");
+      "partial_lse must have shape [80, 8, 6], [40, 16, 6], or "
+      "[27, 32, 6]");
   TORCH_CHECK(k_scale > 0.0f && v_scale > 0.0f,
               "grouped verify E5M2 K/V scales must be positive");
 
@@ -3598,11 +3620,13 @@ at::Tensor flash_attention_grouped_verify_paged(
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
   const dim3 partial_grid(head_groups, grouped_splits, 1);
-  const size_t partial_shared_mem = sizeof(GroupedVerifySmem);
 #define LAUNCH_GROUPED_VERIFY_PARTIAL(MAX_QUERY_TOKENS, TWO_PASS, PAGE_SIZE,   \
                                       SINGLE_QUERY, CONTIGUOUS_LAYOUT,         \
                                       STAGE_PAGE_IDS)                          \
   do {                                                                         \
+    constexpr size_t partial_shared_mem =                                      \
+        sizeof(GroupedVerifySmem<                                              \
+               GroupedVerifyTraits<MAX_QUERY_TOKENS>::kRows>);                 \
     auto partial_kernel =                                                      \
         (void*)flash_attention_grouped_verify_e5m2_partial_kernel<             \
             MAX_QUERY_TOKENS, TWO_PASS, PAGE_SIZE, SINGLE_QUERY,               \
@@ -3675,9 +3699,17 @@ at::Tensor flash_attention_grouped_verify_paged(
   } while (0)
 
   const bool single_query = q.size(0) == 1;
-  if (wide_query && one_pass) {
+  if (q32_query && one_pass) {
+    // q32 is admitted only by the lookup-chain path and currently uses the
+    // runtime-stride layout. Avoid compiling irrelevant legacy page variants.
+    LAUNCH_GROUPED_VERIFY_PARTIAL(kGroupedVerifyQ32MaxQ, false, 0, false,
+                                  false, false);
+  } else if (q32_query) {
+    LAUNCH_GROUPED_VERIFY_PARTIAL(kGroupedVerifyQ32MaxQ, true, 0, false, false,
+                                  false);
+  } else if (q16_query && one_pass) {
     DISPATCH_GROUPED_VERIFY_PARTIAL(kGroupedVerifyQ16MaxQ, false, false);
-  } else if (wide_query) {
+  } else if (q16_query) {
     DISPATCH_GROUPED_VERIFY_PARTIAL(kGroupedVerifyQ16MaxQ, true, false);
   } else if (one_pass && single_query) {
     DISPATCH_GROUPED_VERIFY_PARTIAL(kGroupedVerifyQ8MaxQ, false, true);
@@ -3700,7 +3732,9 @@ at::Tensor flash_attention_grouped_verify_paged(
           partial_lse.data_ptr<float>(), seq_lens.data_ptr<int>(),     \
           reinterpret_cast<__half*>(out.data_ptr()),                   \
           static_cast<int>(q.size(0)))
-  if (wide_query) {
+  if (q32_query) {
+    LAUNCH_GROUPED_VERIFY_COMBINE(kGroupedVerifyQ32MaxQ, false);
+  } else if (q16_query) {
     LAUNCH_GROUPED_VERIFY_COMBINE(kGroupedVerifyQ16MaxQ, false);
   } else if (single_query) {
     LAUNCH_GROUPED_VERIFY_COMBINE(kGroupedVerifyQ8MaxQ, true);

--- a/tests/kernels/attention/test_sm70_flash_v100_grouped_verify.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_grouped_verify.py
@@ -128,16 +128,19 @@ def _reference(
         (16, 6, 506, False),
         (16, 8, 1016, False),
         (16, 16, 1008, True),
+        (16, 32, 992, True),
         (16, 3, 1025, True),
         (784, 5, 2049, True),
         (1648, 8, 4097, True),
         (1648, 16, 4089, True),
         (1728, 8, 4097, True),
         (1728, 16, 4089, True),
+        (1888, 32, 4073, True),
         (3296, 8, 8193, True),
         (3296, 16, 8185, True),
         (3456, 8, 8193, True),
         (3456, 16, 8185, True),
+        (3776, 32, 8169, True),
     ],
 )
 @torch.inference_mode()
@@ -224,7 +227,7 @@ def test_grouped_verify_matches_fp32_reference_with_random_pages(
     torch.testing.assert_close(one_pass, two_pass, atol=6.2e-5, rtol=2.0e-3)
 
 
-@pytest.mark.parametrize("query_len", [8, 16])
+@pytest.mark.parametrize("query_len", [8, 16, 32])
 @torch.inference_mode()
 def test_grouped_verify_cuda_graph_replay_tracks_runtime_seq_len(
     query_len: int,

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -1703,8 +1703,10 @@ def test_flash_v100_smallq_forward_prefers_persistent_decode_metadata():
     assert torch.all(output == 1)
 
 
-@pytest.mark.parametrize("query_len", [8, 16])
-@pytest.mark.parametrize("page_size", [3296, 3456])
+@pytest.mark.parametrize(
+    ("query_len", "page_size"),
+    [(8, 3296), (16, 3456), (32, 3776)],
+)
 def test_flash_v100_dflash2_grouped_verify_uses_original_request_metadata(
     query_len: int, page_size: int
 ):
@@ -1788,6 +1790,34 @@ def test_flash_v100_dflash2_grouped_verify_uses_original_request_metadata(
     assert captured_seq_lens.data_ptr() == original_seq_lens.data_ptr()
     assert captured["one_pass"] is True
     assert torch.all(output == 1)
+
+
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "draft_model_tokens", "expected"),
+    [
+        (7, 7, True),
+        (15, 7, True),
+        (31, 7, True),
+        (8, 7, False),
+        (31, 15, False),
+    ],
+)
+def test_flash_v100_dflash2_grouped_target_width_supported(
+    num_speculative_tokens: int,
+    draft_model_tokens: int,
+    expected: bool,
+) -> None:
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        _dflash2_grouped_target_width_supported,
+    )
+
+    assert (
+        _dflash2_grouped_target_width_supported(
+            num_speculative_tokens,
+            draft_model_tokens,
+        )
+        is expected
+    )
 
 
 def test_flash_v100_decode_forwards_shape_hints():

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -101,6 +101,23 @@ def test_dflash2_grouped_verify_is_default_on_with_rollback(monkeypatch):
         envs.disable_envs_cache()
 
 
+def test_dflash2_chain_is_opt_in_and_greedy_only_by_default(monkeypatch):
+    names = (
+        "VLLM_DFLASH2_CHAIN",
+        "VLLM_DFLASH2_CHAIN_GREEDY_ONLY",
+        "VLLM_DFLASH2_CHAIN_MINMATCH",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert not envs.VLLM_DFLASH2_CHAIN
+        assert envs.VLLM_DFLASH2_CHAIN_GREEDY_ONLY
+        assert envs.VLLM_DFLASH2_CHAIN_MINMATCH == 8
+    finally:
+        envs.disable_envs_cache()
+
+
 def test_sm70_tp4_push_allreduce_is_default_on_with_rollback(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_TP4_PUSH_ALLREDUCE", raising=False)
     envs.disable_envs_cache()

--- a/tests/v1/spec_decode/test_dflash2_lookup.py
+++ b/tests/v1/spec_decode/test_dflash2_lookup.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -11,6 +13,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import (
     suffix_lookup,
 )
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
+    DFlash2Speculator,
     _prepare_lookup_controller_flags_kernel,
 )
 
@@ -215,3 +218,75 @@ def test_point_mass_rewrite_preserves_sparse_cache_invariant() -> None:
         assert int(cached_ids[1, step, 0]) == token
         assert float(cached_scores[1, step, 0]) == 0.0
         assert torch.isneginf(cached_scores[1, step, 1:]).all()
+
+
+def test_drafter_free_chain_fills_block_and_clears_a_miss() -> None:
+    device = torch.device("cuda")
+    num_steps, draft_block, top_k, vocab_size = 15, 7, 16, 64
+    speculator = object.__new__(DFlash2Speculator)
+    speculator.num_speculative_steps = num_steps
+    speculator.draft_block = draft_block
+    speculator.selector_top_k = top_k
+    speculator._lookup_nmin = 6
+    speculator._lookup_nmax = 12
+    speculator._lookup_search = 1 << 30
+    speculator.sample_idx_mapping = torch.zeros(
+        draft_block, dtype=torch.int32, device=device
+    )
+    speculator._lookup_eligible = torch.ones(1, dtype=torch.int32, device=device)
+    speculator._lookup_tokens = torch.zeros(
+        (1, num_steps), dtype=torch.int32, device=device
+    )
+    speculator._lookup_match_len = torch.zeros(1, dtype=torch.int32, device=device)
+    speculator._lookup_valid = torch.zeros(1, dtype=torch.int32, device=device)
+    speculator._lookup_use = torch.zeros(
+        (1, num_steps), dtype=torch.int32, device=device
+    )
+    speculator.draft_tokens = torch.zeros(
+        (1, num_steps), dtype=torch.int64, device=device
+    )
+    speculator.draft_logits = torch.full(
+        (1, num_steps, vocab_size),
+        -float("inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    speculator._cached_candidate_ids = torch.zeros(
+        (1, num_steps, top_k), dtype=torch.int64, device=device
+    )
+    speculator._cached_candidate_scores = torch.full(
+        (1, num_steps, top_k),
+        -float("inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    speculator._selector_scores = torch.empty(
+        (1, draft_block, top_k), dtype=torch.float32, device=device
+    )
+
+    suffix = list(range(1, 9))
+    continuation = list(range(20, 35))
+    history = suffix + continuation + suffix
+    all_ids = torch.zeros((1, 64), dtype=torch.int32, device=device)
+    all_ids[0, : len(history)] = torch.tensor(history, device=device)
+    total_len = torch.tensor([len(history)], dtype=torch.int32, device=device)
+    speculator._req_states = SimpleNamespace(
+        all_token_ids=SimpleNamespace(gpu=all_ids),
+        total_len=SimpleNamespace(gpu=total_len),
+    )
+
+    speculator._generate_chain_proposal(1)
+    assert speculator.draft_tokens[0].tolist() == continuation
+    assert torch.all(speculator._lookup_use == 1)
+    for step, token in enumerate(continuation):
+        finite = torch.where(torch.isfinite(speculator.draft_logits[0, step]))[0]
+        assert finite.tolist() == [token]
+
+    # A miss must not replay the prior continuation from the persistent lookup
+    # buffer. Token zero is the deliberate rejected-tail sentinel.
+    no_match = list(range(40, 50))
+    all_ids.zero_()
+    all_ids[0, : len(no_match)] = torch.tensor(no_match, device=device)
+    total_len.fill_(len(no_match))
+    speculator._generate_chain_proposal(1)
+    assert torch.count_nonzero(speculator.draft_tokens) == 0

--- a/tests/v1/spec_decode/test_dflash2_ngram_assist.py
+++ b/tests/v1/spec_decode/test_dflash2_ngram_assist.py
@@ -20,6 +20,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
     _advance_chain_controller,
     _advance_lookup_controller,
     _apply_ngram_draft_kernel,
+    _chain_rejection_for_controller,
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     dflash2_sparse_topk_rejection_sample,
@@ -89,6 +90,11 @@ class _CopyEvent:
 
     def synchronize(self) -> None:
         self.synchronized = True
+
+
+class _PendingEvent(_CopyEvent):
+    def query(self) -> bool:
+        return self.synchronized
 
 
 def _host_only_speculator() -> DFlash2Speculator:
@@ -304,6 +310,65 @@ def test_chain_controller_exits_on_rejection_and_requires_normal_step() -> None:
         rejected=False,
         entry_evidence=True,
     ) == (True, True, True)
+
+
+def test_chain_rejection_ignores_stale_normal_proposal_verdict() -> None:
+    assert _chain_rejection_for_controller(None) is None
+    assert _chain_rejection_for_controller((True, False)) is None
+    assert _chain_rejection_for_controller((False, False)) is None
+    assert _chain_rejection_for_controller((True, True)) is True
+    assert _chain_rejection_for_controller((False, True)) is False
+
+
+def test_chain_controller_waits_for_tp_local_async_flags() -> None:
+    speculator = object.__new__(DFlash2Speculator)
+    speculator._lookup_current_req_key = ("request-a",)
+    speculator._lookup_pending_req_key = ("request-a",)
+    speculator._lookup_pending_num_reqs = 1
+    speculator._lookup_copy_pending = True
+    speculator._lookup_copy_event = _PendingEvent()
+    speculator._chain_entry_flags_cpu = torch.ones(1, dtype=torch.int32)
+
+    assert speculator._chain_entry_evidence() is True
+    assert speculator._lookup_copy_event.synchronized
+
+    speculator._chain_reject_pending = True
+    speculator._chain_reject_event = _PendingEvent()
+    speculator._chain_reject_req_key = ("request-a",)
+    speculator._chain_rejected_cpu = torch.ones(1, dtype=torch.int32)
+    speculator._chain_reject_pending_was_chain = True
+
+    assert speculator._consume_chain_rejection() == (True, True)
+    assert speculator._chain_reject_event.synchronized
+
+
+def test_lookup_controller_keys_request_lifetime_not_reused_slot() -> None:
+    speculator = object.__new__(DFlash2Speculator)
+    speculator._lookup_enabled = True
+    speculator._lookup_eligible = torch.zeros(1, dtype=torch.int32)
+    speculator._lookup_current_req_key = ()
+    speculator._lookup_controller_req_key = ("request-a",)
+    speculator._lookup_last_want = True
+    speculator._lookup_want_streak = 2
+    speculator._lookup_sticky_remaining = 3
+    speculator._lookup_long_active = True
+    batch = SimpleNamespace(
+        num_reqs=1,
+        req_ids=["request-b"],
+        idx_mapping_np=np.array([0], dtype=np.int32),
+        is_prefilling_np=np.array([False]),
+        has_structured_output_reqs=False,
+    )
+
+    speculator._prepare_proposal_runtime(
+        batch,
+        torch.ones(1, dtype=torch.int32),
+        torch.zeros(1, dtype=torch.int32),
+    )
+
+    assert speculator._lookup_current_req_key == ("request-b",)
+    assert speculator._lookup_controller_req_key == ("request-b",)
+    assert not speculator._lookup_long_active
 
 
 def test_lookup_controller_selects_q8_before_two_strong_hits(monkeypatch) -> None:

--- a/tests/v1/spec_decode/test_dflash2_ngram_assist.py
+++ b/tests/v1/spec_decode/test_dflash2_ngram_assist.py
@@ -17,6 +17,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.ngram_assist import (
 )
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
     DFlash2Speculator,
+    _advance_chain_controller,
     _advance_lookup_controller,
     _apply_ngram_draft_kernel,
 )
@@ -260,6 +261,49 @@ def test_lookup_controller_never_coasts_a_multi_request_batch() -> None:
     )
 
     assert values == (False, 0, 0, False)
+
+
+def test_chain_controller_exits_on_rejection_and_requires_normal_step() -> None:
+    active, previous, engage = _advance_chain_controller(
+        active=False,
+        previous_was_chain=False,
+        rejected=False,
+        entry_evidence=True,
+    )
+    assert (active, previous, engage) == (True, True, True)
+
+    # An unavailable asynchronous verdict must not tear down a live chain.
+    active, previous, engage = _advance_chain_controller(
+        active=active,
+        previous_was_chain=previous,
+        rejected=None,
+        entry_evidence=None,
+    )
+    assert (active, previous, engage) == (True, True, True)
+
+    active, previous, engage = _advance_chain_controller(
+        active=active,
+        previous_was_chain=previous,
+        rejected=True,
+        entry_evidence=True,
+    )
+    assert (active, previous, engage) == (False, True, False)
+
+    # Stale pre-chain evidence cannot immediately re-enter after a miss.
+    active, previous, engage = _advance_chain_controller(
+        active=active,
+        previous_was_chain=previous,
+        rejected=False,
+        entry_evidence=True,
+    )
+    assert (active, previous, engage) == (False, False, False)
+
+    assert _advance_chain_controller(
+        active=active,
+        previous_was_chain=previous,
+        rejected=False,
+        entry_evidence=True,
+    ) == (True, True, True)
 
 
 def test_lookup_controller_selects_q8_before_two_strong_hits(monkeypatch) -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2925,6 +2925,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DFLASH2_LOOKUP_CHEAP_CONTEXT": lambda: max(
         0, int(os.getenv("VLLM_DFLASH2_LOOKUP_CHEAP_CONTEXT", "0"))
     ),
+    # Drafter-free continuation chains layered on top of DFlash2 LABD. The
+    # default gate is deliberately conservative: point-mass context proposals
+    # are exact under rejection sampling, but can be less efficient than the
+    # neural proposal when temperature sampling is active.
+    "VLLM_DFLASH2_CHAIN": lambda: bool(int(os.getenv("VLLM_DFLASH2_CHAIN", "0"))),
+    "VLLM_DFLASH2_CHAIN_MINMATCH": lambda: max(
+        1, int(os.getenv("VLLM_DFLASH2_CHAIN_MINMATCH", "8"))
+    ),
+    "VLLM_DFLASH2_CHAIN_GREEDY_ONLY": lambda: bool(
+        int(os.getenv("VLLM_DFLASH2_CHAIN_GREEDY_ONLY", "1"))
+    ),
+    "VLLM_DFLASH2_CHAIN_LOG_SEC": lambda: max(
+        0.0, float(os.getenv("VLLM_DFLASH2_CHAIN_LOG_SEC", "30"))
+    ),
     "VLLM_DFLASH_DUMP_FIRST_PASS": lambda: bool(
         int(os.getenv("VLLM_DFLASH_DUMP_FIRST_PASS", "0"))
     ),

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -3053,6 +3053,14 @@ def _build_ddtree_visibility_mask(
     return visible
 
 
+def _dflash2_grouped_target_width_supported(
+    num_speculative_tokens: int | None,
+    draft_model_tokens: int,
+) -> bool:
+    """Return whether the selector target has a native grouped graph width."""
+    return draft_model_tokens == 7 and num_speculative_tokens in (7, 15, 31)
+
+
 class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
     """Attach CPU metadata for the dense prefill path."""
 
@@ -3100,8 +3108,10 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         self._is_dflash_selector_target = bool(
             use_dflash
             and not self._is_speculative_draft_model
-            and getattr(spec_config, "num_speculative_tokens", None) in (7, 15)
-            and get_dflash_model_draft_tokens(spec_config) == 7
+            and _dflash2_grouped_target_width_supported(
+                getattr(spec_config, "num_speculative_tokens", None),
+                get_dflash_model_draft_tokens(spec_config),
+            )
             and selector_engine
         )
         self._use_sm70_dflash2_fused_smallq_metadata = bool(
@@ -5180,7 +5190,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             >= self.dflash2_grouped_verify_min_model_len
             and getattr(attn_metadata, "causal", True)
             and self._flash_v100_window_size(causal=True) == (-1, -1)
-            and num_query_tokens in (8, 16)
+            and num_query_tokens in (8, 16, 32)
             and tuple(query.shape) == (num_query_tokens, 6, 256)
             and query.dtype == torch.float16
             and query.is_contiguous()
@@ -5188,10 +5198,10 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             and value_cache.ndim == 4
             and key_cache.device == query.device
             and value_cache.device == query.device
-            # q15 LABD increases the aligned hybrid-cache page from the
-            # block-8 service's 1648/3296 layout to 1728/3456. The grouped
-            # operator's runtime-stride implementation is exact for both.
-            and key_cache.shape[1] in (1648, 1728, 3296, 3456)
+            # Wider LABD graphs increase the aligned hybrid-cache page from
+            # block-8's 1648/3296 layout to q16's 1728/3456 and q32's
+            # 1888/3776 layouts. The grouped operator is exact for all three.
+            and key_cache.shape[1] in (1648, 1728, 1888, 3296, 3456, 3776)
             and tuple(key_cache.shape[2:]) == (1, 256)
             and tuple(value_cache.shape) == tuple(key_cache.shape)
             and key_cache.dtype == torch.uint8

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -253,6 +253,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 num_speculative_tokens=self.num_speculative_steps + 1,
                 use_fp64_gumbel=self.model_config.use_fp64_gumbel,
             )
+            if self.speculator is not None and hasattr(
+                self.speculator, "set_sampling_states"
+            ):
+                self.speculator.set_sampling_states(self.sampler.sampling_states)
             if self.speculative_config is not None:
                 self.rejection_sampler = RejectionSampler(
                     self.sampler,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -359,6 +359,17 @@ class DFlashSpeculator(DraftModelSpeculator):
     def _apply_ngram_assist(self, num_reqs: int) -> None:
         """Override model proposals for ngram-hit rows, if configured."""
 
+    def _prepare_draftless_proposal(
+        self,
+        input_batch: InputBatch,
+        num_rejected: torch.Tensor,
+        *,
+        dummy_run: bool,
+        is_profile: bool,
+    ) -> bool:
+        """Fill a complete proposal without running the draft query model."""
+        return False
+
     @torch.inference_mode()
     def propose(
         self,
@@ -504,6 +515,14 @@ class DFlashSpeculator(DraftModelSpeculator):
                     self._speculator_name,
                 )
                 self._context_only_prefill_logged = True
+            return self.draft_tokens[:num_reqs]
+
+        if self._prepare_draftless_proposal(
+            input_batch,
+            num_rejected,
+            dummy_run=dummy_run,
+            is_profile=is_profile,
+        ):
             return self.draft_tokens[:num_reqs]
 
         if self._prepare_ngram_assist(

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import time
 from typing import Any
 
 import numpy as np
@@ -284,6 +285,20 @@ def _prepare_lookup_controller_flags_kernel(
     tl.store(out_ptr + offsets, wants_long.to(tl.int32), mask=mask)
 
 
+@triton.jit
+def _prepare_chain_entry_flags_kernel(
+    match_len_ptr,
+    out_ptr,
+    min_match,
+    num_reqs,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    mask = offsets < num_reqs
+    match_len = tl.load(match_len_ptr + offsets, mask=mask, other=0)
+    tl.store(out_ptr + offsets, (match_len >= min_match).to(tl.int32), mask=mask)
+
+
 def _advance_lookup_controller(
     *,
     want: bool | None,
@@ -317,6 +332,30 @@ def _advance_lookup_controller(
             long_active = False
             sticky_remaining = 0
     return want, want_streak, sticky_remaining, long_active
+
+
+def _advance_chain_controller(
+    *,
+    active: bool,
+    previous_was_chain: bool,
+    rejected: bool | None,
+    entry_evidence: bool | None,
+) -> tuple[bool, bool, bool]:
+    """Advance a single-request drafter-free chain.
+
+    A missing asynchronous verdict preserves an active chain. After the first
+    rejection, one normal draft step is required before fresh lookup evidence
+    may start another chain.
+    """
+    if active:
+        if rejected:
+            return False, True, False
+        return True, True, True
+    if previous_was_chain:
+        return False, False, False
+    if entry_evidence:
+        return True, True, True
+    return False, False, False
 
 
 class DFlash2Speculator(DFlashSpeculator):
@@ -455,6 +494,13 @@ class DFlash2Speculator(DFlashSpeculator):
         self._lookup_current_req_key: tuple[int, ...] = ()
         self._lookup_current_eligible = False
         self._lookup_last_emitted: torch.Tensor | None = None
+        self._sampling_states = None
+        self._chain_enabled = False
+        self._chain_active = False
+        self._chain_previous_was_chain = False
+        self._chain_req_key: tuple[int, ...] = ()
+        self._chain_steps_total = 0
+        self._chain_steps_engaged = 0
         if self._lookup_enabled:
             if device.type != "cuda":
                 raise ValueError("Lookup-augmented DFlash2 requires a CUDA device")
@@ -500,6 +546,30 @@ class DFlash2Speculator(DFlashSpeculator):
                 device="cpu",
                 pin_memory=True,
             )
+            self._chain_enabled = envs.VLLM_DFLASH2_CHAIN
+            if self._chain_enabled:
+                self._chain_min_match = envs.VLLM_DFLASH2_CHAIN_MINMATCH
+                self._chain_greedy_only = envs.VLLM_DFLASH2_CHAIN_GREEDY_ONLY
+                self._chain_log_sec = envs.VLLM_DFLASH2_CHAIN_LOG_SEC
+                self._chain_entry_flags = torch.zeros_like(self._lookup_match_len)
+                self._chain_entry_flags_cpu = torch.zeros(
+                    self.max_num_reqs,
+                    dtype=torch.int32,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self._chain_rejected = torch.zeros_like(self._lookup_match_len)
+                self._chain_rejected_cpu = torch.zeros(
+                    self.max_num_reqs,
+                    dtype=torch.int32,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self._chain_reject_stream = torch.cuda.Stream(device=device)
+                self._chain_reject_event = torch.cuda.Event()
+                self._chain_reject_pending = False
+                self._chain_reject_req_key: tuple[int, ...] = ()
+                self._chain_last_log = time.monotonic()
             self._lookup_copy_pending = False
             self._lookup_pending_req_key: tuple[int, ...] = ()
             self._lookup_pending_num_reqs = 0
@@ -520,6 +590,19 @@ class DFlash2Speculator(DFlashSpeculator):
                 self._lookup_nmax,
                 self._lookup_adaptive,
             )
+            if self._chain_enabled:
+                logger.info(
+                    "Enabled drafter-free DFlash2 chains "
+                    "(min_match=%d, greedy_only=%s).",
+                    self._chain_min_match,
+                    self._chain_greedy_only,
+                )
+        elif envs.VLLM_DFLASH2_CHAIN:
+            logger.warning(
+                "VLLM_DFLASH2_CHAIN=1 requires lookup-augmented DFlash2 "
+                "(ngram_assist=true and a verifier wider than the checkpoint); "
+                "chains are disabled."
+            )
 
     @property
     def requires_host_token_state(self) -> bool:
@@ -529,6 +612,10 @@ class DFlash2Speculator(DFlashSpeculator):
     def set_req_states(self, req_states) -> None:
         """Expose the request token history used by the device lookup."""
         self._req_states = req_states
+
+    def set_sampling_states(self, sampling_states) -> None:
+        """Expose the host sampling view for the zero-sync chain gate."""
+        self._sampling_states = sampling_states
 
     def _reset_lookup_controller(self, req_key: tuple[int, ...]) -> None:
         self._lookup_controller_req_key = req_key
@@ -615,12 +702,25 @@ class DFlash2Speculator(DFlashSpeculator):
             BLOCK=block,
             num_warps=1,
         )
+        if self._chain_enabled:
+            _prepare_chain_entry_flags_kernel[(1,)](
+                self._lookup_match_len,
+                self._chain_entry_flags,
+                self._chain_min_match,
+                num_reqs,
+                BLOCK=block,
+                num_warps=1,
+            )
         current_stream = torch.cuda.current_stream(self.device)
         self._lookup_copy_stream.wait_stream(current_stream)
         with torch.cuda.stream(self._lookup_copy_stream):
             self._lookup_flags_cpu[:num_reqs].copy_(
                 self._lookup_controller_flags[:num_reqs], non_blocking=True
             )
+            if self._chain_enabled:
+                self._chain_entry_flags_cpu[:num_reqs].copy_(
+                    self._chain_entry_flags[:num_reqs], non_blocking=True
+                )
             self._lookup_copy_event.record(self._lookup_copy_stream)
         self._lookup_pending_req_key = self._lookup_current_req_key
         self._lookup_pending_num_reqs = num_reqs
@@ -630,6 +730,15 @@ class DFlash2Speculator(DFlashSpeculator):
         """Choose q8 or q16 for the next target verification step."""
         if not self._lookup_enabled:
             return self.num_speculative_steps
+
+        if getattr(self, "_chain_enabled", False) and self._chain_active:
+            # Clear the normal-step feedback that admitted the chain. Chain
+            # steps do not run the neural lookup graph and therefore publish
+            # no new adaptive q8/q16 feedback.
+            self._consume_lookup_flags()
+            return self._record_lookup_width(
+                self.num_speculative_steps, "drafter-free-chain"
+            )
 
         num_reqs = len(self._lookup_current_req_key)
         if num_reqs == 0 or not self._lookup_current_eligible:
@@ -670,6 +779,133 @@ class DFlash2Speculator(DFlashSpeculator):
         )
         reason = "strong-copy" if self._lookup_long_active else "adaptive-default"
         return self._record_lookup_width(width, reason)
+
+    def _chain_entry_evidence(self) -> bool | None:
+        if not self._lookup_copy_pending or not self._lookup_copy_event.query():
+            return None
+        if (
+            self._lookup_pending_req_key != self._lookup_current_req_key
+            or self._lookup_pending_num_reqs != 1
+        ):
+            return False
+        return bool(self._chain_entry_flags_cpu[0])
+
+    def _consume_chain_rejection(self) -> bool | None:
+        if not self._chain_reject_pending or not self._chain_reject_event.query():
+            return None
+        self._chain_reject_pending = False
+        if self._chain_reject_req_key != self._lookup_current_req_key:
+            return False
+        return bool(self._chain_rejected_cpu[0])
+
+    def _queue_chain_rejection(self, num_rejected: torch.Tensor) -> None:
+        if self._chain_reject_pending:
+            return
+        self._chain_rejected[:1].copy_(num_rejected[:1])
+        current_stream = torch.cuda.current_stream(self.device)
+        self._chain_reject_stream.wait_stream(current_stream)
+        with torch.cuda.stream(self._chain_reject_stream):
+            self._chain_rejected_cpu[:1].copy_(
+                self._chain_rejected[:1], non_blocking=True
+            )
+            self._chain_reject_event.record(self._chain_reject_stream)
+        self._chain_reject_req_key = self._lookup_current_req_key
+        self._chain_reject_pending = True
+
+    def _reset_chain(self, req_key: tuple[int, ...]) -> None:
+        self._chain_req_key = req_key
+        self._chain_active = False
+        self._chain_previous_was_chain = False
+
+    def _chain_is_eligible(self, input_batch) -> bool:
+        if (
+            not self._chain_enabled
+            or self.dp_size != 1
+            or input_batch.num_reqs != 1
+            or not self._lookup_current_eligible
+            or self._req_states is None
+        ):
+            return False
+        if not self._chain_greedy_only:
+            return True
+        if self._sampling_states is None:
+            return False
+        req_state = int(input_batch.idx_mapping_np[0])
+        return float(self._sampling_states.temperature.np[req_state]) == 0.0
+
+    def _prepare_draftless_proposal(
+        self,
+        input_batch,
+        num_rejected: torch.Tensor,
+        *,
+        dummy_run: bool,
+        is_profile: bool,
+    ) -> bool:
+        if not self._chain_enabled:
+            return False
+
+        req_key = self._lookup_current_req_key
+        if req_key != self._chain_req_key:
+            self._reset_chain(req_key)
+        if dummy_run or is_profile or not self._chain_is_eligible(input_batch):
+            self._reset_chain(req_key)
+            return False
+
+        self._chain_steps_total += 1
+        rejected = self._consume_chain_rejection()
+        self._queue_chain_rejection(num_rejected)
+        (
+            self._chain_active,
+            self._chain_previous_was_chain,
+            engage,
+        ) = _advance_chain_controller(
+            active=self._chain_active,
+            previous_was_chain=self._chain_previous_was_chain,
+            rejected=rejected,
+            entry_evidence=self._chain_entry_evidence(),
+        )
+        if not engage:
+            return False
+
+        self._chain_steps_engaged += 1
+        self._generate_chain_proposal(input_batch.num_reqs)
+        now = time.monotonic()
+        if (
+            self._chain_log_sec > 0
+            and now - self._chain_last_log >= self._chain_log_sec
+        ):
+            logger.info(
+                "DFlash2 chain engaged %d/%d eligible steps.",
+                self._chain_steps_engaged,
+                self._chain_steps_total,
+            )
+            self._chain_last_log = now
+        return True
+
+    def _generate_chain_proposal(self, num_reqs: int) -> None:
+        """Fill the verifier block from request history without draft forward."""
+        assert self._req_states is not None
+        self._lookup_tokens[:num_reqs].zero_()
+        tokens, _, _ = suffix_lookup(
+            self._req_states.all_token_ids.gpu,
+            self._req_states.total_len.gpu,
+            self.sample_idx_mapping,
+            self._lookup_eligible,
+            num_reqs,
+            self.num_speculative_steps,
+            idx_mapping_stride=self.draft_block,
+            nmax=self._lookup_nmax,
+            nmin=self._lookup_nmin,
+            search_max=self._lookup_search,
+            out_tokens=self._lookup_tokens,
+            out_len=self._lookup_match_len,
+            out_valid=self._lookup_valid,
+        )
+        # A missing continuation becomes token zero and is rejected by the
+        # target. That exact miss is the exit signal for the next host step.
+        self.draft_tokens[:num_reqs].copy_(tokens[:num_reqs])
+        self._lookup_use[:num_reqs].fill_(1)
+        self._rewrite_lookup_point_masses(num_reqs)
 
     def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
         # The selector walk and rejection sampler must consume identical scores.
@@ -910,6 +1146,9 @@ class DFlash2Speculator(DFlashSpeculator):
             take_flags=self._lookup_take_flags,
         )
 
+        self._rewrite_lookup_point_masses(num_reqs)
+
+    def _rewrite_lookup_point_masses(self, num_reqs: int) -> None:
         draft_logits = self.draft_logits
         if draft_logits is None:
             return

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -358,6 +358,22 @@ def _advance_chain_controller(
     return False, False, False
 
 
+def _chain_rejection_for_controller(
+    verdict: tuple[bool, bool] | None,
+) -> bool | None:
+    """Filter an async rejection verdict by the proposal that produced it.
+
+    The D2H copy completes one host decision later. A rejection from the
+    normal neural-draft step that admitted a chain must not be applied to the
+    first drafter-free proposal. Only a verdict tagged as coming from a chain
+    proposal may terminate an active chain.
+    """
+    if verdict is None:
+        return None
+    rejected, proposal_was_chain = verdict
+    return rejected if proposal_was_chain else None
+
+
 class DFlash2Speculator(DFlashSpeculator):
     _speculator_name = "DFlash2"
 
@@ -491,14 +507,14 @@ class DFlash2Speculator(DFlashSpeculator):
             ngram_assist and self.draft_block < self.num_speculative_steps
         )
         self._req_states = None
-        self._lookup_current_req_key: tuple[int, ...] = ()
+        self._lookup_current_req_key: tuple[str, ...] = ()
         self._lookup_current_eligible = False
         self._lookup_last_emitted: torch.Tensor | None = None
         self._sampling_states = None
         self._chain_enabled = False
         self._chain_active = False
         self._chain_previous_was_chain = False
-        self._chain_req_key: tuple[int, ...] = ()
+        self._chain_req_key: tuple[str, ...] = ()
         self._chain_steps_total = 0
         self._chain_steps_engaged = 0
         if self._lookup_enabled:
@@ -568,16 +584,18 @@ class DFlash2Speculator(DFlashSpeculator):
                 self._chain_reject_stream = torch.cuda.Stream(device=device)
                 self._chain_reject_event = torch.cuda.Event()
                 self._chain_reject_pending = False
-                self._chain_reject_req_key: tuple[int, ...] = ()
+                self._chain_reject_req_key: tuple[str, ...] = ()
+                self._chain_reject_pending_was_chain = False
+                self._chain_last_proposal_was_chain = False
                 self._chain_last_log = time.monotonic()
             self._lookup_copy_pending = False
-            self._lookup_pending_req_key: tuple[int, ...] = ()
+            self._lookup_pending_req_key: tuple[str, ...] = ()
             self._lookup_pending_num_reqs = 0
             self._lookup_last_want = False
             self._lookup_want_streak = 0
             self._lookup_sticky_remaining = 0
             self._lookup_long_active = False
-            self._lookup_controller_req_key: tuple[int, ...] = ()
+            self._lookup_controller_req_key: tuple[str, ...] = ()
             self._lookup_last_verify_tokens = 0
             self._lookup_q8_rounds = 0
             self._lookup_q16_rounds = 0
@@ -617,7 +635,7 @@ class DFlash2Speculator(DFlashSpeculator):
         """Expose the host sampling view for the zero-sync chain gate."""
         self._sampling_states = sampling_states
 
-    def _reset_lookup_controller(self, req_key: tuple[int, ...]) -> None:
+    def _reset_lookup_controller(self, req_key: tuple[str, ...]) -> None:
         self._lookup_controller_req_key = req_key
         self._lookup_last_want = False
         self._lookup_want_streak = 0
@@ -658,7 +676,12 @@ class DFlash2Speculator(DFlashSpeculator):
             return
 
         num_reqs = input_batch.num_reqs
-        req_key = tuple(int(index) for index in input_batch.idx_mapping_np[:num_reqs])
+        # A request-state slot is reused after a request finishes.  Keying the
+        # asynchronous lookup/chain controllers by slot alone lets a completed
+        # request's pending flags admit a drafter-free proposal for the next
+        # request that lands in the same slot.  Request IDs are stable across
+        # TP ranks and uniquely identify the controller lifetime.
+        req_key = tuple(input_batch.req_ids[:num_reqs])
         self._lookup_current_req_key = req_key
         self._lookup_last_emitted = num_sampled[:num_reqs]
 
@@ -781,8 +804,16 @@ class DFlash2Speculator(DFlashSpeculator):
         return self._record_lookup_width(width, reason)
 
     def _chain_entry_evidence(self) -> bool | None:
-        if not self._lookup_copy_pending or not self._lookup_copy_event.query():
+        if not self._lookup_copy_pending:
             return None
+        # Every TP rank must make the same host-side branch.  Merely querying
+        # an asynchronous D2H event can return ready on one rank and pending on
+        # another, causing only a subset of ranks to skip the draft graph and
+        # corrupting its TP collectives.  The copy was queued in the preceding
+        # proposal step, so this is normally already complete and the fence is
+        # only a correctness backstop for the drafter-free path.
+        if not self._lookup_copy_event.query():
+            self._lookup_copy_event.synchronize()
         if (
             self._lookup_pending_req_key != self._lookup_current_req_key
             or self._lookup_pending_num_reqs != 1
@@ -790,15 +821,27 @@ class DFlash2Speculator(DFlashSpeculator):
             return False
         return bool(self._chain_entry_flags_cpu[0])
 
-    def _consume_chain_rejection(self) -> bool | None:
-        if not self._chain_reject_pending or not self._chain_reject_event.query():
+    def _consume_chain_rejection(self) -> tuple[bool, bool] | None:
+        if not self._chain_reject_pending:
             return None
+        # See _chain_entry_evidence: a TP-local event readiness race must not
+        # choose different draft/skip collective sequences across ranks.
+        if not self._chain_reject_event.query():
+            self._chain_reject_event.synchronize()
         self._chain_reject_pending = False
         if self._chain_reject_req_key != self._lookup_current_req_key:
-            return False
-        return bool(self._chain_rejected_cpu[0])
+            return None
+        return (
+            bool(self._chain_rejected_cpu[0]),
+            self._chain_reject_pending_was_chain,
+        )
 
-    def _queue_chain_rejection(self, num_rejected: torch.Tensor) -> None:
+    def _queue_chain_rejection(
+        self,
+        num_rejected: torch.Tensor,
+        *,
+        proposal_was_chain: bool,
+    ) -> None:
         if self._chain_reject_pending:
             return
         self._chain_rejected[:1].copy_(num_rejected[:1])
@@ -810,12 +853,14 @@ class DFlash2Speculator(DFlashSpeculator):
             )
             self._chain_reject_event.record(self._chain_reject_stream)
         self._chain_reject_req_key = self._lookup_current_req_key
+        self._chain_reject_pending_was_chain = proposal_was_chain
         self._chain_reject_pending = True
 
-    def _reset_chain(self, req_key: tuple[int, ...]) -> None:
+    def _reset_chain(self, req_key: tuple[str, ...]) -> None:
         self._chain_req_key = req_key
         self._chain_active = False
         self._chain_previous_was_chain = False
+        self._chain_last_proposal_was_chain = False
 
     def _chain_is_eligible(self, input_batch) -> bool:
         if (
@@ -852,8 +897,12 @@ class DFlash2Speculator(DFlashSpeculator):
             return False
 
         self._chain_steps_total += 1
-        rejected = self._consume_chain_rejection()
-        self._queue_chain_rejection(num_rejected)
+        verdict = self._consume_chain_rejection()
+        self._queue_chain_rejection(
+            num_rejected,
+            proposal_was_chain=self._chain_last_proposal_was_chain,
+        )
+        rejected = _chain_rejection_for_controller(verdict)
         (
             self._chain_active,
             self._chain_previous_was_chain,
@@ -864,6 +913,7 @@ class DFlash2Speculator(DFlashSpeculator):
             rejected=rejected,
             entry_evidence=self._chain_entry_evidence(),
         )
+        self._chain_last_proposal_was_chain = engage
         if not engage:
             return False
 


### PR DESCRIPTION
## Purpose

- Port lookup-augmented block drafting and the opt-in greedy B1 drafter-free chain from the Apache-2.0 syv-ai/Dmtrii implementations without changing Eagle, MTP, DDTree, the SM70 compact sampler, or the accepted QPN2/target-QPN8 paths.
- Keep the DFlash2 checkpoint at seven neural drafts while allowing lookup to fill a q31 proposal and target to verify q32.
- Add an exact SM70 grouped q32 `Hq6/Hkv1/D256` E5M2 paged-KV verifier instead of falling through to row-wise XQA.
- Make TP4 chain decisions collective-safe: controller lifetimes use request IDs, rejection feedback is tagged by proposal origin, and pending D2H events are fenced before ranks choose whether to skip the neural draft graph.
- Keep `VLLM_DFLASH2_CHAIN` default-off and greedy-only. No token clamp, unverified output, selector-QPN8 rerank, or draft-MLP QPN8 path is introduced.

## Test Plan

- Build the merged Flash-V100 CUDA translation unit for `sm_70`.
- Run the q8/q16/q32 numerical, random-page, and CUDA Graph replay suite on V100.
- Run focused DFlash2 lookup/chain/controller and Flash-V100 policy suites with CUDA hidden where appropriate.
- Run an 18-turn cumulative coding lifetime stress to exercise request-slot reuse, q8/q32 transitions, prefix caching, and repeated chain entry/exit.
- Reuse the frozen 25K-token syv document prompt for a matched chain-off/chain-on pure-decode comparison and exact output hash.

## Test Result

- Latest-main incremental SM70 CUDA build: pass.
- q32 V100 GPU suite: `29 passed`.
- Post-merge focused host/policy suite: `117 passed, 15 skipped, 112 deselected`.
- Full focused DFlash2 files before the final main merge: `109 passed, 15 skipped`.
- Ruff, format check, and `git diff --check`: pass.
- q32 grouped verifier at page 3,776: `2.71x` at 1K and `3.90x` at 32K versus row-wise baseline; maximum absolute error `1.53e-5`.
- Frozen 25K document before chain: q16 `222.734 tok/s` to q32 `337.107 tok/s` (`+51.35%`), same output.
- Frozen 25K q32 chain pair: `337.107 -> 359.770 tok/s` pure decode (`+6.72%`), 28 rounds, mean acceptance `18.75`, all 512 output tokens and text SHA256 unchanged (`7d69c86c...a6dda55c`).
- Cold request remains prefill dominated (`9.336 -> 9.391 s`) and is not claimed as an end-to-end gain. Identical-prefix rerun: TTFT `1.114 s`, decode `359.37 tok/s`, total `2.535 s`.
- Cleaned chain completed the 18-turn stress with 8,325 generated tokens, mean acceptance `7.513`, and no selector assert or HTTP 500.

Detailed provenance, contracts, and artifacts are in `docs/design/sm70_dflash2_drafter_free_chain.md`.
