### PR TITLE
[Bugfix][SM70] Default audited MTP MoE tiles on

### DIFF
--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -605,7 +605,7 @@ def _sm70_turbomind_policy(
     )
     mtp_moe_tuned_config = _env_bool(
         "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
-        False,
+        True,
     )
     awq_warmup = _env_bool("VLLM_SM70_AWQ_WARMUP", True)
     awq_moe_disable = _env_bool("VLLM_SM70_AWQ_MOE_DISABLE", False)

--- a/docs/design/sm70_qwen38_flash_next_nvfp4.md
+++ b/docs/design/sm70_qwen38_flash_next_nvfp4.md
@@ -497,9 +497,10 @@ The exact TP4-local BF16 draft-MoE shape is
 `E=512, N=160, K=2560, topk=10`. An exact-shape SM70 tile of
 `BM=2, BN=128, BK=64, G=1`, four warps, and three stages reduces M5 from
 1492.500 to 283.853 microseconds (5.26x) and M1 from 425.789 to 272.415
-microseconds (1.56x), with bitwise-identical output. The route is bounded to
-Qwen3.8 TP4 and remains opt-in through
-`VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
+microseconds (1.56x), with bitwise-identical output. The route is bounded by
+the exact SM70 TP4 local MoE shape (currently exercised by Qwen3.8), is enabled
+by default, and can be rolled back with
+`VLLM_SM70_MTP_MOE_TUNED_CONFIG=0`.
 
 V2 needs one additional prefill specialization beyond its faithful M5/M1
 decode warmup. The real HumanEval prompt first runs the draft model at M152;

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42936,8 +42936,9 @@ Interpretation:
   M1-M16 plus M33/M257
   and explicitly covers legacy M1/M2/M9/M10 naive/aligned signatures; a fresh
   48-request run then produced no inference-time `fused_moe_kernel` JIT.
-  Unmatched shapes retain the old `(9,33,257)` warmup set, and the tuned route
-  requires `VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
+  Unmatched shapes retain the old `(9,33,257)` warmup set. The audited
+  exact-shape tuned route is now enabled by default and can be rolled back
+  with `VLLM_SM70_MTP_MOE_TUNED_CONFIG=0`.
 - Full-model evidence rejects the isolated M1 result. A physical-GPU4-7 C1
   candidate/control/candidate sandwich measured endpoint-mean summed pure
   decode `112.233` versus control `115.451 tok/s` (`-2.79%`) and endpoint-mean

--- a/tests/benchmarks/test_benchmark_sm70_decode.py
+++ b/tests/benchmarks/test_benchmark_sm70_decode.py
@@ -108,11 +108,16 @@ def test_spec_decoding_delta_reports_one_sequential_prompt():
 
 def test_sm70_policy_records_generic_mtp_moe_tuning(monkeypatch):
     monkeypatch.setenv("VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", "1")
-    monkeypatch.setenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0")
+    monkeypatch.delenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", raising=False)
 
     policy = benchmark_sm70_model_tokens._sm70_turbomind_policy()
 
     assert policy["VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG"] == "1"
-    assert policy["VLLM_SM70_MTP_MOE_TUNED_CONFIG"] == "0"
+    assert policy["VLLM_SM70_MTP_MOE_TUNED_CONFIG"] is None
+    assert policy["mtp_moe_tuned_config_effective"] is True
+    assert policy["qwen36_mtp_moe_tuned_config_effective"] is True
+
+    monkeypatch.setenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0")
+    policy = benchmark_sm70_model_tokens._sm70_turbomind_policy()
     assert policy["mtp_moe_tuned_config_effective"] is False
     assert policy["qwen36_mtp_moe_tuned_config_effective"] is False

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -127,13 +127,18 @@ def test_sm70_concurrency_tuning_envs(
     names = (
         "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING",
         "VLLM_SM70_TOPK_TOPP_8_WARPS",
-        "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
     )
     for name in names:
         monkeypatch.delenv(name, raising=False)
         assert environment_variables[name]() is False
         monkeypatch.setenv(name, "1")
         assert environment_variables[name]() is True
+
+    name = "VLLM_SM70_MTP_MOE_TUNED_CONFIG"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
 
     name = "VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS"
     monkeypatch.delenv(name, raising=False)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -545,7 +545,7 @@ if TYPE_CHECKING:
     VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_DISABLE_QWEN3NEXT_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG: bool = True
-    VLLM_SM70_MTP_MOE_TUNED_CONFIG: bool = False
+    VLLM_SM70_MTP_MOE_TUNED_CONFIG: bool = True
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
@@ -3241,10 +3241,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG": lambda: bool(
         int(os.getenv("VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG", "1"))
     ),
-    # Opt-in decode tiles for the exact E256/N128/K2048/top-k8 SM70 contract.
-    # Larger or unmatched token shapes retain the 0.0.3 config.
+    # Default-on decode tiles for the audited exact-shape SM70 MTP contracts.
+    # Larger or unmatched token shapes retain the 0.0.3 config; setting this
+    # variable to zero is the explicit rollback.
     "VLLM_SM70_MTP_MOE_TUNED_CONFIG": lambda: bool(
-        int(os.getenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0"))
+        int(os.getenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "1"))
     ),
     # Legacy SM70 CUDA-graph capture-size tuning from 0.0.3. Default-off
     # because dense capture can increase startup/compile cost; when enabled on


### PR DESCRIPTION
## Purpose\n\nRepair parent PR #389 before integration.\n\n- Enable the audited exact-shape SM70 MTP MoE tiles by default.\n- Keep VLLM_SM70_MTP_MOE_TUNED_CONFIG=0 as an explicit rollback.\n- Keep dispatch generic and shape-bounded; no model or checkpoint identity gate is added.\n- Align the benchmark policy, environment tests, and design records with the runtime default.\n\n## Base\n\n- Parent PR head: ae560f5432aec2df0b4d60d28ac399d826548605\n- Repair head: ff2602c113000ce11eeec6450af084a0c4427dd1\n- Integration target after parent merge: main at 03c04da68e72bf26271de4986364a72141a7601f\n\n## Test Plan\n\nRun the focused environment, benchmark-policy, MoE-config, Qwen3.8 weight-loading, MTP, and MRV2 warmup tests, then run Ruff and whitespace checks.\n\n## Test Result\n\n- Focused tests: 126 passed, 2 benign SWIG deprecation warnings.\n- Ruff check: pass.\n- Ruff format check: pass.\n- git diff --check: pass.\n- Parent GPU evidence is unchanged because this repair changes only the default gate: Qwen3.8 M5 5.26x, M1 1.56x, bitwise exact; full-model HumanEval 8/8 and 138.26 tok/s.\n- The existing Qwen3.6 M1 rejection remains excluded by the exact M2-M16 shape gate; unmatched shapes retain the 0.0.3 fallback.\n\n## Risk and rollback\n\nThe runtime only selects the two audited SM70 TP4 local-shape families. Set VLLM_SM70_MTP_MOE_TUNED_CONFIG=0 to restore the previous default immediately.