### PR TITLE
[Bugfix][Kernel][SM70] Reconcile GLM KDA GEMV with latest main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn4_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/qwen38_prefill_cutlass.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn2_sm70.cu"
+      "${VLLM_SM70_TURBOMIND_ROOT}/ops/glm53_fp16_gemv_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/awq_sm70_gemm.cu")
 
     set_gencode_flags_for_srcs(

--- a/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
+++ b/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
@@ -13,6 +13,7 @@ import argparse
 import hashlib
 import json
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -100,6 +101,72 @@ def _sm70_glm53_fp16_gemv_cg_kernel(
     tl.store(out_ptr + row, acc)
 
 
+@triton.jit
+def _pair_fold_8x16(values, WIDTH: tl.constexpr):
+    lo, hi = tl.split(tl.reshape(values, (8, WIDTH // 2, 2)))
+    return lo + hi
+
+
+@triton.jit
+def _sm70_glm53_cublas_match_gemv_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    NUM_CHUNKS,
+    CHUNK_TILES,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    VECTOR_WIDTH: tl.constexpr,
+    BUTTERFLY_DOWN: tl.constexpr,
+):
+    """Reconstruct the observed 128-thread cuBLAS gemv2T reduction tree."""
+    rows = tl.program_id(0) * 8 + tl.arange(0, 8)
+    row_mask = rows < N
+    lanes = tl.arange(0, 16)
+    if BUTTERFLY_DOWN:
+        # A bit-reversed lane order turns shfl_down into adjacent pair folds.
+        lane_slots = (
+            (lanes & 1) * 8
+            + ((lanes >> 1) & 1) * 4
+            + ((lanes >> 2) & 1) * 2
+            + ((lanes >> 3) & 1)
+        )
+    else:
+        lane_slots = lanes
+
+    lane_offsets = lane_slots.to(tl.int64) * VECTOR_WIDTH
+    acc = tl.zeros((8, 16), dtype=tl.float32)
+    for chunk in range(0, NUM_CHUNKS):
+        chunk_acc = tl.zeros((8, 16), dtype=tl.float32)
+        chunk_base = chunk * CHUNK_TILES * VECTOR_WIDTH * 16
+        for tile in range(0, CHUNK_TILES):
+            tile_base = chunk_base + tile * VECTOR_WIDTH * 16
+            for item in tl.static_range(0, VECTOR_WIDTH):
+                k = tile_base + lane_offsets + item
+                k_mask = k < K
+                x = tl.load(x_ptr + k, mask=k_mask, other=0.0)
+                weight = tl.load(
+                    weight_ptr + rows[:, None] * K + k[None, :],
+                    mask=row_mask[:, None] & k_mask[None, :],
+                    other=0.0,
+                )
+                chunk_acc += x[None, :].to(tl.float32) * weight.to(tl.float32)
+        acc = tl.where(chunk == 0, chunk_acc, acc + chunk_acc)
+
+    if BUTTERFLY_DOWN:
+        reduced = _pair_fold_8x16(acc, 16)
+        reduced = _pair_fold_8x16(reduced, 8)
+        reduced = _pair_fold_8x16(reduced, 4)
+        reduced = _pair_fold_8x16(reduced, 2)
+        total = tl.reshape(reduced, (8,))
+    else:
+        total = tl.zeros((8,), dtype=tl.float32)
+        for lane in tl.static_range(0, 16):
+            value = tl.sum(tl.where(lanes[None, :] == lane, acc, 0.0), axis=1)
+            total = value if lane == 0 else total + value
+    tl.store(out_ptr + rows, total, mask=row_mask)
+
+
 def _measure_graph_us(
     launch: Callable[[], None], *, warmups: int, repeats: int
 ) -> float:
@@ -173,6 +240,116 @@ def _benchmark_kernel(
         ).item(),
         "cublas_fp16_fp32_reference_relative_l2_error": (
             cublas_fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+    }
+
+
+def _benchmark_cublas_match_kernel(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    reference: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    vector_width: int,
+    chunk_tiles: int,
+    butterfly_down: bool,
+    warmups: int,
+    repeats: int,
+) -> dict[str, Any]:
+    n, k = weight.shape
+    out = torch.empty((1, n), dtype=x.dtype, device=x.device)
+
+    def launch() -> None:
+        _sm70_glm53_cublas_match_gemv_kernel[(triton.cdiv(n, 8),)](
+            x,
+            weight,
+            out,
+            triton.cdiv(k, chunk_tiles * vector_width * 16),
+            chunk_tiles,
+            N=n,
+            K=k,
+            VECTOR_WIDTH=vector_width,
+            BUTTERFLY_DOWN=butterfly_down,
+            num_warps=4,
+        )
+
+    latency_us = _measure_graph_us(launch, warmups=warmups, repeats=repeats)
+    error = out.float() - reference.float()
+    fp32_error = out.float() - fp32_reference
+    traffic_bytes = 2 * (weight.numel() + x.numel() + out.numel())
+    return {
+        "kernel": "cublas_match_gemv2t",
+        "vector_width": vector_width,
+        "chunk_tiles": chunk_tiles,
+        "butterfly_down": butterfly_down,
+        "latency_us": latency_us,
+        "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+        "exact_equal": torch.equal(out, reference),
+        "output_sha256": hashlib.sha256(
+            out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        ).hexdigest(),
+        "max_abs_error": error.abs().max().item(),
+        "relative_l2_error": (error.norm() / reference.float().norm()).item(),
+        "cosine_similarity": torch.nn.functional.cosine_similarity(
+            out.float(), reference.float()
+        ).item(),
+        "fp32_reference_relative_l2_error": (
+            fp32_error.norm() / fp32_reference.norm()
+        ).item(),
+    }
+
+
+def _load_glm53_cuda_extension() -> None:
+    from torch.utils.cpp_extension import load
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "csrc/sm70_turbomind/ops/glm53_fp16_gemv_sm70.cu"
+    )
+    load(
+        name="_C_glm53_gemv_bench",
+        sources=[str(source)],
+        extra_cflags=["-O3"],
+        extra_cuda_cflags=["-O3", "-DVLLM_GLM53_GEMV_STANDALONE"],
+        with_cuda=True,
+        is_python_module=False,
+        verbose=True,
+    )
+
+
+def _benchmark_cuda_chunk_parallel_kernel(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    reference: torch.Tensor,
+    fp32_reference: torch.Tensor,
+    *,
+    warmups: int,
+    repeats: int,
+) -> dict[str, Any]:
+    out = torch.empty_like(reference)
+
+    def launch() -> None:
+        torch.ops._C_glm53_gemv_bench.sm70_glm53_fp16_gemv_out(out, x, weight)
+
+    latency_us = _measure_graph_us(launch, warmups=warmups, repeats=repeats)
+    error = out.float() - reference.float()
+    fp32_error = out.float() - fp32_reference
+    traffic_bytes = 2 * (weight.numel() + x.numel() + out.numel())
+    return {
+        "kernel": "cuda_cublas_match_gemv2t",
+        "latency_us": latency_us,
+        "effective_gbps": traffic_bytes / (latency_us * 1000.0),
+        "exact_equal": torch.equal(out, reference),
+        "output_sha256": hashlib.sha256(
+            out.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        ).hexdigest(),
+        "max_abs_error": error.abs().max().item(),
+        "relative_l2_error": (error.norm() / reference.float().norm()).item(),
+        "cosine_similarity": torch.nn.functional.cosine_similarity(
+            out.float(), reference.float()
+        ).item(),
+        "fp32_reference_relative_l2_error": (
+            fp32_error.norm() / fp32_reference.norm()
         ).item(),
     }
 
@@ -342,10 +519,14 @@ def main() -> None:
     parser.add_argument("--repeats", type=int, default=1000)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--out", type=str)
+    parser.add_argument("--cublas-match-kda-sweep", action="store_true")
+    parser.add_argument("--cuda-kernel-sweep", action="store_true")
     args = parser.parse_args()
 
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("This benchmark requires an NVIDIA SM70 GPU.")
+    if args.cuda_kernel_sweep:
+        _load_glm53_cuda_extension()
     torch.manual_seed(args.seed)
     rows: list[dict[str, Any]] = []
     candidates = (
@@ -353,7 +534,10 @@ def main() -> None:
         ("evict", _sm70_glm53_fp16_gemv_evict_kernel),
         ("cg", _sm70_glm53_fp16_gemv_cg_kernel),
     )
-    for (n, k), (block_k, num_warps) in _SM70_GLM53_FP16_GEMV_CONFIGS.items():
+    shape_configs = _SM70_GLM53_FP16_GEMV_CONFIGS.items()
+    if args.cublas_match_kda_sweep or args.cuda_kernel_sweep:
+        shape_configs = [((6416, 4096), _SM70_GLM53_FP16_GEMV_CONFIGS[(6416, 4096)])]
+    for (n, k), (block_k, num_warps) in shape_configs:
         x = torch.randn((1, k), dtype=torch.float16, device="cuda")
         weight = torch.randn((n, k), dtype=torch.float16, device="cuda")
         reference = torch.nn.functional.linear(x, weight)
@@ -404,6 +588,61 @@ def main() -> None:
                 **result,
             }
         )
+        if args.cublas_match_kda_sweep:
+            for vector_width in (1, 2, 4, 8):
+                for chunk_tiles in (1, 2, 4, 8, 16, 32, 64):
+                    for butterfly_down in (False, True):
+                        try:
+                            result = _benchmark_cublas_match_kernel(
+                                x,
+                                weight,
+                                reference,
+                                fp32_reference,
+                                vector_width=vector_width,
+                                chunk_tiles=chunk_tiles,
+                                butterfly_down=butterfly_down,
+                                warmups=args.warmups,
+                                repeats=args.repeats,
+                            )
+                        except Exception as exc:
+                            result = {
+                                "kernel": "cublas_match_gemv2t",
+                                "vector_width": vector_width,
+                                "chunk_tiles": chunk_tiles,
+                                "butterfly_down": butterfly_down,
+                                "error": f"{type(exc).__name__}: {exc}",
+                            }
+                        rows.append(
+                            {
+                                "shape": [n, k],
+                                "block_k": None,
+                                "num_warps": 4,
+                                **result,
+                            }
+                        )
+        if args.cuda_kernel_sweep:
+            try:
+                result = _benchmark_cuda_chunk_parallel_kernel(
+                    x,
+                    weight,
+                    reference,
+                    fp32_reference,
+                    warmups=args.warmups,
+                    repeats=args.repeats,
+                )
+            except Exception as exc:
+                result = {
+                    "kernel": "cuda_cublas_match_gemv2t",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            rows.append(
+                {
+                    "shape": [n, k],
+                    "block_k": None,
+                    "num_warps": None,
+                    **result,
+                }
+            )
         for padded_m in (1, 2, 4, 8, 16):
             try:
                 result = _benchmark_padded_cublas_gemm(

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -333,6 +333,9 @@ void sm70_glm_kda_fg_b_out(torch::Tensor f_out, torch::Tensor g_out,
                            torch::Tensor f_input, torch::Tensor g_input,
                            torch::Tensor f_weight, torch::Tensor g_weight);
 
+void sm70_glm53_fp16_gemv_out(torch::Tensor output, torch::Tensor input,
+                              torch::Tensor weight);
+
 void sm70_f16_lm_head_top1_out(torch::Tensor values_out,
                                torch::Tensor indices_out,
                                torch::Tensor _in_feats, torch::Tensor _kernel,

--- a/csrc/sm70_turbomind/ops/glm53_fp16_gemv_sm70.cu
+++ b/csrc/sm70_turbomind/ops/glm53_fp16_gemv_sm70.cu
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kGlm53K = 4096;
+constexpr int kGlm53N = 6416;
+constexpr int kLanesPerRow = 16;
+constexpr int kChunkK = 512;
+constexpr int kChunkCount = kGlm53K / kChunkK;
+constexpr int kThreads = kLanesPerRow * kChunkCount;
+
+__global__ void glm53_fp16_gemv_sm70_kernel(half* __restrict__ output,
+                                            const half* __restrict__ input,
+                                            const half* __restrict__ weight) {
+  const int thread = threadIdx.x;
+  const int chunk = thread / kLanesPerRow;
+  const int lane = thread & (kLanesPerRow - 1);
+  const int row = blockIdx.x;
+
+  // Each (chunk, lane) pair preserves cuBLAS's 32-element ascending FMA
+  // chain. Shared memory then joins chunk 0..7 followed by lane 0..15.
+  float chunk_sum = 0.0f;
+#pragma unroll 4
+  for (int tile = 0; tile < kChunkK / kLanesPerRow; ++tile) {
+    const int k = chunk * kChunkK + tile * kLanesPerRow + lane;
+    const half x = __ldg(input + k);
+    const half w = __ldg(weight + static_cast<size_t>(row) * kGlm53K + k);
+    chunk_sum = __fmaf_rn(__half2float(x), __half2float(w), chunk_sum);
+  }
+
+  __shared__ float chunk_partials[kThreads];
+  chunk_partials[chunk * kLanesPerRow + lane] = chunk_sum;
+  __syncthreads();
+
+  if (chunk == 0) {
+    float lane_sum = chunk_partials[lane];
+#pragma unroll
+    for (int source_chunk = 1; source_chunk < kChunkCount; ++source_chunk) {
+      lane_sum = __fadd_rn(lane_sum,
+                           chunk_partials[source_chunk * kLanesPerRow + lane]);
+    }
+
+    float row_sum = 0.0f;
+#pragma unroll
+    for (int source_lane = 0; source_lane < kLanesPerRow; ++source_lane) {
+      const float value =
+          __shfl_sync(0x0000ffffu, lane_sum, source_lane, kLanesPerRow);
+      if (lane == 0) {
+        row_sum = source_lane == 0 ? value : __fadd_rn(row_sum, value);
+      }
+    }
+    if (lane == 0) {
+      output[row] = __float2half_rn(row_sum);
+    }
+  }
+}
+
+void validate_glm53_fp16_gemv_tensors(const torch::Tensor& output,
+                                      const torch::Tensor& input,
+                                      const torch::Tensor& weight) {
+  TORCH_CHECK(input.is_cuda() && weight.is_cuda() && output.is_cuda(),
+              "sm70_glm53_fp16_gemv_out: tensors must be CUDA");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Half &&
+                  weight.scalar_type() == at::ScalarType::Half &&
+                  output.scalar_type() == at::ScalarType::Half,
+              "sm70_glm53_fp16_gemv_out: tensors must be float16");
+  TORCH_CHECK(
+      input.is_contiguous() && weight.is_contiguous() && output.is_contiguous(),
+      "sm70_glm53_fp16_gemv_out: tensors must be contiguous");
+  TORCH_CHECK(
+      input.dim() == 2 && input.size(0) == 1 && input.size(1) == kGlm53K,
+      "sm70_glm53_fp16_gemv_out: input must be [1, 4096]");
+  TORCH_CHECK(weight.dim() == 2 && weight.size(0) == kGlm53N &&
+                  weight.size(1) == kGlm53K,
+              "sm70_glm53_fp16_gemv_out: weight must be [6416, 4096]");
+  TORCH_CHECK(
+      output.dim() == 2 && output.size(0) == 1 && output.size(1) == kGlm53N,
+      "sm70_glm53_fp16_gemv_out: output must be [1, 6416]");
+  TORCH_CHECK(
+      input.device() == weight.device() && input.device() == output.device(),
+      "sm70_glm53_fp16_gemv_out: tensors must share a device");
+}
+
+}  // namespace
+
+void sm70_glm53_fp16_gemv_out(torch::Tensor output, torch::Tensor input,
+                              torch::Tensor weight) {
+  validate_glm53_fp16_gemv_tensors(output, input, weight);
+  const c10::cuda::CUDAGuard device_guard(input.device());
+  const cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(properties->major == 7 && properties->minor == 0,
+              "sm70_glm53_fp16_gemv_out: requires SM70");
+  const cudaStream_t stream =
+      at::cuda::getCurrentCUDAStream(input.device().index());
+  glm53_fp16_gemv_sm70_kernel<<<kGlm53N, kThreads, 0, stream>>>(
+      reinterpret_cast<half*>(output.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(weight.data_ptr<at::Half>()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+#ifdef VLLM_GLM53_GEMV_STANDALONE
+TORCH_LIBRARY_FRAGMENT(_C_glm53_gemv_bench, ops) {
+  ops.def(
+      "sm70_glm53_fp16_gemv_out(Tensor(a!) output, Tensor input, Tensor "
+      "weight) -> ()");
+  ops.impl("sm70_glm53_fp16_gemv_out", torch::kCUDA, &sm70_glm53_fp16_gemv_out);
+}
+#elif defined(VLLM_GLM53_GEMV_SIDECAR)
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "sm70_glm53_fp16_gemv_out(Tensor(a!) output, Tensor input, Tensor "
+      "weight) -> ()");
+  ops.impl("sm70_glm53_fp16_gemv_out", torch::kCUDA, &sm70_glm53_fp16_gemv_out);
+}
+#endif

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -437,6 +437,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("sm70_glm_kda_fg_b_out", torch::kCUDA, &sm70_glm_kda_fg_b_out);
 
   ops.def(
+      "sm70_glm53_fp16_gemv_out(Tensor(a!) output, Tensor input, Tensor "
+      "weight) -> ()");
+  ops.impl("sm70_glm53_fp16_gemv_out", torch::kCUDA, &sm70_glm53_fp16_gemv_out);
+
+  ops.def(
       "sm70_f16_indexed_rerank_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor candidate_ids, Tensor(b!) selected_raw, "
       "Tensor(c!) selected_packed, Tensor(d!) expanded, Tensor(e!) partials, "

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44271,3 +44271,47 @@ Interpretation:
   non-reversible scales retain the ordinary TurboMind transform; explicit
   incompatible opt-in fails closed. `VLLM_SM70_FP8_PRESCALED_M1_SHARED_GATE=0`
   is the rollback.
+
+## 2026-08-28 GLM-5.3 exact KDA FP16 GEMV candidate
+
+- Development starts from public main
+  `03c04da68e72bf26271de4986364a72141a7601f` in isolated worktree
+  `v100-glm53-cublas-match-gemv-20260828-145134`, branch
+  `codex/v100-glm53-cublas-match-gemv-20260828-145134`. The target contract is
+  GLM-5.3-Flash-NVFP4, FP16 unquantized KDA weights, TP4/PP2 on eight V100s,
+  B1 decode, no MTP, FP8 E4M3 KV cache, and CUDA Graphs.
+- An exact-recipe sweep reconstructs the V100 cuBLAS `gemv2T` arithmetic for
+  the TP4 KDA projection `[M=1,N=6416,K=4096]`: 16 lanes per output, eight
+  512-element chunks, 32 ascending FP32 FMAs per `(chunk,lane)`, then chunk
+  `0..7` and lane `0..15` FP32 additions. The only matching Triton recipe is
+  vector width 1, 32 tiles per chunk, and a left-to-right lane fold. It is
+  bitwise equal to cuBLAS across five random seeds but slower, so it remains
+  an arithmetic oracle rather than the production route.
+- The CUDA candidate assigns one 128-thread CTA to each output row. All eight
+  chunks run in parallel, consume 512 bytes of shared memory, and join in the
+  reconstructed cuBLAS order. Across five post-cleanup runs it is bitwise
+  equal with zero maximum error and measures `65.485-65.509 us`; paired
+  cuBLAS measures `77.532-77.657 us`. This is a `15.55%-15.68%` latency
+  reduction and `802.6-802.9 GB/s` effective traffic bandwidth. The sidecar
+  contains only an `sm_70` cubin and has SHA256
+  `21924e7e93634eebce03199d264be5ec2bba08441d4f02f5881979bb6548b404`.
+- The focused native test passes all six cases. Five random seeds require
+  eager and CUDA Graph output to be bitwise equal to `torch.nn.functional.linear`.
+  A checkpoint audit additionally fuses the real layer-0 BF16 q/k/v/b/f_a/g_a
+  weights after the runtime FP16 cast for all four TP ranks. Sixteen changing
+  hidden states plus a CUDA Graph replay per rank, 68 comparisons in total,
+  are all bitwise equal with zero maximum error.
+- Retained evidence is under
+  `/data/minimax-h3/task-cache/glm53-nvfp4-sm70-20260827/`
+  `cublas_match_kda_20260828/`, including `cuda_final_seed0.json` through
+  `cuda_final_seed4.json` and
+  `checkpoint_layer0_tp4_exact_audit.json`. Nsight Compute hardware counters
+  are unavailable on this host with `ERR_NVGPUCTRPERM`; bytes divided by
+  synchronized CUDA Graph time provide only the stated bandwidth lower bound.
+- Rejected one-pass row-grouped CUDA variants reached only about `78.7 us`,
+  and the global split-partial workspace route was about `130 us`. Neither is
+  retained in production. The accepted kernel theoretically removes about
+  `0.403 ms/token` over 34 KDA calls; this is a projection, not an end-to-end
+  result. Production admission still requires a compiled `_C` route hit,
+  real-model token/logit audit, and same-contract unprofiled TP4/PP2 A/B before
+  a new per-token trace is accepted.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44417,6 +44417,7 @@ Interpretation:
   result. Production admission still requires a compiled `_C` route hit,
   real-model token/logit audit, and same-contract unprofiled TP4/PP2 A/B before
   a new per-token trace is accepted.
+
 ## 2026-08-28 Qwen3.8 NVFP4 indexed-A prefill audit
 
 - Public Draft PR #390 is stacked on grouped-QSA PR #387. The retained clean

--- a/tests/models/glm5next/test_sm70_kda.py
+++ b/tests/models/glm5next/test_sm70_kda.py
@@ -48,3 +48,34 @@ def test_sm70_glm_kda_fused_fg_b_matches_fp16_and_graph() -> None:
 
     torch.testing.assert_close(f_out, eager[0], rtol=0, atol=0)
     torch.testing.assert_close(g_out, eager[1], rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not (
+        current_platform.is_cuda()
+        and current_platform.get_device_capability() == DeviceCapability(7, 0)
+        and hasattr(torch.ops._C, "sm70_glm53_fp16_gemv_out")
+    ),
+    reason="native NVIDIA V100/SM70 GLM-5.3 exact FP16 GEMV op required",
+)
+@pytest.mark.parametrize("seed", range(5))
+def test_sm70_glm53_fp16_gemv_matches_cublas_and_graph(seed: int) -> None:
+    torch.manual_seed(seed)
+    device = current_platform.device_type
+    input = torch.randn((1, 4096), device=device, dtype=torch.float16)
+    weight = torch.randn((6416, 4096), device=device, dtype=torch.float16)
+    output = torch.empty((1, 6416), device=device, dtype=torch.float16)
+
+    sm70_ops.sm70_glm53_fp16_gemv_out(output, input, weight)
+    torch.accelerator.synchronize()
+    expected = F.linear(input, weight)
+    assert torch.equal(output, expected)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        sm70_ops.sm70_glm53_fp16_gemv_out(output, input, weight)
+    input.copy_(torch.randn_like(input))
+    expected = F.linear(input, weight)
+    graph.replay()
+    torch.accelerator.synchronize()
+    assert torch.equal(output, expected)

--- a/tests/models/glm5next/test_sm70_kda.py
+++ b/tests/models/glm5next/test_sm70_kda.py
@@ -6,8 +6,25 @@ import torch
 import torch.nn.functional as F
 
 import vllm._sm70_ops as sm70_ops
+from vllm.models.glm5next.nvidia.kda import _sm70_exact_kda_gemv_enabled
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, True), ("1", True), ("0", False)],
+)
+def test_sm70_exact_kda_gemv_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+    expected: bool,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("VLLM_SM70_GLM53_EXACT_KDA_GEMV", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_SM70_GLM53_EXACT_KDA_GEMV", value)
+    assert _sm70_exact_kda_gemv_enabled() is expected
 
 
 @pytest.mark.skipif(

--- a/tests/v1/core/test_glm5_kv_cache_layout.py
+++ b/tests/v1/core/test_glm5_kv_cache_layout.py
@@ -13,6 +13,25 @@ from vllm.v1.kv_cache_interface import (
 )
 
 
+def test_kpool_tail_admission_uses_in_flight_keyword() -> None:
+    spec = KpoolTailSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=256,
+        head_size_v=0,
+        dtype=torch.bfloat16,
+        sliding_window=4,
+    )
+
+    assert (
+        spec.max_admission_blocks_per_request(
+            max_in_flight_tokens=2048,
+            max_model_len=32768,
+        )
+        == 1
+    )
+
+
 def test_glm53_pp2_kpool_tail_shares_indexer_storage(monkeypatch):
     monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
     model_config = SimpleNamespace(

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -46,6 +46,18 @@ def _maybe_load_nvfp4_qpn_m1_library() -> None:
 _maybe_load_nvfp4_qpn_m1_library()
 
 
+def _maybe_load_glm53_fp16_gemv_library() -> None:
+    """Load the exact GLM-5.3 decode GEMV during source-side validation."""
+    if hasattr(torch.ops._C, "sm70_glm53_fp16_gemv_out"):
+        return
+    library_path = os.getenv("VLLM_SM70_GLM53_FP16_GEMV_LIBRARY")
+    if library_path is not None:
+        torch.ops.load_library(library_path)
+
+
+_maybe_load_glm53_fp16_gemv_library()
+
+
 def _maybe_load_sm70_sampler_library() -> None:
     """Load the sampler fragment only when the main ``vllm._C`` lacks it."""
     if hasattr(torch.ops._C, "sm70_sample_chunked_top20_philox_token_out"):
@@ -1823,6 +1835,25 @@ if hasattr(torch.ops._C, "sm70_glm_kda_fg_b_out"):
         g_input: torch.Tensor,
         f_weight: torch.Tensor,
         g_weight: torch.Tensor,
+    ) -> None:
+        return None
+
+
+def sm70_glm53_fp16_gemv_out(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+) -> None:
+    _op("sm70_glm53_fp16_gemv_out")(output, input, weight)
+
+
+if hasattr(torch.ops._C, "sm70_glm53_fp16_gemv_out"):
+
+    @register_fake("_C::sm70_glm53_fp16_gemv_out")
+    def _sm70_glm53_fp16_gemv_out_fake(
+        output: torch.Tensor,
+        input: torch.Tensor,
+        weight: torch.Tensor,
     ) -> None:
         return None
 

--- a/vllm/models/glm5next/nvidia/kda.py
+++ b/vllm/models/glm5next/nvidia/kda.py
@@ -208,6 +208,9 @@ class Glm5NextLinearAttention(GatedDeltaNetAttention):
             and self.head_dim == 128
             and self.local_projection_size == 2048
         )
+        self._use_sm70_exact_kda_gemv = (
+            self._use_sm70_fused_fg_b_decode and self.hidden_size == 4096
+        )
 
         # Merge q, k, v, b, f_a, g_a projections into one GEMM (6→1 launches).
         # Order matches checkpoint's fused_qkvbfg_a_proj convention.
@@ -333,7 +336,31 @@ class Glm5NextLinearAttention(GatedDeltaNetAttention):
     ) -> torch.Tensor:
         num_tokens = hidden_states.size(0)
         # One merged GEMM for q, k, v, b, f_a, g_a (replaces 6 separate GEMMs).
-        projected = self.in_proj_qkvbfg_a(hidden_states)[0]
+        weight = self.in_proj_qkvbfg_a.weight
+        use_sm70_exact_gemv = (
+            self._use_sm70_exact_kda_gemv
+            and num_tokens == 1
+            and hidden_states.dtype == torch.float16
+            and weight.dtype == torch.float16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and weight.shape == (6416, 4096)
+        )
+        if use_sm70_exact_gemv:
+            if not hasattr(torch.ops._C, "sm70_glm53_fp16_gemv_out"):
+                raise RuntimeError(
+                    "SM70 GLM KDA decode requires the exact native FP16 GEMV op. "
+                    "Rebuild vLLM from source with CUDA arch 7.0."
+                )
+            projected = torch.empty(
+                (1, 6416),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            sm70_ops.sm70_glm53_fp16_gemv_out(projected, hidden_states, weight)
+            logger.info_once("SM70 GLM KDA exact FP16 GEMV decode path enabled.")
+        else:
+            projected = self.in_proj_qkvbfg_a(hidden_states)[0]
         qkv, beta_raw, f_a, g_a = projected.split(
             [
                 3 * self.local_projection_size,

--- a/vllm/models/glm5next/nvidia/kda.py
+++ b/vllm/models/glm5next/nvidia/kda.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """GLM-5.3-Flash KDA layer with separate convolutions and a bounded safe gate."""
 
+import os
+
 import torch
 from torch import nn
 
@@ -45,6 +47,10 @@ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
 logger = init_logger(__name__)
+
+
+def _sm70_exact_kda_gemv_enabled() -> bool:
+    return os.getenv("VLLM_SM70_GLM53_EXACT_KDA_GEMV", "1") != "0"
 
 
 class _Glm5NextMergedColumnParallelLinear(MergedColumnParallelLinear):
@@ -209,7 +215,9 @@ class Glm5NextLinearAttention(GatedDeltaNetAttention):
             and self.local_projection_size == 2048
         )
         self._use_sm70_exact_kda_gemv = (
-            self._use_sm70_fused_fg_b_decode and self.hidden_size == 4096
+            self._use_sm70_fused_fg_b_decode
+            and self.hidden_size == 4096
+            and _sm70_exact_kda_gemv_enabled()
         )
 
         # Merge q, k, v, b, f_a, g_a projections into one GEMM (6→1 launches).

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -647,9 +647,9 @@ class KpoolTailSpec(SlidingWindowSpec):
     """Per-request circular cache for an incomplete GLM KPool group."""
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
-        del max_num_batched_tokens, max_model_len
+        del max_in_flight_tokens, max_model_len
         return 1
 
     def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:


### PR DESCRIPTION
## Purpose

Reconcile #392 with the latest main while retaining the exact SM70 GLM KDA GEMV optimization and all newer QSA/NVFP4 release work. The only latest-main conflict was the migration-control document; both evidence sections are preserved.

This repair also adds a default-on rollback gate: `VLLM_SM70_GLM53_EXACT_KDA_GEMV=0` restores the existing cuBLAS linear path. Admission remains structural: SM70, TP4, B1 decode, FP16 contiguous `[1,4096] x [6416,4096]`; prefill and every incompatible shape/dtype use the existing path.

## Test Plan

- Reconcile #392 onto current `main` containing #387, #394, and #390.
- Run focused GLM KDA, KPool, and in-flight window tests.
- Run Ruff, formatting, Python compilation, and diff checks.
- Retain the existing native SM70 build, five-seed bitwise exact operator results, real layer-0 68/68 eager/graph audit, and 15.55%-15.68% operator latency reduction.

## Test Result

- Latest-main merge: clean for all source files; documentation-only conflict resolved by preserving both sections.
- Focused latest-main suite: `18 passed, 6 skipped` (GPU-native cases already covered by #392 artifacts).
- Ruff check and format: pass.
- Python compilation and `git diff --check`: pass.
- Rollback gate: unset/default `true`, `1` true, `0` false.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>