### PR TITLE
[Bugfix][QSA][SM70] Make sparse block selection deterministic

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -261,6 +261,10 @@ void persistent_topk(const torch::stable::Tensor& logits,
                      torch::stable::Tensor& workspace, int64_t k,
                      int64_t max_seq_len);
 
+void qsa_lexicographic_topk(const torch::stable::Tensor& logits,
+                            const torch::stable::Tensor& lengths,
+                            torch::stable::Tensor& output, int64_t k);
+
 void selective_scan_fwd(
     const torch::stable::Tensor& u, const torch::stable::Tensor& delta,
     const torch::stable::Tensor& A, const torch::stable::Tensor& B,

--- a/csrc/libtorch_stable/topk.cu
+++ b/csrc/libtorch_stable/topk.cu
@@ -8,6 +8,7 @@
 
 #ifndef USE_ROCM
   #include "../persistent_topk.cuh"
+  #include "../qsa_lexicographic_topk.cuh"
 #endif
 
 namespace {
@@ -272,5 +273,56 @@ void persistent_topk(const torch::stable::Tensor& logits,
   }
 #else
   STD_TORCH_CHECK(false, "persistent_topk is not supported on ROCm");
+#endif
+}
+
+void qsa_lexicographic_topk(const torch::stable::Tensor& logits,
+                            const torch::stable::Tensor& lengths,
+                            torch::stable::Tensor& output, int64_t k) {
+#ifndef USE_ROCM
+  STD_TORCH_CHECK(logits.is_cuda(), "logits must be CUDA tensor");
+  STD_TORCH_CHECK(lengths.is_cuda(), "lengths must be CUDA tensor");
+  STD_TORCH_CHECK(output.is_cuda(), "output must be CUDA tensor");
+  STD_TORCH_CHECK(logits.scalar_type() == torch::headeronly::ScalarType::Float,
+                  "Only float32 logits are supported");
+  STD_TORCH_CHECK(lengths.scalar_type() == torch::headeronly::ScalarType::Int,
+                  "lengths must be int32");
+  STD_TORCH_CHECK(output.scalar_type() == torch::headeronly::ScalarType::Int,
+                  "output must be int32");
+  STD_TORCH_CHECK(logits.dim() == 2, "logits must be 2D");
+  STD_TORCH_CHECK(logits.stride(1) == 1,
+                  "logits must be contiguous in the column dimension");
+  STD_TORCH_CHECK(lengths.dim() == 1, "lengths must be 1D");
+  STD_TORCH_CHECK(lengths.is_contiguous(), "lengths must be contiguous");
+  STD_TORCH_CHECK(output.dim() == 2, "output must be 2D");
+  STD_TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
+  STD_TORCH_CHECK(k == 512,
+                  "qsa_lexicographic_topk supports only k=512, got k=", k);
+
+  const int64_t num_rows = logits.size(0);
+  STD_TORCH_CHECK(
+      num_rows <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+      "logits row count exceeds uint32 range");
+  STD_TORCH_CHECK(lengths.numel() == num_rows, "lengths size mismatch");
+  STD_TORCH_CHECK(output.size(0) == num_rows && output.size(1) == k,
+                  "output size mismatch");
+  STD_TORCH_CHECK(logits.size(1) <= static_cast<int64_t>(
+                                        std::numeric_limits<uint32_t>::max()),
+                  "logits width exceeds uint32 range");
+  STD_TORCH_CHECK(logits.stride(0) <= static_cast<int64_t>(
+                                          std::numeric_limits<uint32_t>::max()),
+                  "logits row stride exceeds uint32 range");
+  if (num_rows == 0) return;
+
+  vllm::qsa::launch_qsa_lexicographic_topk<512>(
+      logits.const_data_ptr<float>(), lengths.const_data_ptr<int32_t>(),
+      output.mutable_data_ptr<int32_t>(), static_cast<uint32_t>(num_rows),
+      static_cast<uint32_t>(logits.size(1)),
+      static_cast<uint32_t>(logits.stride(0)), get_current_cuda_stream());
+  const cudaError_t err = cudaGetLastError();
+  STD_TORCH_CHECK(err == cudaSuccess,
+                  "qsa_lexicographic_topk failed: ", cudaGetErrorString(err));
+#else
+  STD_TORCH_CHECK(false, "qsa_lexicographic_topk is not supported on ROCm");
 #endif
 }

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -360,6 +360,10 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "persistent_topk(Tensor logits, Tensor lengths, Tensor! output, "
       "Tensor workspace, int k, int max_seq_len) -> ()");
 
+  ops.def(
+      "qsa_lexicographic_topk(Tensor logits, Tensor lengths, Tensor! output, "
+      "int k) -> ()");
+
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");
@@ -585,6 +589,7 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("top_k_per_row_prefill", TORCH_BOX(&top_k_per_row_prefill));
   ops.impl("top_k_per_row_decode", TORCH_BOX(&top_k_per_row_decode));
   ops.impl("persistent_topk", TORCH_BOX(&persistent_topk));
+  ops.impl("qsa_lexicographic_topk", TORCH_BOX(&qsa_lexicographic_topk));
 
   // Activation kernels (shared CUDA/ROCm)
   ops.impl("silu_and_mul", TORCH_BOX(&silu_and_mul));

--- a/csrc/qsa_lexicographic_topk.cuh
+++ b/csrc/qsa_lexicographic_topk.cuh
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#ifndef VLLM_CSRC_QSA_LEXICOGRAPHIC_TOPK_CUH_
+#define VLLM_CSRC_QSA_LEXICOGRAPHIC_TOPK_CUH_
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cub/block/block_scan.cuh>
+#include <cstdint>
+#include <limits>
+
+namespace vllm::qsa {
+
+constexpr int kLexicographicTopKThreads = 1024;
+constexpr int kLexicographicTopKBins = 256;
+
+__device__ __forceinline__ uint32_t ordered_float_bits(float value) {
+  // IEEE -0.0 and +0.0 compare equal, so keep them in the same score bucket
+  // and let the block index provide the deterministic tie break.
+  if (value == 0.0f) value = 0.0f;
+  const uint32_t bits = __float_as_uint(value);
+  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+}
+
+__device__ __forceinline__ uint64_t lexicographic_key(float score,
+                                                      uint32_t index) {
+  // Larger keys win. Scores are ordered first; equal scores prefer the lower
+  // block index. The resulting key is unique for every element in a row.
+  return (static_cast<uint64_t>(ordered_float_bits(score)) << 32) |
+         (std::numeric_limits<uint32_t>::max() - index);
+}
+
+template <int TopK>
+struct LexicographicTopKShared {
+  using BlockScan = cub::BlockScan<uint32_t, kLexicographicTopKThreads>;
+
+  uint32_t histogram[kLexicographicTopKBins];
+  typename BlockScan::TempStorage scan;
+  uint64_t prefix;
+  uint64_t pivot;
+  uint32_t remaining;
+  uint32_t output_base;
+  uint32_t chunk_base;
+};
+
+template <int TopK>
+__global__
+__launch_bounds__(kLexicographicTopKThreads) void qsa_lexicographic_topk_kernel(
+    const float* __restrict__ logits, const int32_t* __restrict__ lengths,
+    int32_t* __restrict__ output, uint32_t num_rows, uint32_t columns,
+    uint32_t stride) {
+  const uint32_t row = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  if (row >= num_rows) return;
+
+  const int32_t raw_length = lengths[row];
+  const uint32_t length =
+      raw_length > 0 ? min(static_cast<uint32_t>(raw_length), columns) : 0;
+  const float* row_logits = logits + static_cast<uint64_t>(row) * stride;
+  int32_t* row_output = output + static_cast<uint64_t>(row) * TopK;
+
+  if (length <= TopK) {
+    for (uint32_t index = tx; index < TopK;
+         index += kLexicographicTopKThreads) {
+      row_output[index] = index < length ? static_cast<int32_t>(index) : -1;
+    }
+    return;
+  }
+
+  __shared__ LexicographicTopKShared<TopK> shared;
+  if (tx == 0) {
+    shared.prefix = 0;
+    shared.remaining = TopK;
+  }
+  __syncthreads();
+
+  // Select the exact k-th (score descending, index ascending) key. Eight
+  // byte-wide radix passes cover the full 64-bit composite key without a
+  // bounded candidate buffer, so dense ties cannot overflow or race.
+#pragma unroll
+  for (int pass = 0; pass < 8; ++pass) {
+    for (uint32_t bin = tx; bin < kLexicographicTopKBins;
+         bin += kLexicographicTopKThreads) {
+      shared.histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const int shift = 56 - pass * 8;
+    const uint64_t prefix = shared.prefix;
+    const uint64_t prefix_mask = pass == 0 ? 0 : (~uint64_t{0} << (shift + 8));
+    for (uint32_t index = tx; index < length;
+         index += kLexicographicTopKThreads) {
+      const uint64_t key = lexicographic_key(row_logits[index], index);
+      if ((key & prefix_mask) == prefix) {
+        atomicAdd(&shared.histogram[(key >> shift) & 0xffu], 1u);
+      }
+    }
+    __syncthreads();
+
+    if (tx == 0) {
+      uint32_t remaining = shared.remaining;
+      for (int bin = kLexicographicTopKBins - 1; bin >= 0; --bin) {
+        const uint32_t count = shared.histogram[bin];
+        if (remaining > count) {
+          remaining -= count;
+        } else {
+          shared.prefix |= static_cast<uint64_t>(bin) << shift;
+          shared.remaining = remaining;
+          break;
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tx == 0) {
+    shared.pivot = shared.prefix;
+    shared.output_base = 0;
+  }
+  __syncthreads();
+
+  // Compact in increasing index order. This is both the deterministic tie
+  // contract and QSA's canonical accumulation order, so no repair or second
+  // sorting pass is needed.
+  using BlockScan = typename LexicographicTopKShared<TopK>::BlockScan;
+  for (uint32_t base = 0; base < length; base += kLexicographicTopKThreads) {
+    const uint32_t index = base + tx;
+    const uint32_t selected =
+        index < length &&
+                lexicographic_key(row_logits[index], index) >= shared.pivot
+            ? 1u
+            : 0u;
+    uint32_t offset = 0;
+    uint32_t aggregate = 0;
+    BlockScan(shared.scan).ExclusiveSum(selected, offset, aggregate);
+    __syncthreads();
+    if (tx == 0) {
+      shared.chunk_base = shared.output_base;
+      shared.output_base += aggregate;
+    }
+    __syncthreads();
+    if (selected) {
+      row_output[shared.chunk_base + offset] = static_cast<int32_t>(index);
+    }
+    __syncthreads();
+  }
+}
+
+template <int TopK>
+void launch_qsa_lexicographic_topk(const float* logits, const int32_t* lengths,
+                                   int32_t* output, uint32_t num_rows,
+                                   uint32_t columns, uint32_t stride,
+                                   cudaStream_t stream) {
+  qsa_lexicographic_topk_kernel<TopK>
+      <<<num_rows, kLexicographicTopKThreads, 0, stream>>>(
+          logits, lengths, output, num_rows, columns, stride);
+}
+
+}  // namespace vllm::qsa
+
+#endif  // VLLM_CSRC_QSA_LEXICOGRAPHIC_TOPK_CUH_

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -843,3 +843,111 @@ def test_persistent_topk_padded_stride(top_k: int) -> None:
                 f"Row {i}: persistent_topk with padded stride doesn't match. "
                 f"seq_len={sl}, stride={padded_stride}"
             )
+
+
+def _qsa_lexicographic_topk_reference(
+    logits: torch.Tensor, lengths: list[int], top_k: int
+) -> torch.Tensor:
+    rows = []
+    for row, length in enumerate(lengths):
+        if length <= top_k:
+            selected = torch.arange(length, device=logits.device, dtype=torch.int32)
+            selected = torch.nn.functional.pad(selected, (0, top_k - length), value=-1)
+        else:
+            # Stable descending argsort gives the required low-index tie break.
+            selected = torch.argsort(
+                logits[row, :length], descending=True, stable=True
+            )[:top_k]
+            selected = selected.sort().values.to(torch.int32)
+        rows.append(selected)
+    return torch.stack(rows)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@torch.inference_mode()
+def test_qsa_lexicographic_topk_is_exact_and_repeatable() -> None:
+    """QSA top-k is exact across overflow ramps and real score ties."""
+
+    torch.set_default_device("cuda:0")
+    top_k = 512
+    padded_stride = 806736
+    live_lengths = [511, 4096, 4096, 16384]
+    logits = torch.full(
+        (len(live_lengths), padded_stride),
+        float("-inf"),
+        dtype=torch.float32,
+    )
+    logits[0, : live_lengths[0]] = torch.arange(
+        live_lengths[0], 0, -1, dtype=torch.float32
+    )
+    # This mirrors the V100 reproducer: every value exceeds FP16 range even
+    # though the FP32 keys are strictly descending and unique.
+    logits[1, : live_lengths[1]] = torch.arange(
+        padded_stride,
+        padded_stride - live_lengths[1],
+        -1,
+        dtype=torch.float32,
+    )
+    logits[2, : live_lengths[2] : 2] = 0.0
+    logits[2, 1 : live_lengths[2] : 2] = -0.0
+    # A dense, natural zero/tie boundary plus nonzero score bands.
+    logits[3, : live_lengths[3]] = (
+        torch.arange(live_lengths[3], dtype=torch.float32) % 17
+    )
+
+    lengths = torch.tensor(live_lengths, dtype=torch.int32)
+    output = torch.empty((len(live_lengths), top_k), dtype=torch.int32)
+    expected = _qsa_lexicographic_topk_reference(logits, live_lengths, top_k)
+
+    for _ in range(10):
+        torch.ops._C.qsa_lexicographic_topk(logits, lengths, output, top_k)
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@torch.inference_mode()
+def test_qsa_lexicographic_topk_supports_prefill_batches() -> None:
+    """The exact path also covers prefill chunks with more than 32 rows."""
+
+    torch.set_default_device("cuda:0")
+    rows = 64
+    columns = 4096
+    top_k = 512
+    logits = (
+        torch.arange(columns, dtype=torch.float32).unsqueeze(0)
+        + torch.arange(rows, dtype=torch.float32).unsqueeze(1)
+    ) % 23
+    live_lengths = [columns - (row % 8) * 128 for row in range(rows)]
+    lengths = torch.tensor(live_lengths, dtype=torch.int32)
+    output = torch.empty((rows, top_k), dtype=torch.int32)
+    expected = _qsa_lexicographic_topk_reference(logits, live_lengths, top_k)
+
+    torch.ops._C.qsa_lexicographic_topk(logits, lengths, output, top_k)
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@torch.inference_mode()
+def test_qsa_lexicographic_topk_cuda_graph_replay_is_stable() -> None:
+    """The selector keeps identical membership and order across graph replays."""
+
+    torch.set_default_device("cuda:0")
+    top_k = 512
+    live_length = 4096
+    logits = torch.zeros((1, 8192), dtype=torch.float32)
+    lengths = torch.tensor([live_length], dtype=torch.int32)
+    output = torch.empty((1, top_k), dtype=torch.int32)
+    expected = torch.arange(top_k, dtype=torch.int32).unsqueeze(0)
+
+    torch.ops._C.qsa_lexicographic_topk(logits, lengths, output, top_k)
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops._C.qsa_lexicographic_topk(logits, lengths, output, top_k)
+
+    for _ in range(10):
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -9,7 +9,10 @@ from vllm.models.qwen4_exp.nvidia.ops.qsa import (
     _qsa_indexer_cublas_shape_supported,
     _qsa_sparse_launch_profile,
     _qsa_xqa_page4_shape_supported,
+    _use_sm70_qsa_lexicographic_topk,
 )
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 def test_sm70_qsa_prefill_uses_narrow_tiles_and_four_warps():
@@ -230,3 +233,21 @@ def test_qsa_indexer_cublas_requires_enough_score_work(monkeypatch):
 
     assert not qsa_ops._qsa_indexer_cublas_work_supported(1024, 512)
     assert qsa_ops._qsa_indexer_cublas_work_supported(2048, 512)
+
+
+def test_qsa_lexicographic_topk_is_limited_to_sm70_qsa_shape(monkeypatch):
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 70,
+    )
+
+    assert _use_sm70_qsa_lexicographic_topk(512)
+    assert not _use_sm70_qsa_lexicographic_topk(1024)
+
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: False,
+    )
+    assert not _use_sm70_qsa_lexicographic_topk(512)

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -972,6 +972,12 @@ def _qsa_indexer_cublas_work_supported(rows: int, columns: int) -> bool:
     return rows * columns >= _SM70_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS
 
 
+def _use_sm70_qsa_lexicographic_topk(topk: int) -> bool:
+    """Use the exact, deterministic selector for Volta QSA."""
+
+    return topk == 512 and current_platform.is_device_capability(70)
+
+
 def _qsa_visible_blocks(
     token_to_req: torch.Tensor,
     query_positions: torch.Tensor,
@@ -1227,19 +1233,31 @@ def qsa_select_paged_tokens(
             and current_platform.has_device_capability(90)
             and not current_platform.is_device_capability_family(120)
         )
-        topk_op = (
-            torch.ops._C.cooperative_topk
-            if use_cooperative_topk
-            else torch.ops._C.persistent_topk
-        )
-        topk_op(
-            logits,
-            visible_blocks,
-            blocks,
-            topk_workspace,
-            block_topk,
-            score_columns,
-        )
+        if _use_sm70_qsa_lexicographic_topk(block_topk):
+            logger.info_once(
+                "Using exact SM70 QSA lexicographic top-k "
+                "(score descending, block index ascending)."
+            )
+            torch.ops._C.qsa_lexicographic_topk(
+                logits,
+                visible_blocks,
+                blocks,
+                block_topk,
+            )
+        else:
+            topk_op = (
+                torch.ops._C.cooperative_topk
+                if use_cooperative_topk
+                else torch.ops._C.persistent_topk
+            )
+            topk_op(
+                logits,
+                visible_blocks,
+                blocks,
+                topk_workspace,
+                block_topk,
+                score_columns,
+            )
         expand_qsa_block_indices_cuda(
             blocks,
             query_positions[row_slice],


### PR DESCRIPTION
## Purpose

Qwen3.8 Flash Next QSA can produce different selected KV-block sets when many scores tie exactly at the top-k cutoff. Sorting the indices returned by `persistent_topk` is insufficient because the selected membership has already drifted.

This PR adds a QSA-specific exact selector with a single deterministic contract:

- score descending;
- lower block index first on exact score ties;
- selected indices emitted in canonical ascending order.

The CUDA kernel packs the score and inverse block index into an exact 64-bit lexicographic key and performs eight byte-radix passes with one CTA per row. It has no bounded tie-candidate buffer or overflow fallback. Signed zero is normalized before key construction. Both QSA prefill and decode use the same selector; the generic `persistent_topk` path is unchanged.

Related generic vLLM issue: https://github.com/vllm-project/vllm/issues/51782

## Test Plan

```bash
python -m pytest -q \
  tests/models/qwen4_exp/test_qsa_ops.py \
  tests/kernels/test_top_k_per_row.py

pre-commit run --files \
  csrc/libtorch_stable/ops.h \
  csrc/libtorch_stable/topk.cu \
  csrc/libtorch_stable/torch_bindings.cpp \
  csrc/qsa_lexicographic_topk.cuh \
  tests/kernels/test_top_k_per_row.py \
  tests/models/qwen4_exp/test_qsa_ops.py \
  vllm/models/qwen4_exp/nvidia/ops/qsa.py
```

On 4x V100 32 GiB, TP4, Qwen3.8 Flash Next NVFP4, run:

- direct, CUDA-graph, and prefill selector probes, 10 repeats each;
- natural-text greedy model gates at 16K under FULL and PIECEWISE graph policies;
- two independent natural-text processes at 32K and 64K, three target repeats per process;
- one final 16K FULL smoke after rebasing onto main with PRs #389 and #391 merged.

## Test Result

- Focused pytest: `8 passed, 116 skipped`.
- Ruff, format, typos, clang-format, mypy, SPDX, and config hooks passed.
- Direct, CUDA-graph, and prefill probes: one unique selected set/order across all 10 repeats; independent-process hashes match.
- 16K FULL A/B and PIECEWISE produce the same 16-token greedy target sequence.
- 32K A/B: `3/3` identical within each process and identical across processes.
- 64K A/B: `3/3` identical within each process and identical across processes; the 65,523-token prompt exercises the page4 route.
- Final rebased 16K FULL smoke: `3/3` identical and equal to the frozen baseline; clean shutdown with all four GPUs at 0 MiB.

A separate cold-first-use short-context XQA anomaly is being diagnosed independently. It can occur before the long-context target in a fresh process, while the exact selector probes and 16K-64K target gates remain stable. It is intentionally not mixed into this selector PR.
