### PR TITLE
[Build][SM70] Make TokenSpeed MLA optional for V100 builds

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -199,7 +199,9 @@ hardware and configuration.
 
 > **‡** Automatic selection tries FlashAttention first. On Blackwell
 > (SM100), the fallback order is TRT-LLM Ragged, FlashInfer, then
-> TokenSpeed MLA. On other GPUs, only FlashAttention is considered.
+> TokenSpeed MLA. On other GPUs, only FlashAttention is considered. TokenSpeed
+> MLA is optional; its package must use an `apache-tvm-ffi` version compatible
+> with the installed TileLang release.
 
 ### Decode Backends
 

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -24,8 +24,8 @@ fastsafetensors >= 0.3.3
 nvidia-cutlass-dsl[cu13]==4.7.0
 quack-kernels>=0.3.3
 
-# Tokenspeed_MLA for faster mla with spec decode
-tokenspeed-mla==0.2.5
+# TokenSpeed MLA is optional. Version 0.2.5 pins apache-tvm-ffi==0.1.13,
+# which cannot coexist with the TileLang version pinned above.
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.2

--- a/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
@@ -30,8 +30,9 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
         return device_capability.major == 10
 
     _INSTALL_HINT = (
-        "tokenspeed_mla package is not installed. "
-        "Install it with: `uv pip install tokenspeed-mla`"
+        "tokenspeed_mla is an optional package and is not installed. "
+        "Its apache-tvm-ffi requirement must be compatible with the installed "
+        "TileLang version."
     )
 
     @classmethod

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -101,8 +101,9 @@ class TokenspeedMLABackend(MLACommonBackend):
             import tokenspeed_mla  # noqa: F401
         except ImportError:
             return (
-                "tokenspeed_mla package is not installed. "
-                "Install it with: `uv pip install tokenspeed-mla`"
+                "tokenspeed_mla is an optional package and is not installed. "
+                "Its apache-tvm-ffi requirement must be compatible with the "
+                "installed TileLang version."
             )
 
         # tokenspeed_mla CuTe DSL kernel is shape-specialized for DeepSeek R1


### PR DESCRIPTION


# [Build][SM70] Make TokenSpeed MLA optional for V100 builds

> AI-assisted draft. AI assistance was used for upstream comparison,
> implementation, dependency resolution, live build validation, and this
> write-up. The human submitter reviewed.

## Purpose

The CUDA requirement set simultaneously pins:

- `apache-tvm-ffi==0.1.10` for the current TileLang stack; and
- `tokenspeed-mla==0.2.5`, which requires `apache-tvm-ffi==0.1.13`.

The set is unsatisfiable. TokenSpeed MLA is already imported as an optional
backend and its decode and prefill implementations accept only compute
capability major 10 (Blackwell). It is not usable on the target SM70/V100
build.

This PR removes TokenSpeed from the mandatory CUDA set, documents it as
optional, and replaces the unconditional install hint with a compatibility
warning. Blackwell backend code, selection, and kernels are unchanged; a
Blackwell user may install a TokenSpeed package once its TVM-FFI requirement is
compatible with the installed TileLang stack.

Base SHA: `62ad1e02693f4c857f3b7547cef1860ee54e8053`.

## Duplicate-work audit

The complete open PR list and TokenSpeed searches were refreshed on 2026-08-28.
No open PR fixes this resolver conflict.
[PR 358](https://github.com/1CatAI/1Cat-vLLM/pull/358) changes Torchaudio only
in `requirements/cuda.txt`. Closed dependency-refresh PRs retain the
conflicting TokenSpeed and TVM-FFI pins. Existing TokenSpeed-related issues
concern runtime or model behavior rather than this exact dependency
contradiction.

## Test Plan

Command used for both states:

```text
uv pip compile requirements/cuda.txt \
  --python-version 3.12 \
  --python-platform x86_64-manylinux_2_28 \
  --no-cache \
  --output-file <validated-temporary-path>
```

Run that command before and after the change, then run Ruff formatting/lint,
Python byte-compilation, patch hygiene, an integrated CUDA 12.8.1 SM70 image
build, import checks, and TP4 V100 health/runtime smoke requests.

## Test Result

Unpatched current main:

```text
exit 1
No solution found when resolving dependencies:
Because tokenspeed-mla==0.2.5 depends on apache-tvm-ffi==0.1.13 and you
require apache-tvm-ffi==0.1.10, ... your requirements and
tokenspeed-mla==0.2.5 are incompatible.
```

Patched SM70 candidate:

```text
exit 0
Resolved 192 packages in 26.18s
apache-tvm-ffi==0.1.10
tilelang==0.1.10
tokenspeed-mla absent
```

On `gazasrv16`, an isolated precompiled editable install from unpatched current
main reproduced the same resolver failure. Applying this candidate allowed the
Linux environment to resolve 191 packages and install both the editable source
and full CUDA test dependency set. This was a disposable worktree; production
containers, GPUs, and host packages were not changed.

Additional checks:

```text
uvx --from ruff==0.14.0 ruff format --check \
  vllm/v1/attention/backends/mla/tokenspeed_mla.py \
  vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
2 files already formatted

uvx --from ruff==0.14.0 ruff check <same files>
All checks passed!

uv run --no-project --python 3.12 python -m py_compile <same files>
exit 0

git diff --check
exit 0

git apply --check 0003-upstream-sm70-optional-tokenspeed.patch
exit 0 against 62ad1e0
```

## Integrated V100 build and runtime smoke

The patched dependency set was used in a successful CUDA 12.8.1 SM70 image
build for four V100-SXM2-32GB GPUs. vLLM core, MoE, the SM70 sampler,
FlashAttention-V100, and FlashQLA imported successfully. HTTP `/health`,
`/v1/models`, and `/metrics` returned 200; the container remained healthy with
zero restarts.

These runtime figures are smoke evidence for the resulting V100 image, not
performance attributed to dependency removal:

| Request | TTFT | Decode | MTP4 acceptance | Total |
| --- | ---: | ---: | ---: | ---: |
| 6,316 prompt / 512 output | 2.9538 s | 87.0357 tok/s | 73.2824% | 8.8249 s |
| 564,577 cold / 512 output | 690.9660 s | 31.2186 tok/s | 79.7131% | 707.3345 s |
| 564,577 identical replay / 512 output | 9.2287 s | 31.1965 tok/s | 79.7131% | 25.6088 s |

The service exposed 2,557,299 FP8 E5M2 KV-cache tokens and reused 99.6087% of
the long identical prefix. Backend tokenization processed the approximately
564.6k-token prompt at 224k-228k tokens/s.

## Blackwell boundary

This change was validated only for SM70/V100. It does not claim TokenSpeed
correctness or performance on Blackwell. The current mandatory pins cannot
install TokenSpeed alongside the repository's TileLang/TVM-FFI stack; the
preferred long-term Blackwell solution is a mutually compatible published
dependency set, after which TokenSpeed can be offered as an explicit optional
extra or architecture-specific image dependency.

## Risk and rollback

SM70 behavior is unchanged because the backend rejects capability 7.0. The
risk is that a Blackwell image no longer receives TokenSpeed transitively; its
documented fallback backends remain available, and explicit installation is
possible when dependencies are compatible. Rollback restores the mandatory
pin but also restores the resolver failure.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the exact TokenSpeed/TVM-FFI conflict and the open dependency PRs checked for duplicates.
- [x] The test plan, including before/after dependency resolution, Ruff, byte-compilation, patch hygiene, SM70 image build/imports, and V100 runtime smoke.
- [x] The test results, including the reproduced resolver failure, successful patched resolution/install, image/runtime health, decode performance, MTP acceptance, KV-cache capacity, prefix-cache reuse, tokenization rate, and restart status.
- [x] (Optional) The necessary documentation update is included in `docs/design/attention_backends.md`, documenting TokenSpeed as optional and requiring TileLang-compatible `apache-tvm-ffi`.

</details>

