### PR TITLE
[Quantization] Repair Quark W4A16 INT4/UINT4 support

### DIFF
--- a/tests/quantization/test_quark_w4a16.py
+++ b/tests/quantization/test_quark_w4a16.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Focused Quark W4A16 INT4/UINT4 config and packing regressions."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
+from vllm.model_executor.layers.quantization.quark.quark_moe import (
+    QuarkW4A16Int4MoEMethod,
+)
+from vllm.model_executor.layers.quantization.quark.schemes import QuarkW4A16Int4
+from vllm.model_executor.layers.quantization.quark.utils import (
+    canonicalize_quark_packed_int4,
+    should_ignore_layer,
+)
+from vllm.model_executor.models.utils import WeightsMapper
+from vllm.platforms import current_platform
+
+_REVERSE_AWQ_PACK_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+def _quark_int4_config(
+    *,
+    pack_method: str = "reorder",
+    symmetric: bool = True,
+    exclude: list[str] | None = None,
+) -> dict:
+    return {
+        "quant_method": "quark",
+        "export": {"pack_method": pack_method, "kv_cache_group": []},
+        "global_quant_config": {
+            "weight": {
+                "dtype": "int4" if symmetric else "uint4",
+                "qscheme": "per_group",
+                "is_dynamic": False,
+                "group_size": 128,
+                "symmetric": symmetric,
+            }
+        },
+        "exclude": exclude or [],
+    }
+
+
+def _pack_nibbles(values: torch.Tensor, order: list[int]) -> torch.Tensor:
+    shifts = torch.tensor(order, dtype=torch.int64, device=values.device) * 4
+    return ((values.to(torch.int64) & 0xF) << shifts).sum(dim=-1).to(torch.int32)
+
+
+@pytest.mark.parametrize("pack_method", ["order", "reorder"])
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_quark_int4_config_selects_native_scheme(pack_method, symmetric):
+    config = QuarkConfig.from_config(
+        _quark_int4_config(pack_method=pack_method, symmetric=symmetric)
+    )
+    scheme = config._get_scheme_from_config(config.quant_config["global_quant_config"])
+
+    assert isinstance(scheme, QuarkW4A16Int4)
+    assert scheme.pack_reorder is (pack_method == "reorder")
+    assert scheme.is_symmetric is symmetric
+
+
+@pytest.mark.parametrize("missing_field", ["group_size", "symmetric"])
+def test_quark_int4_config_requires_layout_fields(missing_field):
+    raw = _quark_int4_config()
+    del raw["global_quant_config"]["weight"][missing_field]
+    config = QuarkConfig.from_config(raw)
+
+    with pytest.raises(ValueError, match=missing_field):
+        config._get_scheme_from_config(config.quant_config["global_quant_config"])
+
+
+def test_quark_mapper_preserves_calibration_metadata_and_bare_excludes():
+    raw = _quark_int4_config(exclude=["lm_head"])
+    raw["algo_config"] = [
+        {"name": "qronos", "inside_layer_modules": ["self_attn.q_proj"]}
+    ]
+    config = QuarkConfig.from_config(raw)
+    config.apply_vllm_mapper(WeightsMapper())
+
+    assert config.quant_config["algo_config"] == raw["algo_config"]
+    assert should_ignore_layer(
+        "language_model.lm_head", ignore=config.quant_config["exclude"]
+    )
+    assert not should_ignore_layer(
+        "language_model.model.layers.0.mlp.gate",
+        ignore=config.quant_config["exclude"],
+    )
+
+
+@pytest.mark.parametrize("pack_reorder", [False, True])
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_quark_packed_int4_canonicalization_is_source_invariant(
+    pack_reorder, symmetric
+):
+    values = torch.tensor(
+        [
+            [[0, 1, 7, 8, 9, 15, 2, 14], [15, 8, 0, 3, 12, 7, 1, 9]],
+            [[3, 11, 5, 13, 6, 10, 4, 12], [2, 14, 1, 9, 0, 8, 7, 15]],
+        ],
+        dtype=torch.int32,
+    )
+    source_order = _REVERSE_AWQ_PACK_ORDER if pack_reorder else list(range(8))
+    packed = _pack_nibbles(values, source_order)
+
+    actual = canonicalize_quark_packed_int4(
+        packed,
+        pack_reorder=pack_reorder,
+        is_symmetric=symmetric,
+    )
+    expected_values = values ^ 0x8 if symmetric else values
+    expected = _pack_nibbles(expected_values, _REVERSE_AWQ_PACK_ORDER)
+
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda() or not torch.accelerator.is_available(),
+    reason="Quark W4A16 dense execution requires a CUDA device",
+)
+@pytest.mark.parametrize("pack_method", ["order", "reorder"])
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_quark_int4_dense_apply_matches_dequantized_reference(pack_method, symmetric):
+    torch.manual_seed(20260828)
+    hidden_size = output_size = 128
+    group_size = 32
+    pack_reorder = pack_method == "reorder"
+    layer = torch.nn.Module()
+    scheme = QuarkW4A16Int4(
+        group_size=group_size,
+        pack_method=pack_method,
+        is_symmetric=symmetric,
+    )
+
+    def weight_loader(param, loaded_weight, *args, **kwargs):
+        del args, kwargs
+        param.data.copy_(loaded_weight)
+
+    with (
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+    ):
+        scheme.create_weights(
+            layer,
+            output_partition_sizes=[output_size],
+            input_size_per_partition=hidden_size,
+            params_dtype=torch.float16,
+            weight_loader=weight_loader,
+            input_size=hidden_size,
+            output_size=output_size,
+        )
+        values = torch.randint(0, 16, (hidden_size, output_size), dtype=torch.int32)
+        zeros = (
+            torch.zeros(hidden_size // group_size, output_size, dtype=torch.int32)
+            if symmetric
+            else torch.randint(
+                0,
+                16,
+                (hidden_size // group_size, output_size),
+                dtype=torch.int32,
+            )
+        )
+        scales = (
+            torch.rand(
+                hidden_size // group_size,
+                output_size,
+                dtype=torch.float16,
+            )
+            * 0.02
+            + 0.002
+        )
+        source_order = _REVERSE_AWQ_PACK_ORDER if pack_reorder else list(range(8))
+        layer.weight.data.copy_(
+            _pack_nibbles(values.view(hidden_size, -1, 8), source_order)
+        )
+        layer.weight_zero_point.data.copy_(
+            _pack_nibbles(zeros.view(hidden_size // group_size, -1, 8), source_order)
+        )
+        layer.weight_scale.data.copy_(scales)
+
+        logical_values = values
+        if symmetric:
+            logical_values = torch.where(values >= 8, values - 16, values)
+        else:
+            logical_values = values - zeros.repeat_interleave(group_size, dim=0)
+        reference_weight = logical_values.to(torch.float16) * scales.repeat_interleave(
+            group_size, dim=0
+        )
+
+        device = torch.accelerator.current_accelerator()
+        layer.to(device)
+        scheme.process_weights_after_loading(layer)
+
+    inputs = (
+        torch.randn(
+            7,
+            hidden_size,
+            device=device,
+            dtype=torch.float16,
+        )
+        * 0.1
+    )
+    actual = scheme.apply_weights(layer, inputs)
+    expected = inputs @ reference_weight.to(device)
+
+    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=2e-2)
+
+
+class _FakeMoEConfig:
+    has_bias = False
+
+    def __init__(self, tp_size: int = 1, tp_rank: int = 0):
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+
+
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_quark_int4_moe_quant_config_tracks_zero_points(symmetric):
+    config = QuarkConfig.from_config(_quark_int4_config(symmetric=symmetric))
+    method = QuarkW4A16Int4MoEMethod(
+        config.quant_config["global_quant_config"]["weight"],
+        config.pack_method,
+        _FakeMoEConfig(),
+    )
+    layer = SimpleNamespace(
+        group_size=128,
+        w13_weight_scale=torch.ones(2, 16, 2),
+        w2_weight_scale=torch.ones(2, 8, 2),
+        w13_weight_zero_point=torch.ones(2, 8, 2, dtype=torch.uint8),
+        w2_weight_zero_point=torch.ones(2, 4, 2, dtype=torch.uint8),
+    )
+
+    quant_config = method.get_fused_moe_quant_config(layer)
+
+    assert quant_config is not None
+    assert quant_config.use_int4_w4a16
+    assert quant_config.block_shape == [0, 128]
+    assert (quant_config.w1_zp is None) is symmetric
+    assert (quant_config.w2_zp is None) is symmetric
+
+
+def _load_w2_zero_point(raw_zp: torch.Tensor, tp_size: int, tp_rank: int):
+    config = QuarkConfig.from_config(_quark_int4_config(symmetric=False))
+    moe_config = _FakeMoEConfig(tp_size, tp_rank)
+    method = QuarkW4A16Int4MoEMethod(
+        config.quant_config["global_quant_config"]["weight"],
+        config.pack_method,
+        moe_config,
+    )
+    layer = SimpleNamespace(
+        moe_config=moe_config,
+        intermediate_size_per_partition=64,
+        group_size_div_factor=1,
+    )
+    param = torch.nn.Parameter(
+        torch.zeros(1, 16, 8 // tp_size, dtype=torch.uint8),
+        requires_grad=False,
+    )
+    loader = method.get_weight_loader(layer, weight_loader=None)
+    loader(
+        param,
+        raw_zp.clone(),
+        weight_name="w2_weight_zero_point",
+        shard_id="w2",
+        expert_id=0,
+    )
+    return param.data[0]
+
+
+def test_quark_int4_moe_loader_shards_w2_zero_point_across_tp_ranks():
+    raw_zp = torch.arange(8 * 16, dtype=torch.uint8).reshape(8, 16)
+
+    full = _load_w2_zero_point(raw_zp, tp_size=1, tp_rank=0)
+    shard0 = _load_w2_zero_point(raw_zp, tp_size=2, tp_rank=0)
+    shard1 = _load_w2_zero_point(raw_zp, tp_size=2, tp_rank=1)
+
+    expected = full.view(full.size(0), 2, -1)
+    assert torch.equal(shard0, expected[:, 0])
+    assert torch.equal(shard1, expected[:, 1])

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -674,6 +674,7 @@ def choose_mp_linear_kernel(
 
         can_implement, failure_reason = kernel.can_implement(config)
         if can_implement:
+            logger.info_once("Using %s for mixed-precision linear", kernel.__name__)
             return kernel
         else:
             failure_reasons.append(

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -131,7 +131,7 @@ def _replace_or_register_parameter(
 def _convert_awq_to_standard_format(
     layer: torch.nn.Module,
     w_q_name: str,
-    w_zp_name: str,
+    w_zp_name: str | None,
     size_bits: int,
 ) -> None:
     """Convert AWQ weight and zero-point tensors to standard GPTQ-like format.
@@ -139,6 +139,7 @@ def _convert_awq_to_standard_format(
     AWQ packs qweight along the output dim with a non-standard bit order.
     This converts to standard bit order and repacks qweight along the input
     dim, matching the format expected by the MPLinearKernel framework.
+    If w_zp_name is None (symmetric quantization), only the weight is converted.
     """
     pack_factor = 32 // size_bits
     mask = (1 << size_bits) - 1
@@ -176,6 +177,9 @@ def _convert_awq_to_standard_format(
         weight_loader=_noop_loader,
     )
     setattr(layer, w_q_name, new_param)
+
+    if w_zp_name is None:
+        return
 
     # --- Convert qzeros: fix AWQ bit ordering and repack
     # AWQ qzeros: (G, N // pack) packed along dim 1, AWQ bit order

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -28,13 +28,16 @@ from vllm.model_executor.layers.quantization.quark.schemes import (
     QuarkOCP_MX,
     QuarkScheme,
     QuarkW4A8_MXFP4_FP8,
+    QuarkW4A16Int4,
     QuarkW8A8Fp8,
     QuarkW8A8Int8,
 )
 from vllm.model_executor.layers.quantization.quark.utils import (
     deep_compare,
+    parse_w4a16_int4_weight_config,
     should_ignore_layer,
 )
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.utils import WeightsMapper
 from vllm.platforms import current_platform
 
@@ -93,8 +96,10 @@ class QuarkConfig(QuantizationConfig):
         quant_config_with_hf_to_vllm_mapper: dict[str, Any] = {}
 
         for k, v in self.quant_config.items():
-            if isinstance(v, list):
+            if isinstance(v, list) and all(isinstance(item, str) for item in v):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_list(v)
+            elif isinstance(v, list):
+                quant_config_with_hf_to_vllm_mapper[k] = v
             elif isinstance(v, dict):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_dict(v)
             else:
@@ -118,7 +123,7 @@ class QuarkConfig(QuantizationConfig):
             if (
                 "self_attn" not in prefix  # only quantize attention projections
                 or not getattr(self, "dynamic_mxfp4_quant", False)
-                or not isinstance(layer, LinearBase)  # Ignore other methods
+                or not isinstance(layer, (LinearBase, ParallelLMHead))
             ):
                 return UnquantizedLinearMethod()
 
@@ -129,7 +134,7 @@ class QuarkConfig(QuantizationConfig):
             )
             layer.scheme = scheme
             return QuarkLinearMethod(self)
-        if isinstance(layer, LinearBase):
+        if isinstance(layer, (LinearBase, ParallelLMHead)):
             scheme = self.get_scheme(layer=layer, layer_name=prefix)
             layer.scheme = scheme
             return QuarkLinearMethod(self)
@@ -339,6 +344,18 @@ class QuarkConfig(QuantizationConfig):
         # Both symmetric and asymmetric input quantization supported.
         # Only symmetric weight quantization supported.
         return is_int8_dtype and is_tensor and is_weight_symmetric and is_static
+
+    def _is_w4a16_int4(
+        self,
+        weight_quant: dict[str, Any] | None,
+        input_quant: dict[str, Any] | None,
+    ) -> bool:
+        if weight_quant is None:
+            return False
+
+        is_int4 = weight_quant.get("dtype") in ("int4", "uint4")
+        is_packed = self.pack_method in ("order", "reorder")
+        return is_int4 and is_packed
 
     def _is_w4a8_mxfp4_fp8(
         self,
@@ -606,6 +623,15 @@ class QuarkConfig(QuantizationConfig):
                 qscheme=weight_qscheme,
                 is_static_input_scheme=True,
                 input_symmetric=input_config.get("symmetric"),
+            )
+        elif self._is_w4a16_int4(weight_config, input_config):
+            group_size, is_symmetric = parse_w4a16_int4_weight_config(weight_config)
+            return QuarkW4A16Int4(
+                group_size=group_size,
+                pack_method=self.pack_method,
+                is_symmetric=is_symmetric,
+                weight_config=weight_config,
+                input_config=input_config,
             )
         elif self._is_w4a8_mxfp4_fp8(weight_config, input_config):
             is_w4a8_supported = self._check_scheme_supported(

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     fp8_w8a8_moe_quant_config,
+    int4_w4a16_moe_quant_config,
     int8_w8a8_moe_quant_config,
     mxfp4_w4a8_moe_quant_config,
     mxfp4_w4a16_moe_quant_config,
@@ -44,6 +45,9 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+from vllm.model_executor.layers.quantization.quark.utils import (
+    parse_w4a16_int4_weight_config,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
     prepare_fp8_moe_layer_for_marlin,
@@ -72,6 +76,7 @@ logger = init_logger(__name__)
 
 __all__ = [
     "QuarkMoEMethod",
+    "QuarkW4A16Int4MoEMethod",
     "QuarkW8A8Fp8MoEMethod",
     "QuarkOCP_MX_MoEMethod",
     "QuarkNvfp4MoEMethod",
@@ -103,6 +108,13 @@ class QuarkMoEMethod(FusedMoEMethodBase):
 
         if quant_config._is_fp8_w4a8(weight_config, input_config):
             return QuarkW4A8Fp8MoEMethod(weight_config, input_config, module.moe_config)
+        elif quant_config._is_w4a16_int4(weight_config, input_config):
+            return QuarkW4A16Int4MoEMethod(
+                weight_config,
+                quant_config.pack_method,
+                module.moe_config,
+                input_config=input_config,
+            )
         elif quant_config._is_nvfp4(weight_config, input_config):
             return QuarkNvfp4MoEMethod(
                 weight_config, input_config, module.moe_config, quant_config
@@ -121,6 +133,252 @@ class QuarkMoEMethod(FusedMoEMethodBase):
             )
         else:
             raise RuntimeError("Unsupported FusedMoe scheme")
+
+
+class QuarkW4A16Int4MoEMethod(QuarkMoEMethod):
+    """Quark packed INT4 weight-only MoE method."""
+
+    def __init__(
+        self,
+        weight_config: dict[str, Any],
+        pack_method: str,
+        moe: FusedMoEConfig,
+        input_config: dict[str, Any] | None = None,
+    ):
+        super().__init__(moe)
+        if input_config is not None:
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod does not support activation "
+                f"quantization; input_tensors must be None, got {input_config}."
+            )
+        if weight_config.get("qscheme", "per_group") != "per_group":
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod only supports per_group weight "
+                f"quantization, got {weight_config.get('qscheme')!r}."
+            )
+        if weight_config.get("is_dynamic"):
+            raise NotImplementedError(
+                "QuarkW4A16Int4MoEMethod only supports static weight quantization."
+            )
+        self.weight_quant = weight_config
+        self.group_size, self.is_symmetric = parse_w4a16_int4_weight_config(
+            weight_config
+        )
+        self.bit8_pack_factor = 2
+        self.pack_reorder = pack_method == "reorder"
+
+    def create_weights(
+        self,
+        layer: RoutedExperts,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        group_size = self.group_size
+        group_size_div_factor = 1
+
+        while intermediate_size_per_partition % group_size or hidden_size % group_size:
+            group_size = group_size // 2
+            group_size_div_factor *= 2
+            assert group_size >= 32
+        layer.group_size = group_size
+        layer.group_size_div_factor = group_size_div_factor
+
+        strategy = FusedMoeWeightScaleSupported.GROUP.value
+        extra_weight_attrs.update({"quant_method": strategy, "is_transposed": False})
+
+        assert "weight_loader" in extra_weight_attrs
+        weight_loader = extra_weight_attrs["weight_loader"]
+        extra_weight_attrs["weight_loader"] = self.get_weight_loader(
+            layer, weight_loader
+        )
+
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // self.bit8_pack_factor,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // self.bit8_pack_factor,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        w13_weight_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_scale", w13_weight_scale)
+        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+
+        w2_weight_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_scale", w2_weight_scale)
+        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+
+        w13_weight_zero_point = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition // self.bit8_pack_factor,
+                hidden_size // group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_zero_point", w13_weight_zero_point)
+        set_weight_attrs(w13_weight_zero_point, extra_weight_attrs)
+
+        w2_weight_zero_point = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                hidden_size // self.bit8_pack_factor,
+                intermediate_size_per_partition // group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_zero_point", w2_weight_zero_point)
+        set_weight_attrs(w2_weight_zero_point, extra_weight_attrs)
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        return int4_w4a16_moe_quant_config(
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            w1_zp=layer.w13_weight_zero_point if not self.is_symmetric else None,
+            w2_zp=layer.w2_weight_zero_point if not self.is_symmetric else None,
+            block_shape=[0, layer.group_size],
+        )
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        from vllm.model_executor.layers.fused_moe import fused_experts
+
+        assert layer.activation == MoEActivation.SILU, (
+            f"Only SiLU activation is supported, not {layer.activation}."
+        )
+
+        return fused_experts(
+            x,
+            layer.w13_weight,
+            layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            quant_config=self.moe_quant_config,
+        )
+
+    def get_weight_loader(self, layer: RoutedExperts, weight_loader):
+        def convert_quark_tensor(tensor: torch.Tensor, tensor_type: str):
+            size0 = tensor.size(0)
+            tensor = tensor.view(torch.uint8)
+
+            shifter = torch.tensor([0, 4], dtype=torch.uint8, device=tensor.device)
+            tensor = (tensor[:, :, None] >> shifter) & 0xF
+
+            if self.pack_reorder:
+                reverse_awq_pack_order = [0, 4, 1, 5, 2, 6, 3, 7]
+                tensor = tensor.view(-1, 8)[:, reverse_awq_pack_order]
+            else:
+                tensor = tensor.view(-1, 8)
+            if self.is_symmetric:
+                tensor = tensor ^ 0x8
+            tensor = tensor.view(size0, -1)
+
+            tensor = tensor.T.contiguous()
+            if tensor_type == "weight":
+                tensor = tensor[:, 1::2] * 16 + tensor[:, ::2]
+            elif tensor_type == "zero_point":
+                tensor = tensor[1::2, :] * 16 + tensor[::2, :]
+            return tensor
+
+        def quark_int4_weight_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            weight_name: str,
+            shard_id: str,
+            expert_id: int,
+            return_success: bool = False,
+        ):
+            loaded_weight = loaded_weight.to(param.data.device)
+            shard_size = layer.intermediate_size_per_partition
+
+            if weight_name.endswith("_weight"):
+                loaded_weight = convert_quark_tensor(loaded_weight, "weight")
+            elif weight_name.endswith("_weight_zero_point"):
+                loaded_weight = convert_quark_tensor(loaded_weight, "zero_point")
+            elif weight_name.endswith("_weight_scale"):
+                loaded_weight = loaded_weight.T
+
+            if layer.group_size_div_factor > 1 and (
+                "weight_zero_point" in weight_name or "weight_scale" in weight_name
+            ):
+                loaded_weight = loaded_weight.repeat_interleave(
+                    layer.group_size_div_factor, 1
+                )
+
+            if "w13_weight_zero_point" in weight_name:
+                tensor = loaded_weight.view(
+                    layer.moe_config.tp_size, -1, loaded_weight.size(1)
+                )[layer.moe_config.tp_rank]
+                if shard_id == "w1":
+                    param.data[expert_id, : shard_size // 2] = tensor
+                else:
+                    param.data[expert_id, shard_size // 2 :] = tensor
+                return True if return_success else None
+            elif "w2_weight_zero_point" in weight_name:
+                param.data[expert_id] = loaded_weight.view(
+                    loaded_weight.size(0), layer.moe_config.tp_size, -1
+                )[:, layer.moe_config.tp_rank]
+                return True if return_success else None
+
+            return weight_loader(
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+                return_success=return_success,
+            )
+
+        return quark_int4_weight_loader
 
 
 class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
@@ -997,8 +1255,8 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 self.input_dtype = input_quant.replace("fp8_e4m3", "fp8")
             else:
                 raise NotImplementedError(
-                    f"Current input dtype {input_quant} is not compatible \
-                        with OCP MX (weight) MoE quantization. Please open an issue"
+                    f"Current input dtype {input_quant} is not compatible "
+                    "with OCP MX (weight) MoE quantization. Please open an issue"
                 )
         else:
             self.input_dtype = None

--- a/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/__init__.py
@@ -5,6 +5,7 @@ from .quark_nvfp4 import QuarkNVFP4
 from .quark_ocp_mx import QuarkOCP_MX
 from .quark_scheme import QuarkScheme
 from .quark_w4a8_mxfp4_fp8 import QuarkW4A8_MXFP4_FP8
+from .quark_w4a16_int4 import QuarkW4A16Int4
 from .quark_w8a8_fp8 import QuarkW8A8Fp8
 from .quark_w8a8_int8 import QuarkW8A8Int8
 
@@ -13,6 +14,7 @@ __all__ = [
     "QuarkW8A8Fp8",
     "QuarkW8A8Int8",
     "QuarkOCP_MX",
+    "QuarkW4A16Int4",
     "QuarkW4A8_MXFP4_FP8",
     "QuarkNVFP4",
 ]

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a16_int4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a16_int4.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearKernel,
+    MPLinearLayerConfig,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.awq_marlin import (
+    _convert_awq_to_standard_format,
+)
+from vllm.model_executor.layers.quantization.quark.schemes.quark_scheme import (
+    QuarkScheme,
+)
+from vllm.model_executor.layers.quantization.quark.utils import (
+    canonicalize_quark_packed_int4,
+)
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    PackedvLLMParameter,
+)
+from vllm.scalar_type import scalar_types
+
+
+class QuarkW4A16Int4(QuarkScheme):
+    """Quark packed INT4 weight-only linear scheme via MPLinearKernel."""
+
+    def __init__(
+        self,
+        group_size: int,
+        pack_method: str,
+        is_symmetric: bool,
+        weight_config: dict[str, Any] | None = None,
+        input_config: dict[str, Any] | None = None,
+    ):
+        if input_config is not None:
+            raise NotImplementedError(
+                "QuarkW4A16Int4 does not support activation quantization; "
+                f"input_tensors must be None, got {input_config}."
+            )
+        if weight_config is not None:
+            if weight_config.get("qscheme", "per_group") != "per_group":
+                raise NotImplementedError(
+                    "QuarkW4A16Int4 only supports per_group weight "
+                    f"quantization, got {weight_config.get('qscheme')!r}."
+                )
+            if weight_config.get("is_dynamic"):
+                raise NotImplementedError(
+                    "QuarkW4A16Int4 only supports static weight quantization."
+                )
+
+        self.group_size = group_size
+        self.pack_factor = 8
+        self.pack_reorder = pack_method == "reorder"
+        self.is_symmetric = is_symmetric
+        self.quant_type = scalar_types.uint4b8 if is_symmetric else scalar_types.uint4
+        self.kernel: MPLinearKernel | None = None
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ):
+        input_size = kwargs["input_size"]
+        output_size = kwargs["output_size"]
+        group_size = (
+            self.group_size if self.group_size != -1 else input_size_per_partition
+        )
+        if input_size_per_partition % group_size != 0:
+            raise ValueError(
+                "The input size is not aligned with the quantized weight shape. "
+                "This can be caused by too large tensor parallel size. "
+                f"input_size_per_partition={input_size_per_partition}, "
+                f"group_size={group_size}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        packed_output_size_per_partition = math.ceil(
+            output_size_per_partition / self.pack_factor
+        )
+        layer.output_size_per_partition = output_size_per_partition
+        layer.packed_output_size_per_partition = packed_output_size_per_partition
+
+        mp_linear_kernel_config = MPLinearLayerConfig(
+            full_weight_shape=(input_size, output_size),
+            partition_weight_shape=(
+                input_size_per_partition,
+                output_size_per_partition,
+            ),
+            weight_type=self.quant_type,
+            act_type=params_dtype,
+            group_size=group_size,
+            zero_points=not self.is_symmetric,
+            has_g_idx=False,
+        )
+        kernel_type = choose_mp_linear_kernel(mp_linear_kernel_config)
+
+        def weight_scale_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            *args,
+            **loader_kwargs,
+        ) -> None:
+            if loaded_weight.shape[1] < param.data.shape[1]:
+                padded_weight = loaded_weight.new_zeros(param.data.shape)
+                padded_weight[:, : loaded_weight.shape[1]] = loaded_weight
+                loaded_weight = padded_weight
+            weight_loader(param, loaded_weight, *args, **loader_kwargs)
+
+        weight = PackedvLLMParameter(
+            data=torch.empty(
+                input_size_per_partition,
+                packed_output_size_per_partition,
+                dtype=torch.int32,
+            ),
+            input_dim=0,
+            output_dim=1,
+            packed_dim=1,
+            packed_factor=self.pack_factor,
+            weight_loader=weight_loader,
+        )
+        num_groups = input_size_per_partition // group_size
+        weight_zero_point = PackedvLLMParameter(
+            data=torch.zeros(
+                num_groups,
+                packed_output_size_per_partition,
+                dtype=torch.int32,
+            ),
+            input_dim=0,
+            output_dim=1,
+            packed_dim=1,
+            packed_factor=self.pack_factor,
+            weight_loader=weight_loader,
+        )
+        weight_scale = GroupQuantScaleParameter(
+            data=torch.empty(
+                num_groups,
+                packed_output_size_per_partition * self.pack_factor,
+                dtype=params_dtype,
+            ),
+            input_dim=0,
+            output_dim=1,
+            weight_loader=weight_scale_loader,
+        )
+
+        layer.register_parameter("weight", weight)
+        layer.register_parameter("weight_zero_point", weight_zero_point)
+        layer.register_parameter("weight_scale", weight_scale)
+
+        self.kernel = kernel_type(
+            mp_linear_kernel_config,
+            w_q_param_name="weight",
+            w_s_param_name="weight_scale",
+            w_zp_param_name="weight_zero_point" if not self.is_symmetric else None,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight.data = canonicalize_quark_packed_int4(
+            layer.weight.data,
+            pack_reorder=self.pack_reorder,
+            is_symmetric=self.is_symmetric,
+            pack_factor=self.pack_factor,
+        )
+        if not self.is_symmetric:
+            layer.weight_zero_point.data = canonicalize_quark_packed_int4(
+                layer.weight_zero_point.data,
+                pack_reorder=self.pack_reorder,
+                is_symmetric=self.is_symmetric,
+                pack_factor=self.pack_factor,
+            )
+        output_size = layer.output_size_per_partition
+        packed_output_size = layer.packed_output_size_per_partition * self.pack_factor
+        if output_size < packed_output_size:
+            layer.weight_scale.data[:, output_size:].zero_()
+
+        _convert_awq_to_standard_format(
+            layer,
+            "weight",
+            "weight_zero_point" if not self.is_symmetric else None,
+            self.quant_type.size_bits,
+        )
+        assert self.kernel is not None
+        self.kernel.process_weights_after_loading(layer)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ):
+        assert self.kernel is not None
+        return self.kernel.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/quark/utils.py
+++ b/vllm/model_executor/layers/quantization/quark/utils.py
@@ -93,6 +93,8 @@ def _is_equal_or_regex_match(
     Checks whether a value is exactly equal or a regex match for target
     if target starts with 're:'. If check_contains is set to True,
     additionally checks if the target string is contained within the value.
+    A bare target with no '.' matches against the leaf module name so that
+    e.g. "lm_head" matches "language_model.lm_head".
     """
 
     if target.startswith("re:"):
@@ -102,9 +104,69 @@ def _is_equal_or_regex_match(
     elif check_contains:
         if target.lower() in value.lower():
             return True
+    elif "." not in target:
+        if value.split(".")[-1] == target:
+            return True
     elif target == value:
         return True
     return False
+
+
+def parse_w4a16_int4_weight_config(
+    weight_config: Mapping[str, Any],
+) -> tuple[int, bool]:
+    """Parse required W4A16 INT4/UINT4 weight fields from Quark config."""
+    if "group_size" not in weight_config:
+        raise ValueError(
+            "Quark W4A16 INT4/UINT4 configs must specify weight.group_size"
+        )
+    if "symmetric" not in weight_config:
+        raise ValueError("Quark W4A16 INT4/UINT4 configs must specify weight.symmetric")
+
+    group_size = weight_config["group_size"]
+    is_symmetric = weight_config["symmetric"]
+    if not isinstance(group_size, int) or group_size <= 0:
+        raise ValueError(
+            f"Quark W4A16 weight.group_size must be a positive int, got {group_size!r}"
+        )
+    if not isinstance(is_symmetric, bool):
+        raise ValueError(
+            f"Quark W4A16 weight.symmetric must be a bool, got {is_symmetric!r}"
+        )
+    return group_size, is_symmetric
+
+
+def canonicalize_quark_packed_int4(
+    packed_weight: torch.Tensor,
+    *,
+    pack_reorder: bool,
+    is_symmetric: bool,
+    pack_factor: int = 8,
+) -> torch.Tensor:
+    """Convert Quark export nibble layout to AWQ checkpoint layout."""
+    from vllm.model_executor.layers.quantization.awq_marlin import (
+        _REVERSE_AWQ_PACK_ORDER,
+    )
+
+    if pack_reorder:
+        source_order = torch.tensor(
+            _REVERSE_AWQ_PACK_ORDER, device=packed_weight.device, dtype=torch.int32
+        )
+    else:
+        source_order = torch.arange(
+            pack_factor, device=packed_weight.device, dtype=torch.int32
+        )
+    target_order = torch.tensor(
+        _REVERSE_AWQ_PACK_ORDER, device=packed_weight.device, dtype=torch.int32
+    )
+    source_shifts = source_order * 4
+    target_shifts = target_order * 4
+
+    values = (packed_weight.to(torch.int32)[..., None] >> source_shifts) & 0xF
+    if is_symmetric:
+        values = values ^ 0x8
+    packed = (values.to(torch.int64) << target_shifts.to(torch.int64)).sum(dim=-1)
+    return packed.to(torch.int32)
 
 
 # utility for tensor dims > 2 cases


### PR DESCRIPTION
## Purpose

Repair and rebase the useful Quark W4A16 INT4/UINT4 support from #395 onto current `main` without carrying its XPU import regression, static-gate failures, unsigned history, or missing tests.

The target is a native Quark loader for dense and MoE W4A16 exports using the repository's existing MPLinearKernel and fused INT4 MoE paths. Admission is configuration/layout based; no model/checkpoint identity defaults are added.

## Test Plan

- Focused Quark config, pack-order, exclude/mapper, dense scheme, MoE quant-config and TP zero-point sharding tests.
- Existing symmetric/asymmetric INT4 fused-MoE kernel correctness case on V100.
- Small synthetic dense INT4/UINT4 apply test on V100 where supported.
- Changed-file Ruff/format/mypy/static gates.

## Test Result

Draft: implementation and validation in progress.
