### PR TITLE
[Quantization] Support native Quark W4A16 INT4/UINT4 exports

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -88,7 +88,7 @@ from vllm.model_executor.kernels.linear.mxfp8.marlin import (
     MarlinMxfp8LinearKernel,
 )
 from vllm.model_executor.kernels.linear.mxfp8.xpu import (
-    XPUMxFp8LinearKernel,
+    XPUMxfp8LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4 import (
     NvFp4LinearKernel,
@@ -368,7 +368,7 @@ _POSSIBLE_MXFP8_KERNELS: dict[PlatformEnum, list[type[Mxfp8LinearKernel]]] = {
         EmulationMxfp8LinearKernel,
     ],
     PlatformEnum.XPU: [
-        XPUMxFp8LinearKernel,
+        XPUMxfp8LinearKernel,
         EmulationMxfp8LinearKernel,
     ],
 }
@@ -674,6 +674,9 @@ def choose_mp_linear_kernel(
 
         can_implement, failure_reason = kernel.can_implement(config)
         if can_implement:
+            logger.info_once(
+                "Using %s for mixed-precision linear", kernel.__name__
+            )
             return kernel
         else:
             failure_reasons.append(
@@ -1046,7 +1049,7 @@ __all__ = [
     "MarlinMxFp4LinearKernel",
     "FlashInferCutlassMxfp8LinearKernel",
     "MarlinMxfp8LinearKernel",
-    "XPUMxFp8LinearKernel",
+    "XPUMxfp8LinearKernel",
     "EmulationMxfp8LinearKernel",
     "CutlassNvFp4LinearKernel",
     "EmulationNvFp4LinearKernel",

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -131,7 +131,7 @@ def _replace_or_register_parameter(
 def _convert_awq_to_standard_format(
     layer: torch.nn.Module,
     w_q_name: str,
-    w_zp_name: str,
+    w_zp_name: str | None,
     size_bits: int,
 ) -> None:
     """Convert AWQ weight and zero-point tensors to standard GPTQ-like format.
@@ -139,6 +139,7 @@ def _convert_awq_to_standard_format(
     AWQ packs qweight along the output dim with a non-standard bit order.
     This converts to standard bit order and repacks qweight along the input
     dim, matching the format expected by the MPLinearKernel framework.
+    If w_zp_name is None (symmetric quantization), only the weight is converted.
     """
     pack_factor = 32 // size_bits
     mask = (1 << size_bits) - 1
@@ -176,6 +177,9 @@ def _convert_awq_to_standard_format(
         weight_loader=_noop_loader,
     )
     setattr(layer, w_q_name, new_param)
+
+    if w_zp_name is None:
+        return
 
     # --- Convert qzeros: fix AWQ bit ordering and repack
     # AWQ qzeros: (G, N // pack) packed along dim 1, AWQ bit order

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -27,14 +27,17 @@ from vllm.model_executor.layers.quantization.quark.schemes import (
     QuarkNVFP4,
     QuarkOCP_MX,
     QuarkScheme,
+    QuarkW4A16Int4,
     QuarkW4A8_MXFP4_FP8,
     QuarkW8A8Fp8,
     QuarkW8A8Int8,
 )
 from vllm.model_executor.layers.quantization.quark.utils import (
     deep_compare,
+    parse_w4a16_int4_weight_config,
     should_ignore_layer,
 )
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.utils import WeightsMapper
 from vllm.platforms import current_platform
 
@@ -93,8 +96,10 @@ class QuarkConfig(QuantizationConfig):
         quant_config_with_hf_to_vllm_mapper: dict[str, Any] = {}
 
         for k, v in self.quant_config.items():
-            if isinstance(v, list):
+            if isinstance(v, list) and all(isinstance(item, str) for item in v):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_list(v)
+            elif isinstance(v, list):
+                quant_config_with_hf_to_vllm_mapper[k] = v
             elif isinstance(v, dict):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_dict(v)
             else:
@@ -118,7 +123,7 @@ class QuarkConfig(QuantizationConfig):
             if (
                 "self_attn" not in prefix  # only quantize attention projections
                 or not getattr(self, "dynamic_mxfp4_quant", False)
-                or not isinstance(layer, LinearBase)  # Ignore other methods
+                or not isinstance(layer, (LinearBase, ParallelLMHead))
             ):
                 return UnquantizedLinearMethod()
 
@@ -129,7 +134,7 @@ class QuarkConfig(QuantizationConfig):
             )
             layer.scheme = scheme
             return QuarkLinearMethod(self)
-        if isinstance(layer, LinearBase):
+        if isinstance(layer, (LinearBase, ParallelLMHead)):
             scheme = self.get_scheme(layer=layer, layer_name=prefix)
             layer.scheme = scheme
             return QuarkLinearMethod(self)
@@ -339,6 +344,18 @@ class QuarkConfig(QuantizationConfig):
         # Both symmetric and asymmetric input quantization supported.
         # Only symmetric weight quantization supported.
         return is_int8_dtype and is_tensor and is_weight_symmetric and is_static
+
+    def _is_w4a16_int4(
+        self,
+        weight_quant: dict[str, Any] | None,
+        input_quant: dict[str, Any] | None,
+    ) -> bool:
+        if weight_quant is None:
+            return False
+
+        is_int4 = weight_quant.get("dtype") in ("int4", "uint4")
+        is_packed = self.pack_method in ("order", "reorder")
+        return is_int4 and is_packed
 
     def _is_w4a8_mxfp4_fp8(
         self,
@@ -606,6 +623,15 @@ class QuarkConfig(QuantizationConfig):
                 qscheme=weight_qscheme,
                 is_static_input_scheme=True,
                 input_symmetric=input_config.get("symmetric"),
+            )
+        elif self._is_w4a16_int4(weight_config, input_config):
+            group_size, is_symmetric = parse_w4a16_int4_weight_config(weight_config)
+            return QuarkW4A16Int4(
+                group_size=group_size,
+                pack_method=self.pack_method,
+                is_symmetric=is_symmetric,
+                weight_config=weight_config,
+                input_config=input_config,
             )
         elif self._is_w4a8_mxfp4_fp8(weight_config, input_config):
             is_w4a8_supported = self._check_scheme_supported(

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     fp8_w8a8_moe_quant_config,
+    int4_w4a16_moe_quant_config,
     int8_w8a8_moe_quant_config,
     mxfp4_w4a8_moe_quant_config,
     mxfp4_w4a16_moe_quant_config,
@@ -64,6 +65,9 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     normalize_e4m3fn_to_e4m3fnuz,
     per_tensor_dequantize,
 )
+from vllm.model_executor.layers.quantization.quark.utils import (
+    parse_w4a16_int4_weight_config,
+)
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
@@ -72,6 +76,7 @@ logger = init_logger(__name__)
 
 __all__ = [
     "QuarkMoEMethod",
+    "QuarkW4A16Int4MoEMethod",
     "QuarkW8A8Fp8MoEMethod",
     "QuarkOCP_MX_MoEMethod",
     "QuarkNvfp4MoEMethod",
@@ -103,6 +108,13 @@ class QuarkMoEMethod(FusedMoEMethodBase):
 
         if quant_config._is_fp8_w4a8(weight_config, input_config):
             return QuarkW4A8Fp8MoEMethod(weight_config, input_config, module.moe_config)
+        elif quant_config._is_w4a16_int4(weight_config, input_config):
+            return QuarkW4A16Int4MoEMethod(
+                weight_config,
+                quant_config.pack_method,
+                module.moe_config,
+                input_config=input_config,
+            )
         elif quant_config._is_nvfp4(weight_config, input_config):
             return QuarkNvfp4MoEMethod(
                 weight_config, input_config, module.moe_config, quant_config
@@ -121,6 +133,252 @@ class QuarkMoEMethod(FusedMoEMethodBase):
             )
         else:
             raise RuntimeError("Unsupported FusedMoe scheme")
+
+
+class QuarkW4A16Int4MoEMethod(QuarkMoEMethod):
+    """Quark packed INT4 weight-only MoE method."""
+
+    def __init__(
+        self,
+        weight_config: dict[str, Any],
+        pack_method: str,
+        moe: FusedMoEConfig,
+        input_config: dict[str, Any] | None = None,
+    ):
+        super().__init__(moe)
+        if input_config is not None:
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod does not support activation "
+                f"quantization; input_tensors must be None, got {input_config}."
+            )
+        if weight_config.get("qscheme", "per_group") != "per_group":
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod only supports per_group weight "
+                f"quantization, got {weight_config.get('qscheme')!r}."
+            )
+        if weight_config.get("is_dynamic"):
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod only supports static weight quantization."
+            )
+        self.weight_quant = weight_config
+        self.group_size, self.is_symmetric = parse_w4a16_int4_weight_config(
+            weight_config
+        )
+        self.bit8_pack_factor = 2
+        self.pack_reorder = pack_method == "reorder"
+
+    def create_weights(
+        self,
+        layer: RoutedExperts,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        group_size = self.group_size
+        group_size_div_factor = 1
+
+        while intermediate_size_per_partition % group_size or hidden_size % group_size:
+            group_size = group_size // 2
+            group_size_div_factor *= 2
+            assert group_size >= 32
+        layer.group_size = group_size
+        layer.group_size_div_factor = group_size_div_factor
+
+        strategy = FusedMoeWeightScaleSupported.GROUP.value
+        extra_weight_attrs.update({"quant_method": strategy, "is_transposed": False})
+
+        assert "weight_loader" in extra_weight_attrs
+        weight_loader = extra_weight_attrs["weight_loader"]
+        extra_weight_attrs["weight_loader"] = self.get_weight_loader(
+            layer, weight_loader
+        )
+
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // self.bit8_pack_factor,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // self.bit8_pack_factor,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        w13_weight_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_scale", w13_weight_scale)
+        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+
+        w2_weight_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_scale", w2_weight_scale)
+        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+
+        w13_weight_zero_point = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition // self.bit8_pack_factor,
+                hidden_size // group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_zero_point", w13_weight_zero_point)
+        set_weight_attrs(w13_weight_zero_point, extra_weight_attrs)
+
+        w2_weight_zero_point = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                hidden_size // self.bit8_pack_factor,
+                intermediate_size_per_partition // group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_zero_point", w2_weight_zero_point)
+        set_weight_attrs(w2_weight_zero_point, extra_weight_attrs)
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        return int4_w4a16_moe_quant_config(
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            w1_zp=layer.w13_weight_zero_point if not self.is_symmetric else None,
+            w2_zp=layer.w2_weight_zero_point if not self.is_symmetric else None,
+            block_shape=[0, layer.group_size],
+        )
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        from vllm.model_executor.layers.fused_moe import fused_experts
+
+        assert layer.activation == MoEActivation.SILU, (
+            f"Only SiLU activation is supported, not {layer.activation}."
+        )
+
+        return fused_experts(
+            x,
+            layer.w13_weight,
+            layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            quant_config=self.moe_quant_config,
+        )
+
+    def get_weight_loader(self, layer: RoutedExperts, weight_loader):
+        def convert_quark_tensor(tensor: torch.Tensor, tensor_type: str):
+            size0 = tensor.size(0)
+            tensor = tensor.view(torch.uint8)
+
+            shifter = torch.tensor([0, 4], dtype=torch.uint8, device=tensor.device)
+            tensor = (tensor[:, :, None] >> shifter) & 0xF
+
+            if self.pack_reorder:
+                reverse_awq_pack_order = [0, 4, 1, 5, 2, 6, 3, 7]
+                tensor = tensor.view(-1, 8)[:, reverse_awq_pack_order]
+            else:
+                tensor = tensor.view(-1, 8)
+            if self.is_symmetric:
+                tensor = tensor ^ 0x8
+            tensor = tensor.view(size0, -1)
+
+            tensor = tensor.T.contiguous()
+            if tensor_type == "weight":
+                tensor = tensor[:, 1::2] * 16 + tensor[:, ::2]
+            elif tensor_type == "zero_point":
+                tensor = tensor[1::2, :] * 16 + tensor[::2, :]
+            return tensor
+
+        def quark_int4_weight_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            weight_name: str,
+            shard_id: str,
+            expert_id: int,
+            return_success: bool = False,
+        ):
+            loaded_weight = loaded_weight.to(param.data.device)
+            shard_size = layer.intermediate_size_per_partition
+
+            if weight_name.endswith("_weight"):
+                loaded_weight = convert_quark_tensor(loaded_weight, "weight")
+            elif weight_name.endswith("_weight_zero_point"):
+                loaded_weight = convert_quark_tensor(loaded_weight, "zero_point")
+            elif weight_name.endswith("_weight_scale"):
+                loaded_weight = loaded_weight.T
+
+            if layer.group_size_div_factor > 1 and (
+                "weight_zero_point" in weight_name or "weight_scale" in weight_name
+            ):
+                loaded_weight = loaded_weight.repeat_interleave(
+                    layer.group_size_div_factor, 1
+                )
+
+            if "w13_weight_zero_point" in weight_name:
+                tensor = loaded_weight.view(
+                    layer.moe_config.tp_size, -1, loaded_weight.size(1)
+                )[layer.moe_config.tp_rank]
+                if shard_id == "w1":
+                    param.data[expert_id, : shard_size // 2] = tensor
+                else:
+                    param.data[expert_id, shard_size // 2 :] = tensor
+                return True if return_success else None
+            elif "w2_weight_zero_point" in weight_name:
+                param.data[expert_id] = loaded_weight.view(
+                    loaded_weight.size(0), layer.moe_config.tp_size, -1
+                )[:, layer.moe_config.tp_rank]
+                return True if return_success else None
+
+            return weight_loader(
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+                return_success=return_success,
+            )
+
+        return quark_int4_weight_loader
 
 
 class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
@@ -997,8 +1255,8 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 self.input_dtype = input_quant.replace("fp8_e4m3", "fp8")
             else:
                 raise NotImplementedError(
-                    f"Current input dtype {input_quant} is not compatible \
-                        with OCP MX (weight) MoE quantization. Please open an issue"
+                    f"Current input dtype {input_quant} is not compatible "
+                    "with OCP MX (weight) MoE quantization. Please open an issue"
                 )
         else:
             self.input_dtype = None

--- a/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
@@ -5,6 +5,7 @@ from .quark_nvfp4 import QuarkNVFP4
 from .quark_ocp_mx import QuarkOCP_MX
 from .quark_scheme import QuarkScheme
 from .quark_w4a8_mxfp4_fp8 import QuarkW4A8_MXFP4_FP8
+from .quark_w4a16_int4 import QuarkW4A16Int4
 from .quark_w8a8_fp8 import QuarkW8A8Fp8
 from .quark_w8a8_int8 import QuarkW8A8Int8
 
@@ -13,6 +14,7 @@ __all__ = [
     "QuarkW8A8Fp8",
     "QuarkW8A8Int8",
     "QuarkOCP_MX",
+    "QuarkW4A16Int4",
     "QuarkW4A8_MXFP4_FP8",
     "QuarkNVFP4",
 ]

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a16_int4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a16_int4.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearKernel,
+    MPLinearLayerConfig,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.awq_marlin import (
+    _convert_awq_to_standard_format,
+)
+from vllm.model_executor.layers.quantization.quark.schemes.quark_scheme import (
+    QuarkScheme,
+)
+from vllm.model_executor.layers.quantization.quark.utils import (
+    canonicalize_quark_packed_int4,
+)
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    PackedvLLMParameter,
+)
+from vllm.scalar_type import scalar_types
+
+
+class QuarkW4A16Int4(QuarkScheme):
+    """Quark packed INT4 weight-only linear scheme via MPLinearKernel."""
+
+    def __init__(
+        self,
+        group_size: int,
+        pack_method: str,
+        is_symmetric: bool,
+        weight_config: dict[str, Any] | None = None,
+        input_config: dict[str, Any] | None = None,
+    ):
+        if input_config is not None:
+            raise NotImplementedError(
+                "QuarkW4A16Int4 does not support activation quantization; "
+                f"input_tensors must be None, got {input_config}."
+            )
+        if weight_config is not None:
+            if weight_config.get("qscheme", "per_group") != "per_group":
+                raise NotImplementedError(
+                    "QuarkW4A16Int4 only supports per_group weight "
+                    f"quantization, got {weight_config.get('qscheme')!r}."
+                )
+            if weight_config.get("is_dynamic"):
+                raise NotImplementedError(
+                    "QuarkW4A16Int4 only supports static weight quantization."
+                )
+
+        self.group_size = group_size
+        self.pack_factor = 8
+        self.pack_reorder = pack_method == "reorder"
+        self.is_symmetric = is_symmetric
+        self.quant_type = scalar_types.uint4b8 if is_symmetric else scalar_types.uint4
+        self.kernel: MPLinearKernel | None = None
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ):
+        input_size = kwargs["input_size"]
+        output_size = kwargs["output_size"]
+        group_size = (
+            self.group_size if self.group_size != -1 else input_size_per_partition
+        )
+        if input_size_per_partition % group_size != 0:
+            raise ValueError(
+                "The input size is not aligned with the quantized weight shape. "
+                "This can be caused by too large tensor parallel size. "
+                f"input_size_per_partition={input_size_per_partition}, "
+                f"group_size={group_size}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        packed_output_size_per_partition = math.ceil(
+            output_size_per_partition / self.pack_factor
+        )
+        layer.output_size_per_partition = output_size_per_partition
+        layer.packed_output_size_per_partition = packed_output_size_per_partition
+
+        mp_linear_kernel_config = MPLinearLayerConfig(
+            full_weight_shape=(input_size, output_size),
+            partition_weight_shape=(
+                input_size_per_partition,
+                output_size_per_partition,
+            ),
+            weight_type=self.quant_type,
+            act_type=params_dtype,
+            group_size=group_size,
+            zero_points=not self.is_symmetric,
+            has_g_idx=False,
+        )
+        kernel_type = choose_mp_linear_kernel(mp_linear_kernel_config)
+
+        def weight_scale_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            *args,
+            **loader_kwargs,
+        ) -> None:
+            if loaded_weight.shape[1] < param.data.shape[1]:
+                padded_weight = loaded_weight.new_zeros(param.data.shape)
+                padded_weight[:, : loaded_weight.shape[1]] = loaded_weight
+                loaded_weight = padded_weight
+            weight_loader(param, loaded_weight, *args, **loader_kwargs)
+
+        weight = PackedvLLMParameter(
+            data=torch.empty(
+                input_size_per_partition,
+                packed_output_size_per_partition,
+                dtype=torch.int32,
+            ),
+            input_dim=0,
+            output_dim=1,
+            packed_dim=1,
+            packed_factor=self.pack_factor,
+            weight_loader=weight_loader,
+        )
+        num_groups = input_size_per_partition // group_size
+        weight_zero_point = PackedvLLMParameter(
+            data=torch.zeros(
+                num_groups,
+                packed_output_size_per_partition,
+                dtype=torch.int32,
+            ),
+            input_dim=0,
+            output_dim=1,
+            packed_dim=1,
+            packed_factor=self.pack_factor,
+            weight_loader=weight_loader,
+        )
+        weight_scale = GroupQuantScaleParameter(
+            data=torch.empty(
+                num_groups,
+                packed_output_size_per_partition * self.pack_factor,
+                dtype=params_dtype,
+            ),
+            input_dim=0,
+            output_dim=1,
+            weight_loader=weight_scale_loader,
+        )
+
+        layer.register_parameter("weight", weight)
+        layer.register_parameter("weight_zero_point", weight_zero_point)
+        layer.register_parameter("weight_scale", weight_scale)
+
+        self.kernel = kernel_type(
+            mp_linear_kernel_config,
+            w_q_param_name="weight",
+            w_s_param_name="weight_scale",
+            w_zp_param_name="weight_zero_point" if not self.is_symmetric else None,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight.data = canonicalize_quark_packed_int4(
+            layer.weight.data,
+            pack_reorder=self.pack_reorder,
+            is_symmetric=self.is_symmetric,
+            pack_factor=self.pack_factor,
+        )
+        if not self.is_symmetric:
+            layer.weight_zero_point.data = canonicalize_quark_packed_int4(
+                layer.weight_zero_point.data,
+                pack_reorder=self.pack_reorder,
+                is_symmetric=self.is_symmetric,
+                pack_factor=self.pack_factor,
+            )
+        output_size = layer.output_size_per_partition
+        packed_output_size = layer.packed_output_size_per_partition * self.pack_factor
+        if output_size < packed_output_size:
+            layer.weight_scale.data[:, output_size:].zero_()
+
+        _convert_awq_to_standard_format(
+            layer,
+            "weight",
+            "weight_zero_point" if not self.is_symmetric else None,
+            self.quant_type.size_bits,
+        )
+        assert self.kernel is not None
+        self.kernel.process_weights_after_loading(layer)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ):
+        assert self.kernel is not None
+        return self.kernel.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/quark/utils.py
+++ b/vllm/model_executor/layers/quantization/quark/utils.py
@@ -93,6 +93,8 @@ def _is_equal_or_regex_match(
     Checks whether a value is exactly equal or a regex match for target
     if target starts with 're:'. If check_contains is set to True,
     additionally checks if the target string is contained within the value.
+    A bare target with no '.' matches against the leaf module name so that
+    e.g. "lm_head" matches "language_model.lm_head".
     """
 
     if target.startswith("re:"):
@@ -102,9 +104,69 @@ def _is_equal_or_regex_match(
     elif check_contains:
         if target.lower() in value.lower():
             return True
+    elif "." not in target:
+        if value.split(".")[-1] == target:
+            return True
     elif target == value:
         return True
     return False
+
+
+def parse_w4a16_int4_weight_config(
+    weight_config: Mapping[str, Any],
+) -> tuple[int, bool]:
+    """Parse required W4A16 INT4/UINT4 weight fields from Quark config."""
+    if "group_size" not in weight_config:
+        raise ValueError(
+            "Quark W4A16 INT4/UINT4 configs must specify weight.group_size"
+        )
+    if "symmetric" not in weight_config:
+        raise ValueError("Quark W4A16 INT4/UINT4 configs must specify weight.symmetric")
+
+    group_size = weight_config["group_size"]
+    is_symmetric = weight_config["symmetric"]
+    if not isinstance(group_size, int) or group_size <= 0:
+        raise ValueError(
+            f"Quark W4A16 weight.group_size must be a positive int, got {group_size!r}"
+        )
+    if not isinstance(is_symmetric, bool):
+        raise ValueError(
+            f"Quark W4A16 weight.symmetric must be a bool, got {is_symmetric!r}"
+        )
+    return group_size, is_symmetric
+
+
+def canonicalize_quark_packed_int4(
+    packed_weight: torch.Tensor,
+    *,
+    pack_reorder: bool,
+    is_symmetric: bool,
+    pack_factor: int = 8,
+) -> torch.Tensor:
+    """Convert Quark export nibble layout to AWQ checkpoint layout."""
+    from vllm.model_executor.layers.quantization.awq_marlin import (
+        _REVERSE_AWQ_PACK_ORDER,
+    )
+
+    if pack_reorder:
+        source_order = torch.tensor(
+            _REVERSE_AWQ_PACK_ORDER, device=packed_weight.device, dtype=torch.int32
+        )
+    else:
+        source_order = torch.arange(
+            pack_factor, device=packed_weight.device, dtype=torch.int32
+        )
+    target_order = torch.tensor(
+        _REVERSE_AWQ_PACK_ORDER, device=packed_weight.device, dtype=torch.int32
+    )
+    source_shifts = source_order * 4
+    target_shifts = target_order * 4
+
+    values = (packed_weight.to(torch.int32)[..., None] >> source_shifts) & 0xF
+    if is_symmetric:
+        values = values ^ 0x8
+    packed = (values.to(torch.int64) << target_shifts.to(torch.int64)).sum(dim=-1)
+    return packed.to(torch.int32)
 
 
 # utility for tensor dims > 2 cases


### PR DESCRIPTION
## Purpose

Adds a native Quark loading path for `real_quantized` INT4/UINT4 checkpoints (`export.pack_method` = `order` / `reorder`). This is a port of [vllm-project/vllm#48606](https://github.com/vllm-project/vllm/pull/48606) adapted to 1Cat-VLLM.

- `QuarkW4A16Int4` dense scheme for quantized linear layers (via `MPLinearKernel`).
- `QuarkW4A16Int4MoEMethod` for routed experts, supporting both symmetric INT4 and asymmetric UINT4 (`fused_experts` + `int4_w4a16_moe_quant_config`, consistent with 1Cat's existing `MoeWNA16Method`).
- Quark pack-order canonicalization to the layout used by the existing `awq_*` ops (compute-kernel layout only).
- `QuarkConfig`: W4A16 weight-config parsing, `apply_vllm_mapper` list handling, `ParallelLMHead` support, and bare exclude leaf-module matching (e.g. `lm_head` matches `language_model.lm_head`).
- `awq_marlin`: allow `w_zp_name=None` (symmetric) in `_convert_awq_to_standard_format`.

> **Note:** Because 1Cat's WNA16 oracle only supports symmetric INT4 (Marlin) and `TritonWNA16Experts` is not yet wired into the oracle, the MoE method here uses `fused_experts` (like `MoeWNA16Method`) so that asymmetric UINT4 MoE experts also work. A follow-up can migrate to the WNA16 oracle once it supports asymmetric INT4.

Mixed FP16 modules (e.g. MoE router `mlp.gate`, `lm_head`) must appear in `quantization_config.exclude`. vLLM does not infer this from tensor dtypes; Quark export should persist all `exclude_layers_name` patterns.

## Test Plan

Verified on a Tesla V100 (CUDA 7.0):

- Dense path `QuarkW4A16Int4`: `create_weights` + `process_weights_after_loading` + `apply_weights` succeed for both symmetric INT4 and asymmetric UINT4 (`MarlinLinearKernel` selected).
- MoE `QuarkW4A16Int4MoEMethod`: `create_weights` and `get_fused_moe_quant_config` produce a valid int4 quant config for both symmetric (no zp) and asymmetric (with zp); weight-loader TP sharding of w2 zero-point verified.
- `canonicalize_quark_packed_int4` is source-invariant across `order`/`reorder` pack methods.
- `QuarkConfig` scheme selection, `apply_vllm_mapper` (exclude + non-string list preservation), and bare exclude leaf matching all pass.
- All modified modules import cleanly; `vllm` package imports with no errors.

Usage:
```python
from vllm import LLM, SamplingParams

llm = LLM(
    model="<quark-w4a16-int4-uint4-checkpoint>",
    quantization="quark",
    dtype="auto",
)
```

## Test Result

- [x] Dense symmetric INT4 & asymmetric UINT4 linear scheme works end-to-end on GPU.
- [x] MoE method instantiation, quant-config, and weight-loader TP sharding correct.
- [x] Canonicalization source-invariant; mapper + exclude leaf matching correct.
- [x] Clean imports; no errors.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [ ] (Optional) The necessary documentation update.

</details>
