### PR TITLE
[Kernel][SM70] Avoid NVFP4 MoE prefill input expansion

### DIFF
--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -1197,6 +1197,9 @@ def _sm70_moe_policy() -> dict[str, Any]:
     add_allreduce = _env_bool("VLLM_SM70_MOE_ADD_ALLREDUCE", False)
     qwen38_router_topk = _env_bool("VLLM_SM70_QWEN38_ROUTER_TOPK", True)
     qwen38_nvfp4_qpn_m1 = _env_bool("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", True)
+    qwen38_nvfp4_indexed_prefill = _env_bool(
+        "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", True
+    )
     single_token_fastpath = _env_bool("VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH", False)
     single_token_permute = _env_bool(
         "VLLM_SM70_MOE_SINGLE_TOKEN_PERMUTE_FASTPATH", False
@@ -1234,6 +1237,10 @@ def _sm70_moe_policy() -> dict[str, Any]:
             "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE"
         ),
         "qwen38_nvfp4_qpn_m1_effective": qwen38_nvfp4_qpn_m1,
+        "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL": os.environ.get(
+            "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL"
+        ),
+        "qwen38_nvfp4_indexed_prefill_effective": (qwen38_nvfp4_indexed_prefill),
         "VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH": os.environ.get(
             "VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH"
         ),
@@ -1282,6 +1289,7 @@ def _sm70_moe_policy() -> dict[str, Any]:
         "expected_default": False,
         "qwen38_router_topk_expected_default": True,
         "qwen38_nvfp4_qpn_m1_expected_default": True,
+        "qwen38_nvfp4_indexed_prefill_expected_default": True,
         "single_token_unpermute_expected_default": True,
         "route_hit_oracle": (
             "The exact Qwen3.8 E512/K10 lane requires "
@@ -1290,6 +1298,9 @@ def _sm70_moe_policy() -> dict[str, Any]:
             "The accepted routed-expert lane additionally requires "
             "qwen38_nvfp4_qpn_m1_effective=true and the `SM70 Qwen3.8 "
             "NVFP4 direct QPN-M1 expert path enabled` marker. "
+            "Long exact TP4 prefill additionally requires "
+            "qwen38_nvfp4_indexed_prefill_effective=true and the `SM70 "
+            "Qwen3.8 NVFP4 indexed-A W13 prefill route enabled` marker. "
             "For CUDA-graph fast-path acceptance, require the C++ trace "
             "`SM70 custom all_reduce_sum2 op reached ... capture=active`; "
             "the Python MoERunner candidate log alone is not a custom-op hit. "

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -51,7 +51,9 @@ void moe_permute_impl(
     const std::optional<torch::Tensor>& maybe_sort_workspace,
     const std::optional<torch::Tensor>& maybe_permuted_experts_id,
     const std::optional<torch::Tensor>& maybe_sorted_row_idx,
-    const std::optional<torch::Tensor>& maybe_topk_ids_for_sort) {
+    const std::optional<torch::Tensor>& maybe_topk_ids_for_sort,
+    const std::optional<torch::Tensor>& maybe_input_row_indices =
+        std::nullopt) {
   TORCH_CHECK(expert_first_token_offset.scalar_type() == at::ScalarType::Long,
               "expert_first_token_offset must be int64");
   TORCH_CHECK(topk_ids.scalar_type() == at::ScalarType::Int,
@@ -70,7 +72,9 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
+  const bool metadata_only = maybe_input_row_indices.has_value();
+  if (!metadata_only &&
+      canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
                                           n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
@@ -134,13 +138,24 @@ void moe_permute_impl(
       get_ptr<int64_t>(expert_first_token_offset), n_token, n_expert,
       n_local_expert, topk, sorter, get_ptr<int>(sort_workspace), stream);
 
-  MOE_DISPATCH(input.scalar_type(), [&] {
-    expandInputRowsKernelLauncher<scalar_t>(
-        get_ptr<scalar_t>(input), get_ptr<scalar_t>(permuted_input),
+  if (metadata_only) {
+    auto input_row_indices =
+        maybe_allocate_tensor(maybe_input_row_indices, inv_permuted_idx.sizes(),
+                              at::ScalarType::Int, device, "input_row_indices");
+    buildMoePermuteMetadataLauncher(
         get_ptr<int>(sorted_row_idx), get_ptr<int>(inv_permuted_idx),
-        get_ptr<int>(permuted_idx), get_ptr<int64_t>(expert_first_token_offset),
-        n_token, valid_num_ptr, n_hidden, topk, n_local_expert, stream);
-  });
+        get_ptr<int>(permuted_idx), get_ptr<int>(input_row_indices),
+        expanded_rows, valid_num_ptr, static_cast<int>(topk), stream);
+  } else {
+    MOE_DISPATCH(input.scalar_type(), [&] {
+      expandInputRowsKernelLauncher<scalar_t>(
+          get_ptr<scalar_t>(input), get_ptr<scalar_t>(permuted_input),
+          get_ptr<int>(sorted_row_idx), get_ptr<int>(inv_permuted_idx),
+          get_ptr<int>(permuted_idx),
+          get_ptr<int64_t>(expert_first_token_offset), n_token, valid_num_ptr,
+          n_hidden, topk, n_local_expert, stream);
+    });
+  }
 }
 
 void moe_permute(
@@ -173,6 +188,23 @@ void moe_permute_with_scratch(
                    expert_first_token_offset, inv_permuted_idx, permuted_idx,
                    sort_workspace, permuted_experts_id, sorted_row_idx,
                    topk_ids_for_sort);
+}
+
+void moe_permute_metadata_with_scratch(
+    const torch::Tensor& input, const torch::Tensor& topk_ids,
+    const torch::Tensor& token_expert_indices,
+    const std::optional<torch::Tensor>& expert_map, int64_t n_expert,
+    int64_t n_local_expert, int64_t topk,
+    torch::Tensor& expert_first_token_offset, torch::Tensor& inv_permuted_idx,
+    torch::Tensor& permuted_idx, torch::Tensor& input_row_indices,
+    torch::Tensor& sort_workspace, torch::Tensor& permuted_experts_id,
+    torch::Tensor& sorted_row_idx, torch::Tensor& topk_ids_for_sort) {
+  auto unused_permuted_input = input;
+  moe_permute_impl(input, topk_ids, token_expert_indices, expert_map, n_expert,
+                   n_local_expert, topk, unused_permuted_input,
+                   expert_first_token_offset, inv_permuted_idx, permuted_idx,
+                   sort_workspace, permuted_experts_id, sorted_row_idx,
+                   topk_ids_for_sort, input_row_indices);
 }
 
 void moe_unpermute(
@@ -318,6 +350,20 @@ void moe_permute_with_scratch(
               "moe_permute_with_scratch is not supported on CUDA < 12.0");
 }
 
+void moe_permute_metadata_with_scratch(
+    const torch::Tensor& input, const torch::Tensor& topk_ids,
+    const torch::Tensor& token_expert_indices,
+    const std::optional<torch::Tensor>& expert_map, int64_t n_expert,
+    int64_t n_local_expert, int64_t topk,
+    torch::Tensor& expert_first_token_offset, torch::Tensor& inv_permuted_idx,
+    torch::Tensor& permuted_idx, torch::Tensor& input_row_indices,
+    torch::Tensor& sort_workspace, torch::Tensor& permuted_experts_id,
+    torch::Tensor& sorted_row_idx, torch::Tensor& topk_ids_for_sort) {
+  TORCH_CHECK(
+      false,
+      "moe_permute_metadata_with_scratch is not supported on CUDA < 12.0");
+}
+
 void moe_unpermute(
     const torch::Tensor& permuted_hidden_states,
     const torch::Tensor& topk_weights, const torch::Tensor& inv_permuted_idx,
@@ -339,5 +385,7 @@ bool moe_permute_unpermute_supported() {
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("moe_permute", &moe_permute);
   m.impl("moe_permute_with_scratch", &moe_permute_with_scratch);
+  m.impl("moe_permute_metadata_with_scratch",
+         &moe_permute_metadata_with_scratch);
   m.impl("moe_unpermute", &moe_unpermute);
 }

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
@@ -92,6 +92,28 @@ bool singleTokenUnpermuteFastPathEnabled() {
   return enabled;
 }
 
+template <bool CHECK_SKIPPED>
+__global__ void buildMoePermuteMetadataKernel(
+    int const* expanded_dest_row_to_expanded_source_row,
+    int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
+    int* input_row_indices, int64_t num_expanded_rows,
+    int64_t const* num_valid_tokens_ptr, int topk) {
+  const int64_t expanded_dest_row =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (expanded_dest_row >= num_expanded_rows) {
+    return;
+  }
+
+  const int expanded_source_row =
+      __ldg(expanded_dest_row_to_expanded_source_row + expanded_dest_row);
+  expanded_source_row_to_expanded_dest_row[expanded_source_row] =
+      static_cast<int>(expanded_dest_row);
+  if (!CHECK_SKIPPED || expanded_dest_row < *num_valid_tokens_ptr) {
+    permuted_idx[expanded_dest_row] = expanded_source_row;
+    input_row_indices[expanded_dest_row] = expanded_source_row / topk;
+  }
+}
+
 template <typename T>
 __global__ void singleTokenMoePermuteKernel(T const* input, int const* topk_ids,
                                             T* permuted_output,
@@ -207,6 +229,27 @@ __global__ void singleTokenMoeUnpermuteKernel(
 }
 
 }  // namespace
+
+void buildMoePermuteMetadataLauncher(
+    int const* expanded_dest_row_to_expanded_source_row,
+    int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
+    int* input_row_indices, int64_t num_expanded_rows,
+    int64_t const* num_valid_tokens_ptr, int topk, cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks =
+      static_cast<int>((num_expanded_rows + kThreads - 1) / kThreads);
+  if (num_valid_tokens_ptr == nullptr) {
+    buildMoePermuteMetadataKernel<false><<<blocks, kThreads, 0, stream>>>(
+        expanded_dest_row_to_expanded_source_row,
+        expanded_source_row_to_expanded_dest_row, permuted_idx,
+        input_row_indices, num_expanded_rows, nullptr, topk);
+  } else {
+    buildMoePermuteMetadataKernel<true><<<blocks, kThreads, 0, stream>>>(
+        expanded_dest_row_to_expanded_source_row,
+        expanded_source_row_to_expanded_dest_row, permuted_idx,
+        input_row_indices, num_expanded_rows, num_valid_tokens_ptr, topk);
+  }
+}
 
 bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
                                          bool has_expert_map, int64_t n_expert,

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -64,6 +64,12 @@ void expandInputRowsKernelLauncher(
     int64_t const* num_valid_tokens_ptr, int64_t const cols, int const k,
     int num_local_experts, cudaStream_t stream);
 
+void buildMoePermuteMetadataLauncher(
+    int const* expanded_dest_row_to_expanded_source_row,
+    int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
+    int* input_row_indices, int64_t num_expanded_rows,
+    int64_t const* num_valid_tokens_ptr, int topk, cudaStream_t stream);
+
 template <class T, class OutputType>
 void finalizeMoeRoutingKernelLauncher(
     T const* expanded_permuted_rows, OutputType* reduced_unpermuted_output,

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -110,6 +110,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "Tensor! sorted_row_idx, Tensor! topk_ids_for_sort)->()");
 
   m.def(
+      "moe_permute_metadata_with_scratch(Tensor input, Tensor topk_ids,"
+      "Tensor token_expert_indices, Tensor? expert_map, int n_expert,"
+      "int n_local_expert, int topk, Tensor! expert_first_token_offset, "
+      "Tensor! inv_permuted_idx, Tensor! permuted_idx, Tensor! "
+      "input_row_indices, Tensor! sort_workspace, Tensor! "
+      "permuted_experts_id, Tensor! sorted_row_idx, Tensor! "
+      "topk_ids_for_sort)->()");
+
+  m.def(
       "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
       "Tensor inv_permuted_idx, Tensor? expert_first_token_offset, "
       "int topk, Tensor! hidden_states)->()");

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -520,6 +520,12 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     int64_t num_experts, int64_t k, int64_t n,
                                     int64_t group_size);
 
+void nvfp4_moe_indexed_dense_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size);
+
 void mxfp4_moe_single_token_prepare_w13_sm70_out(
     torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
     torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8682,7 +8682,9 @@ void nvfp4_moe_gemm_sm70_out_impl(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    torch::Tensor b_group_indices, bool compact_grouped_rows = false) {
+    torch::Tensor b_group_indices, bool compact_grouped_rows = false,
+    int64_t logical_total_tokens = -1,
+    torch::Tensor a_indices = torch::Tensor()) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "nvfp4_moe_gemm_sm70: input must be CUDA float16.");
@@ -8703,9 +8705,6 @@ void nvfp4_moe_gemm_sm70_out_impl(
               "nvfp4_moe_gemm_sm70: k must be divisible by group_size.");
   TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
               "nvfp4_moe_gemm_sm70: input shape mismatch.");
-  TORCH_CHECK(out.dim() == 2 && out.size(0) == sorted_input.size(0) &&
-                  out.size(1) == n && out.stride(1) == 1,
-              "nvfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
               "nvfp4_moe_gemm_sm70: expert_offsets too small.");
   TORCH_CHECK(b_group_indices.is_cuda() &&
@@ -8715,7 +8714,28 @@ void nvfp4_moe_gemm_sm70_out_impl(
               "nvfp4_moe_gemm_sm70: B group indices must be contiguous CUDA "
               "int32.");
 
-  const int64_t total_tokens = sorted_input.size(0);
+  const int64_t input_tokens = sorted_input.size(0);
+  const int64_t total_tokens =
+      logical_total_tokens > 0 ? logical_total_tokens : input_tokens;
+  const bool use_a_indices = a_indices.defined() && a_indices.numel() > 0;
+  torch::Tensor a_indices_flat = a_indices;
+  if (use_a_indices) {
+    TORCH_CHECK(a_indices.is_cuda() &&
+                    a_indices.scalar_type() == torch::kInt32 &&
+                    a_indices.is_contiguous(),
+                "nvfp4_moe_gemm_sm70: A row indices must be contiguous CUDA "
+                "int32.");
+    a_indices_flat = a_indices.view({-1});
+    TORCH_CHECK(a_indices_flat.numel() >= total_tokens,
+                "nvfp4_moe_gemm_sm70: A row indices size mismatch.");
+  } else {
+    TORCH_CHECK(input_tokens == total_tokens,
+                "nvfp4_moe_gemm_sm70: non-indexed input rows must match "
+                "logical rows.");
+  }
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == total_tokens &&
+                  out.size(1) == n && out.stride(1) == 1,
+              "nvfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
   if (total_tokens == 0) {
     return;
   }
@@ -8742,6 +8762,7 @@ void nvfp4_moe_gemm_sm70_out_impl(
   };
   desc_A.num = static_cast<int>(num_experts);
   desc_A.offsets = expert_offsets.data_ptr<int>();
+  desc_A.idxs = use_a_indices ? a_indices_flat.data_ptr<int>() : nullptr;
   turbomind::gemm::MatrixLayout desc_U{};
 
   const auto order_w = conv_w->order;
@@ -8826,6 +8847,43 @@ void nvfp4_moe_gemm_sm70_out_impl(
   TORCH_CHECK(ec == 0,
               "nvfp4_moe_gemm_sm70: TurboMind batched GEMM failed (ec=", ec,
               ").");
+}
+
+void nvfp4_moe_indexed_dense_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size) {
+  constexpr int kQwen38TopK = 10;
+  TORCH_CHECK(input.dim() == 2 && input.size(0) > 0 && input.size(1) == 2560 &&
+                  input.scalar_type() == torch::kFloat16 && input.is_cuda(),
+              "nvfp4_moe_indexed_dense_stage_sm70_out: exact Qwen3.8 CUDA "
+              "FP16 [tokens, 2560] input is required.");
+  TORCH_CHECK(num_experts == 512 && k == 2560 && n == 320 && group_size == 16,
+              "nvfp4_moe_indexed_dense_stage_sm70_out: exact Qwen3.8 TP4 W13 "
+              "contract is required.");
+  TORCH_CHECK(input_row_indices.is_cuda() &&
+                  input_row_indices.scalar_type() == torch::kInt32 &&
+                  input_row_indices.is_contiguous() &&
+                  input_row_indices.numel() == input.size(0) * kQwen38TopK,
+              "nvfp4_moe_indexed_dense_stage_sm70_out: input row indices must "
+              "contain exactly tokens*10 contiguous CUDA int32 entries.");
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == input_row_indices.numel() &&
+                  out.size(1) == n,
+              "nvfp4_moe_indexed_dense_stage_sm70_out: output shape mismatch.");
+  TORCH_CHECK(vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled(),
+              "nvfp4_moe_indexed_dense_stage_sm70_out requires grouped "
+              "prefill dispatch.");
+
+  static std::atomic<unsigned> logged_nvfp4_indexed_prefill{0u};
+  maybe_log_sm70_moe_route_once(
+      logged_nvfp4_indexed_prefill,
+      "SM70 Qwen3.8 NVFP4 MoE indexed-A W13 prefill path enabled C++ op "
+      "reached",
+      input, input_row_indices.numel(), num_experts);
+  nvfp4_moe_gemm_sm70_out_impl(
+      out, input, expert_offsets, ptrs_w, ptrs_s, num_experts, k, n, group_size,
+      dense_expert_ids, false, input_row_indices.numel(), input_row_indices);
 }
 
 void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -692,6 +692,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &nvfp4_moe_dense_stage_sm70_out);
 
   ops.def(
+      "nvfp4_moe_indexed_dense_stage_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
+      "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "
+      "Tensor ptrs_s, int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("nvfp4_moe_indexed_dense_stage_sm70_out", torch::kCUDA,
+           &nvfp4_moe_indexed_dense_stage_sm70_out);
+
+  ops.def(
       "mxfp4_moe_single_token_prepare_w13_sm70_out("
       "Tensor(a!) gate_up, Tensor(b!) compact_input, Tensor x, "
       "Tensor topk_ids, Tensor w13_ptrs_w, Tensor w13_ptrs_s, "

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44372,3 +44372,57 @@ Interpretation:
   non-reversible scales retain the ordinary TurboMind transform; explicit
   incompatible opt-in fails closed. `VLLM_SM70_FP8_PRESCALED_M1_SHARED_GATE=0`
   is the rollback.
+
+## 2026-08-28 Qwen3.8 NVFP4 indexed-A prefill audit
+
+- Public Draft PR #390 is stacked on grouped-QSA PR #387. The retained clean
+  #387 trace showed that the copied routed-MoE input alone cost about
+  `1.488 ms/layer/rank`, while the NVFP4 W13 and W2 grouped GEMMs remained the
+  largest combined post-QSA service category. This follow-up changes only the
+  exact Qwen3.8 TP4 `E512/K10`, `K2560/N320` W13 prefill route; decode, W2,
+  routing order, expert offsets, activation, and weighted unpermute are
+  unchanged.
+- The metadata-only permute keeps the same CUB stable expert sort, inverse map,
+  permuted map, and expert offsets. A 256-thread kernel derives the original
+  token row for each sorted route instead of launching one 256-thread CTA per
+  route to copy 2,560 FP16 values. TurboMind consumes those rows through its
+  existing SM70 `MatrixLayout.idxs` iterator. The materialized
+  `[tokens * 10, 2560]` allocation is omitted for the admitted route.
+- One locked V100 operator screen, using production dimensions and physically
+  distinct repeated real layer-0 packed weights, passes exact metadata and
+  output checks at 128, 512, 2,048, and 8,192 input tokens. At 8,192 tokens:
+    - sort plus materialization moves from `1.578496 ms` to metadata-only
+      `0.095232 ms` (`16.58x`);
+    - contiguous W13 moves from `4.409344 ms` to indexed W13 `4.184064 ms`;
+    - the complete sort/metadata plus W13 chain moves from `6.026752 ms` to
+      `4.235264 ms` (`1.423x`, `1.791488 ms/layer/rank` saved);
+    - expert offsets, inverse maps, permuted maps, sorted rows, and sorted
+      expert IDs are elementwise equal; indexed rows reproduce the expanded
+      input bitwise and W13 output is bitwise equal.
+- Incremental SM70 builds of `_C` and `_moe_C` pass and both new schemas import
+  in the production Python 3.12/Torch 2.10/CUDA 12.8 environment. The focused
+  admission suite passes `15 passed, 5 skipped`; ruff and repository
+  clang-format hooks pass.
+- A single model startup then completes the same TP4 V2, no-MTP, 8,192-token
+  chunk, QSA-page4 endpoint matrix used by #387. Runtime logs hit both
+  `SM70 Qwen3.8 NVFP4 indexed-A W13 prefill route enabled` and grouped QSA.
+  Pure-prefill results are:
+    - 32K: `5.4625646 -> 5.0357304 s`,
+      `5,998.65 -> 6,507.10 token/s` (`+8.47%`);
+    - 64K: `11.3434579 -> 10.5000728 s`,
+      `5,777.43 -> 6,241.48 token/s` (`+8.03%`);
+    - 131K: `24.0326333 -> 22.3112715 s`,
+      `5,450.92 -> 5,871.47 token/s` (`+7.71%`);
+    - 8K: `1.2810527 -> 1.1751880 s`,
+      `6,394.74 -> 6,970.80 token/s` (`+9.01%`).
+- Arithmetic text/hash, Chinese text/hash, and every retained long-context
+  token hash exactly match #387. The route therefore defaults on from 128
+  tokens under the exact contract. `VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL=0`
+  is the rollback. An implicitly enabled route falls back when paired with an
+  older extension; explicit `=1` fails closed if either new operator is
+  missing.
+- This clears 6K at 32K and 64K. The 131K result is still about 2.19% below
+  6K. Using the retained trace plus the measured indexed W13 time, W13 and W2
+  are still projected near 26% of 8K per-rank service, so the next bounded
+  screen remains the NVFP4 grouped-GEMM scheduler/register-pressure path, not
+  another model startup or a return to QSA launch tuning.

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
     _prepare_compact_slot_groups,
     _prepare_single_token_slots,
     _single_token_weighted_reduce,
+    _use_qwen38_indexed_prefill,
     _use_qwen38_qpn_m1_decode,
     _validate_weight_layout,
     validate_nvfp4_sm70_moe_contract,
@@ -142,6 +143,32 @@ def test_qwen38_qpn_m1_decode_is_default_on_and_exact_shape_only(monkeypatch):
 
     layer.moe_config.tp_size = 2
     assert not _use_qwen38_qpn_m1_decode(layer, x, topk_ids)
+
+
+def test_qwen38_indexed_prefill_is_default_on_and_exact_shape_only(monkeypatch):
+    layer = SimpleNamespace(
+        moe_config=_qwen4_moe_contract(),
+        sm70_nvfp4_num_experts=512,
+        sm70_nvfp4_hidden_size=2560,
+        sm70_nvfp4_intermediate_size=160,
+        sm70_nvfp4_top_k=10,
+    )
+    x = torch.empty(128, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(128, 10, dtype=torch.int32)
+
+    monkeypatch.delenv("VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", raising=False)
+    assert _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", "0")
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", "1")
+    assert _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    assert not _use_qwen38_indexed_prefill(layer, x[:127], topk_ids[:127])
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids[:, :9])
+
+    layer.moe_config.tp_size = 2
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
 
 
 def test_nvfp4_moe_contract_rejects_shape_consistent_unvalidated_tp8():

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -1470,6 +1470,53 @@ if hasattr(torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"):
         return None
 
 
+def nvfp4_moe_indexed_dense_stage_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    input_row_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("nvfp4_moe_indexed_dense_stage_sm70_out")(
+        out,
+        input,
+        input_row_indices,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_indexed_dense_stage_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_indexed_dense_stage_sm70_out")
+    def _nvfp4_moe_indexed_dense_stage_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        input_row_indices: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def mxfp4_moe_single_token_prepare_w13_sm70_out(
     gate_up: torch.Tensor,
     compact_input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -181,6 +181,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL: bool = True
     VLLM_SM70_NVFP4_QPN_M1_LIBRARY: str | None = None
     VLLM_SM70_QWEN38_ROUTER_TOPK: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
@@ -1839,6 +1840,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # reached 82.274 tokens/s with unchanged arithmetic and Chinese hashes.
     "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", "1"))
+    ),
+    # Exact TP4 Qwen3.8 W13 prefill route. It retains the stable expert sort
+    # and unpermute maps but reads original token rows through TurboMind's
+    # indexed-A iterator instead of materializing top-k replicated FP16 rows.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", "1"))
     ),
     "VLLM_SM70_NVFP4_QPN_M1_LIBRARY": lambda: os.getenv(
         "VLLM_SM70_NVFP4_QPN_M1_LIBRARY"

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -10,6 +10,7 @@ expert-weight copy.
 
 from __future__ import annotations
 
+import os
 from typing import Final
 
 import torch
@@ -51,6 +52,7 @@ _COMPACT_GROUPED_MAX_TOKENS: Final = 10
 _MAX_SUPPORTED_TOP_K: Final = max(contract[3] for contract in _SUPPORTED_CONTRACTS)
 _QWEN38_QPN_M1_W13_SPLIT_K: Final = 8
 _QWEN38_QPN_M1_W2_SPLIT_K: Final = 1
+_QWEN38_INDEXED_PREFILL_MIN_TOKENS: Final = 128
 
 
 def _use_qwen38_qpn_m1_decode(
@@ -67,6 +69,33 @@ def _use_qwen38_qpn_m1_decode(
         and topk_ids.shape == (1, 10)
         and topk_ids.dtype == torch.int32
         and topk_ids.is_contiguous()
+        and int(layer.moe_config.tp_size) == 4
+        and int(layer.sm70_nvfp4_num_experts) == 512
+        and int(layer.sm70_nvfp4_hidden_size) == 2560
+        and int(layer.sm70_nvfp4_intermediate_size) == 160
+        and int(layer.sm70_nvfp4_top_k) == 10
+    )
+
+
+def _use_qwen38_indexed_prefill(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit only long exact Qwen3.8 TP4 W13 prefill batches."""
+    return bool(
+        getattr(
+            layer,
+            "sm70_nvfp4_qwen38_indexed_prefill",
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL,
+        )
+        and envs.VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL
+        and x.ndim == 2
+        and x.shape[0] >= _QWEN38_INDEXED_PREFILL_MIN_TOKENS
+        and x.shape[1] == 2560
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (x.shape[0], 10)
         and int(layer.moe_config.tp_size) == 4
         and int(layer.sm70_nvfp4_num_experts) == 512
         and int(layer.sm70_nvfp4_hidden_size) == 2560
@@ -325,6 +354,36 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             and not sm70_ops.has_nvfp4_qpn_m1_dispatch()
         ):
             missing.append("nvfp4_moe_qpn_m1_sm70_out")
+        indexed_prefill_ops = {
+            "nvfp4_moe_indexed_dense_stage_sm70_out": hasattr(
+                torch.ops._C, "nvfp4_moe_indexed_dense_stage_sm70_out"
+            ),
+            "moe_permute_metadata_with_scratch": hasattr(
+                torch.ops._moe_C, "moe_permute_metadata_with_scratch"
+            ),
+        }
+        indexed_prefill_requested = bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL
+        )
+        indexed_prefill_available = all(indexed_prefill_ops.values())
+        indexed_prefill_explicit = (
+            "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL" in os.environ
+        )
+        if (
+            indexed_prefill_requested
+            and not indexed_prefill_available
+            and indexed_prefill_explicit
+        ):
+            missing.extend(
+                name for name, available in indexed_prefill_ops.items() if not available
+            )
+        elif indexed_prefill_requested and not indexed_prefill_available:
+            logger.warning_once(
+                "The default SM70 Qwen3.8 indexed-A prefill route is not "
+                "present in the loaded extension; falling back to the "
+                "materialized-input route. Explicitly setting "
+                "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL=1 fails closed."
+            )
         if missing:
             raise RuntimeError(
                 "SM70 NVFP4 MoE requires the TurboMind extension "
@@ -432,6 +491,9 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         layer.sm70_nvfp4_w2_k_dim = intermediate
         layer.sm70_nvfp4_w2_n_dim = hidden
         layer.sm70_nvfp4_group_size = NVFP4_GROUP_SIZE
+        layer.sm70_nvfp4_qwen38_indexed_prefill = bool(
+            indexed_prefill_requested and indexed_prefill_available
+        )
         layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
         layer.sm70_nvfp4_compact_grouped_max_tokens = _COMPACT_GROUPED_MAX_TOKENS
         self._allocate_graph_safe_decode_buffers(layer)
@@ -469,6 +531,9 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         )
         layer._nvfp4_sm70_permuted_input = torch.empty(
             max_slots, hidden, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_input_row_indices = torch.empty(
+            max_slots, dtype=torch.int32, device=device
         )
         layer._nvfp4_sm70_gate_up = torch.empty(
             max_slots, 2 * intermediate, dtype=torch.float16, device=device
@@ -536,6 +601,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         return {
             "output": layer._nvfp4_sm70_output[:num_tokens],
             "permuted_input": layer._nvfp4_sm70_permuted_input[:slots],
+            "input_row_indices": layer._nvfp4_sm70_input_row_indices[:slots],
             "gate_up": layer._nvfp4_sm70_gate_up[:slots],
             "intermediate": layer._nvfp4_sm70_intermediate[:slots],
             "sorted_output": layer._nvfp4_sm70_sorted_output[:slots],
@@ -558,7 +624,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
 
     @staticmethod
     def _eager_buffers(
-        layer: RoutedExperts, num_tokens: int
+        layer: RoutedExperts, num_tokens: int, indexed_w13: bool
     ) -> dict[str, torch.Tensor]:
         device = layer.w13_tm_weight.device
         top_k = int(layer.sm70_nvfp4_top_k)
@@ -573,8 +639,15 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             "output": torch.empty(
                 num_tokens, hidden, dtype=torch.float16, device=device
             ),
-            "permuted_input": torch.empty(
-                slots, hidden, dtype=torch.float16, device=device
+            "permuted_input": (
+                torch.empty(0, hidden, dtype=torch.float16, device=device)
+                if indexed_w13
+                else torch.empty(slots, hidden, dtype=torch.float16, device=device)
+            ),
+            "input_row_indices": (
+                torch.empty(slots, dtype=torch.int32, device=device)
+                if indexed_w13
+                else torch.empty(0, dtype=torch.int32, device=device)
             ),
             "gate_up": torch.empty(
                 slots, 2 * intermediate, dtype=torch.float16, device=device
@@ -615,11 +688,11 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         }
 
     def _get_buffers(
-        self, layer: RoutedExperts, num_tokens: int
+        self, layer: RoutedExperts, num_tokens: int, indexed_w13: bool
     ) -> dict[str, torch.Tensor]:
         if 0 < num_tokens <= _GRAPH_SAFE_MAX_TOKENS:
             return self._persistent_buffers(layer, num_tokens)
-        return self._eager_buffers(layer, num_tokens)
+        return self._eager_buffers(layer, num_tokens, indexed_w13)
 
     @staticmethod
     def _apply_swiglu(
@@ -666,7 +739,8 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         num_tokens = x.shape[0]
         if num_tokens == 0:
             return x.new_empty((0, hidden))
-        buffers = self._get_buffers(layer, num_tokens)
+        indexed_w13 = _use_qwen38_indexed_prefill(layer, x, topk_ids)
+        buffers = self._get_buffers(layer, num_tokens, indexed_w13)
         output = buffers["output"]
         slots = num_tokens * top_k
         direct_single_token = num_tokens == 1
@@ -714,23 +788,42 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             topk_ids_i32 = buffers["topk_ids"]
             topk_ids_i32.copy_(topk_ids, non_blocking=True)
             buffers["permuted_idx"].fill_(slots)
-            torch.ops._moe_C.moe_permute_with_scratch(
-                x,
-                topk_ids_i32,
-                buffers["token_expert_indices"],
-                layer.expert_map,
-                layer.global_num_experts,
-                layer.local_num_experts,
-                top_k,
-                buffers["permuted_input"],
-                buffers["expert_offsets64"],
-                buffers["inv_permuted_idx"],
-                buffers["permuted_idx"],
-                buffers["sort_workspace"],
-                buffers["permuted_experts_id"],
-                buffers["sorted_row_idx"],
-                buffers["topk_ids_for_sort"],
-            )
+            if indexed_w13:
+                torch.ops._moe_C.moe_permute_metadata_with_scratch(
+                    x,
+                    topk_ids_i32,
+                    buffers["token_expert_indices"],
+                    layer.expert_map,
+                    layer.global_num_experts,
+                    layer.local_num_experts,
+                    top_k,
+                    buffers["expert_offsets64"],
+                    buffers["inv_permuted_idx"],
+                    buffers["permuted_idx"],
+                    buffers["input_row_indices"],
+                    buffers["sort_workspace"],
+                    buffers["permuted_experts_id"],
+                    buffers["sorted_row_idx"],
+                    buffers["topk_ids_for_sort"],
+                )
+            else:
+                torch.ops._moe_C.moe_permute_with_scratch(
+                    x,
+                    topk_ids_i32,
+                    buffers["token_expert_indices"],
+                    layer.expert_map,
+                    layer.global_num_experts,
+                    layer.local_num_experts,
+                    top_k,
+                    buffers["permuted_input"],
+                    buffers["expert_offsets64"],
+                    buffers["inv_permuted_idx"],
+                    buffers["permuted_idx"],
+                    buffers["sort_workspace"],
+                    buffers["permuted_experts_id"],
+                    buffers["sorted_row_idx"],
+                    buffers["topk_ids_for_sort"],
+                )
             buffers["expert_offsets"].copy_(
                 buffers["expert_offsets64"], non_blocking=True
             )
@@ -749,18 +842,37 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             stage_expert_ids = buffers["dense_expert_ids"]
             stage_experts = int(layer.sm70_nvfp4_num_experts)
 
-        sm70_ops.nvfp4_moe_dense_stage_sm70_out(
-            buffers["gate_up"],
-            buffers["permuted_input"],
-            stage_offsets,
-            stage_expert_ids,
-            layer.w13_strided_ptrs_w,
-            layer.w13_strided_ptrs_s,
-            stage_experts,
-            layer.sm70_nvfp4_w13_k_dim,
-            layer.sm70_nvfp4_w13_n_dim,
-            layer.sm70_nvfp4_group_size,
-        )
+        if indexed_w13:
+            logger.info_once(
+                "SM70 Qwen3.8 NVFP4 indexed-A W13 prefill route enabled "
+                "(TP4, E512/K10, materialized input rows skipped)."
+            )
+            sm70_ops.nvfp4_moe_indexed_dense_stage_sm70_out(
+                buffers["gate_up"],
+                x,
+                buffers["input_row_indices"],
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_experts,
+                layer.sm70_nvfp4_w13_k_dim,
+                layer.sm70_nvfp4_w13_n_dim,
+                layer.sm70_nvfp4_group_size,
+            )
+        else:
+            sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+                buffers["gate_up"],
+                buffers["permuted_input"],
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_experts,
+                layer.sm70_nvfp4_w13_k_dim,
+                layer.sm70_nvfp4_w13_n_dim,
+                layer.sm70_nvfp4_group_size,
+            )
         self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
         sm70_ops.nvfp4_moe_dense_stage_sm70_out(
             buffers["sorted_output"],


### PR DESCRIPTION
## Purpose

Stacked on #387. Remove the Qwen3.8 TP4 NVFP4 prefill input-expansion bottleneck without changing routing order, W2, activation, unpermute, decode, or output arithmetic.

The exact E512/K10 W13 route keeps the existing stable expert sort, derives original token-row indices in a lightweight metadata kernel, and uses TurboMind SM70 MatrixLayout.idxs instead of materializing [tokens * 10, 2560] FP16 rows.

## Safety

- Restricted to exact TP4 Qwen3.8 W13: E512/K10, K2560/N320, group size 16, at least 128 tokens.
- `VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL=0` restores the old route.
- Implicit default falls back with an older extension; explicit `=1` fails closed when either operator is missing.
- Draft remains stacked on #387 until grouped QSA lands.

## Test Result

- SM70 `_C` and `_moe_C` incremental builds and schema imports pass.
- Focused suite: `15 passed, 5 skipped`.
- Ruff, clang-format, typos, and `git diff --check` pass.
- Locked V100 8192-token operator chain: `6.026752 -> 4.235264 ms` (`1.423x`, `1.791488 ms/layer/rank` saved). All routing metadata and W13 output are bitwise equal.
- One-start TP4 V2/no-MTP endpoint versus #387:
  - 32K: `5998.65 -> 6507.10 tok/s` (`+8.47%`)
  - 64K: `5777.43 -> 6241.48 tok/s` (`+8.03%`)
  - 131K: `5450.92 -> 5871.47 tok/s` (`+7.71%`)
  - 8K: `6394.74 -> 6970.80 tok/s` (`+9.01%`)
- Arithmetic, Chinese, 32K, 64K, 131K, 8K, and profile token hashes match #387 exactly.

Full implementation and benchmark evidence are recorded in `docs/design/sm70_v100_migration_control.md`.