### PR TITLE
[Model][SM70] Optimize Qwen3.8 MTP4 on V100

### DIFF
--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -603,9 +603,9 @@ def _sm70_turbomind_policy(
         "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG",
         True,
     )
-    qwen36_mtp_moe_tuned_config = _env_bool(
-        "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG",
-        True,
+    mtp_moe_tuned_config = _env_bool(
+        "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
+        False,
     )
     awq_warmup = _env_bool("VLLM_SM70_AWQ_WARMUP", True)
     awq_moe_disable = _env_bool("VLLM_SM70_AWQ_MOE_DISABLE", False)
@@ -688,7 +688,13 @@ def _sm70_turbomind_policy(
         "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG": os.environ.get(
             "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG"
         ),
-        "qwen36_mtp_moe_tuned_config_effective": qwen36_mtp_moe_tuned_config,
+        "VLLM_SM70_MTP_MOE_TUNED_CONFIG": os.environ.get(
+            "VLLM_SM70_MTP_MOE_TUNED_CONFIG"
+        ),
+        "mtp_moe_tuned_config_effective": mtp_moe_tuned_config,
+        # Backward-compatible output alias. The old Qwen3.6-only environment
+        # variable is no longer consulted by the runtime.
+        "qwen36_mtp_moe_tuned_config_effective": mtp_moe_tuned_config,
         "VLLM_SM70_AWQ_WARMUP": os.environ.get("VLLM_SM70_AWQ_WARMUP"),
         "awq_warmup_effective": awq_warmup,
         "VLLM_SM70_AWQ_WARMUP_MAX_M": os.environ.get("VLLM_SM70_AWQ_WARMUP_MAX_M"),

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -605,7 +605,7 @@ def _sm70_turbomind_policy(
     )
     mtp_moe_tuned_config = _env_bool(
         "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
-        False,
+        True,
     )
     awq_warmup = _env_bool("VLLM_SM70_AWQ_WARMUP", True)
     awq_moe_disable = _env_bool("VLLM_SM70_AWQ_MOE_DISABLE", False)

--- a/docs/design/sm70_qwen38_flash_next_nvfp4.md
+++ b/docs/design/sm70_qwen38_flash_next_nvfp4.md
@@ -497,9 +497,10 @@ The exact TP4-local BF16 draft-MoE shape is
 `E=512, N=160, K=2560, topk=10`. An exact-shape SM70 tile of
 `BM=2, BN=128, BK=64, G=1`, four warps, and three stages reduces M5 from
 1492.500 to 283.853 microseconds (5.26x) and M1 from 425.789 to 272.415
-microseconds (1.56x), with bitwise-identical output. The route is bounded to
-Qwen3.8 TP4 and remains opt-in through
-`VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
+microseconds (1.56x), with bitwise-identical output. The route is bounded by
+the exact SM70 TP4 local MoE shape (currently exercised by Qwen3.8), is enabled
+by default, and can be rolled back with
+`VLLM_SM70_MTP_MOE_TUNED_CONFIG=0`.
 
 V2 needs one additional prefill specialization beyond its faithful M5/M1
 decode warmup. The real HumanEval prompt first runs the draft model at M152;

--- a/docs/design/sm70_qwen38_flash_next_nvfp4.md
+++ b/docs/design/sm70_qwen38_flash_next_nvfp4.md
@@ -11,13 +11,16 @@
   by 16.97%. The direct NVFP4 ten-route QPN-M1 MoE and online QPN8 routes are
   therefore default-on for the exact SM70/TP4/B1 contract, with explicit
   diagnostic opt-outs. The preceding 77.370-token/s graph-node trace remains
-  the detailed optimization control. Native MTP4 also completes TP4 model
-  load, graph
-  capture, warmup, and two 1024x256 requests; its separate acceptance and
-  cycle-cost evidence remains recorded below.
-- Integration line: public `origin/main`, through Draft PR
-  [#345](https://github.com/1CatAI/1Cat-vLLM/pull/345).
-- Base SHA: `d63e9490f65f9e01f6649053c1ab72922034b931`.
+  the detailed optimization control. Corrected native MTP4 is stable across an
+  11-request TP4 transition run, and the no-thinking HumanEval8 gate reaches
+  4.747 mean accepted length, 93.676% draft acceptance, 126.81 warmed pure
+  decode tokens/s, and 8/8 standard semantic executions. The V2 M16 plus
+  M5/M1 warmup also removes the first-request MTP `fused_moe_kernel` JIT.
+- Integration line: public `main`; Qwen3.8 bring-up
+  [#345](https://github.com/1CatAI/1Cat-vLLM/pull/345) and initial decode work
+  [#361](https://github.com/1CatAI/1Cat-vLLM/pull/361) are merged. The compact
+  MTP loader, exact SM70 MTP tile, and V2 warmup are the current follow-up.
+- Base SHA: `03c04da68e72bf26271de4986364a72141a7601f`.
 - Model: `RadixArk/Qwen3.8-Flash-Next-NVFP4` at revision
   `7b719225242aacd3dbd3f9407468c2ee9a9d2594`.
 - Model download: `/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4`.
@@ -451,14 +454,73 @@ the draft loader fail closed if either routed-expert parameter is absent, so a
 future mapping regression cannot masquerade as a successful model start. The
 focused loader gate is 21 passed tests plus Ruff and format checks.
 
-The next GPU gate is one TP4, prefix-cache-on, four-prompt native MTP4 run with
-greedy local argmax and QSA index sharing explicitly enabled. It uses the same
-prompts, order, sampling, and output cap as the completed four-request baseline
-and records per-request and per-position accepted length, code output quality,
-emitted tokens/s, and peak memory. MTP3 is not an optimization candidate for
-this gate. A subsequent Nsight trace is warranted only after the corrected
-MTP4 acceptance result is stable; it will report proposal time, five-token
-target verification time, and cycle cost per emitted token separately.
+### Corrected MTP4 acceptance, quality, and warmup closure
+
+The standalone drafter now prefers the four compact `model-bf16-*` shards that
+contain all 33 required MTP/shared parameters instead of rescanning all 206
+target shards. The complete-expert validation remains fail closed, and generic
+safetensors/bin/pt patterns remain compatibility fallbacks. In the accepted
+11-request transition artifact
+`.artifacts/qwen4_exp_mtp_tp4_20260827/mtp4_transition9_v16_storage_ratio_natural4_same7_gpu4567.json`,
+target loading reads 206 shards once and MTP reads only four shards / 14.91 GiB
+in 5.04 seconds. All requests complete without a new GPU Xid or cross-request
+state drift.
+
+That run emits 2,816 tokens with 2.9159 mean accepted length including the
+target token, 47.8972% draft-token acceptance, and 72.8972%, 50.2596%,
+38.5254%, and 29.9065% position acceptance. The ten warmed requests average
+78.98 pure decode tokens/s. Minimum host `MemAvailable` is 47.46 GiB, peak swap
+use is 8.03 GiB, and process exit restores roughly 115--120 GiB available with
+no vLLM worker left behind.
+
+Matched QSA index-sharing A/B/A did not expose an acceptance defect: sharing
+is 0.0359 accepted tokens better overall than recomputing indices. SGLang's
+causal-tail refresh candidate is also rejected because it loses 0.0322 accepted
+tokens and reduces decode speed. The retained natural-prompt control measures
+2.762 mean accepted length and 44.05% draft acceptance, inside the published
+NVFP4 range. Conditional acceptance after the first draft is roughly 70--74%,
+so the weakest event is the first proposal rather than accumulated MTP-step
+drift.
+
+The corrected no-thinking HumanEval8 artifact is
+`.artifacts/qwen4_exp_mtp_tp4_20260827/mtp4_transition16_v23_q38_moe_warmup_humaneval8_nothink_gpu0123.json`.
+It emits 797 tokens. Global MTP4 acceptance is 4.747 mean length and 93.676%
+draft acceptance, with 98.82%, 95.88%, 91.76%, and 88.24% by position.
+Excluding the cold first request gives 4.696 mean length, 92.407% draft
+acceptance, and 126.81 weighted pure decode tokens/s. The standard semantic
+policy preserves each task's imports and signature and passes 8/8 in the
+sandboxed executor. Minimum host `MemAvailable` is 48.08 GiB, peak swap use is
+7.98 GiB, and each GPU peaks at 32,179 MiB; the post-exit audit finds no
+persistent worker or host-memory leak.
+
+The exact TP4-local BF16 draft-MoE shape is
+`E=512, N=160, K=2560, topk=10`. An exact-shape SM70 tile of
+`BM=2, BN=128, BK=64, G=1`, four warps, and three stages reduces M5 from
+1492.500 to 283.853 microseconds (5.26x) and M1 from 425.789 to 272.415
+microseconds (1.56x), with bitwise-identical output. The route is bounded to
+Qwen3.8 TP4 and remains opt-in through
+`VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
+
+V2 needs one additional prefill specialization beyond its faithful M5/M1
+decode warmup. The real HumanEval prompt first runs the draft model at M152;
+existing M8 and M18 captures do not cover the sorted-assignment,
+`M * topk`-divisible-by-16 specialization. A fresh-cache V100 microtest records
+two new compilations and 526.97 ms at M152 without M16. Adding only M16 reduces
+M152 to zero new compilations and 4.51 ms. The final TP4 integration run logs
+KV-zero, M16, and M5/M1 warmup before request monitoring and has no first-
+request `fused_moe_kernel` JIT. Its artifact is
+`.artifacts/qwen4_exp_mtp_tp4_20260827/mtp4_transition19_v26_q38_v2_m16_moe_warmup_humaneval1_nothink_gpu0123.json`.
+It emits the same 173 token IDs as the earlier quality run, keeps 4.943 mean
+accepted length / 98.571% draft acceptance, and reaches 138.26 steady decode
+tokens/s.
+
+The accepted Nsight control still identifies target verification as the next
+MTP cost center: one 43.348-ms speculative round spends 30.040 ms in the
+five-token verifier, versus 2.733 ms in the first draft graph and 5.603 ms of
+critical GPU service in the remaining draft/sampling passes. Further MTP speed
+work should reduce verifier cost without trading away the now-validated
+acceptance or code quality. The separate no-MTP final target remains at least
+100 tokens/s; its last accepted control is 82.274 tokens/s.
 
 ## Acceptance gates
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42936,8 +42936,9 @@ Interpretation:
   M1-M16 plus M33/M257
   and explicitly covers legacy M1/M2/M9/M10 naive/aligned signatures; a fresh
   48-request run then produced no inference-time `fused_moe_kernel` JIT.
-  Unmatched shapes retain the old `(9,33,257)` warmup set, and the tuned route
-  requires `VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
+  Unmatched shapes retain the old `(9,33,257)` warmup set. The audited
+  exact-shape tuned route is now enabled by default and can be rolled back
+  with `VLLM_SM70_MTP_MOE_TUNED_CONFIG=0`.
 - Full-model evidence rejects the isolated M1 result. A physical-GPU4-7 C1
   candidate/control/candidate sandwich measured endpoint-mean summed pure
   decode `112.233` versus control `115.451 tok/s` (`-2.79%`) and endpoint-mean

--- a/tests/benchmarks/test_benchmark_sm70_decode.py
+++ b/tests/benchmarks/test_benchmark_sm70_decode.py
@@ -108,11 +108,16 @@ def test_spec_decoding_delta_reports_one_sequential_prompt():
 
 def test_sm70_policy_records_generic_mtp_moe_tuning(monkeypatch):
     monkeypatch.setenv("VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", "1")
-    monkeypatch.setenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0")
+    monkeypatch.delenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", raising=False)
 
     policy = benchmark_sm70_model_tokens._sm70_turbomind_policy()
 
     assert policy["VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG"] == "1"
-    assert policy["VLLM_SM70_MTP_MOE_TUNED_CONFIG"] == "0"
+    assert policy["VLLM_SM70_MTP_MOE_TUNED_CONFIG"] is None
+    assert policy["mtp_moe_tuned_config_effective"] is True
+    assert policy["qwen36_mtp_moe_tuned_config_effective"] is True
+
+    monkeypatch.setenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0")
+    policy = benchmark_sm70_model_tokens._sm70_turbomind_policy()
     assert policy["mtp_moe_tuned_config_effective"] is False
     assert policy["qwen36_mtp_moe_tuned_config_effective"] is False

--- a/tests/benchmarks/test_benchmark_sm70_decode.py
+++ b/tests/benchmarks/test_benchmark_sm70_decode.py
@@ -104,3 +104,15 @@ def test_spec_decoding_delta_reports_one_sequential_prompt():
     assert metrics["num_accepted_tokens"] == 7
     assert metrics["accepted_tokens_per_pos"] == [3, 2, 2]
     assert metrics["mean_acceptance_length"] == 2.75
+
+
+def test_sm70_policy_records_generic_mtp_moe_tuning(monkeypatch):
+    monkeypatch.setenv("VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", "1")
+    monkeypatch.setenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0")
+
+    policy = benchmark_sm70_model_tokens._sm70_turbomind_policy()
+
+    assert policy["VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG"] == "1"
+    assert policy["VLLM_SM70_MTP_MOE_TUNED_CONFIG"] == "0"
+    assert policy["mtp_moe_tuned_config_effective"] is False
+    assert policy["qwen36_mtp_moe_tuned_config_effective"] is False

--- a/tests/kernels/moe/test_sm70_unquantized_moe_config.py
+++ b/tests/kernels/moe/test_sm70_unquantized_moe_config.py
@@ -30,6 +30,16 @@ def test_mtp_sm70_decode_config_uses_exact_local_tile(m):
     assert config["BLOCK_SIZE_K"] == 32
 
 
+@pytest.mark.parametrize("m", [1, 5])
+def test_qwen38_mtp_sm70_decode_config_uses_exact_local_tile(m):
+    config = _get_sm70_mtp_moe_decode_config(m, 512, 160, 2560, 10)
+
+    assert config is not None
+    assert config["BLOCK_SIZE_M"] == 2
+    assert config["BLOCK_SIZE_N"] == 128
+    assert config["BLOCK_SIZE_K"] == 64
+
+
 @pytest.mark.parametrize(
     "shape",
     [
@@ -38,6 +48,11 @@ def test_mtp_sm70_decode_config_uses_exact_local_tile(m):
         (2, 256, 512, 2048, 8),
         (2, 256, 128, 4096, 8),
         (2, 256, 128, 2048, 4),
+        (2, 512, 160, 2560, 10),
+        (5, 256, 160, 2560, 10),
+        (5, 512, 128, 2560, 10),
+        (5, 512, 160, 2048, 10),
+        (5, 512, 160, 2560, 8),
     ],
 )
 def test_mtp_sm70_decode_config_is_shape_bounded(shape):

--- a/tests/models/qwen4_exp/test_weight_loading.py
+++ b/tests/models/qwen4_exp/test_weight_loading.py
@@ -13,7 +13,19 @@ from vllm.models.qwen4_exp.nvidia.model import (
     Qwen4ExpSparseMoeBlock,
     _remap_qsa_cache_scale_name,
 )
-from vllm.models.qwen4_exp.nvidia.mtp import _validate_mtp_expert_weights_loaded
+from vllm.models.qwen4_exp.nvidia.mtp import (
+    Qwen4ExpMTP,
+    _validate_mtp_expert_weights_loaded,
+)
+
+
+def test_mtp_loader_prefers_compact_bf16_checkpoint_shards() -> None:
+    assert Qwen4ExpMTP.allow_patterns_overrides == [
+        "model-bf16-*.safetensors",
+        "*.safetensors",
+        "*.bin",
+        "*.pt",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -127,13 +127,18 @@ def test_sm70_concurrency_tuning_envs(
     names = (
         "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING",
         "VLLM_SM70_TOPK_TOPP_8_WARPS",
-        "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
     )
     for name in names:
         monkeypatch.delenv(name, raising=False)
         assert environment_variables[name]() is False
         monkeypatch.setenv(name, "1")
         assert environment_variables[name]() is True
+
+    name = "VLLM_SM70_MTP_MOE_TUNED_CONFIG"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
 
     name = "VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS"
     monkeypatch.delenv(name, raising=False)

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -143,6 +143,46 @@ def test_sm70_mtp_moe_warmup_covers_opted_in_exact_tiles():
     ]
 
 
+def test_sm70_mtp_moe_warmup_covers_qwen38_exact_tiles():
+    dummy_run = mock.Mock()
+    draft_model_config = SimpleNamespace(
+        is_moe=True,
+        hf_text_config=SimpleNamespace(
+            num_experts_per_tok=10,
+            moe_intermediate_size=640,
+        ),
+        get_num_experts=lambda: 512,
+        get_hidden_size=lambda: 2560,
+    )
+    proposer = SimpleNamespace(
+        method="mtp",
+        device=torch.device("cuda"),
+        draft_model_config=draft_model_config,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(tensor_parallel_size=4)
+        ),
+        max_num_tokens=8192,
+        dummy_run=dummy_run,
+        _sm70_mtp_moe_warmed=False,
+    )
+
+    with (
+        mock.patch.object(current_platform, "is_device_capability", return_value=True),
+        mock.patch.object(torch.accelerator, "synchronize"),
+        mock.patch.object(envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", True),
+    ):
+        assert SpecDecodeBaseProposer.warmup_sm70_mtp_moe_kernels(proposer) == (
+            "mtp_draft_moe",
+        )
+
+    assert [call.args[0] for call in dummy_run.call_args_list] == [
+        *range(1, 6),
+        13,
+        52,
+        513,
+    ]
+
+
 def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:
     """Create an MTP proposer with unified model configuration."""
     model_config = ModelConfig(

--- a/tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py
@@ -3,10 +3,12 @@
 
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import torch
 
 from vllm.v1.worker.gpu import model_runner as mrv2
+from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 
 
 class FakeKVBlockZeroer:
@@ -84,4 +86,52 @@ def test_v2_clears_new_cache_blocks_before_zero_token_return() -> None:
         "apply",
         ("zero", [3, 7]),
         "no_forward",
+    ]
+
+
+def test_v2_warms_qwen38_mtp_moe_prefill_and_decode_shapes(monkeypatch) -> None:
+    zeroer = mock.Mock()
+    zeroer.warmup_kernel.return_value = True
+    draft_model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(
+            num_experts_per_tok=10,
+            moe_intermediate_size=640,
+        ),
+        get_num_experts=lambda: 512,
+        get_hidden_size=lambda: 2560,
+    )
+    speculator = EagleSpeculator.__new__(EagleSpeculator)
+    speculator.method = "mtp"
+    speculator.device = torch.device("cuda")
+    speculator.draft_model_config = draft_model_config
+    speculator.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(tensor_parallel_size=4)
+    )
+    speculator.max_num_tokens = 8192
+
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    runner._kv_block_zeroer = zeroer
+    runner.speculator = speculator
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
+    runner._dummy_run = mock.Mock()
+
+    with (
+        mock.patch.object(
+            mrv2.current_platform, "is_device_capability", return_value=True
+        ),
+        mock.patch(
+            "vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn."
+            "_warmup_sm70_qwen_gdn_causal_conv1d",
+            return_value=False,
+        ),
+        mock.patch.object(mrv2.envs, "VLLM_SM70_AUX_KERNEL_WARMUP", True),
+        mock.patch.object(mrv2.envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", True),
+        mock.patch.object(torch.accelerator, "synchronize"),
+    ):
+        runner._warmup_sm70_aux_kernels()
+
+    zeroer.warmup_kernel.assert_called_once_with()
+    assert runner._dummy_run.call_args_list == [
+        mock.call(16),
+        mock.call(1, uniform_decode=True),
     ]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -545,7 +545,7 @@ if TYPE_CHECKING:
     VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_DISABLE_QWEN3NEXT_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG: bool = True
-    VLLM_SM70_MTP_MOE_TUNED_CONFIG: bool = False
+    VLLM_SM70_MTP_MOE_TUNED_CONFIG: bool = True
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
@@ -3241,10 +3241,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG": lambda: bool(
         int(os.getenv("VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG", "1"))
     ),
-    # Opt-in decode tiles for the exact E256/N128/K2048/top-k8 SM70 contract.
-    # Larger or unmatched token shapes retain the 0.0.3 config.
+    # Default-on decode tiles for the audited exact-shape SM70 MTP contracts.
+    # Larger or unmatched token shapes retain the 0.0.3 config; setting this
+    # variable to zero is the explicit rollback.
     "VLLM_SM70_MTP_MOE_TUNED_CONFIG": lambda: bool(
-        int(os.getenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0"))
+        int(os.getenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "1"))
     ),
     # Legacy SM70 CUDA-graph capture-size tuning from 0.0.3. Default-off
     # because dense capture can increase startup/compile cost; when enabled on

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1223,23 +1223,37 @@ def _get_sm70_mtp_moe_decode_config(
     K: int,
     topk: int,
 ) -> dict[str, int] | None:
-    """Return the graph-tuned exact-shape SM70 MTP tile for M2-M16."""
+    """Return graph-tuned exact-shape SM70 MTP tiles."""
     if _force_sm70_mtp_moe_legacy_config or not envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG:
         return None
-    if (E, N, K, topk) != (256, 128, 2048, 8) or not 2 <= M <= 16:
-        return None
-
-    # TP4 shards the checkpoint-global I512 expert width to I128 per rank.
-    # M2-M16 all select this tile in the exact local-shape graph oracle.
-    return {
-        "BLOCK_SIZE_M": 8,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "SPLIT_K": 1,
-        "num_warps": 4,
-        "num_stages": 3,
-    }
+    if (E, N, K, topk) == (256, 128, 2048, 8) and 2 <= M <= 16:
+        # Qwen3.6 TP4 shards the checkpoint-global I512 expert width to I128
+        # per rank. M2-M16 all select this tile in the exact local-shape graph
+        # oracle.
+        return {
+            "BLOCK_SIZE_M": 8,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 1,
+            "SPLIT_K": 1,
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+    if (E, N, K, topk) == (512, 160, 2560, 10) and M in (1, 5):
+        # Qwen3.8-Flash-Next TP4 keeps the BF16 MTP expert weights and shards
+        # the checkpoint-global I640 expert width to I160 per rank. M5 is the
+        # first proposer pass over the verifier window; M1 covers its three
+        # autoregressive continuation passes.
+        return {
+            "BLOCK_SIZE_M": 2,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 1,
+            "SPLIT_K": 1,
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+    return None
 
 
 def get_default_config(

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -388,6 +388,18 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
     }
 )
 class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
+    # Qwen4Exp repacks the small BF16/shared/MTP tensors separately from the
+    # target experts and PLE tables. Loading the standalone drafter from that
+    # compact shard set avoids scanning the full target checkpoint a second
+    # time. The remaining patterns preserve compatibility with conventional
+    # Hugging Face checkpoint layouts.
+    allow_patterns_overrides = [
+        "model-bf16-*.safetensors",
+        "*.safetensors",
+        "*.bin",
+        "*.pt",
+    ]
+
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1055,7 +1055,7 @@ class SpecDecodeBaseProposer:
         top_k = int(getattr(text_config, "num_experts_per_tok", 0))
         num_experts = self.draft_model_config.get_num_experts()
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        use_mtp_decode_tiles = (
+        use_qwen36_mtp_decode_tiles = (
             envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG
             and num_experts == 256
             and top_k == 8
@@ -1063,13 +1063,28 @@ class SpecDecodeBaseProposer:
             and int(getattr(text_config, "moe_intermediate_size", 0)) == 512
             and tp_size == 4
         )
+        use_qwen38_mtp_decode_tiles = (
+            envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG
+            and num_experts == 512
+            and top_k == 10
+            and self.draft_model_config.get_hidden_size() == 2560
+            and int(getattr(text_config, "moe_intermediate_size", 0)) == 640
+            and tp_size == 4
+        )
+        decode_tile_max_tokens = (
+            16
+            if use_qwen36_mtp_decode_tiles
+            else 5
+            if use_qwen38_mtp_decode_tiles
+            else 0
+        )
         sizes = _sm70_mtp_moe_warmup_sizes(
             num_experts,
             top_k,
             self.max_num_tokens,
-            decode_tile_max_tokens=16 if use_mtp_decode_tiles else 0,
+            decode_tile_max_tokens=decode_tile_max_tokens,
         )
-        legacy_sizes = (1, 2, 9, 10) if use_mtp_decode_tiles else ()
+        legacy_sizes = (1, 2, 9, 10) if use_qwen36_mtp_decode_tiles else ()
         if not sizes:
             return ()
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -27,6 +27,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
@@ -553,6 +554,27 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.compilation_config.static_forward_context
         ):
             logger.info_once("SM70 MRV2 GDN causal-conv warmup finished.")
+
+        if (
+            not envs.VLLM_SM70_AUX_KERNEL_WARMUP
+            or not current_platform.is_device_capability(70)
+        ):
+            return
+
+        warmed: list[str] = []
+        if hasattr(self, "_kv_block_zeroer") and self._kv_block_zeroer.warmup_kernel():
+            warmed.append("zero_kv_blocks")
+
+        speculator_warmup = getattr(
+            self.speculator, "warmup_sm70_mtp_moe_kernels", None
+        )
+        if speculator_warmup is not None:
+            warmed.extend(speculator_warmup(self._dummy_run))
+
+        if warmed:
+            logger.info_once(
+                "SM70 V2 auxiliary kernel warmup finished: %s", tuple(warmed)
+            )
 
     @torch.inference_mode()
     @step_eplb_after(is_dummy=True)

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import SpeculativeConfig, VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import (
@@ -197,6 +200,52 @@ class EagleSpeculator:
             active_layer_names=self.draft_attn_layer_names,
         )
         self.block_tables = block_tables
+
+    def warmup_sm70_mtp_moe_kernels(
+        self, dummy_run: Callable[..., Any]
+    ) -> tuple[str, ...]:
+        """Warm the finite Qwen3.8 MTP-MoE prefill and decode signatures."""
+        if (
+            self.method != "mtp"
+            or self.device.type != "cuda"
+            or not current_platform.is_device_capability(70)
+            or not envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG
+        ):
+            return ()
+        if getattr(self, "_sm70_mtp_moe_warmed", False):
+            return ()
+
+        text_config = self.draft_model_config.hf_text_config
+        if not (
+            self.draft_model_config.get_num_experts() == 512
+            and int(getattr(text_config, "num_experts_per_tok", 0)) == 10
+            and self.draft_model_config.get_hidden_size() == 2560
+            and int(getattr(text_config, "moe_intermediate_size", 0)) == 640
+            and self.vllm_config.parallel_config.tensor_parallel_size == 4
+        ):
+            return ()
+        self._sm70_mtp_moe_warmed = True
+
+        warmed: list[str] = []
+        try:
+            if self.max_num_tokens >= 16:
+                # M16 is the smallest sorted-assignment shape with
+                # M * topk divisible by 16. It covers the Triton
+                # specialization used by longer aligned prompt prefills such
+                # as the 152-token HumanEval request; M18 graph capture covers
+                # only the non-divisible specialization.
+                dummy_run(16)
+                warmed.append("mtp_draft_moe_prefill_m16")
+
+            # One real decode-shaped round executes the M5 verifier window
+            # followed by all three M1 continuation passes.
+            dummy_run(1, uniform_decode=True)
+            torch.accelerator.synchronize()
+            warmed.append("mtp_draft_moe_decode_m5_m1")
+        except Exception as err:  # pragma: no cover - best-effort warmup
+            logger.warning_once("SM70 V2 MTP MoE warmup skipped: %s", err)
+            return ()
+        return tuple(warmed)
 
     @torch.inference_mode()
     def run_model(


### PR DESCRIPTION
## Purpose\n\n- Load the standalone Qwen3.8 MTP drafter from the four compact BF16 shards instead of rescanning all 206 target shards.\n- Add the exact TP4-local SM70 MTP-MoE tile for the audited M5/M1 proposal shapes while preserving the existing Qwen3.6 route.\n- Warm the V2 M16 sorted-assignment specialization and one faithful M5/M1 decode round before first-request monitoring.\n- Keep runtime dispatch generic and exact-shape bounded. The audited route is enabled by default; VLLM_SM70_MTP_MOE_TUNED_CONFIG=0 is the explicit rollback.\n- Record the generic MTP tuning policy and accepted TP4/MTP4 quality, performance, verifier-cost, and memory evidence.\n\n## Test Plan\n\n- pytest -q tests/kernels/moe/test_sm70_unquantized_moe_config.py tests/models/qwen4_exp/test_weight_loading.py tests/v1/spec_decode/test_mtp.py tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py\n- pytest -q tests/benchmarks/test_benchmark_sm70_decode.py\n- pytest -q tests/test_envs.py\n- Ruff check and format check on every changed Python file.\n- markdownlint-cli2 on the Qwen3.8 SM70 design record.\n- typos and git diff --check.\n- One TP4/V2/MTP4 full-model cold-JIT gate after the exact-shape microbenchmark localized the missing specialization.\n\n## Test Result\n\n- Original focused tests: 65 passed; benchmark policy tests: 5 passed.\n- Final integrated source audit: 126 focused tests passed.\n- Ruff, format, markdownlint, typos, diff checks, DCO, and GitHub pre-commit pass.\n- Eleven-request transition run: all 11 complete with no Xid or state drift; mean accepted length 2.9159, draft acceptance 47.8972%, warmed pure decode 78.98 tok/s.\n- No-thinking HumanEval8: 8/8 standard semantic executions pass; mean accepted length 4.747, draft acceptance 93.676%, warmed pure decode 126.81 tok/s.\n- Exact MTP-MoE microbenchmark: M5 1492.500 -> 283.853 us (5.26x), M1 425.789 -> 272.415 us (1.56x), bitwise exact.\n- Final V2 cold-JIT gate: no first-request fused_moe_kernel compilation; 173 output token IDs remain identical, mean accepted length 4.943, draft acceptance 98.571%, steady decode 138.26 tok/s.\n- Memory: accepted runs bottom at 47.46-48.08 GiB host MemAvailable in solo multi-request gates; the final overlapped gate bottoms at 39.68 GiB. Every run exits without a residual worker or GPU allocation. Compact MTP load is four shards / 14.91 GiB instead of a second 206-shard scan.\n- Nsight control: target verification consumes 30.040 ms of a 43.348-ms speculative round, so verifier cost is the next MTP optimization target.\n- Scope note: MTP-assisted throughput above 100 tok/s does not satisfy the separate no-MTP target. The accepted no-MTP control remains 82.274 tok/s.\n\n## Risk and rollback\n\n- Dispatch is bounded by SM70, TP4, dtype/backend eligibility, and exact local MoE shapes; unmatched shapes retain the existing fallback.\n- Set VLLM_SM70_MTP_MOE_TUNED_CONFIG=0 to restore the previous default immediately.\n- The default-on repair was reviewed and merged through #391.\n\n## Upstream references\n\n- vLLM Qwen3.8 support: https://github.com/vllm-project/vllm/pull/53896\n- SGLang Qwen3.8 support: https://github.com/sgl-project/sglang/pull/36497