### PR TITLE
[Bugfix][Model][SM70] Repair Qwen3.8 Flash Next correctness

### DIFF
--- a/docs/design/sm70_qwen38_flash_next_nvfp4.md
+++ b/docs/design/sm70_qwen38_flash_next_nvfp4.md
@@ -4,15 +4,17 @@
 
 - Status: source bring-up, pinned-host PLE, native Qwen4Exp MTP, and
   prefix-cache configuration are implemented; focused CPU/configuration gates
-  pass and the local ModelScope snapshot is fully verified. The current
-  accepted no-MTP TP4 candidate reaches 82.274 steady decode tokens/s on the
-  8192x512 contract. A matched 96-request GSM8K screen keeps 96/96 answers
-  correct with online QPN8 both off and on while QPN8 raises mean steady decode
-  by 16.97%. The direct NVFP4 ten-route QPN-M1 MoE and online QPN8 routes are
-  therefore default-on for the exact SM70/TP4/B1 contract, with explicit
-  diagnostic opt-outs. The preceding 77.370-token/s graph-node trace remains
-  the detailed optimization control. Corrected native MTP4 is stable across an
-  11-request TP4 transition run, and the no-thinking HumanEval8 gate reaches
+  pass and the local ModelScope snapshot is fully verified. The historical
+  no-MTP TP4 online-QPN8 candidate reaches 82.274 steady decode tokens/s on the
+  8192x512 contract, but online QPN8 requantizes dense checkpoint weights and
+  is now experimental opt-in. Its matched 96-request GSM8K screen keeps 96/96
+  answers correct in both arms but changes 88/96 token sequences and contains
+  a large long-output/repetition outlier. The exact, byte-preserving NVFP4
+  ten-route QPN-M1 MoE remains default-on; online QPN8 is default-off. The
+  precision-preserving no-MTP control is about 67.6 tokens/s, so reaching 80
+  tokens/s without online QPN8 remains an open optimization target. Corrected
+  native MTP4 is stable across an 11-request TP4 transition run, and the
+  no-thinking HumanEval8 gate reaches
   4.747 mean accepted length, 93.676% draft acceptance, 126.81 warmed pure
   decode tokens/s, and 8/8 standard semantic executions. The V2 M16 plus
   M5/M1 warmup also removes the first-request MTP `fused_moe_kernel` JIT.
@@ -20,7 +22,8 @@
   [#345](https://github.com/1CatAI/1Cat-vLLM/pull/345) and initial decode work
   [#361](https://github.com/1CatAI/1Cat-vLLM/pull/361) are merged. The compact
   MTP loader, exact SM70 MTP tile, and V2 warmup are the current follow-up.
-- Base SHA: `03c04da68e72bf26271de4986364a72141a7601f`.
+- Current correctness-audit base SHA:
+  `62ad1e02693f4c857f3b7547cef1860ee54e8053`.
 - Model: `RadixArk/Qwen3.8-Flash-Next-NVFP4` at revision
   `7b719225242aacd3dbd3f9407468c2ee9a9d2594`.
 - Model download: `/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4`.
@@ -133,7 +136,7 @@ will load safely.
 
 ## No-MTP TP4 decode performance and quality audit
 
-The retained performance candidate is
+The retained experimental online-QPN8 performance candidate is
 `.artifacts/qwen38_flash_next_nvfp4_20260826/results/target80-qpn-m1-mtp-off-8192x512.json`.
 It uses one request, TP4/PP1, FP16 activations, MTP off, V2, CUDA graphs, the
 direct QPN-M1 NVFP4 experts, online channel-QPN8 attention/GR projections,
@@ -202,17 +205,15 @@ arms, with zero invalid, replacement-character, NUL, or non-`stop` outputs.
 QPN8 raises mean steady decode from 67.627 to 79.105 tokens/s (+16.97%) and
 median steady decode from 67.640 to 79.369 tokens/s (+17.34%).
 
-Only 8/96 token hashes match, which is expected for a sampled low-precision
-route and is not a rejection criterion. The mean absolute output-length delta
-is 133.5 tokens and the maximum is 4477. One ambiguous-interest sample remains
-correct but grows from 1653 tokens and a repeated-4-gram ratio of 0.199 with
-QPN8 off to 3626 tokens and 0.507 with QPN8 on. Aggregate mean repetition is
-nearly unchanged (0.0394 versus 0.0410), so the evidence identifies a single
-long-output outlier rather than a task-accuracy or aggregate-quality
-regression. Under the performance-default policy, the 16.97% mean decode gain
-and unchanged 96/96 task result keep QPN8 default-on. Operators can set
-`VLLM_SM70_QWEN4_EXP_ONLINE_QPN8=0` for diagnosis while broader long-output
-quality monitoring continues.
+Only 8/96 token hashes match. The mean absolute output-length delta is 133.5
+tokens and the maximum is 4477. One sample remains correct but grows from 1653
+tokens and a repeated-4-gram ratio of 0.199 with QPN8 off to 3626 tokens and
+0.507 with QPN8 on. A short GSM8K score therefore does not establish that
+requantizing the checkpoint's dense BF16 projections preserves general output
+quality. Online QPN8 is default-off and requires the explicit experimental
+opt-in `VLLM_SM70_QWEN4_EXP_ONLINE_QPN8=1`; accepted no-MTP quality and speed
+baselines must report the flag and must not attribute an opt-in QPN8 result to
+the precision-preserving default route.
 
 The fixed A/B execution SHA predates the compressed-QSA zeroing repair merged
 as PR #373 (`ddd8c0b601`). A compressed QSA scheduler block is logically 784
@@ -222,6 +223,48 @@ was reused. Current main derives zeroing from `storage_block_size`, clears
 exactly the selected physical page, and is covered by a real V100 page test
 and a TP4 1K/4K generation smoke. Both A/B arms intentionally use the same old
 binary to isolate QPN8, while this branch includes the QSA repair.
+
+### Upstream correctness sync (2026-08-29)
+
+The correctness audit starts from public `main` at
+`62ad1e02693f4c857f3b7547cef1860ee54e8053` in the isolated branch
+`codex/v100-qwen38-correctness-upstream-20260828-152418`. It adapts the
+request-layout fix from vLLM PR #53896, the Mamba state-grid fixes from vLLM
+PRs #53802 and #54076, and the EAGLE cache-drop fix from vLLM PR #48375. The
+local adaptations also reject the unvalidated Qwen4Exp V1 runner override,
+stop QSA from claiming batch-invariant split-K reductions, and make online
+QPN8 experimental opt-in.
+
+The retained source/unit evidence is:
+
+- 124 focused Qwen4Exp, hybrid-cache, prefix-cache, QSA, and QPN policy tests
+  passed; one separately executed native QPN operator test also passed.
+- Seven V100 packed-GDN tests passed, including an exact FP32-beta state check.
+- Changed-file pre-commit passed every applicable hook, including Ruff,
+  markdownlint, mypy, SPDX, forbidden-import, configuration, and API checks.
+- The downloaded RadixArk safetensors index assigns 296,475 tensors across 206
+  files; comparing every file's actual keys found zero extra or missing keys,
+  so vLLM PR #54230 does not affect this checkpoint and was not duplicated.
+- vLLM PR #51599's async Mamba accepted-count race is already covered by the
+  local MRV2 runner-owned snapshots and request-ID remapping; `InputBatch` is
+  not an asynchronous D2H destination on this path.
+- vLLM PR #53520 fixes prompt-logprob lifetime in the legacy runner. Qwen4Exp
+  now rejects that runner, while MRV2 computes prompt logprobs before invoking
+  its padded model drafter, so the vulnerable ordering is absent.
+- vLLM PR #53122 configures quantized standalone DFlash draft models. Native
+  Qwen4Exp MTP already calls `configure_quant_config` with `Qwen4ExpMTP`, so
+  importing the DFlash guard would not change this checkpoint's route.
+- vLLM issue #53982's narrow circular-table read is avoided in both local
+  runners: QSA circular groups skip the generic slot-mapping kernel and build
+  ring slots from logical positions in their metadata builder.
+
+Two separate risks remain explicit. 1Cat PR #406 owns the independent
+`KVBlockZeroer` asynchronous H2D staging-lifetime fix and should merge before a
+high-concurrency prefix-cache acceptance run. Upstream issue #54199 still has
+no proven fix for a donor-lifecycle overlap in Mamba prefix-cache precopy; a
+bounds-only workaround would trade a crash for silent recurrent-state
+corruption and is therefore not accepted without a reproducer and state
+oracle.
 
 The checkpoint also carries multimodal `mrope_section` and
 `mrope_interleaved` fields in its text config. The initial SM70 route requires
@@ -251,12 +294,12 @@ unrelated upstream platform changes. The
 describes the production HC strategy more precisely: low-M Mix uses split-K
 GEMMs with SiLU in the down epilogue and sigmoid/four-stream reduction in the
 up epilogue, while Combine splits the hidden dimension to expose more CTAs.
-The accepted QPN8 HC route already mirrors those two epilogue fusions and the
-SM70 Combine kernel already partitions the hidden dimension; importing the
+The experimental QPN8 HC route already mirrors those two epilogue fusions and
+the SM70 Combine kernel already partitions the hidden dimension; importing the
 SM100-only CuTeDSL implementation from
 [FlashInfer PR 4266](https://github.com/flashinfer-ai/flashinfer/pull/4266)
 would therefore add no V100 kernel. The exact V100 screen also rejects
-collapsing the accepted two-QPN8-kernel path into one persistent launch. The
+collapsing the two-QPN8-kernel experiment into one persistent launch. The
 [SGLang day-zero HC kernel](https://github.com/sgl-project/sglang/blob/02d38b77db92699e5d4f1a78226bf711e9cc762a/python/sglang/srt/layers/hc_mix_triton.py)
 replaces the FP16 down-GEMV, SiLU, up-GEMV, sigmoid, and four-branch mean with
 one persistent kernel. A V100 form preserves the existing QPN8 weights and
@@ -307,8 +350,8 @@ The currently admitted candidates are deliberately narrow:
   `SM70 Qwen3.8 E512/K10 router top-k path enabled` marker.
 - GR/HC persistent launch: rejected despite bitwise output and clean replay
   state because it is 3.072 microseconds slower per call in the checkpoint-
-  shape cold-cache screen, a projected 0.298-ms/token regression. The accepted
-  split-QPN8 down/reduce/up implementation remains unchanged.
+  shape cold-cache screen, a projected 0.298-ms/token regression. The
+  experimental split-QPN8 down/reduce/up implementation remains unchanged.
 - MRv2 greedy sampling: the active V2 runner always materialized globally
   gathered logits and then launched Gumbel sampling, even for the exact
   temperature-zero single-request decode used here. The new SM70-only route
@@ -319,12 +362,11 @@ The currently admitted candidates are deliberately narrow:
   kernel and 0.044-ms full-logit all-gather before accounting for the local
   argmax cost.
 
-The QSA scorer, router, and V2 greedy projections together expose about
-0.90-1.01 ms/token of gross trace cost, which is enough on paper to cross the
-immediate 80 tokens/s gate after allowing for the pair-gather argmax overhead.
-A single resident-model run will validate them together; the model will not be
-restarted separately for each micro-optimization. The rejected persistent GR
-candidate is not included in that run.
+The QSA scorer, router, and V2 greedy projections expose about 0.90-1.01
+ms/token in the historical online-QPN8 trace. That trace is useful for kernel
+ranking but no longer proves the precision-preserving 80 tokens/s target; the
+next optimization cycle must use a fresh no-QPN8 trace and retain the exact
+checkpoint weights. The rejected persistent GR candidate is not included.
 
 ## Native MTP4 TP4 validation snapshot
 

--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -40,7 +40,7 @@ def _fused_recurrent_reference_from_mixed_qkv(
         x <= 20.0, torch.log1p(torch.exp(torch.clamp(x, max=20.0))), x
     )
     g = (-torch.exp(A_log.float()) * softplus_x).unsqueeze(1)
-    beta = torch.sigmoid(b.float()).to(a.dtype).unsqueeze(1)
+    beta = torch.sigmoid(b.float()).unsqueeze(1)
 
     return fused_recurrent_gated_delta_rule(
         q=q,
@@ -128,6 +128,39 @@ def test_fused_recurrent_packed_decode_matches_reference(
     rtol = 1e-2 if dtype != torch.float32 else 1e-4
     torch.testing.assert_close(out_packed, out_ref, rtol=rtol, atol=atol)
     torch.testing.assert_close(state_packed, state_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+def test_packed_decode_keeps_beta_in_fp32() -> None:
+    """Guard the no-MTP Qwen GDN state update against beta re-rounding."""
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    mixed_qkv = torch.ones((1, 3), device=device, dtype=dtype)
+    a = torch.zeros((1, 1), device=device, dtype=dtype)
+    b = torch.full((1, 1), 0.5, device=device, dtype=dtype)
+    params = torch.zeros((1,), device=device, dtype=dtype)
+    ssm_state_indices = torch.ones((1,), device=device, dtype=torch.int32)
+
+    state_packed = torch.zeros((2, 1, 1, 1), device=device, dtype=torch.float32)
+    out_packed = torch.empty((1, 1, 1, 1), device=device, dtype=dtype)
+
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=params,
+        dt_bias=params,
+        scale=1.0,
+        initial_state=state_packed,
+        out=out_packed,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    expected_beta = torch.sigmoid(b.float()).squeeze()
+    torch.testing.assert_close(
+        state_packed[1, 0, 0, 0], expected_beta, rtol=1e-6, atol=1e-6
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")

--- a/tests/models/qwen4_exp/test_config.py
+++ b/tests/models/qwen4_exp/test_config.py
@@ -102,6 +102,24 @@ def test_qwen4_exp_defaults_to_v2_even_when_quantized_moe(
     assert VllmConfig._is_default_v2_model_runner_model(vllm_config)
 
 
+def test_qwen4_exp_rejects_explicit_v1_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vllm.config.vllm.envs.VLLM_USE_V2_MODEL_RUNNER",
+        False,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=None,
+        model_config=SimpleNamespace(
+            architectures=["Qwen4ExpForCausalLM"],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires Model Runner V2"):
+        VllmConfig.use_v2_model_runner.fget(vllm_config)
+
+
 def test_initial_sm70_v2_route_accepts_native_mtp(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -152,6 +152,7 @@ def test_ngram_embedding_accepts_checkpoint_seed_none(
             max_total_tokens=8,
             max_num_reqs=2,
             prefix="model.layers.2.ple.ple_embedding",
+            layer_name="model.layers.2.ple",
             params_dtype=torch.float16,
         )
 
@@ -450,6 +451,51 @@ def test_ple_fp8_embedding_respects_checkpoint_shard_exclusions() -> None:
 
     quant_config.ignored_layers = [f"{prefix}.shard_0"]
     assert _get_ple_embedding_quant_method(quant_config, prefix) is None
+
+
+def test_ple_ngram_ids_custom_op_uses_current_request_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RuntimeNGramEmbedding(nn.Module):
+        def compute_ngram_ids(
+            self,
+            input_ids: torch.Tensor,
+            query_start_loc: torch.Tensor,
+            ngram_context: torch.Tensor,
+        ) -> torch.Tensor:
+            del input_ids, ngram_context
+            num_reqs = query_start_loc.numel() - 1
+            return torch.full((4, 2), num_reqs, dtype=torch.long)
+
+    layer = Qwen4ExpPLELayer.__new__(Qwen4ExpPLELayer)
+    nn.Module.__init__(layer)
+    layer.ple_embedding = RuntimeNGramEmbedding()
+    monkeypatch.setattr(
+        ple_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(no_compile_layers={"ple": layer}),
+    )
+    input_ids = torch.arange(4)
+    ngram_context = torch.zeros(2, 2, dtype=torch.long)
+    output = torch.empty(4, 2, dtype=torch.long)
+
+    ple_module.qwen4_exp_compute_ple_ngram_ids(
+        input_ids,
+        torch.tensor([0, 4]),
+        ngram_context,
+        output,
+        "ple",
+    )
+    assert torch.equal(output, torch.ones_like(output))
+
+    ple_module.qwen4_exp_compute_ple_ngram_ids(
+        input_ids,
+        torch.tensor([0, 2, 4]),
+        ngram_context,
+        output,
+        "ple",
+    )
+    assert torch.equal(output, torch.full_like(output, 2))
 
 
 def test_ngram_cpu_offload_padding_does_not_overwrite_real_tokens(

--- a/tests/models/qwen4_exp/test_qsa_cache.py
+++ b/tests/models/qwen4_exp/test_qsa_cache.py
@@ -7,8 +7,15 @@ from typing import Any
 import torch
 
 from vllm.models.qwen4_exp.common.qsa_cache import QSAKeyStateCache
-from vllm.models.qwen4_exp.nvidia.qsa import Qwen4ExpQSAFlashAttentionImpl
+from vllm.models.qwen4_exp.nvidia.qsa import (
+    Qwen4ExpQSAFlashAttentionBackend,
+    Qwen4ExpQSAFlashAttentionImpl,
+)
 from vllm.v1.worker.utils import bind_kv_cache
+
+
+def test_qsa_does_not_claim_batch_invariant_reductions() -> None:
+    assert not Qwen4ExpQSAFlashAttentionBackend.supports_batch_invariance()
 
 
 def test_bind_qsa_key_cache_builds_key_and_mrope_views() -> None:

--- a/tests/quantization/test_sm70_online_qpn8.py
+++ b/tests/quantization/test_sm70_online_qpn8.py
@@ -10,14 +10,14 @@ import vllm.envs as envs
 from vllm.model_executor.layers.quantization import sm70_online_qpn8 as online_qpn8
 
 
-def test_qwen4_exp_online_qpn8_defaults_on_and_can_be_disabled(monkeypatch):
+def test_qwen4_exp_online_qpn8_defaults_off_and_can_be_enabled(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", raising=False)
     envs.disable_envs_cache()
     try:
-        assert envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
-        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0")
-        envs.disable_envs_cache()
         assert not envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
+        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1")
+        envs.disable_envs_cache()
+        assert envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
     finally:
         envs.disable_envs_cache()
 
@@ -34,7 +34,7 @@ def test_qwen3next_shared_gate_fusion_defaults_on_and_can_be_disabled(monkeypatc
         envs.disable_envs_cache()
 
 
-def test_default_on_qpn_sidecars_load_without_enable_overrides(monkeypatch):
+def test_qpn_sidecars_respect_safe_online_default(monkeypatch):
     calls: list[str] = []
     monkeypatch.setenv("VLLM_SM70_FP8_QPN8_LIBRARY", "/tmp/qpn8.so")
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY", "/tmp/qpn-m1.so")
@@ -45,7 +45,12 @@ def test_default_on_qpn_sidecars_load_without_enable_overrides(monkeypatch):
     online_qpn8.sm70_ops._maybe_load_fp8_qpn8_library()
     online_qpn8.sm70_ops._maybe_load_nvfp4_qpn_m1_library()
 
-    assert calls == ["/tmp/qpn8.so", "/tmp/qpn-m1.so"]
+    assert calls == ["/tmp/qpn-m1.so"]
+
+    calls.clear()
+    monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1")
+    online_qpn8.sm70_ops._maybe_load_fp8_qpn8_library()
+    assert calls == ["/tmp/qpn8.so"]
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+MAMBA_BLOCK_SIZE = 816
+
+
+def _split(request, num_new_tokens: int) -> int:
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        mamba_state_block_size=MAMBA_BLOCK_SIZE,
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=False,
+    )
+    return Scheduler._mamba_block_aligned_split(scheduler, request, num_new_tokens)
+
+
+def test_scheduler_records_mamba_group_block_size() -> None:
+    mamba_spec = MambaSpec(
+        block_size=MAMBA_BLOCK_SIZE,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+
+    scheduler = create_scheduler(
+        block_size=16,
+        num_blocks=16,
+        kv_cache_spec=mamba_spec,
+    )
+
+    assert scheduler.mamba_state_block_size == MAMBA_BLOCK_SIZE
+
+
+def test_chunks_stop_at_every_mamba_state_boundary() -> None:
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 30
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=prompt_len,
+        block_size=16,
+    )
+    position = 0
+    chunk_ends = []
+
+    while position < prompt_len:
+        request.num_computed_tokens = position
+        num_new_tokens = _split(request, prompt_len - position)
+        assert num_new_tokens > 0
+        position += num_new_tokens
+        chunk_ends.append(position)
+
+    assert chunk_ends == [816, 1632, 2448, prompt_len]

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,11 +14,15 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     PrefixAnchoredSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
     PrefixAnchoredSWASpec,
     SlidingWindowSpec,
 )
@@ -586,3 +590,58 @@ def test_prefix_anchored_swa_manager_registered():
     )
     assert isinstance(manager, PrefixAnchoredSWAManager)
     assert manager.decode_sliding_window == 128
+
+
+def test_mamba_honors_eagle_cache_drop() -> None:
+    block_size = 16
+    num_blocks = 5
+    full_group_id, mamba_group_id = 0, 1
+    block_pool = BlockPool(
+        num_gpu_blocks=64,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    block_hashes = [BlockHash(f"block-{i}".encode()) for i in range(num_blocks)]
+
+    for group_id, block_offset in ((full_group_id, 10), (mamba_group_id, 20)):
+        for index, block_hash in enumerate(block_hashes):
+            block_pool.cached_block_hash_to_block.insert(
+                make_block_hash_with_group_id(block_hash, group_id),
+                block_pool.blocks[block_offset + index],
+            )
+
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+
+    def hit_length(manager, group_id, spec, use_eagle: bool) -> int:
+        return len(
+            manager.find_longest_cache_hit(
+                block_hashes=block_hashes,
+                max_length=num_blocks * block_size,
+                kv_cache_group_ids=[group_id],
+                block_pool=block_pool,
+                kv_cache_spec=spec,
+                use_eagle=use_eagle,
+                alignment_tokens=block_size,
+            )[0]
+        )
+
+    assert (
+        hit_length(FullAttentionManager, full_group_id, full_spec, False) == num_blocks
+    )
+    assert hit_length(MambaManager, mamba_group_id, mamba_spec, False) == num_blocks
+
+    full_hit = hit_length(FullAttentionManager, full_group_id, full_spec, True)
+    mamba_hit = hit_length(MambaManager, mamba_group_id, mamba_spec, True)
+    assert full_hit == num_blocks - 1
+    assert mamba_hit == full_hit

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -27,7 +27,7 @@ def _maybe_load_fp8_qpn8_library() -> None:
     online_override = os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8")
     generic_enabled = generic_override == "1"
     specific_enabled = generic_override != "0" and specific_override == "1"
-    online_enabled = online_override != "0"
+    online_enabled = online_override == "1"
     if generic_enabled or specific_enabled or online_enabled:
         torch.ops.load_library(library_path)
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -759,6 +759,7 @@ class CompilationConfig:
         "vllm::mamba_mixer2",
         "vllm::mamba_mixer",
         "vllm::short_conv",
+        "vllm::qwen4_exp_compute_ple_ngram_ids",
         "vllm::qwen4_exp_ple_short_conv",
         "vllm::qwen4_exp_qsa_with_output",
         "vllm::linear_attention",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -660,10 +660,23 @@ class VllmConfig:
     @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        architectures = (
+            getattr(self.model_config, "architectures", [])
+            if self.model_config is not None
+            else []
+        )
+        is_qwen4_exp = any(
+            architecture.startswith("Qwen4ExpFor") for architecture in architectures
+        )
         is_mrv2_dflash = (
             self.speculative_config is not None and self.speculative_config.use_dflash()
         )
         if use_v2_model_runner is not None:
+            if is_qwen4_exp and not use_v2_model_runner:
+                raise ValueError(
+                    "Qwen4Exp requires Model Runner V2 for its QSA ring cache "
+                    "and rollback-safe PLE n-gram context."
+                )
             if is_mrv2_dflash and not use_v2_model_runner:
                 raise ValueError(
                     "method='dflash' is implemented only by Model Runner V2. "

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -166,7 +166,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = False
-    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = True
+    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = False
     VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = True
     VLLM_SM70_FP8_QPN8_PP2_TP4: bool = False
     VLLM_SM70_FP8_QPN8_PP2_TP4_SHARED_GATE: bool = False
@@ -1704,12 +1704,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
     # Memory-neutral QPN8 layout for shape- and runtime-gated TP4 block-FP8
-    # dense projections. Pure-FP8 checkpoints must opt in;
-    # a mixed NVFP4 checkpoint may select its separately validated default in
-    # the compressed-tensors scheme. Explicit 0 disables both routes.
+    # dense projections. Pure-FP8 checkpoints must opt in. The Qwen4Exp
+    # online route also stays opt-in because it requantizes checkpoint BF16
+    # attention, GDN, QSA, and mHC weights without calibration.
     "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),
     "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1"))
+        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0"))
     ),
     # Exact M=1 Qwen3Next/Qwen4Exp shared-expert output gate. This replaces
     # the scalar GEMV, sigmoid, and output multiply with one SM70 kernel while

--- a/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
+++ b/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Narrow online QPN8 route for Qwen4Exp FP16 decode projections on SM70."""
+"""Opt-in online QPN8 route for Qwen4Exp FP16 decode projections on SM70.
+
+This route requantizes selected dense checkpoint weights at load time. It is a
+performance experiment rather than a precision-preserving checkpoint route and
+therefore requires an explicit environment opt-in.
+"""
 
 from __future__ import annotations
 
@@ -185,9 +190,10 @@ def maybe_prepare_online_qpn8(layer: nn.Module) -> bool:
     layer.sm70_fp8_qpn8 = True
     layer.sm70_fp8_prefill_exact_dense_workspace_ptr = workspace.data_ptr()
     setattr(layer, _STATE_ATTR, True)
-    logger.info_once(
-        "SM70 Qwen4Exp online channel-QPN8 enabled for selected FP16 decode "
-        "projections."
+    logger.warning_once(
+        "Experimental SM70 Qwen4Exp online channel-QPN8 is requantizing "
+        "selected FP16 decode projections; model-level quality is not "
+        "guaranteed."
     )
     return True
 

--- a/vllm/models/qwen4_exp/amd/qsa.py
+++ b/vllm/models/qwen4_exp/amd/qsa.py
@@ -86,6 +86,12 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
         return True
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # QSA chooses its split-K reduction depth from the runtime batch
+        # shape, so it cannot inherit FlashAttention's stronger guarantee.
+        return False
+
+    @classmethod
     def supports_kv_connector(cls) -> bool:
         return False
 

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -457,10 +457,12 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         max_total_tokens: int,
         max_num_reqs: int,
         prefix: str,
+        layer_name: str,
         quant_config: QuantizationConfig | None = None,
         params_dtype: torch.dtype | None = None,
     ) -> None:
         super().__init__()
+        self.layer_name = layer_name
         self.embedding_dim = embedding_dim
         self.ngram_size = int(config.ngram_size)
         self.heads_per_ngram = int(config.heads_per_ngram)
@@ -598,33 +600,32 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
         return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
 
-    def forward_impl(  # type: ignore[override]
+    def compute_ngram_ids(
         self,
-        hidden_states: torch.Tensor,
         input_ids: torch.Tensor,
         query_start_loc: torch.Tensor,
         ngram_context: torch.Tensor,
-        output_buffer: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        del hidden_states
+        """Compute PLE indices for the current, unpadded request layout."""
         input_ids = input_ids.reshape(-1).long()
         query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
         num_tokens = input_ids.shape[0]
 
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+        if num_reqs <= 0:
+            raise ValueError("PLE requires at least one request")
+
         if is_offload_process():
-            num_reqs = query_start_loc.numel() - 1
-            if num_tokens > self.positions_buffer.numel():
-                raise ValueError(
-                    f"PLE received {num_tokens} tokens, but its workspace supports "
-                    f"at most {self.positions_buffer.numel()}"
-                )
-            if num_reqs > self.padded_buffer.shape[0]:
-                raise ValueError(
-                    f"PLE received {num_reqs} requests, but its workspace supports "
-                    f"at most {self.padded_buffer.shape[0]}"
-                )
-            if num_reqs <= 0:
-                raise ValueError("PLE CPU offload requires at least one request")
             max_seq_len = max(
                 1,
                 int((query_start_loc[1:] - query_start_loc[:-1]).max().item()),
@@ -634,10 +635,10 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             # padded IDs overwrite the final real token after index clamping.
             num_valid_tokens = min(int(query_start_loc[-1].item()), num_tokens)
         else:
-            # Preserve MRV2's dynamic-shape contract: scheduler limits already
-            # bound these symbolic dimensions, so avoid Python shape tests.
-            num_reqs = ngram_context.shape[0]
-            max_seq_len = self.padded_buffer.shape[1]
+            # This method runs behind a splitting custom op on GPU, so request
+            # dimensions are evaluated for every replay instead of being
+            # specialized into a PIECEWISE graph keyed only by token count.
+            max_seq_len = num_tokens
             num_valid_tokens = num_tokens
 
         positions = self.positions_buffer[:num_tokens]
@@ -652,10 +653,11 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             packed[request_indices[:num_valid_tokens], columns[:num_valid_tokens]] = (
                 input_ids[:num_valid_tokens]
             )
-            ngram_context = ngram_context[:num_reqs]
         else:
             packed[request_indices, columns] = input_ids
-        ngram_context = ngram_context.to(device=input_ids.device, dtype=torch.long)
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
 
         context = torch.cat([ngram_context, packed], dim=-1)
         positions_2d, position_in_segment = self._shift_precompute(
@@ -686,7 +688,37 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             offsets = self.ngram_heads_offsets[start:end]
             ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
             id_blocks.append(ids[request_indices, adjusted_columns])
-        ngram_ids = torch.cat(id_blocks, dim=-1)
+        return torch.cat(id_blocks, dim=-1)
+
+    def forward_impl(  # type: ignore[override]
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+        output_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del hidden_states
+        input_ids = input_ids.reshape(-1)
+        num_tokens = input_ids.shape[0]
+        if is_offload_process():
+            ngram_ids = self.compute_ngram_ids(
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+        else:
+            ngram_ids = input_ids.new_empty(
+                (num_tokens, self.ngram_heads),
+                dtype=torch.long,
+            )
+            torch.ops.vllm.qwen4_exp_compute_ple_ngram_ids(
+                input_ids,
+                query_start_loc,
+                ngram_context,
+                ngram_ids,
+                self.layer_name,
+            )
         if output_buffer is not None:
             output = output_buffer[:num_tokens, : self.embedding_dim]
             # Cross-process FP8 results travel as raw bytes. Keeping the IPC
@@ -856,7 +888,8 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 self.ple_dense_layer_id,
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 vllm_config.scheduler_config.max_num_seqs,
-                f"{prefix}.ple_embedding",
+                prefix=f"{prefix}.ple_embedding",
+                layer_name=prefix,
                 quant_config=quant_config,
                 params_dtype=model_config.dtype,
             )
@@ -1533,6 +1566,33 @@ def qwen4_exp_ple_short_conv_fake(
     return
 
 
+def qwen4_exp_compute_ple_ngram_ids(
+    input_ids: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    ngram_context: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Compute request-dependent PLE IDs outside PIECEWISE CUDA graphs."""
+    layer = get_forward_context().no_compile_layers[layer_name]
+    ngram_ids = layer.ple_embedding.compute_ngram_ids(
+        input_ids,
+        query_start_loc,
+        ngram_context,
+    )
+    output.copy_(ngram_ids)
+
+
+def qwen4_exp_compute_ple_ngram_ids_fake(
+    input_ids: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    ngram_context: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
 def qwen4_exp_ple_pinned_gather(
     input_ids: torch.Tensor,
     output: torch.Tensor,
@@ -1592,6 +1652,14 @@ def qwen4_exp_ple_fp8_bytes_dequant_fake(
     output: torch.Tensor,
 ) -> None:
     return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_compute_ple_ngram_ids",
+    op_func=qwen4_exp_compute_ple_ngram_ids,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_compute_ple_ngram_ids_fake,
+)
 
 
 direct_register_custom_op(

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -92,6 +92,12 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
         return True
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # QSA chooses its split-K reduction depth from the runtime batch
+        # shape, so it cannot inherit FlashAttention's stronger guarantee.
+        return False
+
+    @classmethod
     def supports_kv_connector(cls) -> bool:
         return False
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -50,7 +50,7 @@ from vllm.v1.core.sched.request_queue import (
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -284,6 +284,22 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        # A Mamba state is materialized only when a scheduler chunk ends on
+        # the Mamba group's own block grid. The global cache block size can be
+        # much smaller in heterogeneous layouts (Qwen3.8 uses 16-token hashes
+        # with an 816-token recurrent-state block), so it is not a valid grid.
+        mamba_state_block_sizes = {
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        assert len(mamba_state_block_sizes) <= 1, (
+            "mamba align scheduling requires a single state block size, "
+            f"got {sorted(mamba_state_block_sizes)}"
+        )
+        self.mamba_state_block_size = (
+            next(iter(mamba_state_block_sizes)) if mamba_state_block_sizes else None
+        )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -400,45 +416,52 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        num_computed_tokens = (
+        start = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
             + num_external_computed_tokens
         )
-        # Perform block-aligned splitting at prefill phase, including:
-        # * non-resumed requests: num_computed_tokens < num_prompt_tokens + 0
-        # * resumed requests: num_computed_tokens < (
-        #                       num_prompt_tokens + num_output_tokens
-        #                     )
-        # NOTE: Use `request.num_tokens - 1` to bypass normal decoding.
-        if num_computed_tokens < max(request.num_prompt_tokens, request.num_tokens - 1):
-            # To enable block-aligned caching of the Mamba state, `num_new_tokens`
-            # must be a multiple of `block_size`.
-            # As an exception, if `num_new_tokens` is less than `block_size`, the
-            # state is simply not cached, requiring no special handling.
-            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
-            # matching block. To prevent this from causing a Mamba cache miss, the
-            # last chunk must be not smaller than `block_size`.
-            block_size = self.cache_config.block_size
-            last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
-            if self.use_eagle:
-                last_cache_position = max(last_cache_position - block_size, 0)
-            num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
-            if num_computed_tokens_after_sched < last_cache_position:
-                # align to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
-            elif (
-                num_computed_tokens
-                < last_cache_position
-                < num_computed_tokens_after_sched
-            ):
-                # force to cache the last chunk
-                num_new_tokens = last_cache_position - num_computed_tokens
-            else:
-                # prefill the last few tokens
-                pass
-        return num_new_tokens
+        # `request.num_tokens - 1` extends prefill handling to resumed requests
+        # replaying output tokens while leaving ordinary decode untouched.
+        prefill_end = max(request.num_prompt_tokens, request.num_tokens - 1)
+        if start >= prefill_end:
+            return num_new_tokens
+
+        block_size = (
+            self.mamba_state_block_size
+            if self.mamba_state_block_size is not None
+            else self.cache_config.block_size
+        )
+        # Prefix lookup is capped at n - 1. Flooring from n would register an
+        # unreachable state whenever the request length is block aligned.
+        last_token = request.num_tokens - 1
+        last_cache_position = last_token - last_token % block_size
+        if self.use_eagle:
+            last_cache_position = max(last_cache_position - block_size, 0)
+
+        end = start + num_new_tokens
+        if end < prefill_end:
+            max_prefill_tokens = self.max_num_scheduled_tokens
+            long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
+            if long_prefill_threshold > 0:
+                max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
+            aligned_end = end // block_size * block_size
+            if aligned_end > start or block_size <= max_prefill_tokens:
+                end = aligned_end
+
+        # The align allocator materializes one recurrent-state column per
+        # scheduler step. A step spanning multiple state blocks leaves the
+        # interior slots null, so every crossed boundary must end a chunk.
+        next_block_boundary = (start // block_size + 1) * block_size
+        end = min(
+            (
+                stop
+                for stop in (next_block_boundary, last_cache_position)
+                if start < stop < end
+            ),
+            default=end,
+        )
+        return max(end - start, 0)
 
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1170,6 +1170,13 @@ class MambaManager(SingleTypeKVCacheManager):
 
         block_size = kv_cache_spec.block_size
         max_num_blocks = max_length // block_size
+        if use_eagle and max_num_blocks > 0:
+            # EAGLE/MTP must recompute the final matched page because its
+            # recurrent snapshot may include draft tokens later rejected by
+            # verification. Mamba returns a null-padded list whose only real
+            # state is the rightmost block, so popping the result would remove
+            # the state itself; search one page earlier instead.
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(


### PR DESCRIPTION
## Purpose

Repair the Qwen3.8-Flash-Next correctness gaps found while auditing current
1Cat public `main` against the live vLLM support PRs, without weakening the
existing V100/SM70 routes.

Base SHA: `62ad1e02693f4c857f3b7547cef1860ee54e8053`.

This PR:

- adapts vLLM #53896's request-layout-safe PLE n-gram ID custom op while
  preserving 1Cat's pinned-host CPU PLE offload;
- adapts vLLM #53802/#54076 so hybrid Mamba/GDN prefill uses the real Mamba
  state grid and stops at every state boundary, including the `(n - 1)` tail;
- adapts vLLM #48375 so EAGLE/MTP drops the final Mamba cache-hit state;
- rejects the unvalidated legacy Qwen4Exp runner and keeps QSA from claiming
  batch-invariant split-K reductions;
- pins the packed GDN FP32-beta behavior with an exact V100 regression; and
- changes online QPN8 from default-on to explicit experimental opt-in. QPN8
  requantizes dense checkpoint weights at load time; the exact checkpoint
  NVFP4 QPN-M1 expert route remains default-on and unchanged.

## Output-quality decision

The historical online-QPN8 A/B kept 96/96 GSM8K answers correct but only 8/96
token sequences matched. One answer expanded from 1,653 to 3,626 tokens and
its repeated-4-gram ratio rose from 0.199 to 0.507. This does not justify a
precision-preserving default, so `VLLM_SM70_QWEN4_EXP_ONLINE_QPN8` now defaults
to `0` and requires explicit `=1` opt-in with a quality warning.

The previous ~82.3 tokens/s result used online QPN8 and is not an accepted
no-loss baseline. The precision-preserving no-MTP control is about 67.6
tokens/s; reaching 80 tokens/s without QPN8 remains a separate optimization
target.

## Test Plan

- Run focused Qwen4Exp configuration, PLE, QSA, hybrid-cache, prefix-cache,
  and QPN policy tests.
- Run the native QPN operator test against the existing source-built sidecar.
- Run packed GDN reference and exact FP32-beta tests on V100.
- Run all applicable pre-commit hooks on every changed file.
- When a clean TP4 window is available, run one combined V2/no-MTP/CPU-PLE
  model gate with QPN8 unset, rather than restarting once per scenario.

## Test Result

- `124 passed, 1 deselected, 18 warnings` in 52.17 seconds for the focused
  Qwen4Exp/hybrid/prefix/QPN suite.
- Native QPN sidecar operator: `1 passed` with explicit online-QPN8 opt-in.
- Packed GDN: `7 passed`, including the exact FP16-input/FP32-beta state test.
- Changed-file pre-commit: all applicable Ruff, format, typos, markdownlint,
  mypy, SPDX, forbidden-import, configuration, and API checks passed.
- `git diff --check` passed.
- The downloaded RadixArk index was checked against all 296,475 tensors in 206
  safetensors files: zero extra and zero missing keys, so vLLM #54230 does not
  affect this checkpoint.

No branch E2E result is claimed yet. GPUs 0-3 host the existing public MTP4
service, and GPUs 4-7 were held by a separate Nsight task at validation time;
this PR deliberately did not preempt either workload or repeatedly restart the
model.

## Remaining gates and dependencies

- 1Cat #406 owns the independent `KVBlockZeroer` asynchronous H2D staging
  lifetime fix and should land before high-concurrency prefix-cache acceptance.
- vLLM issue #54199 remains open for overlapping donor/request lifetimes in
  Mamba prefix-cache precopy. A bounds-only workaround is not included because
  it can replace a crash with silent recurrent-state corruption.
- A final combined TP4/V2/no-MTP/CPU-PLE gate is required before merge. It must
  cover deterministic generation, tool calls, PLE request-layout changes, and
  prefix lengths around the real state boundaries.

## Duplicate-work audit

- vLLM #51599's async accepted-count race is already covered by the local MRV2
  runner-owned snapshots and request-ID remapping.
- vLLM #53520 fixes legacy-runner prompt-logprob ordering; MRV2 computes prompt
  logprobs before its drafter, and this PR rejects Qwen4Exp legacy-runner use.
- vLLM #53122 targets standalone DFlash draft quantization; native Qwen4Exp MTP
  already calls `configure_quant_config(Qwen4ExpMTP)`.
- vLLM issue #53982's circular block-table OOB path is already avoided in both
  local runners by disabling generic slot mapping for QSA circular groups.
- Disk/mmap PLE PRs are intentionally not imported because the target contract
  keeps PLE in host RAM.

AI assistance was used for upstream comparison, implementation, tests, and the
audit write-up. Every changed line and reported result was reviewed locally.
