### PR TITLE
[Benchmark][SM70] Audit GLM reasoning completion

### DIFF
--- a/benchmarks/run_sm70_quality_speed_matrix.py
+++ b/benchmarks/run_sm70_quality_speed_matrix.py
@@ -204,21 +204,21 @@ def _make_chat_prompt(
     content: str,
     *,
     enable_thinking: bool,
+    reasoning_effort: str | None = None,
 ) -> str:
     messages = [{"role": "user", "content": content}]
+    template_kwargs: dict[str, Any] = {
+        "tokenize": False,
+        "add_generation_prompt": True,
+        "enable_thinking": enable_thinking,
+    }
+    if reasoning_effort is not None:
+        template_kwargs["reasoning_effort"] = reasoning_effort
     try:
-        return tokenizer.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            enable_thinking=enable_thinking,
-        )
+        return tokenizer.apply_chat_template(messages, **template_kwargs)
     except TypeError:
-        return tokenizer.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-        )
+        template_kwargs.pop("enable_thinking")
+        return tokenizer.apply_chat_template(messages, **template_kwargs)
 
 
 def _safe_delta(end: float, start: float) -> float | None:
@@ -327,7 +327,13 @@ def _max_same_line_run(text: str) -> int:
     return best
 
 
-def _quality_metrics(text: str, token_ids: list[int]) -> dict[str, Any]:
+def _quality_metrics(
+    text: str,
+    token_ids: list[int],
+    *,
+    finish_reason: str | None = None,
+    chat_prompt: str | None = None,
+) -> dict[str, Any]:
     bad_markers = [
         "rgba(rgba",
         "UTF-UTF",
@@ -338,6 +344,17 @@ def _quality_metrics(text: str, token_ids: list[int]) -> dict[str, Any]:
         "\ufffd",
     ]
     marker_hits = {m: text.count(m) for m in bad_markers if m in text}
+    expects_reasoning_close = bool(
+        chat_prompt is not None and chat_prompt.rstrip().endswith("<think>")
+    )
+    reasoning_closed = "</think>" in text if expects_reasoning_close else None
+    if expects_reasoning_close and reasoning_closed:
+        visible_final_chars = len(text.split("</think>", 1)[1].strip())
+    elif expects_reasoning_close:
+        visible_final_chars = 0
+    else:
+        visible_final_chars = len(text.strip())
+
     metrics = {
         "chars": len(text),
         "tokens": len(token_ids),
@@ -353,10 +370,17 @@ def _quality_metrics(text: str, token_ids: list[int]) -> dict[str, Any]:
         "max_same_line_run": _max_same_line_run(text),
         "replacement_char_count": text.count("\ufffd"),
         "bad_marker_hits": marker_hits,
+        "expects_reasoning_close": expects_reasoning_close,
+        "reasoning_closed": reasoning_closed,
+        "visible_final_chars": visible_final_chars,
     }
     failures = []
-    if metrics["tokens"] < 64:
+    if metrics["tokens"] < 64 and finish_reason != "stop":
         failures.append("too_few_output_tokens")
+    if expects_reasoning_close and not reasoning_closed:
+        failures.append("unclosed_reasoning")
+    elif expects_reasoning_close and visible_final_chars == 0:
+        failures.append("missing_final_answer")
     if metrics["max_same_token_run"] > 48:
         failures.append("same_token_run")
     if metrics["max_digit_run"] > 80:
@@ -488,6 +512,7 @@ def _run_worker(args: argparse.Namespace) -> int:
             tokenizer,
             prompt["content"],
             enable_thinking=args.enable_thinking,
+            reasoning_effort=args.reasoning_effort,
         )
         for repeat_idx in range(args.quality_repeat):
             request = llm.generate([chat_prompt], official_sampling)[0]
@@ -499,8 +524,14 @@ def _run_worker(args: argparse.Namespace) -> int:
                     "finish_reason": q_finish_reason,
                     "stop_reason": q_stop_reason,
                     "prompt_tokens": len(request.prompt_token_ids or []),
+                    "chat_prompt_hash": _sha256_text(chat_prompt),
                     "token_ids": token_ids,
-                    "metrics": _quality_metrics(text, token_ids),
+                    "metrics": _quality_metrics(
+                        text,
+                        token_ids,
+                        finish_reason=q_finish_reason,
+                        chat_prompt=chat_prompt,
+                    ),
                     "preview": text[:1000],
                     "tail": text[-1000:],
                 }
@@ -510,6 +541,7 @@ def _run_worker(args: argparse.Namespace) -> int:
         tokenizer,
         DETERMINISM_PROMPT,
         enable_thinking=args.enable_thinking,
+        reasoning_effort=args.reasoning_effort,
     )
     det_sampling = SamplingParams(
         max_tokens=256,
@@ -526,8 +558,14 @@ def _run_worker(args: argparse.Namespace) -> int:
             {
                 "finish_reason": det_finish_reason,
                 "stop_reason": det_stop_reason,
+                "chat_prompt_hash": _sha256_text(det_prompt),
                 "token_ids": token_ids,
-                "metrics": _quality_metrics(text, token_ids),
+                "metrics": _quality_metrics(
+                    text,
+                    token_ids,
+                    finish_reason=det_finish_reason,
+                    chat_prompt=det_prompt,
+                ),
                 "preview": text[:800],
             }
         )
@@ -584,6 +622,7 @@ def _run_worker(args: argparse.Namespace) -> int:
                 "max_tokens": args.quality_max_tokens,
                 "ignore_eos": False,
                 "enable_thinking": args.enable_thinking,
+                "reasoning_effort": args.reasoning_effort,
             },
             "records": quality_records,
             "determinism": {
@@ -724,7 +763,9 @@ def _write_summary(out_dir: Path, rows: list[dict[str, Any]]) -> None:
             "",
             "Quality gates: official generation_config sampling, no ignore_eos; "
             "fatal gates are repeated windows, long digit/same-token runs, bad "
-            "markers, and greedy repeat determinism mismatch.",
+            "markers, unclosed reasoning, a missing visible final answer, and "
+            "greedy repeat determinism mismatch. Naturally stopped short answers "
+            "are allowed.",
         ]
     )
     (out_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -808,6 +849,8 @@ def _run_matrix(args: argparse.Namespace) -> int:
             ]
             if not args.enable_thinking:
                 cmd.append("--disable-thinking")
+            if args.reasoning_effort is not None:
+                cmd.extend(["--reasoning-effort", args.reasoning_effort])
             for engine_arg in args.engine_arg:
                 cmd.extend(["--engine-arg", engine_arg])
             for prompt_id in args.quality_prompt_id or []:
@@ -878,6 +921,11 @@ def _parse_args() -> argparse.Namespace:
         "--disable-thinking", action="store_false", dest="enable_thinking"
     )
     parser.set_defaults(enable_thinking=True)
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("low", "high", "max"),
+        help="Model-specific chat-template reasoning effort.",
+    )
     parser.add_argument("--engine-arg", action="append", default=[])
     parser.add_argument("--out", type=Path)
     return parser.parse_args()

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44414,9 +44414,82 @@ Interpretation:
   and the global split-partial workspace route was about `130 us`. Neither is
   retained in production. The accepted kernel theoretically removes about
   `0.403 ms/token` over 34 KDA calls; this is a projection, not an end-to-end
-  result. Production admission still requires a compiled `_C` route hit,
-  real-model token/logit audit, and same-contract unprofiled TP4/PP2 A/B before
-  a new per-token trace is accepted.
+  result. The following stability and quality audit records the compiled `_C`
+  route hit, real-model output gates, and same-contract unprofiled TP4/PP2
+  result required for production admission.
+
+## 2026-08-28 GLM-5.3 TP4/PP2 stability and output-quality audit
+
+- The production audit uses source
+  `5de4e1c063747af776b9f834d4ea36b053549a84`, Torch `2.10.0+cu128`, CUDA
+  `12.8`, and eight 32-GiB V100-SXM2 GPUs. The `_C` binary is SM70-only and
+  has SHA256
+  `65b424044f4237557226025078a80b9e949c62a9946843ea2652a099299bd627`.
+  Public main contains the same exact KDA route and default-on rollback gate
+  through merged repair PR #396. Subsequent main changes are exact Qwen3.8 or
+  Quark routes; there are no later GLM model or KDA source changes.
+- The frozen speed contract is GLM-5.3-Flash-NVFP4, `modelopt_fp4` routed-MoE
+  weights, FP16 non-expert weights, FP8 E4M3 KV cache, TP4/PP2 with layer
+  partition `24,21`, B1, no MTP, `max_model_len=4096`, 1,024 input tokens,
+  256 greedy output tokens with EOS ignored, and `FULL_DECODE_ONLY` CUDA Graph
+  capture at B1. Runtime logs hit GLM sparse MLA, exact KDA GEMV, fused KDA
+  f/g, native/Triton mHC, TurboMind NVFP4 MoE, custom TP4 all-reduce, and the
+  full decode graph.
+- Three prefix-cache-reset, unprofiled repeats measure steady decode at
+  `53.013085`, `53.018516`, and `53.017527 token/s`, mean
+  `53.016376 token/s`. Mean TPOT is `18.862097 ms`; the full range is only
+  `0.005431 token/s` (`0.01024%`). All three 256-token outputs have hash
+  `a28466cfa75e5850b532fabf18ead71af6a044ab69f17763327cea7522540343`.
+  This is the accepted stable baseline; neither `62` nor `75 token/s` is a
+  measured result for this contract.
+- The same repeats measure 1,024-token prefill at `3.845156`, `3.851318`, and
+  `3.850663 s`, mean `3.849045 s` or `266.039984 token/s`. Mean first-token
+  latency is `3.851276 s`. This is a 1K-prefill result, not a projection for
+  longer contexts. Single quality-worker cross-checks are only
+  `240.7-241.4 token/s` because they use separate one-shot worker startups;
+  they are not substituted for the stable three-repeat baseline.
+- At `gpu_memory_utilization=0.90`, the limiting worker reports `2.94 GiB`
+  available for KV, `255,122` aggregate GPU KV-cache tokens, and `62.29x`
+  maximum concurrency at 4,096 tokens. A separate `max_model_len=8192` audit
+  reports `326,769` tokens and `39.89x`; hybrid-cache block geometry changes
+  with maximum length, so those token capacities must not be compared as a
+  simple byte ratio.
+- Official quality sampling follows the checkpoint generation config:
+  temperature `1.0`, top-p `0.95`, top-k `-1`, EOS enabled, and fixed seed
+  `20260828`. Eight external prompts cover arithmetic, executable Python,
+  medication safety, strict JSON, translation, logic, kernel-validation
+  concepts, and code-only stable deduplication. With the template's default
+  Max reasoning and budgets extended from 1,024 through 4,096 tokens, six
+  tasks naturally stop and pass task-level review. The algorithm and
+  code-only tasks consume all 4,096 tokens without closing `</think>` or
+  producing a visible answer, so default Max reasoning is `6/8`, not a full
+  quality pass.
+- GLM's chat template ignores `enable_thinking`; both true and false render
+  `Reasoning Effort: Max` with identical prompt hashes. The actual control is
+  the model-specific `reasoning_effort`. Re-running the two failed tasks with
+  `reasoning_effort=low` makes both stop naturally at 514 and 62 tokens. Both
+  code blocks parse; the longest-run implementation passes six external
+  execution cases and the stable-unique implementation passes four. The
+  longest-run response contains one incorrect tie assertion in its explanation
+  and immediately corrects it; the implementation and final assertion are
+  correct, but this remains a minor model-text issue rather than a kernel
+  failure.
+- Kernel-causal gates remain clean: the exact KDA on/off A/B produced identical
+  full token sequences, the real checkpoint audit was bitwise exact for all
+  68 comparisons, each three-run greedy determinism set is exact, and repeated
+  quality runs retain stable speed hashes. There is no observed acceleration
+  or FP8-KV corruption in these short-context tests. This does not justify an
+  unconditional default-Max quality claim: production should pass
+  `reasoning_effort=low` for concise code/structured requests and reserve Max
+  for workloads with a sufficiently large reasoning budget.
+- Retained speed evidence is
+  `/data/minimax-h3/task-cache/glm53-nvfp4-sm70-20260827/`
+  `postmain_5de4e1c063_exact_kda_fp8kv_tp4pp2_i1024_o256_r3_20260828.json`.
+  Quality evidence is in the sibling `quality_official_*q1024`,
+  `quality_official_*q2048_remaining7`,
+  `quality_official_*q4096_remaining4`, and `quality_reasoning_low_*code2`
+  JSON artifacts. The fixed prompt set has SHA256
+  `cb8f877ca930299393816d06fb1584c2227f2c3971206fd622955a032c451d0d`.
 
 ## 2026-08-28 Qwen3.8 NVFP4 indexed-A prefill audit
 

--- a/tests/benchmarks/test_sm70_quality_speed_matrix.py
+++ b/tests/benchmarks/test_sm70_quality_speed_matrix.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+from benchmarks.run_sm70_quality_speed_matrix import (
+    _make_chat_prompt,
+    _quality_metrics,
+)
+
+
+class RecordingTokenizer:
+    def __init__(self, *, rejects_enable_thinking: bool = False) -> None:
+        self.rejects_enable_thinking = rejects_enable_thinking
+        self.calls: list[dict[str, Any]] = []
+
+    def apply_chat_template(self, messages: list[dict[str, str]], **kwargs: Any) -> str:
+        self.calls.append(kwargs)
+        if self.rejects_enable_thinking and "enable_thinking" in kwargs:
+            raise TypeError("enable_thinking is unsupported")
+        return f"{messages[0]['content']}<think>"
+
+
+def test_make_chat_prompt_forwards_reasoning_effort():
+    tokenizer = RecordingTokenizer()
+
+    prompt = _make_chat_prompt(
+        tokenizer,
+        "question",
+        enable_thinking=True,
+        reasoning_effort="low",
+    )
+
+    assert prompt == "question<think>"
+    assert tokenizer.calls == [
+        {
+            "tokenize": False,
+            "add_generation_prompt": True,
+            "enable_thinking": True,
+            "reasoning_effort": "low",
+        }
+    ]
+
+
+def test_make_chat_prompt_fallback_preserves_reasoning_effort():
+    tokenizer = RecordingTokenizer(rejects_enable_thinking=True)
+
+    _make_chat_prompt(
+        tokenizer,
+        "question",
+        enable_thinking=False,
+        reasoning_effort="high",
+    )
+
+    assert tokenizer.calls[-1]["reasoning_effort"] == "high"
+    assert "enable_thinking" not in tokenizer.calls[-1]
+
+
+def test_quality_metrics_reject_unclosed_reasoning():
+    metrics = _quality_metrics(
+        "still reasoning",
+        list(range(64)),
+        finish_reason="length",
+        chat_prompt="question<think>",
+    )
+
+    assert metrics["reasoning_closed"] is False
+    assert metrics["visible_final_chars"] == 0
+    assert "unclosed_reasoning" in metrics["failures"]
+
+
+def test_quality_metrics_reject_missing_final_answer():
+    metrics = _quality_metrics(
+        "reasoning</think>\n",
+        list(range(64)),
+        finish_reason="stop",
+        chat_prompt="question<think>",
+    )
+
+    assert metrics["reasoning_closed"] is True
+    assert metrics["visible_final_chars"] == 0
+    assert "missing_final_answer" in metrics["failures"]
+
+
+def test_quality_metrics_accept_short_natural_stop():
+    metrics = _quality_metrics(
+        "</think>\n```python\ndef stable_unique(items):\n    return list(items)\n```",
+        list(range(16)),
+        finish_reason="stop",
+        chat_prompt="question<think>",
+    )
+
+    assert metrics["visible_final_chars"] > 0
+    assert "too_few_output_tokens" not in metrics["failures"]
+    assert metrics["passed"]
+
+
+def test_quality_metrics_reject_short_length_cutoff():
+    metrics = _quality_metrics(
+        "incomplete output",
+        list(range(16)),
+        finish_reason="length",
+    )
+
+    assert "too_few_output_tokens" in metrics["failures"]


### PR DESCRIPTION
## Purpose

Make the SM70 quality/speed matrix understand GLM-5.3's real chat-template control and reject outputs that exhaust their budget inside reasoning without a visible final answer. Record the stabilized TP4/PP2 decode, prefill, KV-capacity, and task-level quality evidence.

Base SHA: `62ad1e02693f4c857f3b7547cef1860ee54e8053`
Head SHA: `70f1d4fb3c`

## Why This Is Not A Duplicate

An open-PR search for quality-audit, reasoning-effort, and GLM matrix work returned no match. Runtime PRs #392 and #396 provide the exact KDA kernel; this PR changes only the audit harness, focused tests, and retained acceptance record.

## Implementation

- Add `--reasoning-effort={low,high,max}` and preserve it through tokenizer fallbacks and matrix worker subprocesses.
- Record rendered chat-prompt hashes, reasoning closure, and visible-final-answer length.
- Fail closed on unclosed reasoning or an empty final answer. Allow a short output only when it naturally stops.
- Add six focused tests for template forwarding/fallback and output-completion gates.
- Record exact speed/quality artifacts and the production reasoning-mode caveat.

## Test Plan And Result

- `pytest -q --confcutdir=tests/benchmarks tests/benchmarks/test_sm70_quality_speed_matrix.py`: `6 passed`.
- Ruff 0.14 check and format: pass.
- Typos and markdownlint pre-commit hooks: pass.
- Python compileall, CLI help smoke, and `git diff --check`: pass.
- Real GLM tokenizer render check: `enable_thinking=true/false` are identical Max prompts; `reasoning_effort=low/high/max` renders the intended mode.

## Retained GPU Evidence

Contract: GLM-5.3-Flash-NVFP4, modelopt NVFP4 MoE plus FP16 non-expert weights, FP8 E4M3 KV, TP4/PP2 on eight V100 32GB, B1, no MTP, 1K input / 256 output, full decode CUDA Graph.

- Stable decode: `53.013085 / 53.018516 / 53.017527 token/s`; mean `53.016376 token/s`, mean TPOT `18.862097 ms`.
- 1K prefill: `3.845156 / 3.851318 / 3.850663 s`; mean `3.849045 s` or `266.039984 token/s`.
- KV: `2.94 GiB` available on the limiting worker, `255,122` cache tokens, `62.29x` at 4,096 tokens.
- Official Max reasoning: six of eight tasks pass by 4,096 output tokens; two code tasks remain inside unclosed reasoning.
- Low reasoning rerun: both targeted code tasks stop and pass AST plus external execution tests (`2/2`).
- Exact KDA on/off sequences and real-weight operator comparisons remain exact; no tested fast-path or FP8-KV corruption was observed.

Artifacts: `/data/minimax-h3/task-cache/glm53-nvfp4-sm70-20260827/`.

## Risk

This does not claim unconditional default-Max model quality: production must pass `reasoning_effort=low` for concise code/structured work or allocate a sufficiently large Max reasoning budget. No runtime CUDA, model, attention, quantization, or KV-cache source is changed by this PR.

## AI Assistance

AI assistance was used to implement and test this change. The human submitter must review every changed line and be able to defend the result before promotion from Draft.