### PR TITLE
[Bugfix] Avoid KVBlockZeroer H2D staging races

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -318,9 +318,6 @@ def test_zeroer_supports_heterogeneous_page_sizes() -> None:
     small = torch.ones((3, 8), dtype=torch.int32, device=device)
     large = torch.ones((3, 20), dtype=torch.int32, device=device)
     zeroer = KVBlockZeroer(device, pin_memory=False)
-    zeroer._id_cap = 8
-    zeroer._ids_pinned = torch.empty(8, dtype=torch.int64)
-    zeroer._ids_gpu = torch.empty(8, dtype=torch.int64, device=device)
     zeroer._meta = (
         torch.tensor(
             [small.data_ptr(), large.data_ptr()], dtype=torch.uint64, device=device
@@ -341,3 +338,32 @@ def test_zeroer_supports_heterogeneous_page_sizes() -> None:
     torch.testing.assert_close(large[0], torch.ones_like(large[0]))
     torch.testing.assert_close(large[1], torch.zeros_like(large[1]))
     torch.testing.assert_close(large[2], torch.ones_like(large[2]))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_block_ids_are_not_overwritten_while_copy_is_in_flight() -> None:
+    device = torch.device("cuda")
+    storage = torch.ones((4, 4), dtype=torch.int32, device=device)
+    zeroer = KVBlockZeroer(device, pin_memory=True)
+    zeroer._meta = (
+        torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
+        torch.tensor([4], dtype=torch.int64, device=device),
+        torch.tensor([4], dtype=torch.int64, device=device),
+        1,
+        4,
+        1,
+    )
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        # Hold both copies behind pending GPU work. The second CPU submission
+        # must not mutate the pinned source used by the first copy.
+        torch.cuda._sleep(10_000_000)
+        zeroer.zero_block_ids([1])
+        zeroer.zero_block_ids([2])
+    stream.synchronize()
+
+    torch.testing.assert_close(storage[0], torch.ones_like(storage[0]))
+    torch.testing.assert_close(storage[1], torch.zeros_like(storage[1]))
+    torch.testing.assert_close(storage[2], torch.zeros_like(storage[2]))
+    torch.testing.assert_close(storage[3], torch.ones_like(storage[3]))

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -18,6 +18,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import PAGED_MQA_PAGE_SIZES
 from vllm.utils.mem_utils import MemorySnapshot, format_gib
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionMetadataBuilder,
@@ -168,9 +169,6 @@ class KVBlockZeroer:
         self._meta: (
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None
         ) = None
-        self._id_cap: int = 0
-        self._ids_pinned: torch.Tensor | None = None
-        self._ids_gpu: torch.Tensor | None = None
 
     def init_meta(
         self,
@@ -291,13 +289,6 @@ class KVBlockZeroer:
             device=self.device,
         )
 
-        self._id_cap = 8192
-        self._ids_pinned = torch.empty(
-            self._id_cap,
-            dtype=torch.int64,
-            pin_memory=self.pin_memory,
-        )
-        self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
         self._meta = (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
             seg_block_strides,
@@ -320,20 +311,17 @@ class KVBlockZeroer:
             n_segs,
         ) = self._meta
         n_blocks = len(block_ids)
-        if n_blocks > self._id_cap:
-            self._id_cap = n_blocks * 2
-            self._ids_pinned = torch.empty(
-                self._id_cap,
-                dtype=torch.int64,
-                pin_memory=self.pin_memory,
-            )
-            self._ids_gpu = torch.empty(
-                self._id_cap, dtype=torch.int64, device=self.device
-            )
-        assert self._ids_pinned is not None and self._ids_gpu is not None
-        self._ids_pinned[:n_blocks].numpy()[:] = block_ids
-        idx = self._ids_gpu[:n_blocks]
-        idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
+        # Each nonblocking H2D copy needs its own pinned source allocation.
+        # Reusing one host buffer lets a later scheduler step overwrite block
+        # IDs while an earlier DMA is still in flight, which can clear the
+        # wrong KV pages. The pinned allocator keeps this temporary source
+        # alive until its transfer completes.
+        idx = async_tensor_h2d(
+            block_ids,
+            dtype=torch.int64,
+            device=self.device,
+            pin_memory=self.pin_memory,
+        )
         grid = (n_blocks, n_segs, max_chunks)
         _zero_kv_blocks_kernel[grid](
             seg_addrs,


### PR DESCRIPTION
## Summary

Prevent `KVBlockZeroer` from reusing one pinned host ID buffer across nonblocking H2D copies. Each submission now uses `async_tensor_h2d`, so a later scheduler step cannot overwrite the source of an earlier in-flight DMA and make the zeroing kernel clear the wrong KV pages.

This restores the upstream vLLM race fix that was lost during the 1Cat release-line reconciliation. It is independent of QSA block selection and of the compressed-KV layout fixes in #276/#280.

## Root cause

`zero_block_ids()` wrote every scheduler batch into the same `_ids_pinned` allocation and launched `idx.copy_(..., non_blocking=True)`. The method returned without fencing that copy. A subsequent scheduler call could therefore mutate the pinned source before the previous transfer consumed it.

The failure is timing-sensitive: changing shared-memory size, build output, or launch scheduling can expose it, but those changes are only triggers. The invalid lifetime of the reused H2D staging buffer is the bug.

## Changes

- Remove the reusable `_ids_pinned`/`_ids_gpu` staging pair.
- Create an independently owned async H2D tensor for every block-ID submission.
- Add a CUDA-stream regression test that holds two copies behind pending GPU work and verifies that both requested blocks, and only those blocks, are cleared.

## Validation

- `tests/v1/worker/test_kv_block_zeroer.py` on Tesla V100: **14 passed**.
- New in-flight race test, ten independent executions on V100: **10/10 passed**.
- Pre-commit on both changed files: all hooks passed, including ruff, mypy, SPDX, and configuration checks.
- Qwen3.8 Flash Next natural 16K (`16,383` prompt tokens), temperature
  0, three in-process repeats, current SM70 FULL+PIECEWISE graph stack:
  **3/3 token-identical**, with no mismatch across all 16 decoded tokens.

## Provenance and duplicate audit

- Upstream fix: vllm-project/vllm#48085.
- Upstream simplification used here: vllm-project/vllm#48399.
- 1Cat search found no equivalent open or merged H2D-staging-lifetime PR. #276 and #280 address different zeroer correctness contracts.
- Rebased on 1Cat upstream `62ad1e026` before the final runtime gate. The
  `18b0b44e0..62ad1e026` delta is Python-only Quark W4A16 work and does not
  change the runtime CUDA/C++ sources reused by the gate.

## Risk

The per-call block-ID tensor is small. Its pinned source is retained by the async transfer lifetime and returned through PyTorch's pinned allocator only when safe; no synchronization is added to the scheduler hot path.
