### PR TITLE
[Bugfix] Honor safetensors index tensor assignments

### DIFF
--- a/tests/model_executor/model_loader/test_safetensors_index_filter.py
+++ b/tests/model_executor/model_loader/test_safetensors_index_filter.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
+@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
+def test_default_loader_only_yields_tensors_assigned_by_index(
+    tmp_path, load_format: str, load_strategy: str | None
+) -> None:
+    main_shard = tmp_path / "model-00001-of-00002.safetensors"
+    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file(
+        {"main.weight": torch.tensor([1.0])},
+        main_shard,
+    )
+    save_file(
+        {
+            "ple.weight": torch.tensor([2.0]),
+            "main.weight": torch.tensor([99.0]),
+            "unindexed.weight": torch.tensor([3.0]),
+        },
+        reused_shard,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "weight_map": {
+                    "main.weight": main_shard.name,
+                    "ple.weight": reused_shard.name,
+                },
+            }
+        )
+    )
+
+    loader = DefaultModelLoader(
+        LoadConfig(
+            load_format=load_format,
+            safetensors_load_strategy=load_strategy,
+            use_tqdm_on_load=False,
+        )
+    )
+    source = DefaultModelLoader.Source(
+        model_or_path=str(tmp_path),
+        revision=None,
+        fall_back_to_pt=False,
+    )
+
+    weights = list(loader._get_weights_iterator(source))
+
+    assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
+    torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
+    torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))

--- a/tests/model_executor/model_loader/test_safetensors_index_filter.py
+++ b/tests/model_executor/model_loader/test_safetensors_index_filter.py
@@ -62,3 +62,48 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
     assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
     torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
     torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
+
+
+@pytest.mark.skip_global_cleanup
+def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> None:
+    main_shard = tmp_path / "model-00001-of-00002.safetensors"
+    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
+    save_file(
+        {
+            "ple.weight": torch.tensor([2.0]),
+            "main.weight": torch.tensor([99.0]),
+            "unindexed.weight": torch.tensor([3.0]),
+        },
+        reused_shard,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "weight_map": {
+                    "main.weight": main_shard.name,
+                    "ple.weight": reused_shard.name,
+                },
+            }
+        )
+    )
+
+    loader = DefaultModelLoader(
+        LoadConfig(
+            load_format="safetensors",
+            use_tqdm_on_load=False,
+            model_loader_extra_config={"enable_multithread_load": True},
+        )
+    )
+    source = DefaultModelLoader.Source(
+        model_or_path=str(tmp_path),
+        revision=None,
+        fall_back_to_pt=False,
+    )
+
+    weights = sorted(loader._get_weights_iterator(source), key=lambda kv: kv[0])
+
+    assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
+    torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
+    torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -247,12 +247,27 @@ class DefaultModelLoader(BaseModelLoader):
                 self.load_config.use_tqdm_on_load,
             )
         elif use_safetensors:
-            if self.load_config.load_format == "fastsafetensors":
+            # fastsafetensors/instanttensor iterators cannot filter tensors
+            # inside a reused shard, so indexed-subset checkpoints must take
+            # the standard filtered iterator to honor the index assignments.
+            use_special_format = self.load_config.load_format in (
+                "fastsafetensors",
+                "instanttensor",
+            )
+            if use_special_format and indexed_weights_by_file is not None:
+                logger.warning(
+                    "Checkpoint index assigns a subset of stored tensors; "
+                    "falling back from %s to the filtered safetensors "
+                    "iterator.",
+                    self.load_config.load_format,
+                )
+                use_special_format = False
+            if use_special_format and self.load_config.load_format == "fastsafetensors":
                 weights_iterator = fastsafetensors_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
                 )
-            elif self.load_config.load_format == "instanttensor":
+            elif use_special_format and self.load_config.load_format == "instanttensor":
                 weights_iterator = instanttensor_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
@@ -265,6 +280,7 @@ class DefaultModelLoader(BaseModelLoader):
                         max_workers=extra_config.get(
                             "num_threads", self.DEFAULT_NUM_THREADS
                         ),
+                        indexed_weights_by_file=indexed_weights_by_file,
                     )
                 else:
                     weights_iterator = safetensors_weights_iterator(

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -26,6 +26,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     filter_duplicate_safetensors_files,
     filter_files_not_needed_for_inference,
     get_quant_config,
+    get_safetensors_index_weights_by_file,
     instanttensor_weights_iterator,
     maybe_download_from_modelscope,
     multi_thread_pt_weights_iterator,
@@ -101,7 +102,7 @@ class DefaultModelLoader(BaseModelLoader):
         revision: str | None,
         fall_back_to_pt: bool,
         allow_patterns_overrides: list[str] | None,
-    ) -> tuple[str, list[str], bool]:
+    ) -> tuple[str, list[str], bool, dict[str, set[str]] | None]:
         """Prepare weights for the model.
 
         If the model is not local, it will be downloaded."""
@@ -206,14 +207,29 @@ class DefaultModelLoader(BaseModelLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
-        return hf_folder, hf_weights_files, use_safetensors
+        indexed_weights_by_file = (
+            get_safetensors_index_weights_by_file(hf_folder, index_file)
+            if use_safetensors
+            else None
+        )
+        return (
+            hf_folder,
+            hf_weights_files,
+            use_safetensors,
+            indexed_weights_by_file,
+        )
 
     def _get_weights_iterator(
         self, source: "Source"
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
         extra_config = self.load_config.model_loader_extra_config
-        hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
+        (
+            hf_folder,
+            hf_weights_files,
+            use_safetensors,
+            indexed_weights_by_file,
+        ) = self._prepare_weights(
             source.model_or_path,
             source.subfolder,
             source.revision,
@@ -256,6 +272,7 @@ class DefaultModelLoader(BaseModelLoader):
                         self.load_config.use_tqdm_on_load,
                         self.load_config.safetensors_load_strategy,
                         local_expert_ids=self.local_expert_ids,
+                        indexed_weights_by_file=indexed_weights_by_file,
                         safetensors_prefetch_num_threads=(
                             self.load_config.safetensors_prefetch_num_threads
                         ),

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1083,11 +1083,22 @@ def multi_thread_safetensors_weights_iterator(
     hf_weights_files: list[str],
     use_tqdm_on_load: bool,
     max_workers: int = 4,
+    indexed_weights_by_file: Mapping[str, set[str]] | None = None,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Multi-Thread iterate over the weights in the model safetensor files."""
 
     def _load_file(st_file: str):
         result = load_file(st_file, device="cpu")
+        if indexed_weights_by_file is not None:
+            indexed_weights = indexed_weights_by_file.get(os.path.normpath(st_file))
+            if indexed_weights is None:
+                raise ValueError(
+                    f"Safetensors shard {st_file!r} is not present in the "
+                    "checkpoint index"
+                )
+            for name in list(result):
+                if name not in indexed_weights:
+                    del result[name]
         return result
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -13,7 +13,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
@@ -678,6 +678,31 @@ def filter_duplicate_safetensors_files(
     return hf_weights_files
 
 
+def get_safetensors_index_weights_by_file(
+    hf_folder: str, index_file: str
+) -> dict[str, set[str]] | None:
+    """Return the exact tensor names assigned to each indexed shard.
+
+    A safetensors shard can contain tensors that are not referenced by the
+    checkpoint index (for example, when a checkpoint reuses part of another
+    model's shard).  The index is authoritative in that case: loading every
+    tensor from an otherwise referenced file can inject stale or incompatible
+    weights into the model.
+    """
+    index_file_name = os.path.join(hf_folder, index_file)
+    if not os.path.isfile(index_file_name):
+        return None
+
+    with open(index_file_name) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    weights_by_file: dict[str, set[str]] = defaultdict(set)
+    for weight_name, filename in weight_map.items():
+        shard_path = os.path.normpath(os.path.join(hf_folder, filename))
+        weights_by_file[shard_path].add(weight_name)
+    return dict(weights_by_file)
+
+
 def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[str]:
     """
     Exclude files that are not needed for inference.
@@ -901,6 +926,7 @@ def safetensors_weights_iterator(
     safetensors_load_strategy: str | None = None,
     local_expert_ids: set[int] | None = None,
     *,
+    indexed_weights_by_file: Mapping[str, set[str]] | None = None,
     safetensors_prefetch_num_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
     safetensors_prefetch_block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
@@ -914,6 +940,14 @@ def safetensors_weights_iterator(
     if safetensors_load_strategy == "eager":
         loading_desc += " (eager)"
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
+
+    if indexed_weights_by_file is not None:
+        logger.info_once(
+            "Restricting safetensors loading to %d tensor entries assigned "
+            "by the checkpoint index across %d shards.",
+            sum(len(names) for names in indexed_weights_by_file.values()),
+            len(indexed_weights_by_file),
+        )
 
     fs_type = _get_fs_type(sorted_files)
     is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
@@ -986,10 +1020,20 @@ def safetensors_weights_iterator(
         disable=not enable_tqdm(use_tqdm_on_load),
         bar_format=_BAR_FORMAT,
     ):
+        indexed_weights = None
+        if indexed_weights_by_file is not None:
+            indexed_weights = indexed_weights_by_file.get(os.path.normpath(st_file))
+            if indexed_weights is None:
+                raise ValueError(
+                    f"Safetensors shard {st_file!r} is not present in the "
+                    "checkpoint index"
+                )
         if safetensors_load_strategy == "eager":
             with open(st_file, "rb") as f:
                 state_dict = load(f.read())
             for name, param in state_dict.items():
+                if indexed_weights is not None and name not in indexed_weights:
+                    continue
                 if not should_skip_weight(name, local_expert_ids):
                     yield name, param
         elif safetensors_load_strategy == "torchao":
@@ -1007,6 +1051,8 @@ def safetensors_weights_iterator(
             with safe_open(st_file, framework="pt") as f:
                 state_dict = {}
                 for name in f.keys():  # noqa: SIM118
+                    if indexed_weights is not None and name not in indexed_weights:
+                        continue
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     state_dict[name] = f.get_tensor(name)
@@ -1025,6 +1071,8 @@ def safetensors_weights_iterator(
         else:
             with safe_open(st_file, framework="pt") as f:
                 for name in f.keys():  # noqa: SIM118
+                    if indexed_weights is not None and name not in indexed_weights:
+                        continue
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     param = f.get_tensor(name)


### PR DESCRIPTION
## Purpose

A safetensors index assigns each tensor name to one shard. The default loader currently uses the index only to filter the shard file list, then yields every tensor stored in each selected file.

That is unsafe for reused or hardlinked shards. A Qwen3.8 Flash Next AWQ checkpoint reused 33 official PLE shards while its index selected only 129 PLE tensors. Those files also contained 1,024 unindexed layer-1 FP8 expert tensors, which the loader attempted to apply over the indexed AWQ experts.

This change treats `weight_map` as a per-file tensor allowlist for the standard safetensors iterator. Unindexed tensors are skipped before materialization in lazy, eager, and torchao branches. Checkpoints without an index keep the existing behavior.

No equivalent open 1Cat PR was found in the final duplicate-work search. The separate fastsafetensors and instanttensor backends are outside this patch.

AI assistance: OpenAI Codex assisted with implementation, tests, and PR preparation. Leon supplied the production reproducer and requested submission.

## Test Plan

```bash
/home/leon/1Cat/1Cat-vLLM/.venv/bin/python -m pytest \
  --confcutdir=tests/model_executor/model_loader \
  tests/model_executor/model_loader/test_registry.py \
  tests/model_executor/model_loader/test_safetensors_index_filter.py -vv

/home/leon/1Cat/1Cat-vLLM/.venv/bin/pre-commit run --files \
  vllm/model_executor/model_loader/default_loader.py \
  vllm/model_executor/model_loader/weight_utils.py \
  tests/model_executor/model_loader/test_safetensors_index_filter.py
```

The regression creates two shards with a duplicate `main.weight`: the indexed shard stores `1.0`, while a reused shard stores stale value `99.0` plus an unindexed tensor. It covers `auto` and explicit `safetensors` loading with default, lazy, and eager strategies.

## Test Result

- Focused CPU pytest: `8 passed`.
- Pre-commit on all changed files: passed.
- Existing real-model evidence: the same loader change completed TP4 loading of the 222,747-tensor Qwen3.8 Flash Next AWQ checkpoint and prevented the 1,024 unindexed FP8 expert tensors from reaching model weight loading.
- No GPU was required for this isolated PR validation.