### PR TITLE
[Kernel][SM70] Promote exact MTP5 router fast path

### DIFF
--- a/benchmarks/kernels/benchmark_qwen38_router_mtp5.py
+++ b/benchmarks/kernels/benchmark_qwen38_router_mtp5.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark the exact SM70 Qwen3.8 E512/K10 router at verifier M=5."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+
+import torch
+
+import vllm._custom_ops as ops
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
+    _sm70_qwen38_router_topk,
+)
+
+TOKENS = 5
+EXPERTS = 512
+TOP_K = 10
+LAYERS = 48
+
+
+def _capture_round(launch: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for _ in range(LAYERS):
+            launch()
+    return graph
+
+
+def _time_graph(
+    graph: torch.cuda.CUDAGraph, *, warmup: int, iterations: int
+) -> tuple[float, list[float]]:
+    for _ in range(warmup):
+        graph.replay()
+    torch.accelerator.synchronize()
+    samples: list[float] = []
+    for _ in range(7):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iterations):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) / iterations)
+    return statistics.median(samples), samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    args = parser.parse_args()
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("benchmark requires exact SM70")
+
+    torch.manual_seed(args.seed)
+    logits = torch.randn(TOKENS, EXPERTS, device="cuda", dtype=torch.float16)
+    baseline_weights = torch.empty(TOKENS, TOP_K, device="cuda", dtype=torch.float32)
+    baseline_ids = torch.empty(TOKENS, TOP_K, device="cuda", dtype=torch.int32)
+    baseline_rows = torch.empty_like(baseline_ids)
+    candidate_weights = torch.empty_like(baseline_weights)
+    candidate_ids = torch.empty_like(baseline_ids)
+    candidate_rows = torch.empty_like(baseline_rows)
+
+    def baseline_launch() -> None:
+        ops.topk_softmax(
+            baseline_weights,
+            baseline_ids,
+            baseline_rows,
+            logits,
+            True,
+        )
+
+    def candidate_launch() -> None:
+        _sm70_qwen38_router_topk(
+            candidate_weights,
+            candidate_ids,
+            candidate_rows,
+            logits,
+        )
+
+    for _ in range(8):
+        baseline_launch()
+        candidate_launch()
+    torch.accelerator.synchronize()
+    baseline_graph = _capture_round(baseline_launch)
+    candidate_graph = _capture_round(candidate_launch)
+
+    logits.mul_(0.75).add_(0.03125)
+    baseline_graph.replay()
+    candidate_graph.replay()
+    torch.accelerator.synchronize()
+    comparison = {
+        "ids_equal": bool(torch.equal(candidate_ids, baseline_ids)),
+        "rows_equal": bool(torch.equal(candidate_rows, baseline_rows)),
+        "weights_max_abs": float((candidate_weights - baseline_weights).abs().max()),
+        "weights_allclose_1e7": bool(
+            torch.allclose(
+                candidate_weights,
+                baseline_weights,
+                atol=1e-7,
+                rtol=1e-7,
+            )
+        ),
+    }
+
+    baseline_ms, baseline_samples = _time_graph(
+        baseline_graph, warmup=args.warmup, iterations=args.iterations
+    )
+    candidate_ms, candidate_samples = _time_graph(
+        candidate_graph, warmup=args.warmup, iterations=args.iterations
+    )
+    result = {
+        "device": torch.cuda.get_device_name(),
+        "shape": [TOKENS, EXPERTS],
+        "top_k": TOP_K,
+        "layers_per_round": LAYERS,
+        "dynamic_graph_comparison": comparison,
+        "baseline_ms_per_48_layers": baseline_ms,
+        "candidate_ms_per_48_layers": candidate_ms,
+        "saved_ms_per_verifier": baseline_ms - candidate_ms,
+        "speedup": baseline_ms / candidate_ms,
+        "baseline_us_per_layer": baseline_ms * 1000.0 / LAYERS,
+        "candidate_us_per_layer": candidate_ms * 1000.0 / LAYERS,
+        "baseline_samples_ms": baseline_samples,
+        "candidate_samples_ms": candidate_samples,
+        "warmup_replays": args.warmup,
+        "timed_replays": args.iterations,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not (
+        comparison["ids_equal"]
+        and comparison["rows_equal"]
+        and comparison["weights_allclose_1e7"]
+    ):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/moe/test_fused_topk.py
+++ b/tests/kernels/moe/test_fused_topk.py
@@ -55,9 +55,10 @@ def torch_topk(
 @pytest.mark.parametrize(
     "case", ["random", "ties", "signed_zero", "nan", "inf", "negative_inf"]
 )
-def test_sm70_qwen38_router_topk(case: str):
+@pytest.mark.parametrize("num_tokens", [1, 5])
+def test_sm70_qwen38_router_topk(case: str, num_tokens: int):
     torch.manual_seed(0)
-    gating_output = torch.randn(1, 512, dtype=torch.float16, device="cuda")
+    gating_output = torch.randn(num_tokens, 512, dtype=torch.float16, device="cuda")
     if case == "ties":
         gating_output[:, :16] = 1.0
     elif case == "signed_zero":
@@ -70,8 +71,8 @@ def test_sm70_qwen38_router_topk(case: str):
     elif case == "negative_inf":
         gating_output.fill_(-float("inf"))
 
-    expected_weights = torch.empty(1, 10, dtype=torch.float32, device="cuda")
-    expected_ids = torch.empty(1, 10, dtype=torch.int32, device="cuda")
+    expected_weights = torch.empty(num_tokens, 10, dtype=torch.float32, device="cuda")
+    expected_ids = torch.empty(num_tokens, 10, dtype=torch.int32, device="cuda")
     expected_rows = torch.empty_like(expected_ids)
     ops.topk_softmax(
         expected_weights,

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -28,15 +28,19 @@ def _sm70_qwen38_router_topk_kernel(
     token_expert_indices_ptr,
     E: tl.constexpr,
     K: tl.constexpr,
+    M: tl.constexpr,
     BLOCK_E: tl.constexpr,
 ) -> None:
-    """Sort the exact Qwen3.8 decode router in one SM70 program."""
+    """Sort one exact Qwen3.8 decode or MTP verifier row per program."""
 
+    row = tl.program_id(0)
     offsets = tl.arange(0, BLOCK_E)
     valid = offsets < E
-    logits = tl.load(gating_ptr + offsets, mask=valid, other=-float("inf")).to(
-        tl.float32
-    )
+    logits = tl.load(
+        gating_ptr + row * E + offsets,
+        mask=valid,
+        other=-float("inf"),
+    ).to(tl.float32)
     max_logit = tl.max(logits, axis=0)
 
     # Match topk_softmax's degenerate-row behavior: NaN, +Inf, or all -Inf
@@ -71,10 +75,13 @@ def _sm70_qwen38_router_topk_kernel(
     denominator = tl.where(denominator > 0.0, denominator, 1.0)
     weights = raw_weights / denominator
 
-    tl.store(topk_ids_ptr + offsets, sorted_ids, mask=top_mask)
-    tl.store(topk_weights_ptr + offsets, weights, mask=top_mask)
-    # The generic op stores rank-major source rows. M is exactly one here.
-    tl.store(token_expert_indices_ptr + offsets, offsets, mask=top_mask)
+    output_offsets = row * K + offsets
+    tl.store(topk_ids_ptr + output_offsets, sorted_ids, mask=top_mask)
+    tl.store(topk_weights_ptr + output_offsets, weights, mask=top_mask)
+    # Match topkGating's rank-major source-row convention.
+    tl.store(
+        token_expert_indices_ptr + output_offsets, offsets * M + row, mask=top_mask
+    )
 
 
 def _sm70_qwen38_router_topk(
@@ -83,13 +90,15 @@ def _sm70_qwen38_router_topk(
     token_expert_indices: torch.Tensor,
     gating_output: torch.Tensor,
 ) -> None:
-    _sm70_qwen38_router_topk_kernel[(1,)](
+    num_tokens = gating_output.shape[0]
+    _sm70_qwen38_router_topk_kernel[(num_tokens,)](
         gating_output,
         topk_weights,
         topk_ids,
         token_expert_indices,
         E=512,
         K=10,
+        M=num_tokens,
         BLOCK_E=512,
         num_warps=8,
     )
@@ -175,8 +184,8 @@ def fused_topk(
     if scoring_func == "softmax":
         if (
             envs.VLLM_SM70_QWEN38_ROUTER_TOPK
-            and M == 1
-            and gating_output.shape == (1, 512)
+            and M in (1, 5)
+            and gating_output.shape == (M, 512)
             and gating_output.dtype == torch.float16
             and gating_output.is_contiguous()
             and topk == 10
@@ -184,7 +193,9 @@ def fused_topk(
             and topk_ids.dtype == torch.int32
             and current_platform.is_device_capability(70)
         ):
-            logger.info_once("SM70 Qwen3.8 E512/K10 router top-k path enabled.")
+            logger.info_once(
+                "SM70 Qwen3.8 E512/K10 router top-k path enabled for M=%d.", M
+            )
             _sm70_qwen38_router_topk(
                 topk_weights,
                 topk_ids,


### PR DESCRIPTION
## Purpose

Promote only the independently validated M=5 extension of the existing exact SM70 E512/K10 router from #398. Keep the unvalidated NVFP4 and 25-KiB all-reduce candidates out of this review boundary.

Base: `7fe23397637334b12af1fde7523efa19f227bb18`.

## Test Plan

- Compare M=1 and M=5 against `topk_softmax` for random, ties, signed zero, NaN, +Inf and -Inf.
- Replay changing M=5 logits under CUDA Graph and compare IDs, source rows and weights.
- Measure an exact 48-layer verifier router round on one V100.
- Run changed-file static gates and full project pre-commit.

## Current Evidence

- 12 focused SM70 cases pass.
- Dynamic graph: IDs and source rows exact; max weight delta `1.49e-8`.
- V100 M=5: `12.906 -> 5.312 us/layer`, `0.6195 -> 0.2550 ms` per 48-layer verifier, `2.43x`.

Draft until the isolated source/test/benchmark patch and CI are complete.
