### PR TITLE
[Bugfix][Spec Decode] Validate YaRN for extended native MTP context

### DIFF
--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -2,7 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Test whether spec decoding handles the max model length properly."""
 
+import copy
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
+from transformers import PretrainedConfig
 
 from tests.utils import get_attn_backend_list_based_on_platform
 from vllm import LLM, SamplingParams
@@ -98,3 +103,100 @@ def test_mtp_speculative_config_max_model_len(spec_max_model_len: int):
         max_model_len=spec_max_model_len,
     )
     assert spec_config.draft_model_config.max_model_len == spec_max_model_len
+
+
+def _native_mtp_yarn_config(
+    *,
+    max_model_len: int = 1_000_000,
+    rope_parameters: dict[str, Any] | None = None,
+) -> tuple[Any, PretrainedConfig]:
+    if rope_parameters is None:
+        rope_parameters = {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 262_144,
+        }
+    target_hf_config = PretrainedConfig(rope_parameters=rope_parameters)
+    draft_hf_config = PretrainedConfig(max_position_embeddings=262_144)
+    target_model_config = SimpleNamespace(
+        model="test/native-mtp",
+        max_model_len=1_000_000,
+        hf_config=target_hf_config,
+    )
+    config = SimpleNamespace(
+        method="mtp",
+        model=target_model_config.model,
+        max_model_len=max_model_len,
+        target_model_config=target_model_config,
+        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+    )
+    return config, draft_hf_config
+
+
+def test_native_mtp_inherits_validated_target_yarn() -> None:
+    config, draft_hf_config = _native_mtp_yarn_config()
+    target_rope = config.target_model_config.hf_config.rope_parameters
+
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+    assert draft_hf_config.rope_parameters == target_rope
+    assert draft_hf_config.rope_parameters is not target_rope
+    target_rope["factor"] = 2.0
+    assert draft_hf_config.rope_parameters["factor"] == 4.0
+
+
+@pytest.mark.parametrize(
+    ("rope_parameters", "match"),
+    [
+        ({}, "explicit target YaRN"),
+        (
+            {
+                "rope_type": "dynamic",
+                "factor": 4.0,
+                "original_max_position_embeddings": 262_144,
+            },
+            "explicit target YaRN",
+        ),
+        (
+            {
+                "rope_type": "yarn",
+                "factor": "invalid",
+                "original_max_position_embeddings": 262_144,
+            },
+            "requires numeric",
+        ),
+        (
+            {
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 131_072,
+            },
+            "to match the drafter",
+        ),
+    ],
+)
+def test_native_mtp_rejects_unvalidated_rope(
+    rope_parameters: dict[str, Any],
+    match: str,
+) -> None:
+    config, _ = _native_mtp_yarn_config(rope_parameters=rope_parameters)
+
+    with pytest.raises(ValueError, match=match):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+def test_native_mtp_rejects_length_above_validated_yarn_limit() -> None:
+    config, _ = _native_mtp_yarn_config(max_model_len=1_048_577)
+    config.target_model_config.max_model_len = 1_048_577
+
+    with pytest.raises(ValueError, match="validated target YaRN limit=1048576"):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+def test_native_mtp_does_not_modify_unextended_drafter() -> None:
+    config, draft_hf_config = _native_mtp_yarn_config(max_model_len=262_144)
+    original = copy.deepcopy(draft_hf_config.to_dict())
+
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+    assert draft_hf_config.to_dict() == original

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -881,6 +881,7 @@ class SpeculativeConfig:
                     MTPModelTypes
                 ):
                     self.method = "mtp"
+                    self._inherit_target_rope_for_extended_native_mtp()
                     if (
                         self.num_speculative_tokens > 1
                         and self.draft_model_config.hf_config.model_type
@@ -1070,6 +1071,81 @@ class SpeculativeConfig:
                 f"stage [{last_start}, {last_end}); got {layer_ids}. Adjust "
                 "VLLM_PP_LAYER_PARTITION or the DSpark layer contract."
             )
+
+    def _inherit_target_rope_for_extended_native_mtp(self) -> None:
+        """Validate and inherit target YaRN for an extended native drafter."""
+        if (
+            self.method != "mtp"
+            or self.max_model_len is None
+            or self.target_model_config is None
+            or self.draft_model_config is None
+            or self.model != self.target_model_config.model
+        ):
+            return
+
+        draft_text_config = get_hf_text_config(self.draft_model_config.hf_config)
+        draft_native_limit = getattr(draft_text_config, "max_position_embeddings", None)
+        if draft_native_limit is None or self.max_model_len <= draft_native_limit:
+            return
+
+        target_text_config = get_hf_text_config(self.target_model_config.hf_config)
+        rope_parameters = getattr(target_text_config, "rope_parameters", None)
+        if (
+            not isinstance(rope_parameters, dict)
+            or rope_parameters.get("rope_type") != "yarn"
+        ):
+            raise ValueError(
+                "Extending native MTP beyond max_position_embeddings requires "
+                "explicit target YaRN rope_parameters; got "
+                f"{rope_parameters!r}."
+            )
+
+        original_limit = rope_parameters.get("original_max_position_embeddings")
+        factor = rope_parameters.get("factor")
+        try:
+            original_limit_value = float(original_limit)
+            factor_value = float(factor)
+            draft_native_limit_value = float(draft_native_limit)
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                "Native MTP YaRN extension requires numeric "
+                "original_max_position_embeddings and factor."
+            ) from error
+
+        if (
+            not math.isfinite(original_limit_value)
+            or not math.isfinite(factor_value)
+            or original_limit_value <= 0
+            or factor_value <= 1
+            or original_limit_value != draft_native_limit_value
+        ):
+            raise ValueError(
+                "Native MTP YaRN extension requires the target's positive "
+                "original_max_position_embeddings to match the drafter's "
+                "native max_position_embeddings and factor to be greater "
+                f"than one; got original={original_limit!r}, "
+                f"native={draft_native_limit!r}, factor={factor!r}."
+            )
+
+        validated_yarn_limit = int(original_limit_value * factor_value)
+        validated_limit = min(
+            validated_yarn_limit,
+            self.target_model_config.max_model_len,
+        )
+        if self.max_model_len > validated_limit:
+            raise ValueError(
+                f"Native MTP max_model_len={self.max_model_len} exceeds the "
+                f"validated target YaRN limit={validated_limit}."
+            )
+
+        draft_text_config.rope_parameters = copy.deepcopy(rope_parameters)
+        logger.info(
+            "Extended native MTP context from %s to %s with validated target "
+            "YaRN parameters (factor=%s).",
+            draft_native_limit,
+            self.max_model_len,
+            factor,
+        )
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -9336,14 +9336,13 @@ class GPUModelRunner(
                 # make token id 0 look like a real speculative token to the
                 # scheduler and verifier.
                 logger.warning_once(
-                    "Skipping speculative drafts because the drafter context "
-                    "limit is reached: max_seq_len=%s, num_spec_tokens=%s, "
-                    "effective_drafter_max_model_len=%s.",
-                    spec_decode_common_attn_metadata.max_seq_len
-                    if spec_decode_common_attn_metadata is not None
-                    else None,
+                    "Skipping speculative drafts after reaching the drafter "
+                    "context limit: num_spec_tokens=%s, "
+                    "effective_drafter_max_model_len=%s. Future over-limit "
+                    "batches are suppressed.",
                     self.num_spec_tokens,
                     self.effective_drafter_max_model_len,
+                    scope="global",
                 )
                 self._draft_token_ids = [[] for _ in self.input_batch.req_ids]
                 self._draft_probs = None


### PR DESCRIPTION


# [Bugfix][Spec Decode] Validate YaRN for extended native MTP context

> AI-assisted draft. AI assistance was used for upstream comparison,
> implementation, tests, live profiling, and this write-up. Upstream requires
> the human submitter to review every changed line and run the relevant tests
> before submitting this PR. This note must not be removed; once completed, the
> submitter should add their human-review confirmation and final Linux test
> results.

## Purpose

A same-checkpoint native MTP drafter can retain the checkpoint's native
`max_position_embeddings` even when the target is explicitly extended with
YaRN. For Qwen3.8 this left the drafter at 262,144 while the target was served
at a larger context. Above the drafter limit, speculative decoding fell back to
target-only decoding and the changing `max_seq_len` argument defeated
`warning_once`, producing one warning per output step.

This PR:

- extends only same-checkpoint native MTP drafters;
- requires explicit target `rope_parameters` with `rope_type: yarn`;
- validates finite numeric values, `factor > 1`, and an
  `original_max_position_embeddings` that exactly matches the drafter's native
  limit;
- refuses a requested limit above either the target limit or the validated
  `original * factor` YaRN ceiling;
- deep-copies the validated target parameters to the drafter; and
- makes the over-limit fallback warning stable and globally one-shot.

It does not invent RoPE scaling, change the target limit, change unrelated
draft models, or silently extend an unvalidated drafter.

Base SHA: `62ad1e02693f4c857f3b7547cef1860ee54e8053`.

## Context relationship

The validated V100 checkpoint has a native target/drafter limit of 262,144.
Factor-4 YaRN gives a mathematical ceiling of 1,048,576. The tested service
caps both target and native drafter at 1,000,000, leaving 48,576 tokens of
margin. The former 320,000 and 512,000 values were rollout tiers, not model
limits.

## Duplicate-work audit

The complete open PR list was refreshed on 2026-08-28 at the base SHA; no open
PR contains this fail-closed inheritance or stable fallback warning.

- [PR 241](https://github.com/1CatAI/1Cat-vLLM/pull/241) is an old-base,
  rejected aggregate. It unconditionally overwrites the
  drafter length and changes automatic NTK behavior. This PR instead accepts
  only an explicit, internally consistent target YaRN configuration and
  otherwise fails closed.
- Merged [PR 389](https://github.com/1CatAI/1Cat-vLLM/pull/389),
  [PR 391](https://github.com/1CatAI/1Cat-vLLM/pull/391), and
  [PR 399](https://github.com/1CatAI/1Cat-vLLM/pull/399), plus open
  [PR 398](https://github.com/1CatAI/1Cat-vLLM/pull/398), improve V100 MTP4
  execution but do not extend the drafter's validated context.
- [PR 408](https://github.com/1CatAI/1Cat-vLLM/pull/408) addresses Qwen3.8
  runtime correctness, not YaRN context inheritance.
- [Issue 214](https://github.com/1CatAI/1Cat-vLLM/issues/214) and
  [issue 93](https://github.com/1CatAI/1Cat-vLLM/issues/93) describe separate
  long-prefill and non-MTP paths and are not claimed as fixed here.

## Test Plan

Local current-main checks:

```text
uvx --from ruff==0.14.0 ruff format --check \
  vllm/config/speculative.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_max_len.py
3 files already formatted

uvx --from ruff==0.14.0 ruff check <same files>
All checks passed!

uv run --no-project --python 3.12 python -m py_compile <same files>
exit 0

git diff --check
exit 0

git apply --check 0001-upstream-native-mtp-yarn-context.patch
exit 0 against 62ad1e0
```

Focused CPU tests were added for:

- valid YaRN inheritance and deep-copy isolation;
- missing, dynamic, non-numeric, and native-limit-mismatched parameters;
- rejection above the 1,048,576 validated ceiling; and
- no mutation when the drafter is not extended.

## Test Result

The same formatting, lint, byte-compilation, and diff checks also pass in a
disposable Linux worktree on `gazasrv16`, with the patch applied to the stated
base SHA. No production container or GPU was touched.

A focused pytest run was attempted there. An isolated editable environment
from unmodified current main first failed dependency resolution because of the
separate TokenSpeed/TVM-FFI conflict described in the companion candidate. A
test-only overlay of that companion patch allowed the precompiled editable
install (191 packages) and the full CUDA test dependency set to install. Pytest
then stopped during collection because the precompiled editable source layout
did not provide `vllm._C`. A CPU-source fallback compiled most targets but was
blocked by the host's missing `numa.h` development header and a Torch CPU API
mismatch. The production host packages were deliberately not changed.

Accordingly, the new test cases are present but no pytest pass is claimed. The
human submitter must run them in the prescribed, fully provisioned Linux UV
environment before upstream submission:

```text
.venv/bin/python -m pytest tests/v1/spec_decode/test_max_len.py -v
pre-commit run --files \
  vllm/config/speculative.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_max_len.py
```

## Live V100 validation

The exact source behavior was also built and exercised in a running SM70
image. These measurements are specifically for four V100-SXM2-32GB GPUs with
TP4; they are not Blackwell results.

| Setting | Value |
| --- | --- |
| Model | `philbert440/Qwen3.8-27B-W4A16-AWQ` |
| Hardware | 4 x V100-SXM2-32GB, tensor parallel 4 |
| Image | `1cat-vllm-sm70:qwen38-27b-awq-main-62ad1e0-mtp4-yarn-pr331-cu128` |
| Image digest | `sha256:d0fdeefbea5b61a12caa75e57543e06a01b2dadf3ea4eb74d0dfa0a90a48b95a` |
| CUDA / KV | CUDA 12.8.1; FP8 E5M2 KV cache |
| Speculation | Native MTP4; target and drafter both 1,000,000 |
| KV capacity | 2,557,299 tokens, or 2.56 x 1M sequences; `max-num-seqs=2` |

HTTP `/health`, `/v1/models`, and `/metrics` all returned 200. The service
remained healthy with zero restarts. All four V100s saturated during cold
prefill; peak observed KV occupancy was 35.1%.

### Performance

| Route / request | TTFT | Decode | Acceptance | Total |
| --- | ---: | ---: | ---: | ---: |
| Current MTP4, 6,316 prompt / 512 output | 2.9538 s | 87.0357 tok/s | 73.2824% | 8.8249 s |
| Current MTP4, 564,577 cold / 512 output | 690.9660 s | 31.2186 tok/s | 79.7131% | 707.3345 s |
| Current MTP4, 564,580 cold with changed salt / 512 output | 690.7554 s | 32.0822 tok/s | 82.3529% | 706.6832 s |
| Current MTP4, identical 564,577 replay / 512 output | 9.2287 s | 31.1965 tok/s | 79.7131% | 25.6088 s |
| Earlier target-only above drafter cap, 564,575 / 512 | 545.395 s | 8.772 tok/s | none | 603.647 s |
| Earlier validated MTP2, 564,575 / 512 | 552.084 s | 22.874 tok/s | 81.70% | 574.423 s |

At this long prompt, current MTP4 decode was 3.56x-3.66x the target-only
baseline and 1.37x-1.40x the earlier MTP2 result. The total-latency crossover
was approximately 1,800 generated tokens versus target-only and 11,000-12,000
versus MTP2 because current-main cold prefill is slower.

The current-main cold TTFT of about 691 seconds is roughly 139-146 seconds
slower than the earlier target-only/MTP2 baselines. This PR does not claim to
fix that separate prefill regression.

### Tokenization and prefix cache

Backend tokenization took 2.4811-2.51695 seconds for roughly 564.6k tokens,
equivalent to 224,311-227,549 tokens/s, so tokenization was not the cold-query
bottleneck. The identical replay reused 562,368 of 564,577 queried prefix
tokens (99.6087%), reducing TTFT from about 691 seconds to 9.2287 seconds.

### Warning and fallback behavior

- Before this change, one OpenWebUI request ended at 326,399 sequence tokens,
  generated 18,167 output tokens, and emitted 18,169 changing-argument
  over-limit warnings.
- With the stable fallback warning, a 321,914-token request above a staged 320k
  drafter tier generated 128 tokens with zero drafts and exactly one warning.
- A later 520,339-token request above a staged 512k tier also cleanly used zero
  drafts and emitted one warning.
- The 564.6k MTP4 runs under the 1M validated limit emitted no MTP warning
  flood. Each cold request emitted one separate Transformers advisory because
  the original checkpoint metadata still declares 262,144.

### Real OpenWebUI workload

A production OpenWebUI agent request on the target-only control received
733,366 prompt tokens, reused 720,000 prefix tokens, and generated 23,724
tokens at approximately 8.5-9.2 tok/s. It completed without a proxy timeout,
queue, engine error, or restart. Its long generation lies well beyond the
measured MTP4 total-latency crossover and motivated keeping the MTP4 route for
Hermes/OpenClaw workloads.

## Validation boundary

The service booted with matching 1,000,000 target/drafter limits and MTP was
tested end to end through 564,580 prompt tokens. A near-1M cold prefill has not
yet been executed, so this PR does not claim an end-to-end measurement at the
absolute configured limit.

## Risk and rollback

Invalid or implicit scaling fails during configuration instead of failing
mid-request. Unextended native MTP and separate draft checkpoints are unchanged.
At runtime, requests above an intentionally lower drafter cap still fall back
to target-only decoding; only repetitive logging is suppressed. Rollback is a
revert of these three files.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the related PRs and issues that were checked without incorrectly claiming they are resolved.
- [x] The test plan, including the focused pytest and pre-commit commands required before upstream submission.
- [x] The test results, including Linux source checks, test-environment limitations, SM70/V100 E2E results, decode performance, MTP acceptance, TTFT, KV-cache capacity/occupancy, prefix-cache reuse, tokenization rate, health, and restart status.
- [x] (Optional) The necessary documentation update was considered. No public API, CLI, or supported-model surface changes; focused tests describe the validation contract.

</details>

