### PR TITLE
[Kernel][SM70] Accelerate Qwen3.8 NVFP4 grouped prefill

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -526,6 +526,12 @@ void nvfp4_moe_indexed_dense_stage_sm70_out(
     torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
     int64_t n, int64_t group_size);
 
+void nvfp4_moe_indexed_fused_swiglu_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size);
+
 void mxfp4_moe_single_token_prepare_w13_sm70_out(
     torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
     torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -90,6 +90,12 @@ bool Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled() {
   return !raw || std::atoi(raw) != 0;
 }
 
+bool Sm70Nvfp4Qwen38MoeFastPrefillEnabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL");
+  return !raw || std::atoi(raw) != 0;
+}
+
 // Default-on gate for exact block-FP8 8K prefill GEMM descriptors.
 bool Sm70Fp8BlockPrefillFastSelectorEnabled() {
   const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR");
@@ -175,6 +181,26 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(
 std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(
     const GemmDesc& desc) {
   const std::string desc_str = to_string(desc);
+  if (Sm70Nvfp4Qwen38MoeFastPrefillEnabled() && desc.arch == 700 &&
+      desc_str.starts_with("sm70_f16_e2m1k16_f16_tnt_") && desc.m >= 1280 &&
+      desc.num == 512) {
+    if (desc.n == 320 && desc.k == 2560) {
+      return Sm70AwqTp2FastTarget{
+          desc.n, desc.k, 32, 128, 32, 1, 2, true, "c32x128_a1x1x32_01"};
+    }
+    if (desc.n == 256 && desc.k == 2560) {
+      return Sm70AwqTp2FastTarget{
+          desc.n, desc.k, 32, 128, 32, 1, 0, true, "c32x128_a1x1x32_01"};
+    }
+    if (desc.n == 64 && desc.k == 2560) {
+      return Sm70AwqTp2FastTarget{
+          desc.n, desc.k, 32, 64, 32, 1, 0, true, "c32x64_a1x1x32_01"};
+    }
+    if (desc.n == 2560 && desc.k == 160) {
+      return Sm70AwqTp2FastTarget{
+          desc.n, desc.k, 32, 128, 32, 1, 2, true, "c32x128_a1x1x32_00"};
+    }
+  }
   if (Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()) {
     // Qwen3.8-27B NVFP4 TP4 decode. The exact-MNK registry entries keep
     // these small-N tactics out of prefill and unrelated model shapes.

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -4,6 +4,8 @@
 #include "src/turbomind/kernels/gemm/registry.h"
 #include "src/turbomind/kernels/gemm/types.h"
 
+#include <cstdlib>
+
 namespace turbomind::gemm {
 
 using namespace sm70_s884;
@@ -28,6 +30,38 @@ class ExactMnkKernelImpl final : public KernelImpl<Gemm> {
  public:
   bool is_feasible(const GemmDesc& desc) const noexcept override {
     return desc.m == ExactM && desc.n == ExactN && desc.k == ExactK &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
+};
+
+// Default-cache-B kernel for the exact Qwen3.8 TP4 W2 prefill descriptor.
+// Expert-sorted prefill gives each expert several adjacent M tiles, so keeping
+// B cacheable may reuse its FP4 weights across those tiles. The exact contract
+// and default-on feature gate keep it out of unrelated descriptors and provide
+// an operational rollback.
+template <class Gemm>
+class Qwen38Nvfp4W2CacheBKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    const char* enabled =
+        std::getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL");
+    return (!enabled || std::atoi(enabled) != 0) && desc.m >= 1280 &&
+           desc.num == 512 && desc.n == 2560 && desc.k == 160 &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
+};
+
+// The full W13 N=320 shape is faster with N128 tiles, but its final tile does
+// half-empty work. This N64 kernel is exposed only for the exact split-W13
+// tail, while the first 256 columns retain the established N128 kernel.
+template <class Gemm>
+class Qwen38Nvfp4W13TailN64KernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    const char* enabled =
+        std::getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL");
+    return (!enabled || std::atoi(enabled) != 0) && desc.m >= 1280 &&
+           desc.num == 512 && desc.n == 64 && desc.k == 2560 &&
            KernelImpl<Gemm>::is_feasible(desc);
   }
 };
@@ -118,6 +152,10 @@ void Registry::sm70_884_4() {
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 16>>();
+        using Qwen38CacheB = C::Type<32, 128, 32, 1, 4, 1, D, D, 2, true, 1, 16>;
+        Add(std::make_unique<Qwen38Nvfp4W2CacheBKernelImpl<typename Qwen38CacheB::Kernel>>());
+        using Qwen38W13TailN64 = C::Type<32, 64, 32, 1, 2, 1, D, S, 2, true, 1, 16>;
+        Add(std::make_unique<Qwen38Nvfp4W13TailN64KernelImpl<typename Qwen38W13TailN64::Kernel>>());
         using C32K64L1 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16>;
         using C32K64L2 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16, -1, -1, 2>;
         using C32K128L1 = C::Type<8, 32, 128, 1, 1, 1, D, S, 2, true, 1, 16>;

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8684,7 +8684,7 @@ void nvfp4_moe_gemm_sm70_out_impl(
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
     torch::Tensor b_group_indices, bool compact_grouped_rows = false,
     int64_t logical_total_tokens = -1,
-    torch::Tensor a_indices = torch::Tensor()) {
+    torch::Tensor a_indices = torch::Tensor(), bool gated_silu = false) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "nvfp4_moe_gemm_sm70: input must be CUDA float16.");
@@ -8733,8 +8733,10 @@ void nvfp4_moe_gemm_sm70_out_impl(
                 "nvfp4_moe_gemm_sm70: non-indexed input rows must match "
                 "logical rows.");
   }
+  TORCH_CHECK(!gated_silu || n % 2 == 0,
+              "nvfp4_moe_gemm_sm70: gated SiLU requires even n.");
   TORCH_CHECK(out.dim() == 2 && out.size(0) == total_tokens &&
-                  out.size(1) == n && out.stride(1) == 1,
+                  out.size(1) == (gated_silu ? n / 2 : n) && out.stride(1) == 1,
               "nvfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
   if (total_tokens == 0) {
     return;
@@ -8829,7 +8831,8 @@ void nvfp4_moe_gemm_sm70_out_impl(
       device, static_cast<int>(total_tokens), static_cast<int>(n),
       static_cast<int>(k), static_cast<int>(num_experts),
       static_cast<int>(group_size), stream);
-  op.epilogue = turbomind::gemm::Epilogue::kNone;
+  op.epilogue = gated_silu ? turbomind::gemm::Epilogue::kGatedSilu
+                           : turbomind::gemm::Epilogue::kNone;
   op.quant_a = {turbomind::gemm::QuantType::kNone, 0};
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
   op.batch_dim = 0;
@@ -8849,17 +8852,23 @@ void nvfp4_moe_gemm_sm70_out_impl(
               ").");
 }
 
-void nvfp4_moe_indexed_dense_stage_sm70_out(
+void nvfp4_moe_indexed_dense_stage_sm70_out_impl(
     torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
     torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
     torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
-    int64_t n, int64_t group_size) {
+    int64_t n, int64_t group_size, bool fused_swiglu) {
   constexpr int kQwen38TopK = 10;
+  const char* split_w13_raw =
+      std::getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL");
+  const bool split_w13_candidate =
+      (!split_w13_raw || std::atoi(split_w13_raw) != 0) && fused_swiglu &&
+      (n == 256 || n == 64);
   TORCH_CHECK(input.dim() == 2 && input.size(0) > 0 && input.size(1) == 2560 &&
                   input.scalar_type() == torch::kFloat16 && input.is_cuda(),
               "nvfp4_moe_indexed_dense_stage_sm70_out: exact Qwen3.8 CUDA "
               "FP16 [tokens, 2560] input is required.");
-  TORCH_CHECK(num_experts == 512 && k == 2560 && n == 320 && group_size == 16,
+  TORCH_CHECK(num_experts == 512 && k == 2560 &&
+                  (n == 320 || split_w13_candidate) && group_size == 16,
               "nvfp4_moe_indexed_dense_stage_sm70_out: exact Qwen3.8 TP4 W13 "
               "contract is required.");
   TORCH_CHECK(input_row_indices.is_cuda() &&
@@ -8869,21 +8878,47 @@ void nvfp4_moe_indexed_dense_stage_sm70_out(
               "nvfp4_moe_indexed_dense_stage_sm70_out: input row indices must "
               "contain exactly tokens*10 contiguous CUDA int32 entries.");
   TORCH_CHECK(out.dim() == 2 && out.size(0) == input_row_indices.numel() &&
-                  out.size(1) == n,
+                  out.size(1) == (fused_swiglu ? n / 2 : n),
               "nvfp4_moe_indexed_dense_stage_sm70_out: output shape mismatch.");
   TORCH_CHECK(vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled(),
               "nvfp4_moe_indexed_dense_stage_sm70_out requires grouped "
               "prefill dispatch.");
 
   static std::atomic<unsigned> logged_nvfp4_indexed_prefill{0u};
+  static std::atomic<unsigned> logged_nvfp4_indexed_fused_prefill{0u};
   maybe_log_sm70_moe_route_once(
-      logged_nvfp4_indexed_prefill,
-      "SM70 Qwen3.8 NVFP4 MoE indexed-A W13 prefill path enabled C++ op "
-      "reached",
+      fused_swiglu ? logged_nvfp4_indexed_fused_prefill
+                   : logged_nvfp4_indexed_prefill,
+      fused_swiglu
+          ? "SM70 Qwen3.8 NVFP4 MoE indexed-A fused-SwiGLU W13 prefill "
+            "path enabled C++ op reached"
+          : "SM70 Qwen3.8 NVFP4 MoE indexed-A W13 prefill path enabled C++ "
+            "op reached",
       input, input_row_indices.numel(), num_experts);
-  nvfp4_moe_gemm_sm70_out_impl(
-      out, input, expert_offsets, ptrs_w, ptrs_s, num_experts, k, n, group_size,
-      dense_expert_ids, false, input_row_indices.numel(), input_row_indices);
+  nvfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
+                               num_experts, k, n, group_size, dense_expert_ids,
+                               false, input_row_indices.numel(),
+                               input_row_indices, fused_swiglu);
+}
+
+void nvfp4_moe_indexed_dense_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size) {
+  nvfp4_moe_indexed_dense_stage_sm70_out_impl(
+      out, input, input_row_indices, expert_offsets, dense_expert_ids, ptrs_w,
+      ptrs_s, num_experts, k, n, group_size, false);
+}
+
+void nvfp4_moe_indexed_fused_swiglu_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size) {
+  nvfp4_moe_indexed_dense_stage_sm70_out_impl(
+      out, input, input_row_indices, expert_offsets, dense_expert_ids, ptrs_w,
+      ptrs_s, num_experts, k, n, group_size, true);
 }
 
 void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -700,6 +700,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &nvfp4_moe_indexed_dense_stage_sm70_out);
 
   ops.def(
+      "nvfp4_moe_indexed_fused_swiglu_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
+      "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "
+      "Tensor ptrs_s, int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("nvfp4_moe_indexed_fused_swiglu_sm70_out", torch::kCUDA,
+           &nvfp4_moe_indexed_fused_swiglu_sm70_out);
+
+  ops.def(
       "mxfp4_moe_single_token_prepare_w13_sm70_out("
       "Tensor(a!) gate_up, Tensor(b!) compact_input, Tensor x, "
       "Tensor topk_ids, Tensor w13_ptrs_w, Tensor w13_ptrs_s, "

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44426,3 +44426,75 @@ Interpretation:
   are still projected near 26% of 8K per-rank service, so the next bounded
   screen remains the NVFP4 grouped-GEMM scheduler/register-pressure path, not
   another model startup or a return to QSA launch tuning.
+
+## 2026-08-28 Qwen3.8 NVFP4 grouped-GEMM prefill audit
+
+- Public Draft PR #393 is stacked on indexed-A PR #390. The retained route is
+  restricted to the exact Qwen3.8 TP4 prefill descriptors and leaves decode
+  on the original packed weights. W13 partitions its existing packed N320
+  storage without copies: the N256 head uses the SM70 M32xN128xK32 streaming-B
+  tactic and the N64 tail uses M32xN64xK32. W2 keeps M32xN128xK32 and changes
+  only its cache-B policy. The W13 epilogue writes exact FP16 clamp-SwiGLU
+  values directly, removing the separate activation launch.
+- The partition is zero-copy. For every expert, the N256 head is the first
+  81,920 packed int32 words and the N64 tail the last 20,480 words. Their scale
+  tensors are column views with the original N320 leading dimension, so the
+  route adds no duplicate expert weights and no roughly 10-GiB/rank capacity
+  penalty. Missing operators in an older extension retain the unsplit route
+  unless the feature was explicitly forced.
+- One locked V100 operator screen uses physically repeated real layer-0 expert
+  weights, 8,192 tokens, top-K 10, and 512 local expert slots. The original
+  indexed W13 plus activation plus W2 chain measures `6.684 ms/layer/rank`.
+  The default production selector measures `6.12096 ms/layer/rank`: W13 is
+  `3.97773 ms`, W2 is `2.27123 ms`, and intermediate and final hashes are
+  exactly
+  `6d96da1848ed7ac92111df786a04afd54ef743f2e768dbc1ebca9ac9ffa2eae4`
+  and
+  `ceb78a76571ff57ea5eec6cba7b5c3b796d2af96e4225b8b2b4618a3fe592a1f`.
+  The measured saving is about `0.563 ms/layer/rank` per 8K chunk.
+- Bounded screens rejected the following paths and they must not be retried
+  without a new kernel design: full-W13 N64 tiles (`6.098 ms` for W13 alone),
+  M16 tactics, larger W2 M64/M128 tactics, and a padded dequantize-to-FP16
+  `bmm` route (`3.684 + 2.223 ms` before paying for about 1.26 GiB of
+  dequantized writes). A direct W2 atomic weighted reduction is also rejected
+  because multi-token accumulation is nondeterministic. Cache-B helps W2 by
+  about `0.08 ms`; applying the same policy to W13 does not help.
+- The first exact-256K startup exposed two PLE CPU-offload graph-boundary bugs
+  before any benchmark request ran. GPU placeholders now retain the checkpoint
+  scale in the model dtype, preventing a BF16 graph input on the FP16 V100
+  route. Quantized PLE IPC results are transported in the same one-byte-per-
+  element footprint as raw `uint8`, then decoded by an opaque SM70 Triton
+  E4M3FN-byte kernel. This keeps the 20-MiB-per-8K-chunk transfer size and
+  prevents TorchInductor from generating unsupported native-FP8 loads on
+  compute capability 7.0. The focused PLE suite passes 18 tests, and a Dynamo
+  export contains the opaque byte-dequant op with no float8 graph nodes.
+- A locked V100 gate covers all 256 E4M3FN byte patterns. Eager and
+  `torch.compile(fullgraph=True)` results exactly match the PyTorch FP8
+  reference for finite values and agree on NaN patterns. Dequantizing one
+  production `8192x2560` raw-byte
+  buffer takes `0.127 ms` median (`0.114 ms` minimum) and produces hash
+  `c15a97bc70b4d7de66d4cff36b989e34413b5fe966ccafe18f422ece8c897728`.
+  The ten PLE checkpoint files occupy 47.684 GiB on host storage/RAM; no PLE
+  embedding table is replicated onto any GPU.
+- One subsequent startup completed the full TP4 V2, no-MTP, FP16-KV,
+  PLE-CPU-offload, 8,192-token-chunk matrix through the model's exact
+  262,144-token limit. Every request reports `is_corrupted=false`; arithmetic
+  and Chinese outputs are respectively `42<|im_end|>` and
+  `在标准大气压下，水的沸点是100摄氏度。<|im_end|>`. Pure prefill is:
+    - 8K: `1.160956 s`, `7,056.26 token/s`;
+    - 32K: `4.962370 s`, `6,603.30 token/s`;
+    - 64K: `10.357441 s`, `6,327.43 token/s`;
+    - 131K: `22.101014 s`, `5,927.33 token/s`;
+    - input 262,143 plus output 1: `49.945010 s`,
+      `5,248.63 token/s`.
+- Against #390 at the four shared lengths, throughput improves
+  1.23%/1.48%/1.38%/0.95%. The exact-256K output is token `This`, hash
+  `274dfec6e079fb08d6b5771537c54d3f0bd36c64c3d8ed0a4e6d2f201b489274`.
+  KV capacity is 487,405 tokens/rank (1.86x maximum 256K concurrency), with
+  5.98 GiB reported free for KV allocation after model profiling. During the
+  steady 256K request, allocation is 32,409-32,471 MiB/rank; three ranks sample
+  100% GPU utilization for all 48 interior seconds and rank zero averages
+  99.81%, at 261-267 W average power. This rules out CPU/PLE starvation as the
+  long-context limiter. The next trace must be taken at 256K and separate the
+  context-growing QSA indexer/attention work from the now-fixed MoE projection
+  cost; 128K-only traces are no longer sufficient acceptance evidence.

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -292,12 +292,13 @@ def test_ngram_embedding_loads_fp8_shards_and_global_scale() -> None:
         torch.cat((shard_0[2:4], shard_1[0:2])).float(),
     )
     assert torch.equal(module.ngram_embedding.weight_scale, weight_scale)
-    assert module.get_offload_output_dtype(torch.bfloat16) == torch.float8_e4m3fn
+    assert module.get_offload_output_dtype(torch.bfloat16) == torch.uint8
 
 
 def test_ngram_gpu_offload_retains_only_fp8_global_scale(monkeypatch) -> None:
     module = Qwen4ExpNGramEmbedding.__new__(Qwen4ExpNGramEmbedding)
     nn.Module.__init__(module)
+    module._offload_model_dtype = torch.float16
     weight_scale = torch.tensor([0.25], dtype=torch.bfloat16)
     monkeypatch.setattr(ple_module.envs, "VLLM_PLE_CPU_OFFLOAD", True)
     monkeypatch.setattr(ple_module, "is_offload_process", lambda: False)
@@ -315,8 +316,9 @@ def test_ngram_gpu_offload_retains_only_fp8_global_scale(monkeypatch) -> None:
     )
 
     assert loaded == {"ngram_embedding.weight_scale"}
-    assert torch.equal(module._offload_weight_scale, weight_scale)
-    assert module.get_offload_output_dtype(torch.bfloat16) == torch.float8_e4m3fn
+    assert module._offload_weight_scale.dtype == torch.float16
+    assert torch.equal(module._offload_weight_scale, weight_scale.to(torch.float16))
+    assert module.get_offload_output_dtype(torch.bfloat16) == torch.uint8
 
     ple_layer = Qwen4ExpPLELayer.__new__(Qwen4ExpPLELayer)
     nn.Module.__init__(ple_layer)
@@ -519,7 +521,7 @@ def test_ngram_fp8_cpu_offload_preserves_quantized_output(
         query_start_loc,
         ngram_context,
     )
-    output_buffer = torch.empty(2, 2, dtype=torch.float8_e4m3fn)
+    output_buffer = torch.empty(2, 2, dtype=torch.uint8)
 
     output = module.forward_impl(
         hidden_states,
@@ -530,8 +532,8 @@ def test_ngram_fp8_cpu_offload_preserves_quantized_output(
     )
 
     assert output.data_ptr() == output_buffer.data_ptr()
-    assert output.dtype == torch.float8_e4m3fn
-    torch.testing.assert_close(output.float(), quantized.float())
+    assert output.dtype == torch.uint8
+    assert torch.equal(output, quantized.view(torch.uint8))
 
 
 def test_dilated_ple_spec_state_rolls_back_before_next_forward() -> None:

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -99,6 +99,22 @@ def test_nvfp4_grouped_prefill_defaults_on_and_can_be_disabled(monkeypatch):
     assert not envs.VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL
 
 
+def test_qwen38_fast_prefill_defaults_on_and_can_be_disabled(monkeypatch):
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL"
+    monkeypatch.delenv(name, raising=False)
+    assert envs.VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL
+
+    monkeypatch.setenv(name, "0")
+    assert not envs.VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL
+
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL"
+    monkeypatch.delenv(name, raising=False)
+    assert envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
+
+    monkeypatch.setenv(name, "0")
+    assert not envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -1517,6 +1517,53 @@ if hasattr(torch.ops._C, "nvfp4_moe_indexed_dense_stage_sm70_out"):
         return None
 
 
+def nvfp4_moe_indexed_fused_swiglu_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    input_row_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("nvfp4_moe_indexed_fused_swiglu_sm70_out")(
+        out,
+        input,
+        input_row_indices,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_indexed_fused_swiglu_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_indexed_fused_swiglu_sm70_out")
+    def _nvfp4_moe_indexed_fused_swiglu_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        input_row_indices: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def mxfp4_moe_single_token_prepare_w13_sm70_out(
     gate_up: torch.Tensor,
     compact_input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -182,6 +182,8 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL: bool = True
     VLLM_SM70_NVFP4_QPN_M1_LIBRARY: str | None = None
     VLLM_SM70_QWEN38_ROUTER_TOPK: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
@@ -1846,6 +1848,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # indexed-A iterator instead of materializing top-k replicated FP16 rows.
     "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL", "1"))
+    ),
+    # Exact Qwen3.8 route: interleave W13 columns at load time and apply SwiGLU
+    # in the indexed grouped-GEMM epilogue. The arithmetic is bitwise equal to
+    # the standalone FP16 activation and avoids its intermediate traffic.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL", "1"))
+    ),
+    # Exact TP4 long-prefill grouped-GEMM policy: split W13 N320 into an N256
+    # head plus N64 tail, and retain W2 weights in cache across expert-local M
+    # tiles. Both use zero-copy views of the established packed weights.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL", "1"))
     ),
     "VLLM_SM70_NVFP4_QPN_M1_LIBRARY": lambda: os.getenv(
         "VLLM_SM70_NVFP4_QPN_M1_LIBRARY"

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -415,6 +415,40 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         num_experts = int(layer.local_num_experts)
         hidden = int(layer.moe_config.hidden_dim)
         intermediate = int(layer.moe_config.intermediate_size_per_partition)
+        fused_swiglu_requested = bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL
+            and int(layer.moe_config.tp_size) == 4
+            and num_experts == 512
+            and hidden == 2560
+            and intermediate == 160
+            and int(layer.moe_config.experts_per_token) == 10
+            and layer.swiglu_limit is None
+        )
+        fused_swiglu_available = hasattr(
+            torch.ops._C, "nvfp4_moe_indexed_fused_swiglu_sm70_out"
+        )
+        fused_swiglu_explicit = (
+            "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL" in os.environ
+        )
+        if (
+            fused_swiglu_requested
+            and not fused_swiglu_available
+            and fused_swiglu_explicit
+        ):
+            raise RuntimeError(
+                "SM70 Qwen3.8 fused-SwiGLU prefill requires the TurboMind "
+                "extension with nvfp4_moe_indexed_fused_swiglu_sm70_out."
+            )
+        if fused_swiglu_requested and not fused_swiglu_available:
+            logger.warning_once(
+                "The default SM70 Qwen3.8 fused-SwiGLU prefill op is absent "
+                "from the loaded extension; retaining the standalone "
+                "activation route. Explicit opt-in fails closed."
+            )
+        fused_swiglu_prefill = bool(fused_swiglu_requested and fused_swiglu_available)
+        fast_prefill = bool(
+            fused_swiglu_prefill and envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
+        )
 
         w13_tm_weights: list[torch.Tensor] = []
         w13_tm_scales: list[torch.Tensor] = []
@@ -432,6 +466,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 w13_packed,
                 w13_scales.half().t().contiguous(),
                 NVFP4_GROUP_SIZE,
+                interleave_gated_silu=fused_swiglu_prefill,
             )
             w13_tm_weights.append(prepared_w13[0])
             w13_tm_scales.append(prepared_w13[1])
@@ -476,6 +511,39 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             w2_q_ld,
             num_experts,
         )
+        if fast_prefill:
+            # TurboMind packs this exact N320 weight as five contiguous N64
+            # tiles per expert. The N256/N64 views therefore partition the
+            # existing allocation without copying it. Scales remain a strided
+            # N320 view, so both subprojections retain the original q_ld.
+            w13_flat = layer.w13_tm_weight.view(num_experts, -1)
+            head_words = hidden * 256 // 8
+            w13_head_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+                w13_flat[:, :head_words],
+                layer.w13_tm_scales[:, :, :256],
+                w13_k_ld,
+                w13_q_ld,
+                num_experts,
+            )
+            w13_tail_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+                w13_flat[:, head_words:],
+                layer.w13_tm_scales[:, :, 256:],
+                w13_k_ld,
+                w13_q_ld,
+                num_experts,
+            )
+            layer.w13_head_strided_ptrs_w = Parameter(
+                w13_head_ptrs[0], requires_grad=False
+            )
+            layer.w13_head_strided_ptrs_s = Parameter(
+                w13_head_ptrs[1], requires_grad=False
+            )
+            layer.w13_tail_strided_ptrs_w = Parameter(
+                w13_tail_ptrs[0], requires_grad=False
+            )
+            layer.w13_tail_strided_ptrs_s = Parameter(
+                w13_tail_ptrs[1], requires_grad=False
+            )
         layer.w13_strided_ptrs_w = Parameter(w13_ptrs[0], requires_grad=False)
         layer.w13_strided_ptrs_s = Parameter(w13_ptrs[1], requires_grad=False)
         layer.w2_strided_ptrs_w = Parameter(w2_ptrs[0], requires_grad=False)
@@ -494,6 +562,8 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         layer.sm70_nvfp4_qwen38_indexed_prefill = bool(
             indexed_prefill_requested and indexed_prefill_available
         )
+        layer.sm70_nvfp4_qwen38_fused_swiglu_prefill = fused_swiglu_prefill
+        layer.sm70_nvfp4_qwen38_fast_prefill = fast_prefill
         layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
         layer.sm70_nvfp4_compact_grouped_max_tokens = _COMPACT_GROUPED_MAX_TOKENS
         self._allocate_graph_safe_decode_buffers(layer)
@@ -517,6 +587,16 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             _GRAPH_SAFE_MAX_TOKENS,
             _COMPACT_GROUPED_MAX_TOKENS,
         )
+        if fused_swiglu_prefill:
+            logger.info_once(
+                "SM70 Qwen3.8 indexed-A fused-SwiGLU prefill candidate "
+                "enabled (interleaved W13, exact FP16 epilogue arithmetic)."
+            )
+        if fast_prefill:
+            logger.info_once(
+                "SM70 Qwen3.8 NVFP4 fast grouped prefill enabled "
+                "(zero-copy W13 N256+N64, cached-B W2)."
+            )
 
     def _allocate_graph_safe_decode_buffers(self, layer: RoutedExperts) -> None:
         device = layer.w13_tm_weight.device
@@ -696,8 +776,19 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
 
     @staticmethod
     def _apply_swiglu(
-        layer: RoutedExperts, out: torch.Tensor, gate_up: torch.Tensor
+        layer: RoutedExperts,
+        out: torch.Tensor,
+        gate_up: torch.Tensor,
+        *,
+        interleaved: bool = False,
     ) -> None:
+        if interleaved:
+            if layer.swiglu_limit is not None:
+                raise RuntimeError(
+                    "Interleaved SM70 NVFP4 SwiGLU does not support clamping."
+                )
+            torch.ops._C.silu_and_mul_interleaved(out, gate_up)
+            return
         if layer.swiglu_limit is None:
             torch.ops._C.silu_and_mul(out, gate_up)
         else:
@@ -740,6 +831,13 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         if num_tokens == 0:
             return x.new_empty((0, hidden))
         indexed_w13 = _use_qwen38_indexed_prefill(layer, x, topk_ids)
+        interleaved_w13 = bool(
+            getattr(layer, "sm70_nvfp4_qwen38_fused_swiglu_prefill", False)
+        )
+        fused_indexed_w13 = indexed_w13 and interleaved_w13
+        split_fused_indexed_w13 = fused_indexed_w13 and bool(
+            getattr(layer, "sm70_nvfp4_qwen38_fast_prefill", False)
+        )
         buffers = self._get_buffers(layer, num_tokens, indexed_w13)
         output = buffers["output"]
         slots = num_tokens * top_k
@@ -759,7 +857,12 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 True,
                 _QWEN38_QPN_M1_W13_SPLIT_K,
             )
-            self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
+            self._apply_swiglu(
+                layer,
+                buffers["intermediate"],
+                buffers["gate_up"],
+                interleaved=interleaved_w13,
+            )
             sm70_ops.nvfp4_moe_qpn_m1_sm70_out(
                 buffers["sorted_output"],
                 buffers["intermediate"],
@@ -842,7 +945,57 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             stage_expert_ids = buffers["dense_expert_ids"]
             stage_experts = int(layer.sm70_nvfp4_num_experts)
 
-        if indexed_w13:
+        if split_fused_indexed_w13:
+            logger.info_once(
+                "SM70 Qwen3.8 NVFP4 indexed-A fused-SwiGLU split-W13 "
+                "prefill route enabled (N256+N64)."
+            )
+            for intermediate, ptrs_w, ptrs_s, n in (
+                (
+                    buffers["intermediate"][:, :128],
+                    layer.w13_head_strided_ptrs_w,
+                    layer.w13_head_strided_ptrs_s,
+                    256,
+                ),
+                (
+                    buffers["intermediate"][:, 128:],
+                    layer.w13_tail_strided_ptrs_w,
+                    layer.w13_tail_strided_ptrs_s,
+                    64,
+                ),
+            ):
+                sm70_ops.nvfp4_moe_indexed_fused_swiglu_sm70_out(
+                    intermediate,
+                    x,
+                    buffers["input_row_indices"],
+                    stage_offsets,
+                    stage_expert_ids,
+                    ptrs_w,
+                    ptrs_s,
+                    stage_experts,
+                    layer.sm70_nvfp4_w13_k_dim,
+                    n,
+                    layer.sm70_nvfp4_group_size,
+                )
+        elif fused_indexed_w13:
+            logger.info_once(
+                "SM70 Qwen3.8 NVFP4 indexed-A fused-SwiGLU W13 prefill "
+                "candidate enabled."
+            )
+            sm70_ops.nvfp4_moe_indexed_fused_swiglu_sm70_out(
+                buffers["intermediate"],
+                x,
+                buffers["input_row_indices"],
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_experts,
+                layer.sm70_nvfp4_w13_k_dim,
+                layer.sm70_nvfp4_w13_n_dim,
+                layer.sm70_nvfp4_group_size,
+            )
+        elif indexed_w13:
             logger.info_once(
                 "SM70 Qwen3.8 NVFP4 indexed-A W13 prefill route enabled "
                 "(TP4, E512/K10, materialized input rows skipped)."
@@ -873,7 +1026,13 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 layer.sm70_nvfp4_w13_n_dim,
                 layer.sm70_nvfp4_group_size,
             )
-        self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
+        if not fused_indexed_w13:
+            self._apply_swiglu(
+                layer,
+                buffers["intermediate"],
+                buffers["gate_up"],
+                interleaved=interleaved_w13,
+            )
         sm70_ops.nvfp4_moe_dense_stage_sm70_out(
             buffers["sorted_output"],
             buffers["intermediate"],

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -128,6 +128,24 @@ def _gather_ple_fp8_from_pinned_kernel(
     tl.store(output_ptr + row_idx * embedding_dim + offsets, values, mask=mask)
 
 
+@triton.jit
+def _dequantize_ple_fp8_bytes_kernel(
+    input_ptr,
+    scale_ptr,
+    output_ptr,
+    numel,
+    BLOCK: tl.constexpr,
+):
+    """Dequantize raw E4M3FN bytes without exposing FP8 to SM70 Inductor."""
+
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < numel
+    raw = tl.load(input_ptr + offsets, mask=mask, other=0)
+    scale = tl.load(scale_ptr).to(tl.float32)
+    values = _e4m3fn_byte_to_float(raw) * scale
+    tl.store(output_ptr + offsets, values, mask=mask)
+
+
 def _splitmix64(value: int) -> int:
     value = (value + _SPLITMIX_GAMMA) & _MASK64
     value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
@@ -671,23 +689,33 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         ngram_ids = torch.cat(id_blocks, dim=-1)
         if output_buffer is not None:
             output = output_buffer[:num_tokens, : self.embedding_dim]
+            # Cross-process FP8 results travel as raw bytes. Keeping the IPC
+            # buffers uint8 prevents TorchInductor from treating their graph
+            # inputs as native FP8, which SM70 Triton does not support.
+            embedding_output = (
+                output.view(torch.float8_e4m3fn)
+                if output.dtype == torch.uint8
+                else output
+            )
             torch.index_select(
                 self.ngram_embedding.weight,
                 0,
                 ngram_ids.reshape(-1),
-                out=output.reshape(-1, self.head_dim),
+                out=embedding_output.reshape(-1, self.head_dim),
             )
             return output
         return self.ngram_embedding(ngram_ids).flatten(-2)
 
     def get_offload_output_dtype(self, default_dtype: torch.dtype) -> torch.dtype:
-        """Keep quantized lookup results in their embedding storage dtype."""
+        """Transport quantized lookup results as opaque E4M3FN bytes."""
         embedding = getattr(self, "ngram_embedding", None)
         weight = getattr(embedding, "weight", None)
+        if weight is not None and weight.dtype == torch.float8_e4m3fn:
+            return torch.uint8
+        if hasattr(self, "_offload_weight_scale"):
+            return torch.uint8
         if weight is not None:
             return weight.dtype
-        if hasattr(self, "_offload_weight_scale"):
-            return torch.float8_e4m3fn
         return default_dtype
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -701,9 +729,17 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             for name, loaded_weight in weights:
                 if name != "ngram_embedding.weight_scale":
                     continue
+                # Match the resident FP8 embedding contract: its global scale
+                # is a graph input in the model dtype. Retaining a checkpoint
+                # BF16 scale in an otherwise-FP16 graph makes Inductor reject
+                # SM70 before the explicit dequantization cast is lowered.
+                scale_dtype = getattr(self, "_offload_model_dtype", loaded_weight.dtype)
                 self.register_buffer(
                     "_offload_weight_scale",
-                    loaded_weight.to(device=torch.accelerator.current_accelerator()),
+                    loaded_weight.to(
+                        device=torch.accelerator.current_accelerator(),
+                        dtype=scale_dtype,
+                    ),
                     persistent=False,
                 )
                 retained.add(name)
@@ -824,6 +860,10 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 quant_config=quant_config,
                 params_dtype=model_config.dtype,
             )
+        # PleOffloadLayer skips the embedding subclass constructor in GPU
+        # workers, so preserve the model-dtype scale contract explicitly for
+        # its checkpoint-only load path.
+        self.ple_embedding._offload_model_dtype = model_config.dtype
         self.key_proj = ReplicatedLinear(
             int(config.ple_embed_dim),
             self.hc_hidden_size,
@@ -879,6 +919,21 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
     ) -> torch.Tensor:
         """Dequantize PLE lookup output."""
 
+        if embeddings.dtype == torch.uint8:
+            weight_scale = self._get_embedding_weight_scale()
+            if weight_scale is None:
+                raise RuntimeError("FP8 PLE embedding is missing its global scale")
+            if weight_scale.device != embeddings.device:
+                raise RuntimeError(
+                    "FP8 PLE embedding scale must be on the output device"
+                )
+            output = torch.empty_like(embeddings, dtype=output_dtype)
+            torch.ops.vllm.qwen4_exp_ple_fp8_bytes_dequant(
+                embeddings,
+                weight_scale,
+                output,
+            )
+            return output
         if not is_fp8(embeddings):
             return embeddings
         weight_scale = self._get_embedding_weight_scale()
@@ -1509,11 +1564,49 @@ def qwen4_exp_ple_pinned_gather_fake(
     return
 
 
+def qwen4_exp_ple_fp8_bytes_dequant(
+    input_bytes: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    if input_bytes.dtype != torch.uint8:
+        raise TypeError(
+            f"Qwen4Exp PLE byte dequant expects uint8 input, got {input_bytes.dtype}"
+        )
+    if input_bytes.numel() == 0:
+        return
+    block = 1024
+    _dequantize_ple_fp8_bytes_kernel[(triton.cdiv(input_bytes.numel(), block),)](
+        input_bytes,
+        weight_scale,
+        output,
+        input_bytes.numel(),
+        BLOCK=block,
+        num_warps=4,
+    )
+
+
+def qwen4_exp_ple_fp8_bytes_dequant_fake(
+    input_bytes: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    return
+
+
 direct_register_custom_op(
     op_name="qwen4_exp_ple_pinned_gather",
     op_func=qwen4_exp_ple_pinned_gather,
     mutates_args=["output"],
     fake_impl=qwen4_exp_ple_pinned_gather_fake,
+)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_ple_fp8_bytes_dequant",
+    op_func=qwen4_exp_ple_fp8_bytes_dequant,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_ple_fp8_bytes_dequant_fake,
 )
 
 


### PR DESCRIPTION
## Purpose

Stacked on #390. Accelerate the exact Qwen3.8 Flash Next NVFP4 TP4 prefill route on SM70 without changing decode or duplicating expert weights.

- Fuse exact FP16 SwiGLU into indexed W13.
- Partition packed W13 N320 into zero-copy N256 + N64 projections so the tail no longer wastes half an N128 tile.
- Use the measured cache-B W2 kernel for the exact E512/K10 descriptor.
- Make FP8 PLE CPU offload compile-safe on V100 by transporting raw bytes and dequantizing through an opaque SM70 kernel.

Both new performance gates default on only for the exact admitted contract and retain environment-variable rollbacks. Older extensions fall back unless the new route is explicitly forced.

## Test Plan

- Production-shaped real-weight operator/hash screen on one V100.
- All-256-value E4M3FN eager and `torch.compile(fullgraph=True)` dequant gate on V100.
- Focused PLE and mixed-NVFP4 unit suites.
- One TP4 V2/no-MTP/FP16-KV/PLE-CPU-offload endpoint startup covering quality plus 8K, 32K, 64K, 131K, and exact 256K.
- Ruff, diff check, and repository clang-format hook.

## Test Result

- Real-weight 8K operator chain: `6.684 -> 6.12096 ms/layer/rank`; retained intermediate and output hashes are exact.
- PLE byte dequant: all 256 encodings match the reference; `8192x2560` median is `0.127 ms` with unchanged 20 MiB IPC footprint.
- Unit tests: `39 passed` (`test_ple.py` plus `test_sm70_modelopt_mixed_nvfp4.py`).
- Ruff, `git diff --check`, and clang-format pass.
- Full endpoint, pure prefill:
  - 8K: `1.160956 s`, `7,056.26 token/s` (`+1.23%` vs #390)
  - 32K: `4.962370 s`, `6,603.30 token/s` (`+1.48%`)
  - 64K: `10.357441 s`, `6,327.43 token/s` (`+1.38%`)
  - 131K: `22.101014 s`, `5,927.33 token/s` (`+0.95%`)
  - input 262,143 + output 1: `49.945010 s`, `5,248.63 token/s`
- All seven requests report `is_corrupted=false`; arithmetic and Chinese quality outputs are correct. Exact-256K output hash: `274dfec6e079fb08d6b5771537c54d3f0bd36c64c3d8ed0a4e6d2f201b489274`.
- 256K steady-state allocation is 32,409-32,471 MiB/rank. Interior NVML samples are 99.81-100% GPU utilization, so the next optimization should profile context-growing attention/indexer work at 256K rather than repeat 128K-only startup tests.
