### PR TITLE
[Kernel][SM70] Accelerate exact Qwen3.8 decode

### DIFF
--- a/csrc/qsa_lexicographic_topk.cuh
+++ b/csrc/qsa_lexicographic_topk.cuh
@@ -8,7 +8,6 @@
 #include <cuda_runtime.h>
 #include <cub/block/block_scan.cuh>
 #include <cstdint>
-#include <limits>
 
 namespace vllm::qsa {
 
@@ -23,25 +22,19 @@ __device__ __forceinline__ uint32_t ordered_float_bits(float value) {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
-__device__ __forceinline__ uint64_t lexicographic_key(float score,
-                                                      uint32_t index) {
-  // Larger keys win. Scores are ordered first; equal scores prefer the lower
-  // block index. The resulting key is unique for every element in a row.
-  return (static_cast<uint64_t>(ordered_float_bits(score)) << 32) |
-         (std::numeric_limits<uint32_t>::max() - index);
-}
-
 template <int TopK>
 struct LexicographicTopKShared {
-  using BlockScan = cub::BlockScan<uint32_t, kLexicographicTopKThreads>;
+  using BlockScan = cub::BlockScan<uint64_t, kLexicographicTopKThreads>;
 
   uint32_t histogram[kLexicographicTopKBins];
   typename BlockScan::TempStorage scan;
-  uint64_t prefix;
-  uint64_t pivot;
+  uint32_t prefix;
+  uint32_t pivot;
   uint32_t remaining;
-  uint32_t output_base;
-  uint32_t chunk_base;
+  uint32_t greater_seen;
+  uint32_t equal_seen;
+  uint32_t chunk_greater_base;
+  uint32_t chunk_equal_base;
 };
 
 template <int TopK>
@@ -75,23 +68,24 @@ __launch_bounds__(kLexicographicTopKThreads) void qsa_lexicographic_topk_kernel(
   }
   __syncthreads();
 
-  // Select the exact k-th (score descending, index ascending) key. Eight
-  // byte-wide radix passes cover the full 64-bit composite key without a
-  // bounded candidate buffer, so dense ties cannot overflow or race.
+  // Select the exact k-th score with four byte-wide radix passes. The prior
+  // implementation also radix-selected the 32-bit index tie-break, requiring
+  // eight full scans. We only need the score pivot: the final increasing-index
+  // compaction can admit exactly `remaining` values from the pivot bucket.
 #pragma unroll
-  for (int pass = 0; pass < 8; ++pass) {
+  for (int pass = 0; pass < 4; ++pass) {
     for (uint32_t bin = tx; bin < kLexicographicTopKBins;
          bin += kLexicographicTopKThreads) {
       shared.histogram[bin] = 0;
     }
     __syncthreads();
 
-    const int shift = 56 - pass * 8;
-    const uint64_t prefix = shared.prefix;
-    const uint64_t prefix_mask = pass == 0 ? 0 : (~uint64_t{0} << (shift + 8));
+    const int shift = 24 - pass * 8;
+    const uint32_t prefix = shared.prefix;
+    const uint32_t prefix_mask = pass == 0 ? 0 : (~uint32_t{0} << (shift + 8));
     for (uint32_t index = tx; index < length;
          index += kLexicographicTopKThreads) {
-      const uint64_t key = lexicographic_key(row_logits[index], index);
+      const uint32_t key = ordered_float_bits(row_logits[index]);
       if ((key & prefix_mask) == prefix) {
         atomicAdd(&shared.histogram[(key >> shift) & 0xffu], 1u);
       }
@@ -105,7 +99,7 @@ __launch_bounds__(kLexicographicTopKThreads) void qsa_lexicographic_topk_kernel(
         if (remaining > count) {
           remaining -= count;
         } else {
-          shared.prefix |= static_cast<uint64_t>(bin) << shift;
+          shared.prefix |= static_cast<uint32_t>(bin) << shift;
           shared.remaining = remaining;
           break;
         }
@@ -116,32 +110,44 @@ __launch_bounds__(kLexicographicTopKThreads) void qsa_lexicographic_topk_kernel(
 
   if (tx == 0) {
     shared.pivot = shared.prefix;
-    shared.output_base = 0;
+    shared.greater_seen = 0;
+    shared.equal_seen = 0;
   }
   __syncthreads();
 
-  // Compact in increasing index order. This is both the deterministic tie
-  // contract and QSA's canonical accumulation order, so no repair or second
-  // sorting pass is needed.
+  // Compact in increasing index order. A packed 64-bit scan tracks counts of
+  // greater and pivot-equal scores at once. Every greater score is selected;
+  // only the first `remaining` pivot ties are admitted, preserving the exact
+  // lower-index tie break and QSA's canonical accumulation order.
   using BlockScan = typename LexicographicTopKShared<TopK>::BlockScan;
   for (uint32_t base = 0; base < length; base += kLexicographicTopKThreads) {
     const uint32_t index = base + tx;
-    const uint32_t selected =
-        index < length &&
-                lexicographic_key(row_logits[index], index) >= shared.pivot
-            ? 1u
-            : 0u;
-    uint32_t offset = 0;
-    uint32_t aggregate = 0;
-    BlockScan(shared.scan).ExclusiveSum(selected, offset, aggregate);
+    const uint32_t key =
+        index < length ? ordered_float_bits(row_logits[index]) : 0;
+    const uint32_t greater = index < length && key > shared.pivot ? 1u : 0u;
+    const uint32_t equal = index < length && key == shared.pivot ? 1u : 0u;
+    const uint64_t counts = (static_cast<uint64_t>(greater) << 32) | equal;
+    uint64_t prefix_counts = 0;
+    uint64_t aggregate_counts = 0;
+    BlockScan(shared.scan)
+        .ExclusiveSum(counts, prefix_counts, aggregate_counts);
     __syncthreads();
     if (tx == 0) {
-      shared.chunk_base = shared.output_base;
-      shared.output_base += aggregate;
+      shared.chunk_greater_base = shared.greater_seen;
+      shared.chunk_equal_base = shared.equal_seen;
+      shared.greater_seen += static_cast<uint32_t>(aggregate_counts >> 32);
+      shared.equal_seen += static_cast<uint32_t>(aggregate_counts);
     }
     __syncthreads();
+    const uint32_t greater_before =
+        shared.chunk_greater_base + static_cast<uint32_t>(prefix_counts >> 32);
+    const uint32_t equal_before =
+        shared.chunk_equal_base + static_cast<uint32_t>(prefix_counts);
+    const bool selected = greater || (equal && equal_before < shared.remaining);
     if (selected) {
-      row_output[shared.chunk_base + offset] = static_cast<int32_t>(index);
+      const uint32_t offset =
+          greater_before + min(equal_before, shared.remaining);
+      row_output[offset] = static_cast<int32_t>(index);
     }
     __syncthreads();
   }

--- a/docs/design/sm70_qwen38_flash_next_nvfp4.md
+++ b/docs/design/sm70_qwen38_flash_next_nvfp4.md
@@ -4,15 +4,17 @@
 
 - Status: source bring-up, pinned-host PLE, native Qwen4Exp MTP, and
   prefix-cache configuration are implemented; focused CPU/configuration gates
-  pass and the local ModelScope snapshot is fully verified. The current
-  accepted no-MTP TP4 candidate reaches 82.274 steady decode tokens/s on the
-  8192x512 contract. A matched 96-request GSM8K screen keeps 96/96 answers
-  correct with online QPN8 both off and on while QPN8 raises mean steady decode
-  by 16.97%. The direct NVFP4 ten-route QPN-M1 MoE and online QPN8 routes are
-  therefore default-on for the exact SM70/TP4/B1 contract, with explicit
-  diagnostic opt-outs. The preceding 77.370-token/s graph-node trace remains
-  the detailed optimization control. Corrected native MTP4 is stable across an
-  11-request TP4 transition run, and the no-thinking HumanEval8 gate reaches
+  pass and the local ModelScope snapshot is fully verified. The historical
+  no-MTP TP4 online-QPN8 candidate reaches 82.274 steady decode tokens/s on the
+  8192x512 contract, but online QPN8 requantizes dense checkpoint weights and
+  is now experimental opt-in. Its matched 96-request GSM8K screen keeps 96/96
+  answers correct in both arms but changes 88/96 token sequences and contains
+  a large long-output/repetition outlier. The exact, byte-preserving NVFP4
+  ten-route QPN-M1 MoE remains default-on; online QPN8 is default-off. The
+  precision-preserving no-MTP control is about 67.6 tokens/s, so reaching 80
+  tokens/s without online QPN8 remains an open optimization target. Corrected
+  native MTP4 is stable across an 11-request TP4 transition run, and the
+  no-thinking HumanEval8 gate reaches
   4.747 mean accepted length, 93.676% draft acceptance, 126.81 warmed pure
   decode tokens/s, and 8/8 standard semantic executions. The V2 M16 plus
   M5/M1 warmup also removes the first-request MTP `fused_moe_kernel` JIT.
@@ -20,7 +22,8 @@
   [#345](https://github.com/1CatAI/1Cat-vLLM/pull/345) and initial decode work
   [#361](https://github.com/1CatAI/1Cat-vLLM/pull/361) are merged. The compact
   MTP loader, exact SM70 MTP tile, and V2 warmup are the current follow-up.
-- Base SHA: `03c04da68e72bf26271de4986364a72141a7601f`.
+- Current correctness-audit base SHA:
+  `62ad1e02693f4c857f3b7547cef1860ee54e8053`.
 - Model: `RadixArk/Qwen3.8-Flash-Next-NVFP4` at revision
   `7b719225242aacd3dbd3f9407468c2ee9a9d2594`.
 - Model download: `/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4`.
@@ -133,7 +136,7 @@ will load safely.
 
 ## No-MTP TP4 decode performance and quality audit
 
-The retained performance candidate is
+The retained experimental online-QPN8 performance candidate is
 `.artifacts/qwen38_flash_next_nvfp4_20260826/results/target80-qpn-m1-mtp-off-8192x512.json`.
 It uses one request, TP4/PP1, FP16 activations, MTP off, V2, CUDA graphs, the
 direct QPN-M1 NVFP4 experts, online channel-QPN8 attention/GR projections,
@@ -202,17 +205,15 @@ arms, with zero invalid, replacement-character, NUL, or non-`stop` outputs.
 QPN8 raises mean steady decode from 67.627 to 79.105 tokens/s (+16.97%) and
 median steady decode from 67.640 to 79.369 tokens/s (+17.34%).
 
-Only 8/96 token hashes match, which is expected for a sampled low-precision
-route and is not a rejection criterion. The mean absolute output-length delta
-is 133.5 tokens and the maximum is 4477. One ambiguous-interest sample remains
-correct but grows from 1653 tokens and a repeated-4-gram ratio of 0.199 with
-QPN8 off to 3626 tokens and 0.507 with QPN8 on. Aggregate mean repetition is
-nearly unchanged (0.0394 versus 0.0410), so the evidence identifies a single
-long-output outlier rather than a task-accuracy or aggregate-quality
-regression. Under the performance-default policy, the 16.97% mean decode gain
-and unchanged 96/96 task result keep QPN8 default-on. Operators can set
-`VLLM_SM70_QWEN4_EXP_ONLINE_QPN8=0` for diagnosis while broader long-output
-quality monitoring continues.
+Only 8/96 token hashes match. The mean absolute output-length delta is 133.5
+tokens and the maximum is 4477. One sample remains correct but grows from 1653
+tokens and a repeated-4-gram ratio of 0.199 with QPN8 off to 3626 tokens and
+0.507 with QPN8 on. A short GSM8K score therefore does not establish that
+requantizing the checkpoint's dense BF16 projections preserves general output
+quality. Online QPN8 is default-off and requires the explicit experimental
+opt-in `VLLM_SM70_QWEN4_EXP_ONLINE_QPN8=1`; accepted no-MTP quality and speed
+baselines must report the flag and must not attribute an opt-in QPN8 result to
+the precision-preserving default route.
 
 The fixed A/B execution SHA predates the compressed-QSA zeroing repair merged
 as PR #373 (`ddd8c0b601`). A compressed QSA scheduler block is logically 784
@@ -222,6 +223,48 @@ was reused. Current main derives zeroing from `storage_block_size`, clears
 exactly the selected physical page, and is covered by a real V100 page test
 and a TP4 1K/4K generation smoke. Both A/B arms intentionally use the same old
 binary to isolate QPN8, while this branch includes the QSA repair.
+
+### Upstream correctness sync (2026-08-29)
+
+The correctness audit starts from public `main` at
+`62ad1e02693f4c857f3b7547cef1860ee54e8053` in the isolated branch
+`codex/v100-qwen38-correctness-upstream-20260828-152418`. It adapts the
+request-layout fix from vLLM PR #53896, the Mamba state-grid fixes from vLLM
+PRs #53802 and #54076, and the EAGLE cache-drop fix from vLLM PR #48375. The
+local adaptations also reject the unvalidated Qwen4Exp V1 runner override,
+stop QSA from claiming batch-invariant split-K reductions, and make online
+QPN8 experimental opt-in.
+
+The retained source/unit evidence is:
+
+- 124 focused Qwen4Exp, hybrid-cache, prefix-cache, QSA, and QPN policy tests
+  passed; one separately executed native QPN operator test also passed.
+- Seven V100 packed-GDN tests passed, including an exact FP32-beta state check.
+- Changed-file pre-commit passed every applicable hook, including Ruff,
+  markdownlint, mypy, SPDX, forbidden-import, configuration, and API checks.
+- The downloaded RadixArk safetensors index assigns 296,475 tensors across 206
+  files; comparing every file's actual keys found zero extra or missing keys,
+  so vLLM PR #54230 does not affect this checkpoint and was not duplicated.
+- vLLM PR #51599's async Mamba accepted-count race is already covered by the
+  local MRV2 runner-owned snapshots and request-ID remapping; `InputBatch` is
+  not an asynchronous D2H destination on this path.
+- vLLM PR #53520 fixes prompt-logprob lifetime in the legacy runner. Qwen4Exp
+  now rejects that runner, while MRV2 computes prompt logprobs before invoking
+  its padded model drafter, so the vulnerable ordering is absent.
+- vLLM PR #53122 configures quantized standalone DFlash draft models. Native
+  Qwen4Exp MTP already calls `configure_quant_config` with `Qwen4ExpMTP`, so
+  importing the DFlash guard would not change this checkpoint's route.
+- vLLM issue #53982's narrow circular-table read is avoided in both local
+  runners: QSA circular groups skip the generic slot-mapping kernel and build
+  ring slots from logical positions in their metadata builder.
+
+Two separate risks remain explicit. 1Cat PR #406 owns the independent
+`KVBlockZeroer` asynchronous H2D staging-lifetime fix and should merge before a
+high-concurrency prefix-cache acceptance run. Upstream issue #54199 still has
+no proven fix for a donor-lifecycle overlap in Mamba prefix-cache precopy; a
+bounds-only workaround would trade a crash for silent recurrent-state
+corruption and is therefore not accepted without a reproducer and state
+oracle.
 
 The checkpoint also carries multimodal `mrope_section` and
 `mrope_interleaved` fields in its text config. The initial SM70 route requires
@@ -251,12 +294,12 @@ unrelated upstream platform changes. The
 describes the production HC strategy more precisely: low-M Mix uses split-K
 GEMMs with SiLU in the down epilogue and sigmoid/four-stream reduction in the
 up epilogue, while Combine splits the hidden dimension to expose more CTAs.
-The accepted QPN8 HC route already mirrors those two epilogue fusions and the
-SM70 Combine kernel already partitions the hidden dimension; importing the
+The experimental QPN8 HC route already mirrors those two epilogue fusions and
+the SM70 Combine kernel already partitions the hidden dimension; importing the
 SM100-only CuTeDSL implementation from
 [FlashInfer PR 4266](https://github.com/flashinfer-ai/flashinfer/pull/4266)
 would therefore add no V100 kernel. The exact V100 screen also rejects
-collapsing the accepted two-QPN8-kernel path into one persistent launch. The
+collapsing the two-QPN8-kernel experiment into one persistent launch. The
 [SGLang day-zero HC kernel](https://github.com/sgl-project/sglang/blob/02d38b77db92699e5d4f1a78226bf711e9cc762a/python/sglang/srt/layers/hc_mix_triton.py)
 replaces the FP16 down-GEMV, SiLU, up-GEMV, sigmoid, and four-branch mean with
 one persistent kernel. A V100 form preserves the existing QPN8 weights and
@@ -307,8 +350,8 @@ The currently admitted candidates are deliberately narrow:
   `SM70 Qwen3.8 E512/K10 router top-k path enabled` marker.
 - GR/HC persistent launch: rejected despite bitwise output and clean replay
   state because it is 3.072 microseconds slower per call in the checkpoint-
-  shape cold-cache screen, a projected 0.298-ms/token regression. The accepted
-  split-QPN8 down/reduce/up implementation remains unchanged.
+  shape cold-cache screen, a projected 0.298-ms/token regression. The
+  experimental split-QPN8 down/reduce/up implementation remains unchanged.
 - MRv2 greedy sampling: the active V2 runner always materialized globally
   gathered logits and then launched Gumbel sampling, even for the exact
   temperature-zero single-request decode used here. The new SM70-only route
@@ -319,12 +362,11 @@ The currently admitted candidates are deliberately narrow:
   kernel and 0.044-ms full-logit all-gather before accounting for the local
   argmax cost.
 
-The QSA scorer, router, and V2 greedy projections together expose about
-0.90-1.01 ms/token of gross trace cost, which is enough on paper to cross the
-immediate 80 tokens/s gate after allowing for the pair-gather argmax overhead.
-A single resident-model run will validate them together; the model will not be
-restarted separately for each micro-optimization. The rejected persistent GR
-candidate is not included in that run.
+The QSA scorer, router, and V2 greedy projections expose about 0.90-1.01
+ms/token in the historical online-QPN8 trace. That trace is useful for kernel
+ranking but no longer proves the precision-preserving 80 tokens/s target; the
+next optimization cycle must use a fresh no-QPN8 trace and retain the exact
+checkpoint weights. The rejected persistent GR candidate is not included.
 
 ## Native MTP4 TP4 validation snapshot
 

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -1,6 +1,6 @@
 # SM70 Qwen3.8-27B-NVFP4 Decode Recovery
 
-Date: 2026-08-23; acceptance updated 2026-08-24
+Date: 2026-08-23; acceptance updated 2026-08-29
 
 ## Decision
 
@@ -709,3 +709,110 @@ Primary retained evidence is:
 - `.artifacts/qwen38_e4m3_xqa_long_route/results/page_ids_packed_lut/`
 - `.artifacts/qwen38_e4m3_xqa_long_route/results/page_ids_fast_address/`
 - `.artifacts/qwen38_e4m3_xqa_long_route/profiles/e4m3_xqa_final_merged_wave_p1664_l262144_nsys.nsys-rep`
+
+## 2026-08-29 Flash-Next Checkpoint-Native FP16-KV Decode
+
+This result is a separate contract from the 2026-08-24 80 tok/s acceptance
+above. The earlier result used input 1,024/output 256, E4M3 KV, admitted QPN8
+projections, and a sampler sidecar. The current
+`/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4` target keeps FP16 KV and
+checkpoint-native NVFP4 experts, explicitly disables online QPN8 and the
+top1-only LM-head shortcut, and measures input 8,192/output 512. The two
+numbers must not be compared as though they were the same baseline.
+
+### Matched contract and trace decision
+
+The locked endpoint uses four V100-SXM2-32GB GPUs, TP4/PP1, the V2 runner,
+FP16 activation and KV, ModelOpt FP4, Flash-V100, prefix caching with aligned
+Mamba state, chunked prefill, `max_model_len=262144`,
+`max_num_batched_tokens=2048`, `max_num_seqs=1`, and full CUDA Graph.
+The speed request is deterministic greedy decode with input 8,192, output 512,
+five repetitions, prefix-cache reset between repetitions, and `ignore_eos`
+so every sample contributes the same 511 steady intervals. Pure decode
+excludes TTFT and prefill. Natural-EOS official sampling is a separate quality
+gate below.
+
+The matched control is 65.853-65.882 tok/s across five repetitions, with mean
+**65.864 tok/s** and **15.183 ms** TPOT. Its Nsight Systems graph-node trace
+shows dense GEMV/GEMM and compressor service at 7.502 ms/rank/token and 812
+launches/rank/token. The two largest cuBLAS GEMV families alone contribute
+3.656 and 2.254 ms/rank/token. That evidence selected projection and
+HyperConnection work instead of another attention or sampler experiment.
+
+The retained exact-topology route is default-off and contains:
+
+- checkpoint-FP16 SM70 row GEMV for the eight audited Qwen3.8 projection
+  roles; 288 projections are prepared in the base model;
+- a two-launch HyperConnection projection/mix route for the exact
+  `hc_count=4`, hidden 2,560, low-rank 320 shape; 96 modules are marked;
+- exact QSA lexicographic top-k using four score-radix passes followed by
+  increasing-index pivot-tie compaction, replacing the redundant four index
+  radix passes while retaining score-descending/index-ascending semantics;
+- a single GDN input launch that computes QKVZ and b/a and writes the consumed
+  qkv/z/b/a splits directly for the 36 exact non-interleaved TP4 GDN modules.
+
+The final GDN operator screen uses 256 changing real-weight inputs. QKV and z
+are bitwise equal in all 256 cases; b and a are bitwise equal in 253 and 254
+cases, with worst absolute differences 0.00024414 and 0.00003052. The fused
+launch measures 35.840 us versus 39.936 us for two GEMVs plus the split,
+projecting 0.147 ms/token over 36 layers. QSA exactness, dense ties,
+prefill-batch behavior, and CUDA Graph replay were also covered by the three
+focused GPU tests.
+
+### Endpoint result
+
+| Route | Five steady decode samples (tok/s) | Mean TPOT | Mean speed |
+|---|---|---:|---:|
+| checkpoint-native control | 65.872, 65.882, 65.856, 65.855, 65.853 | 15.183 ms | 65.864 tok/s |
+| retained FP16/QSA/GDN/HC route | 80.367, 80.451, 80.463, 81.560, 80.822 | **12.387 ms** | **80.732 tok/s** |
+
+The gain is 14.869 tok/s, or **22.57%**, while TPOT falls **18.41%**. Every
+candidate repetition exceeds 80 tok/s, population standard deviation is
+0.442 tok/s, and all five 512-token sequences are identical. The first EOS is
+at index 8 in every forced-length sample; the repeated chat markers after that
+point are expected `ignore_eos` behavior and are not used as quality
+evidence. Warm 8K prefill median is 2,766.4 ms versus 2,777.6 ms for control,
+so the decode route does not show a material warm-prefill regression.
+
+### Natural-output quality
+
+The quality contract freezes GSM8K indices 8-23 with the official xhigh chat
+template, temperature 1.0, top-p 0.95, top-k 20, seed 20260828, output cap
+4,096, and natural EOS. It uses the same TP4 model route with MTP off.
+Results are **15/16 raw and 15/16 strict**, 16/16 natural stops, 16/16 closed
+thinking sections, zero length caps, and zero structurally invalid outputs.
+The frozen same-prompt MTP4 reference is 15/16 raw and 14/16 strict. The only
+candidate miss is the same reference miss: GSM8K item 12 predicts 12 instead
+of 13, so it is not a new corruption signature.
+
+Repository long-output health checks pass all 16 candidate responses: zero
+replacement characters or bad markers, longest same-token run 3, longest
+same-line run 1, and maximum repeated 50-character window count 6 against the
+failure threshold of 40. The quality run itself reports weighted pure decode
+at 80.935 tok/s and mean request decode at 81.017 tok/s.
+
+The three feature switches are
+`VLLM_SM70_QWEN38_FP16_GEMV`,
+`VLLM_SM70_QWEN38_FUSED_HC_FP16`, and
+`VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16`; all default to false and require
+the exact SM70, TP4, no-speculation, FP16 Qwen3.8 topology. Unsupported shapes,
+prefill, other dtypes, online QPN8, and speculative decoding retain the
+ordinary path.
+
+Rejected work is intentionally absent from the retained source. An opaque
+whole-GDN projection route fell to 73.277 tok/s; one-pass GDN RMSNorm was
+neutral and changed output; CUB and sort-compaction QSA variants were slower;
+the fused shared-expert screen was neutral; and the unaccepted fused W13
+prototype was removed. Online QPN8 reached about 82.27 tok/s but changed token
+trajectories and produced a repetition outlier. The top1-only LM-head shortcut
+also changed long output and remains off.
+
+Primary evidence is:
+
+- `.artifacts/qwen38_exact_decode80/control/control_i8192_o512_r5.json`
+- `.artifacts/qwen38_exact_decode80/trace_control_matched/control_i8192_o32_per_token.md`
+- `.artifacts/qwen38_exact_decode80/trace_gemv_router_ba_index_hc_gate_overlap_matched/trace_gemv_router_ba_index_hc_gate_overlap_matched_i8192_o32_per_token.md`
+- `.artifacts/qwen38_exact_decode80/operator_fp16_gdn_dual.json`
+- `.artifacts/qwen38_exact_decode80/gemv_router_ba_index_hc_bk256_qsa4_gdndual_gate_overlap_full/gemv_router_ba_index_hc_bk256_qsa4_gdndual_gate_overlap_full_i8192_o512_r5.json`
+- `.artifacts/qwen38_exact_decode80/gsm16_exact_decode80_official_xhigh/audit.json`
+- `.artifacts/qwen38_exact_decode80/gsm16_exact_decode80_official_xhigh/health.json`

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44543,3 +44543,47 @@ Interpretation:
   long-context limiter. The next trace must be taken at 256K and separate the
   context-growing QSA indexer/attention work from the now-fixed MoE projection
   cost; 128K-only traces are no longer sufficient acceptance evidence.
+
+## 2026-08-29 Qwen3.8 Flash-Next no-MTP checkpoint-native decode
+
+- Draft PR #415 carries the isolated source work. This contract is
+  `/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4`, TP4 on GPU0-3, V2,
+  ModelOpt FP4, FP16 activation/KV, Flash-V100, full CUDA Graph, aligned Mamba
+  prefix caching, max length 262,144, input 8,192, output 512, five cache-reset
+  greedy repetitions, and no MTP. Online QPN8 and top1-only LM-head lanes are
+  explicitly off. It is not the input-1,024/output-256 E4M3/QPN8 acceptance
+  recorded on 2026-08-24.
+- The matched control is 65.872/65.882/65.856/65.855/65.853 tok/s:
+  **65.864 tok/s** mean and **15.183 ms** mean TPOT. A four-rank graph-node
+  trace localizes 7.502 ms/rank/token and 812 launches/rank/token to dense
+  GEMV/GEMM and compressor work, led by two cuBLAS GEMV families at 3.656 and
+  2.254 ms/rank/token.
+- The retained default-off exact-topology route replaces audited
+  checkpoint-FP16 batch-one projections with SM70 row GEMV, fuses the exact
+  HyperConnection projection/mix, reduces QSA lexicographic top-k from eight
+  composite-key radix passes to four score-pivot passes plus exact
+  increasing-index tie compaction, and computes GDN QKVZ+b/a with direct
+  qkv/z/b/a outputs in one launch. It prepares 288 projections, 96 HC modules,
+  and 36 GDN inputs. Unsupported contracts retain the prior path.
+- The full matched candidate records
+  80.367/80.451/80.463/81.560/80.822 tok/s: **80.732 tok/s** mean,
+  **12.387 ms** mean TPOT, and 0.442 tok/s population standard deviation.
+  This is +22.57% throughput and -18.41% TPOT from control; all five token
+  arrays are identical. Warm 8K prefill median is 2,766.4 ms versus 2,777.6 ms
+  for control.
+- Frozen natural-output GSM8K indices 8-23 at xhigh,
+  temperature/top-p/top-k `1.0/0.95/20`, seed 20260828, and max output 4,096
+  score **15/16 raw and 15/16 strict**. All 16 stop naturally, all thinking
+  sections close, and there are no caps or structural failures. The historical
+  same-prompt MTP4 result is 15/16 raw and 14/16 strict; both miss item 12 with
+  prediction 12 versus answer 13. Repository repetition/character health
+  checks pass 16/16 with zero replacement characters and maximum same-token
+  run 3.
+- Focused static closure currently includes 25/25 QSA and new route policy tests,
+  Ruff check/format, shell syntax, and `git diff --check`. The exact QSA
+  sidecar previously passed its three GPU exactness, prefill-batch, and CUDA
+  Graph replay tests. Unused fused-W13 and shared-expert prototypes were
+  removed rather than stacked onto the accepted result.
+- Retained and rejected routes, full contracts, operator evidence, trace
+  tables, quality details, and artifact paths are recorded in
+  `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -40,7 +40,7 @@ def _fused_recurrent_reference_from_mixed_qkv(
         x <= 20.0, torch.log1p(torch.exp(torch.clamp(x, max=20.0))), x
     )
     g = (-torch.exp(A_log.float()) * softplus_x).unsqueeze(1)
-    beta = torch.sigmoid(b.float()).to(a.dtype).unsqueeze(1)
+    beta = torch.sigmoid(b.float()).unsqueeze(1)
 
     return fused_recurrent_gated_delta_rule(
         q=q,
@@ -128,6 +128,39 @@ def test_fused_recurrent_packed_decode_matches_reference(
     rtol = 1e-2 if dtype != torch.float32 else 1e-4
     torch.testing.assert_close(out_packed, out_ref, rtol=rtol, atol=atol)
     torch.testing.assert_close(state_packed, state_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+def test_packed_decode_keeps_beta_in_fp32() -> None:
+    """Guard the no-MTP Qwen GDN state update against beta re-rounding."""
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    mixed_qkv = torch.ones((1, 3), device=device, dtype=dtype)
+    a = torch.zeros((1, 1), device=device, dtype=dtype)
+    b = torch.full((1, 1), 0.5, device=device, dtype=dtype)
+    params = torch.zeros((1,), device=device, dtype=dtype)
+    ssm_state_indices = torch.ones((1,), device=device, dtype=torch.int32)
+
+    state_packed = torch.zeros((2, 1, 1, 1), device=device, dtype=torch.float32)
+    out_packed = torch.empty((1, 1, 1, 1), device=device, dtype=dtype)
+
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=params,
+        dt_bias=params,
+        scale=1.0,
+        initial_state=state_packed,
+        out=out_packed,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    expected_beta = torch.sigmoid(b.float()).squeeze()
+    torch.testing.assert_close(
+        state_packed[1, 0, 0, 0], expected_beta, rtol=1e-6, atol=1e-6
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")

--- a/tests/models/qwen4_exp/test_config.py
+++ b/tests/models/qwen4_exp/test_config.py
@@ -102,6 +102,24 @@ def test_qwen4_exp_defaults_to_v2_even_when_quantized_moe(
     assert VllmConfig._is_default_v2_model_runner_model(vllm_config)
 
 
+def test_qwen4_exp_rejects_explicit_v1_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vllm.config.vllm.envs.VLLM_USE_V2_MODEL_RUNNER",
+        False,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=None,
+        model_config=SimpleNamespace(
+            architectures=["Qwen4ExpForCausalLM"],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires Model Runner V2"):
+        VllmConfig.use_v2_model_runner.fget(vllm_config)
+
+
 def test_initial_sm70_v2_route_accepts_native_mtp(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -152,6 +152,7 @@ def test_ngram_embedding_accepts_checkpoint_seed_none(
             max_total_tokens=8,
             max_num_reqs=2,
             prefix="model.layers.2.ple.ple_embedding",
+            layer_name="model.layers.2.ple",
             params_dtype=torch.float16,
         )
 
@@ -450,6 +451,51 @@ def test_ple_fp8_embedding_respects_checkpoint_shard_exclusions() -> None:
 
     quant_config.ignored_layers = [f"{prefix}.shard_0"]
     assert _get_ple_embedding_quant_method(quant_config, prefix) is None
+
+
+def test_ple_ngram_ids_custom_op_uses_current_request_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RuntimeNGramEmbedding(nn.Module):
+        def compute_ngram_ids(
+            self,
+            input_ids: torch.Tensor,
+            query_start_loc: torch.Tensor,
+            ngram_context: torch.Tensor,
+        ) -> torch.Tensor:
+            del input_ids, ngram_context
+            num_reqs = query_start_loc.numel() - 1
+            return torch.full((4, 2), num_reqs, dtype=torch.long)
+
+    layer = Qwen4ExpPLELayer.__new__(Qwen4ExpPLELayer)
+    nn.Module.__init__(layer)
+    layer.ple_embedding = RuntimeNGramEmbedding()
+    monkeypatch.setattr(
+        ple_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(no_compile_layers={"ple": layer}),
+    )
+    input_ids = torch.arange(4)
+    ngram_context = torch.zeros(2, 2, dtype=torch.long)
+    output = torch.empty(4, 2, dtype=torch.long)
+
+    ple_module.qwen4_exp_compute_ple_ngram_ids(
+        input_ids,
+        torch.tensor([0, 4]),
+        ngram_context,
+        output,
+        "ple",
+    )
+    assert torch.equal(output, torch.ones_like(output))
+
+    ple_module.qwen4_exp_compute_ple_ngram_ids(
+        input_ids,
+        torch.tensor([0, 2, 4]),
+        ngram_context,
+        output,
+        "ple",
+    )
+    assert torch.equal(output, torch.full_like(output, 2))
 
 
 def test_ngram_cpu_offload_padding_does_not_overwrite_real_tokens(

--- a/tests/models/qwen4_exp/test_qsa_cache.py
+++ b/tests/models/qwen4_exp/test_qsa_cache.py
@@ -7,8 +7,15 @@ from typing import Any
 import torch
 
 from vllm.models.qwen4_exp.common.qsa_cache import QSAKeyStateCache
-from vllm.models.qwen4_exp.nvidia.qsa import Qwen4ExpQSAFlashAttentionImpl
+from vllm.models.qwen4_exp.nvidia.qsa import (
+    Qwen4ExpQSAFlashAttentionBackend,
+    Qwen4ExpQSAFlashAttentionImpl,
+)
 from vllm.v1.worker.utils import bind_kv_cache
+
+
+def test_qsa_does_not_claim_batch_invariant_reductions() -> None:
+    assert not Qwen4ExpQSAFlashAttentionBackend.supports_batch_invariance()
 
 
 def test_bind_qsa_key_cache_builds_key_and_mrope_views() -> None:

--- a/tests/models/qwen4_exp/test_sm70_fp16_gemv.py
+++ b/tests/models/qwen4_exp/test_sm70_fp16_gemv.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+import vllm.envs as envs
+from vllm.models.qwen4_exp.nvidia.sm70_fp16_gemv import _plan_for
+
+
+def test_qwen38_sm70_fp16_gemv_is_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    name = "VLLM_SM70_QWEN38_FP16_GEMV"
+    monkeypatch.delenv(name, raising=False)
+    assert not envs.VLLM_SM70_QWEN38_FP16_GEMV
+    monkeypatch.setenv(name, "1")
+    assert envs.VLLM_SM70_QWEN38_FP16_GEMV
+
+
+def test_qwen38_sm70_fp16_hc_is_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    name = "VLLM_SM70_QWEN38_FUSED_HC_FP16"
+    monkeypatch.delenv(name, raising=False)
+    assert not envs.VLLM_SM70_QWEN38_FUSED_HC_FP16
+    monkeypatch.setenv(name, "1")
+    assert envs.VLLM_SM70_QWEN38_FUSED_HC_FP16
+
+
+def test_qwen38_sm70_fp16_gdn_input_is_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = "VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16"
+    monkeypatch.delenv(name, raising=False)
+    assert not envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16
+    monkeypatch.setenv(name, "1")
+    assert envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16
+
+
+@pytest.mark.parametrize(
+    ("prefix", "shape"),
+    [
+        (
+            "model.layers.0.attn_hyper_connection.input_mix_weight_down_block_inject",
+            (336, 10240),
+        ),
+        ("model.layers.0.linear_attn.in_proj_qkvz", (4096, 2560)),
+        ("model.layers.0.linear_attn.in_proj_ba", (24, 2560)),
+        ("model.layers.0.linear_attn.out_proj", (2560, 1536)),
+        ("model.layers.3.self_attn.qkv_proj", (3584, 2560)),
+        ("model.layers.3.self_attn.o_proj", (2560, 1536)),
+        ("model.layers.3.self_attn.indexer.index_qk_proj", (640, 2560)),
+        ("model.layers.3.mlp.gate", (512, 2560)),
+    ],
+)
+def test_qwen38_sm70_fp16_gemv_exact_role_allowlist(
+    prefix: str, shape: tuple[int, int]
+) -> None:
+    assert _plan_for(prefix, shape) is not None
+
+
+@pytest.mark.parametrize(
+    ("prefix", "shape"),
+    [
+        ("model.layers.0.attn_hyper_connection.input_mix_weight_up", (10240, 320)),
+        ("model.layers.0.mlp.shared_expert.gate_up_proj", (320, 2560)),
+        ("model.layers.0.mlp.shared_expert_gate", (1, 2560)),
+        ("model.layers.0.linear_attn.out_proj", (2560, 2560)),
+        ("other.linear_attn.in_proj_qkvz", (4096, 2561)),
+    ],
+)
+def test_qwen38_sm70_fp16_gemv_rejects_other_roles(
+    prefix: str, shape: tuple[int, int]
+) -> None:
+    assert _plan_for(prefix, shape) is None

--- a/tests/quantization/test_sm70_online_qpn8.py
+++ b/tests/quantization/test_sm70_online_qpn8.py
@@ -10,14 +10,14 @@ import vllm.envs as envs
 from vllm.model_executor.layers.quantization import sm70_online_qpn8 as online_qpn8
 
 
-def test_qwen4_exp_online_qpn8_defaults_on_and_can_be_disabled(monkeypatch):
+def test_qwen4_exp_online_qpn8_defaults_off_and_can_be_enabled(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", raising=False)
     envs.disable_envs_cache()
     try:
-        assert envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
-        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0")
-        envs.disable_envs_cache()
         assert not envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
+        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1")
+        envs.disable_envs_cache()
+        assert envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
     finally:
         envs.disable_envs_cache()
 
@@ -34,7 +34,7 @@ def test_qwen3next_shared_gate_fusion_defaults_on_and_can_be_disabled(monkeypatc
         envs.disable_envs_cache()
 
 
-def test_default_on_qpn_sidecars_load_without_enable_overrides(monkeypatch):
+def test_qpn_sidecars_respect_safe_online_default(monkeypatch):
     calls: list[str] = []
     monkeypatch.setenv("VLLM_SM70_FP8_QPN8_LIBRARY", "/tmp/qpn8.so")
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY", "/tmp/qpn-m1.so")
@@ -45,7 +45,12 @@ def test_default_on_qpn_sidecars_load_without_enable_overrides(monkeypatch):
     online_qpn8.sm70_ops._maybe_load_fp8_qpn8_library()
     online_qpn8.sm70_ops._maybe_load_nvfp4_qpn_m1_library()
 
-    assert calls == ["/tmp/qpn8.so", "/tmp/qpn-m1.so"]
+    assert calls == ["/tmp/qpn-m1.so"]
+
+    calls.clear()
+    monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1")
+    online_qpn8.sm70_ops._maybe_load_fp8_qpn8_library()
+    assert calls == ["/tmp/qpn8.so"]
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+MAMBA_BLOCK_SIZE = 816
+
+
+def _split(request, num_new_tokens: int) -> int:
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        mamba_state_block_size=MAMBA_BLOCK_SIZE,
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=False,
+    )
+    return Scheduler._mamba_block_aligned_split(scheduler, request, num_new_tokens)
+
+
+def test_scheduler_records_mamba_group_block_size() -> None:
+    mamba_spec = MambaSpec(
+        block_size=MAMBA_BLOCK_SIZE,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+
+    scheduler = create_scheduler(
+        block_size=16,
+        num_blocks=16,
+        kv_cache_spec=mamba_spec,
+    )
+
+    assert scheduler.mamba_state_block_size == MAMBA_BLOCK_SIZE
+
+
+def test_chunks_stop_at_every_mamba_state_boundary() -> None:
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 30
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=prompt_len,
+        block_size=16,
+    )
+    position = 0
+    chunk_ends = []
+
+    while position < prompt_len:
+        request.num_computed_tokens = position
+        num_new_tokens = _split(request, prompt_len - position)
+        assert num_new_tokens > 0
+        position += num_new_tokens
+        chunk_ends.append(position)
+
+    assert chunk_ends == [816, 1632, 2448, prompt_len]

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,11 +14,15 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     PrefixAnchoredSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
     PrefixAnchoredSWASpec,
     SlidingWindowSpec,
 )
@@ -586,3 +590,58 @@ def test_prefix_anchored_swa_manager_registered():
     )
     assert isinstance(manager, PrefixAnchoredSWAManager)
     assert manager.decode_sliding_window == 128
+
+
+def test_mamba_honors_eagle_cache_drop() -> None:
+    block_size = 16
+    num_blocks = 5
+    full_group_id, mamba_group_id = 0, 1
+    block_pool = BlockPool(
+        num_gpu_blocks=64,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    block_hashes = [BlockHash(f"block-{i}".encode()) for i in range(num_blocks)]
+
+    for group_id, block_offset in ((full_group_id, 10), (mamba_group_id, 20)):
+        for index, block_hash in enumerate(block_hashes):
+            block_pool.cached_block_hash_to_block.insert(
+                make_block_hash_with_group_id(block_hash, group_id),
+                block_pool.blocks[block_offset + index],
+            )
+
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+
+    def hit_length(manager, group_id, spec, use_eagle: bool) -> int:
+        return len(
+            manager.find_longest_cache_hit(
+                block_hashes=block_hashes,
+                max_length=num_blocks * block_size,
+                kv_cache_group_ids=[group_id],
+                block_pool=block_pool,
+                kv_cache_spec=spec,
+                use_eagle=use_eagle,
+                alignment_tokens=block_size,
+            )[0]
+        )
+
+    assert (
+        hit_length(FullAttentionManager, full_group_id, full_spec, False) == num_blocks
+    )
+    assert hit_length(MambaManager, mamba_group_id, mamba_spec, False) == num_blocks
+
+    full_hit = hit_length(FullAttentionManager, full_group_id, full_spec, True)
+    mamba_hit = hit_length(MambaManager, mamba_group_id, mamba_spec, True)
+    assert full_hit == num_blocks - 1
+    assert mamba_hit == full_hit

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -27,7 +27,7 @@ def _maybe_load_fp8_qpn8_library() -> None:
     online_override = os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8")
     generic_enabled = generic_override == "1"
     specific_enabled = generic_override != "0" and specific_override == "1"
-    online_enabled = online_override != "0"
+    online_enabled = online_override == "1"
     if generic_enabled or specific_enabled or online_enabled:
         torch.ops.load_library(library_path)
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -759,6 +759,7 @@ class CompilationConfig:
         "vllm::mamba_mixer2",
         "vllm::mamba_mixer",
         "vllm::short_conv",
+        "vllm::qwen4_exp_compute_ple_ngram_ids",
         "vllm::qwen4_exp_ple_short_conv",
         "vllm::qwen4_exp_qsa_with_output",
         "vllm::linear_attention",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -660,10 +660,23 @@ class VllmConfig:
     @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        architectures = (
+            getattr(self.model_config, "architectures", [])
+            if self.model_config is not None
+            else []
+        )
+        is_qwen4_exp = any(
+            architecture.startswith("Qwen4ExpFor") for architecture in architectures
+        )
         is_mrv2_dflash = (
             self.speculative_config is not None and self.speculative_config.use_dflash()
         )
         if use_v2_model_runner is not None:
+            if is_qwen4_exp and not use_v2_model_runner:
+                raise ValueError(
+                    "Qwen4Exp requires Model Runner V2 for its QSA ring cache "
+                    "and rollback-safe PLE n-gram context."
+                )
             if is_mrv2_dflash and not use_v2_model_runner:
                 raise ValueError(
                     "method='dflash' is implemented only by Model Runner V2. "

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -167,6 +167,9 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = False
     VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = False
+    VLLM_SM70_QWEN38_FP16_GEMV: bool = False
+    VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16: bool = False
+    VLLM_SM70_QWEN38_FUSED_HC_FP16: bool = False
     VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = True
     VLLM_SM70_FP8_QPN8_PP2_TP4: bool = False
     VLLM_SM70_FP8_QPN8_PP2_TP4_SHARED_GATE: bool = False
@@ -1710,6 +1713,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),
     "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8": lambda: bool(
         int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0"))
+    ),
+    # Precision-preserving checkpoint-FP16 row GEMV for the exact no-MTP,
+    # TP4 Qwen3.8 Flash Next single-token decode contract on SM70. This stays
+    # opt-in until operator, token, task-quality, and matched speed gates pass.
+    "VLLM_SM70_QWEN38_FP16_GEMV": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN38_FP16_GEMV", "0"))
+    ),
+    # Exact-topology Qwen3.8 decode candidate: compute checkpoint-FP16 GDN
+    # QKVZ and b/a projections and write their consumed splits in one launch.
+    "VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16", "0"))
+    ),
+    # Fuse the exact Qwen3.8 M=1 HyperConnection down/SiLU and up/gate-mix
+    # stages while retaining FP16 checkpoint weights and inter-stage rounding.
+    # This remains opt-in pending the same model-level quality gates as GEMV.
+    "VLLM_SM70_QWEN38_FUSED_HC_FP16": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN38_FUSED_HC_FP16", "0"))
     ),
     # Exact M=1 Qwen3Next/Qwen4Exp shared-expert output gate. This replaces
     # the scalar GEMV, sigmoid, and output multiply with one SM70 kernel while

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -166,7 +166,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = False
-    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = True
+    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = False
     VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = True
     VLLM_SM70_FP8_QPN8_PP2_TP4: bool = False
     VLLM_SM70_FP8_QPN8_PP2_TP4_SHARED_GATE: bool = False
@@ -1704,12 +1704,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
     # Memory-neutral QPN8 layout for shape- and runtime-gated TP4 block-FP8
-    # dense projections. Pure-FP8 checkpoints must opt in;
-    # a mixed NVFP4 checkpoint may select its separately validated default in
-    # the compressed-tensors scheme. Explicit 0 disables both routes.
+    # dense projections. Pure-FP8 checkpoints must opt in. The Qwen4Exp
+    # online route also stays opt-in because it requantizes checkpoint BF16
+    # attention, GDN, QSA, and mHC weights without calibration.
     "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),
     "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1"))
+        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0"))
     ),
     # Exact M=1 Qwen3Next/Qwen4Exp shared-expert output gate. This replaces
     # the scalar GEMV, sigmoid, and output multiply with one SM70 kernel while

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -4133,45 +4133,59 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             layer_name,
             hidden_states,
         )
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
-        mixed_qkvz = _sm70_dump_gdn_projection_tensor(
-            "in_proj_qkvz", layer_name, mixed_qkvz
+        use_qwen38_fused_input = bool(
+            getattr(self, "sm70_qwen38_fp16_fused_input", False)
+            and not _sm70_gdn_projection_dump_requested(layer_name)
         )
-        ba = _sm70_dump_gdn_projection_tensor("in_proj_ba", layer_name, ba)
-
-        if self.gqa_interleaved_layout:
-            # Qwen3-Next: unpack the interleaved GQA layout
-            query, key, value, z, b, a = self.fix_query_key_value_ordering(
-                mixed_qkvz, ba
+        if use_qwen38_fused_input:
+            assert self.in_proj_ba is not None
+            mixed_qkv, z, b, a = torch.ops.vllm.qwen38_sm70_fp16_gdn_input(
+                hidden_states,
+                self.in_proj_qkvz.weight,
+                self.in_proj_ba.weight,
             )
-            query, key, value = map(
-                lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
-            )
-            mixed_qkv = torch.cat((query, key, value), dim=-1)
-        else:
-            # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
-            mixed_qkv = mixed_qkvz[..., :qkv_size]
-            mixed_qkv = _sm70_dump_gdn_projection_tensor(
-                "split_mixed_qkv", layer_name, mixed_qkv
-            )
-            if envs.VLLM_SM70_GDN_MIXED_QKV_CONTIGUOUS:
-                mixed_qkv = mixed_qkv.contiguous()
-            z = _sm70_compile_graph_slice_dim(mixed_qkvz, -1, qkv_size, z_size)
-            z = _sm70_dump_gdn_projection_tensor("split_z", layer_name, z)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
-            ba_size = ba.shape[-1] // 2
-            b = ba[..., :ba_size]
-            a = _sm70_compile_graph_slice_dim(ba, -1, ba_size, ba_size)
-            if self.disable_tp_for_ba_proj and self.tp_size > 1:
-                ba_chunk = self.num_v_heads // self.tp_size
-                ba_start = self.tp_rank * ba_chunk
-                b = b[:, ba_start : ba_start + ba_chunk]
-                a = a[:, ba_start : ba_start + ba_chunk]
-            b = b.contiguous()
-            a = a.contiguous()
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+            mixed_qkvz = _sm70_dump_gdn_projection_tensor(
+                "in_proj_qkvz", layer_name, mixed_qkvz
+            )
+            ba = _sm70_dump_gdn_projection_tensor("in_proj_ba", layer_name, ba)
+
+            if self.gqa_interleaved_layout:
+                # Qwen3-Next: unpack the interleaved GQA layout
+                query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                    mixed_qkvz, ba
+                )
+                query, key, value = map(
+                    lambda x: rearrange(x, "l p d -> l (p d)"),
+                    (query, key, value),
+                )
+                mixed_qkv = torch.cat((query, key, value), dim=-1)
+            else:
+                # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+                qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+                z_size = self.value_dim // self.tp_size
+                mixed_qkv = mixed_qkvz[..., :qkv_size]
+                mixed_qkv = _sm70_dump_gdn_projection_tensor(
+                    "split_mixed_qkv", layer_name, mixed_qkv
+                )
+                if envs.VLLM_SM70_GDN_MIXED_QKV_CONTIGUOUS:
+                    mixed_qkv = mixed_qkv.contiguous()
+                z = _sm70_compile_graph_slice_dim(mixed_qkvz, -1, qkv_size, z_size)
+                z = _sm70_dump_gdn_projection_tensor("split_z", layer_name, z)
+                z = z.reshape(z.size(0), -1, self.head_v_dim)
+                ba_size = ba.shape[-1] // 2
+                b = ba[..., :ba_size]
+                a = _sm70_compile_graph_slice_dim(ba, -1, ba_size, ba_size)
+                if self.disable_tp_for_ba_proj and self.tp_size > 1:
+                    ba_chunk = self.num_v_heads // self.tp_size
+                    ba_start = self.tp_rank * ba_chunk
+                    b = b[:, ba_start : ba_start + ba_chunk]
+                    a = a[:, ba_start : ba_start + ba_chunk]
+                b = b.contiguous()
+                a = a.contiguous()
 
         if envs.VLLM_SM70_GDN_Z_CONTIGUOUS and current_platform.is_device_capability(
             70

--- a/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
+++ b/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Narrow online QPN8 route for Qwen4Exp FP16 decode projections on SM70."""
+"""Opt-in online QPN8 route for Qwen4Exp FP16 decode projections on SM70.
+
+This route requantizes selected dense checkpoint weights at load time. It is a
+performance experiment rather than a precision-preserving checkpoint route and
+therefore requires an explicit environment opt-in.
+"""
 
 from __future__ import annotations
 
@@ -185,9 +190,10 @@ def maybe_prepare_online_qpn8(layer: nn.Module) -> bool:
     layer.sm70_fp8_qpn8 = True
     layer.sm70_fp8_prefill_exact_dense_workspace_ptr = workspace.data_ptr()
     setattr(layer, _STATE_ATTR, True)
-    logger.info_once(
-        "SM70 Qwen4Exp online channel-QPN8 enabled for selected FP16 decode "
-        "projections."
+    logger.warning_once(
+        "Experimental SM70 Qwen4Exp online channel-QPN8 is requantizing "
+        "selected FP16 decode projections; model-level quality is not "
+        "guaranteed."
     )
     return True
 

--- a/vllm/models/qwen4_exp/amd/qsa.py
+++ b/vllm/models/qwen4_exp/amd/qsa.py
@@ -86,6 +86,12 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
         return True
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # QSA chooses its split-K reduction depth from the runtime batch
+        # shape, so it cannot inherit FlashAttention's stronger guarantee.
+        return False
+
+    @classmethod
     def supports_kv_connector(cls) -> bool:
         return False
 

--- a/vllm/models/qwen4_exp/nvidia/hyperconnection.py
+++ b/vllm/models/qwen4_exp/nvidia/hyperconnection.py
@@ -45,6 +45,7 @@ from .ops.hc import (
     hc_gate_mix,
     hc_silu,
 )
+from .sm70_fp16_hc import maybe_apply_qwen38_sm70_fp16_fused_hc
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +130,15 @@ class GatedResidual(nn.Module):
 
     def _project(self, xn: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self.use_combine:
+            fused_fp16 = maybe_apply_qwen38_sm70_fp16_fused_hc(
+                self.input_mix_weight_down_block_inject,
+                self.input_mix_weight_up,
+                xn,
+                getattr(self, "_sm70_qwen38_fp16_fused_hc", False),
+            )
+            if fused_fp16 is not None:
+                return fused_fp16
+
             fused = maybe_apply_fused_hc(
                 self.input_mix_weight_down_block_inject,
                 self.input_mix_weight_up,

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -78,6 +78,8 @@ from vllm.v1.kv_cache_interface import MambaSpec
 
 from ..config import Qwen4ExpConfig
 from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .sm70_fp16_gemv import enable_qwen38_sm70_fp16_gemv
+from .sm70_fp16_hc import enable_qwen38_sm70_fp16_fused_hc
 
 try:
     from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
@@ -697,6 +699,10 @@ class Qwen4ExpForCausalLM(
         )
         self.set_moe_parameters(self.model.layers)
         enable_qwen4_exp_low_latency_gemm(self, self.model_config.dtype)
+        enable_qwen38_sm70_fp16_gemv(self, self.model_config.dtype, self.vllm_config)
+        enable_qwen38_sm70_fp16_fused_hc(
+            self, self.model_config.dtype, self.vllm_config
+        )
 
     @staticmethod
     def get_model_state_cls():

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -457,10 +457,12 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         max_total_tokens: int,
         max_num_reqs: int,
         prefix: str,
+        layer_name: str,
         quant_config: QuantizationConfig | None = None,
         params_dtype: torch.dtype | None = None,
     ) -> None:
         super().__init__()
+        self.layer_name = layer_name
         self.embedding_dim = embedding_dim
         self.ngram_size = int(config.ngram_size)
         self.heads_per_ngram = int(config.heads_per_ngram)
@@ -598,33 +600,32 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
         return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
 
-    def forward_impl(  # type: ignore[override]
+    def compute_ngram_ids(
         self,
-        hidden_states: torch.Tensor,
         input_ids: torch.Tensor,
         query_start_loc: torch.Tensor,
         ngram_context: torch.Tensor,
-        output_buffer: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        del hidden_states
+        """Compute PLE indices for the current, unpadded request layout."""
         input_ids = input_ids.reshape(-1).long()
         query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
         num_tokens = input_ids.shape[0]
 
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+        if num_reqs <= 0:
+            raise ValueError("PLE requires at least one request")
+
         if is_offload_process():
-            num_reqs = query_start_loc.numel() - 1
-            if num_tokens > self.positions_buffer.numel():
-                raise ValueError(
-                    f"PLE received {num_tokens} tokens, but its workspace supports "
-                    f"at most {self.positions_buffer.numel()}"
-                )
-            if num_reqs > self.padded_buffer.shape[0]:
-                raise ValueError(
-                    f"PLE received {num_reqs} requests, but its workspace supports "
-                    f"at most {self.padded_buffer.shape[0]}"
-                )
-            if num_reqs <= 0:
-                raise ValueError("PLE CPU offload requires at least one request")
             max_seq_len = max(
                 1,
                 int((query_start_loc[1:] - query_start_loc[:-1]).max().item()),
@@ -634,10 +635,10 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             # padded IDs overwrite the final real token after index clamping.
             num_valid_tokens = min(int(query_start_loc[-1].item()), num_tokens)
         else:
-            # Preserve MRV2's dynamic-shape contract: scheduler limits already
-            # bound these symbolic dimensions, so avoid Python shape tests.
-            num_reqs = ngram_context.shape[0]
-            max_seq_len = self.padded_buffer.shape[1]
+            # This method runs behind a splitting custom op on GPU, so request
+            # dimensions are evaluated for every replay instead of being
+            # specialized into a PIECEWISE graph keyed only by token count.
+            max_seq_len = num_tokens
             num_valid_tokens = num_tokens
 
         positions = self.positions_buffer[:num_tokens]
@@ -652,10 +653,11 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             packed[request_indices[:num_valid_tokens], columns[:num_valid_tokens]] = (
                 input_ids[:num_valid_tokens]
             )
-            ngram_context = ngram_context[:num_reqs]
         else:
             packed[request_indices, columns] = input_ids
-        ngram_context = ngram_context.to(device=input_ids.device, dtype=torch.long)
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
 
         context = torch.cat([ngram_context, packed], dim=-1)
         positions_2d, position_in_segment = self._shift_precompute(
@@ -686,7 +688,37 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             offsets = self.ngram_heads_offsets[start:end]
             ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
             id_blocks.append(ids[request_indices, adjusted_columns])
-        ngram_ids = torch.cat(id_blocks, dim=-1)
+        return torch.cat(id_blocks, dim=-1)
+
+    def forward_impl(  # type: ignore[override]
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+        output_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del hidden_states
+        input_ids = input_ids.reshape(-1)
+        num_tokens = input_ids.shape[0]
+        if is_offload_process():
+            ngram_ids = self.compute_ngram_ids(
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+        else:
+            ngram_ids = input_ids.new_empty(
+                (num_tokens, self.ngram_heads),
+                dtype=torch.long,
+            )
+            torch.ops.vllm.qwen4_exp_compute_ple_ngram_ids(
+                input_ids,
+                query_start_loc,
+                ngram_context,
+                ngram_ids,
+                self.layer_name,
+            )
         if output_buffer is not None:
             output = output_buffer[:num_tokens, : self.embedding_dim]
             # Cross-process FP8 results travel as raw bytes. Keeping the IPC
@@ -856,7 +888,8 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 self.ple_dense_layer_id,
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 vllm_config.scheduler_config.max_num_seqs,
-                f"{prefix}.ple_embedding",
+                prefix=f"{prefix}.ple_embedding",
+                layer_name=prefix,
                 quant_config=quant_config,
                 params_dtype=model_config.dtype,
             )
@@ -1533,6 +1566,33 @@ def qwen4_exp_ple_short_conv_fake(
     return
 
 
+def qwen4_exp_compute_ple_ngram_ids(
+    input_ids: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    ngram_context: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Compute request-dependent PLE IDs outside PIECEWISE CUDA graphs."""
+    layer = get_forward_context().no_compile_layers[layer_name]
+    ngram_ids = layer.ple_embedding.compute_ngram_ids(
+        input_ids,
+        query_start_loc,
+        ngram_context,
+    )
+    output.copy_(ngram_ids)
+
+
+def qwen4_exp_compute_ple_ngram_ids_fake(
+    input_ids: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    ngram_context: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
 def qwen4_exp_ple_pinned_gather(
     input_ids: torch.Tensor,
     output: torch.Tensor,
@@ -1592,6 +1652,14 @@ def qwen4_exp_ple_fp8_bytes_dequant_fake(
     output: torch.Tensor,
 ) -> None:
     return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_compute_ple_ngram_ids",
+    op_func=qwen4_exp_compute_ple_ngram_ids,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_compute_ple_ngram_ids_fake,
+)
 
 
 direct_register_custom_op(

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -92,6 +92,12 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
         return True
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # QSA chooses its split-K reduction depth from the runtime batch
+        # shape, so it cannot inherit FlashAttention's stronger guarantee.
+        return False
+
+    @classmethod
     def supports_kv_connector(cls) -> bool:
         return False
 

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opt-in checkpoint-FP16 Qwen3.8 decode GEMV kernels for SM70.
+
+The route is deliberately narrow: exact Qwen3.8 Flash Next topology, TP4,
+no speculative decoding, FP16 checkpoint weights, and one decode token. All
+prefill and unsupported shapes retain the ordinary unquantized linear path.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+from torch import nn
+
+import vllm.envs as envs
+from vllm.config import get_current_vllm_config
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+logger = init_logger(__name__)
+
+
+class _GemvPlan(NamedTuple):
+    block_k: int
+    num_warps: int
+    load_policy: int
+
+
+_HC_DOWN_SUFFIX = ".input_mix_weight_down_block_inject"
+_GDN_QKVZ_SUFFIX = ".linear_attn.in_proj_qkvz"
+_GDN_BA_SUFFIX = ".linear_attn.in_proj_ba"
+_GDN_OUT_SUFFIX = ".linear_attn.out_proj"
+_QSA_QKV_SUFFIX = ".self_attn.qkv_proj"
+_QSA_OUT_SUFFIX = ".self_attn.o_proj"
+_QSA_INDEX_SUFFIX = ".self_attn.indexer.index_qk_proj"
+_ROUTER_SUFFIX = ".mlp.gate"
+
+# Plans are cold-cache CUDA Graph winners on real checkpoint weights. Keep the
+# role in the key: GDN and QSA can share a physical shape while remaining
+# independently auditable.
+_ROLE_PLANS: tuple[tuple[str, tuple[int, int], _GemvPlan], ...] = (
+    (_HC_DOWN_SUFFIX, (336, 10240), _GemvPlan(512, 4, 1)),
+    (_GDN_QKVZ_SUFFIX, (4096, 2560), _GemvPlan(512, 2, 0)),
+    (_GDN_BA_SUFFIX, (24, 2560), _GemvPlan(512, 4, 0)),
+    (_GDN_OUT_SUFFIX, (2560, 1536), _GemvPlan(512, 4, 1)),
+    (_QSA_QKV_SUFFIX, (3584, 2560), _GemvPlan(512, 2, 0)),
+    (_QSA_OUT_SUFFIX, (2560, 1536), _GemvPlan(512, 4, 0)),
+    (_QSA_INDEX_SUFFIX, (640, 2560), _GemvPlan(512, 2, 0)),
+    (_ROUTER_SUFFIX, (512, 2560), _GemvPlan(1024, 8, 0)),
+)
+
+_SHAPE_PLANS = {shape: plan for _, shape, plan in _ROLE_PLANS}
+
+
+@triton.jit
+def _qwen38_fp16_row_gemv_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    LOAD_POLICY: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        indices = block_start + offsets
+        mask = indices < K
+        if LOAD_POLICY == 1:
+            x = tl.load(
+                x_ptr + indices,
+                mask=mask,
+                other=0.0,
+                eviction_policy="evict_last",
+            )
+            weight = tl.load(
+                weight_ptr + row * K + indices,
+                mask=mask,
+                other=0.0,
+                eviction_policy="evict_first",
+            )
+        else:
+            x = tl.load(x_ptr + indices, mask=mask, other=0.0)
+            weight = tl.load(
+                weight_ptr + row * K + indices,
+                mask=mask,
+                other=0.0,
+            )
+        acc += x.to(tl.float32) * weight.to(tl.float32)
+    tl.store(out_ptr + row, tl.sum(acc, axis=0))
+
+
+@triton.jit
+def _qwen38_fp16_gdn_input_kernel(
+    x_ptr,
+    qkvz_weight_ptr,
+    ba_weight_ptr,
+    qkv_out_ptr,
+    z_out_ptr,
+    b_out_ptr,
+    a_out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    is_qkvz = row < 4096
+    ba_row = row - 4096
+    offsets = tl.arange(0, BLOCK_K)
+    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        indices = block_start + offsets
+        mask = indices < K
+        x = tl.load(x_ptr + indices, mask=mask, other=0.0)
+        qkvz_weight = tl.load(
+            qkvz_weight_ptr + row * K + indices,
+            mask=is_qkvz & mask,
+            other=0.0,
+        )
+        ba_weight = tl.load(
+            ba_weight_ptr + ba_row * K + indices,
+            mask=(~is_qkvz) & mask,
+            other=0.0,
+        )
+        weight = tl.where(is_qkvz, qkvz_weight, ba_weight)
+        acc += x.to(tl.float32) * weight.to(tl.float32)
+
+    value = tl.sum(acc, axis=0)
+    is_qkv = is_qkvz & (row < 2560)
+    is_z = is_qkvz & (row >= 2560)
+    is_b = (~is_qkvz) & (ba_row < 12)
+    is_a = (~is_qkvz) & (ba_row >= 12)
+    tl.store(qkv_out_ptr + row, value, mask=is_qkv)
+    tl.store(z_out_ptr + row - 2560, value, mask=is_z)
+    tl.store(b_out_ptr + ba_row, value, mask=is_b)
+    tl.store(a_out_ptr + ba_row - 12, value, mask=is_a)
+
+
+def _is_packed_row_major(tensor: torch.Tensor) -> bool:
+    return tensor.ndim == 2 and tensor.stride() == (tensor.shape[1], 1)
+
+
+def _runtime_ok(x: torch.Tensor, weight: torch.Tensor) -> bool:
+    return bool(
+        not envs.VLLM_BATCH_INVARIANT
+        and x.shape[0] == 1
+        and _is_packed_row_major(x)
+        and _is_packed_row_major(weight)
+        and x.dtype == torch.float16
+        and weight.dtype == torch.float16
+        and x.is_cuda
+        and weight.is_cuda
+        and x.device == weight.device
+        and x.shape[1] == weight.shape[1]
+    )
+
+
+def _qwen38_sm70_fp16_gemv(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    plan = _SHAPE_PLANS.get((weight.shape[0], weight.shape[1]))
+    if plan is None or not _runtime_ok(x, weight):
+        return torch.nn.functional.linear(x, weight)
+
+    out = torch.empty((1, weight.shape[0]), dtype=x.dtype, device=x.device)
+    _qwen38_fp16_row_gemv_kernel[(weight.shape[0],)](
+        x,
+        weight,
+        out,
+        K=weight.shape[1],
+        BLOCK_K=plan.block_k,
+        LOAD_POLICY=plan.load_policy,
+        num_warps=plan.num_warps,
+    )
+    logger.info_once("SM70 Qwen3.8 checkpoint-FP16 M=1 GEMV route enabled.")
+    return out
+
+
+def _qwen38_sm70_fp16_gemv_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
+
+
+direct_register_custom_op(
+    op_name="qwen38_sm70_fp16_gemv",
+    op_func=_qwen38_sm70_fp16_gemv,
+    fake_impl=_qwen38_sm70_fp16_gemv_fake,
+)
+
+
+def _qwen38_sm70_fp16_gdn_input(
+    x: torch.Tensor,
+    qkvz_weight: torch.Tensor,
+    ba_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not (
+        qkvz_weight.shape == (4096, 2560)
+        and ba_weight.shape == (24, 2560)
+        and _runtime_ok(x, qkvz_weight)
+        and _runtime_ok(x, ba_weight)
+    ):
+        qkvz = torch.nn.functional.linear(x, qkvz_weight)
+        ba = torch.nn.functional.linear(x, ba_weight)
+        return (
+            qkvz[..., :2560].contiguous(),
+            qkvz[..., 2560:].contiguous(),
+            ba[..., :12].contiguous(),
+            ba[..., 12:].contiguous(),
+        )
+
+    qkv = x.new_empty((1, 2560))
+    z = x.new_empty((1, 1536))
+    b = x.new_empty((1, 12))
+    a = x.new_empty((1, 12))
+    _qwen38_fp16_gdn_input_kernel[(4096 + 24,)](
+        x,
+        qkvz_weight,
+        ba_weight,
+        qkv,
+        z,
+        b,
+        a,
+        K=2560,
+        BLOCK_K=512,
+        num_warps=2,
+    )
+    logger.info_once("SM70 Qwen3.8 checkpoint-FP16 fused GDN input route enabled.")
+    return qkv, z, b, a
+
+
+def _qwen38_sm70_fp16_gdn_input_fake(
+    x: torch.Tensor,
+    qkvz_weight: torch.Tensor,
+    ba_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del qkvz_weight, ba_weight
+    batch_shape = x.shape[:-1]
+    return (
+        x.new_empty((*batch_shape, 2560)),
+        x.new_empty((*batch_shape, 1536)),
+        x.new_empty((*batch_shape, 12)),
+        x.new_empty((*batch_shape, 12)),
+    )
+
+
+direct_register_custom_op(
+    op_name="qwen38_sm70_fp16_gdn_input",
+    op_func=_qwen38_sm70_fp16_gdn_input,
+    fake_impl=_qwen38_sm70_fp16_gdn_input_fake,
+)
+
+
+class Qwen38SM70FP16LinearMethod(UnquantizedLinearMethod):
+    """Use the row-GEMV custom op for admitted single-token projections."""
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # The first dynamic compile sees prefill (M > 1). Keep the M=1
+        # decision inside the opaque op so decode does not inherit a baked-in
+        # prefill branch.
+        if bias is None:
+            return torch.ops.vllm.qwen38_sm70_fp16_gemv(x, layer.weight)
+        return super().apply(layer, x, bias)
+
+
+def _plan_for(prefix: str, shape: tuple[int, int]) -> _GemvPlan | None:
+    for suffix, expected_shape, plan in _ROLE_PLANS:
+        if prefix.endswith(suffix) and shape == expected_shape:
+            return plan
+    return None
+
+
+def _exact_runtime_contract(vllm_config=None) -> bool:
+    try:
+        config = vllm_config or get_current_vllm_config()
+        text_config = config.model_config.hf_text_config
+        tp_size = int(config.parallel_config.tensor_parallel_size)
+    except (AssertionError, AttributeError, RuntimeError):
+        return False
+
+    return bool(
+        tp_size == 4
+        and config.speculative_config is None
+        and int(getattr(text_config, "hidden_size", 0)) == 2560
+        and int(getattr(text_config, "num_hidden_layers", 0)) == 48
+        and int(getattr(text_config, "num_experts", 0)) == 512
+        and int(getattr(text_config, "num_experts_per_tok", 0)) == 10
+        and int(getattr(text_config, "moe_intermediate_size", 0)) == 640
+        and int(getattr(text_config, "hc_count", 0)) == 4
+        and int(getattr(text_config, "hc_lowrank", 0)) == 320
+        and int(getattr(text_config, "num_attention_heads", 0)) == 24
+        and int(getattr(text_config, "num_key_value_heads", 0)) == 2
+        and int(getattr(text_config, "indexer_head_dim", 0)) == 128
+        and int(getattr(text_config, "indexer_budget", 0)) == 2048
+        and int(getattr(text_config, "indexer_compress_ratio", 0)) == 4
+    )
+
+
+def enable_qwen38_sm70_fp16_gemv(
+    module: nn.Module, dtype: torch.dtype, vllm_config=None
+) -> None:
+    """Replace admitted unquantized methods before checkpoint loading."""
+    if not envs.VLLM_SM70_QWEN38_FP16_GEMV:
+        return
+    capability_ok = current_platform.is_device_capability((7, 0))
+    contract_ok = _exact_runtime_contract(vllm_config)
+    if (
+        envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
+        or dtype != torch.float16
+        or not capability_ok
+        or not contract_ok
+    ):
+        logger.warning_once(
+            "Qwen3.8 checkpoint-FP16 GEMV opt-in rejected: "
+            "online_qpn8=%s dtype=%s sm70=%s exact_contract=%s.",
+            envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8,
+            dtype,
+            capability_ok,
+            contract_ok,
+        )
+        return
+
+    replaced = 0
+    for child in module.modules():
+        if not (
+            isinstance(child, LinearBase)
+            and type(child.quant_method) is UnquantizedLinearMethod
+        ):
+            continue
+        weight = getattr(child, "weight", None)
+        if weight is None or weight.ndim != 2:
+            continue
+        shape = (int(weight.shape[0]), int(weight.shape[1]))
+        if _plan_for(str(getattr(child, "prefix", "")), shape) is None:
+            continue
+        child.quant_method = Qwen38SM70FP16LinearMethod()
+        replaced += 1
+
+    fused_gdn_inputs = 0
+    if envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16:
+        for child in module.modules():
+            qkvz = getattr(child, "in_proj_qkvz", None)
+            ba = getattr(child, "in_proj_ba", None)
+            qkvz_weight = getattr(qkvz, "weight", None)
+            ba_weight = getattr(ba, "weight", None)
+            if not (
+                isinstance(qkvz_weight, torch.Tensor)
+                and qkvz_weight.shape == (4096, 2560)
+                and isinstance(ba_weight, torch.Tensor)
+                and ba_weight.shape == (24, 2560)
+                and isinstance(
+                    getattr(qkvz, "quant_method", None),
+                    Qwen38SM70FP16LinearMethod,
+                )
+                and isinstance(
+                    getattr(ba, "quant_method", None),
+                    Qwen38SM70FP16LinearMethod,
+                )
+                and not bool(getattr(child, "gqa_interleaved_layout", True))
+                and not bool(getattr(child, "disable_tp_for_ba_proj", True))
+            ):
+                continue
+            child.sm70_qwen38_fp16_fused_input = True
+            fused_gdn_inputs += 1
+
+    if replaced:
+        logger.info_once(
+            "Prepared %d Qwen3.8 checkpoint-FP16 SM70 M=1 GEMV projections.",
+            replaced,
+        )
+    else:
+        logger.warning_once(
+            "Qwen3.8 checkpoint-FP16 GEMV opt-in matched the runtime but no "
+            "target projections were found."
+        )
+    if fused_gdn_inputs:
+        logger.info_once(
+            "Prepared %d Qwen3.8 fused checkpoint-FP16 GDN inputs.",
+            fused_gdn_inputs,
+        )
+    elif envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16:
+        logger.warning_once(
+            "Qwen3.8 fused checkpoint-FP16 GDN input opt-in found no targets."
+        )
+
+
+__all__ = [
+    "Qwen38SM70FP16LinearMethod",
+    "_qwen38_fp16_gdn_input_kernel",
+    "enable_qwen38_sm70_fp16_gemv",
+]

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_hc.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_hc.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opt-in fused checkpoint-FP16 HyperConnection decode route for SM70."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .sm70_fp16_gemv import _exact_runtime_contract
+
+logger = init_logger(__name__)
+
+_HC_COUNT = 4
+_HC_DIM = 2560
+_HC_RANK = 320
+_HC_HIDDEN = _HC_COUNT * _HC_DIM
+
+
+@triton.jit
+def _qwen38_hc_down_silu_inject_kernel(
+    x_ptr,
+    weight_ptr,
+    lora_ptr,
+    injection_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    RANK_VALUE: tl.constexpr,
+    HC_COUNT: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        indices = block_start + offsets
+        mask = indices < K
+        x = tl.load(
+            x_ptr + indices,
+            mask=mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        weight = tl.load(
+            weight_ptr + row * K + indices,
+            mask=mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        acc += x.to(tl.float32) * weight.to(tl.float32)
+
+    # Preserve the baseline GEMV -> FP16 -> SiLU boundary.
+    value = tl.sum(acc, axis=0).to(tl.float16).to(tl.float32)
+    is_lora = row < RANK_VALUE
+    scaled = value / HC_COUNT
+    tl.store(lora_ptr + row, scaled * tl.sigmoid(scaled), mask=is_lora)
+    tl.store(injection_ptr + row - RANK_VALUE, value, mask=~is_lora)
+
+
+@triton.jit
+def _qwen38_hc_up_gate_mix_kernel(
+    lora_ptr,
+    weight_ptr,
+    x_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    HC_DIMENSION: tl.constexpr,
+    HC_COUNT: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    hidden = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < K
+    lora = tl.load(
+        lora_ptr + offsets,
+        mask=mask,
+        other=0.0,
+        eviction_policy="evict_last",
+    ).to(tl.float32)
+
+    result = 0.0
+    for stream in tl.static_range(HC_COUNT):
+        row = stream * HC_DIMENSION + hidden
+        weight = tl.load(
+            weight_ptr + row * K + offsets,
+            mask=mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        # Preserve the baseline GEMV -> FP16 gate -> sigmoid boundary.
+        gate = tl.sum(lora * weight.to(tl.float32), axis=0)
+        gate = gate.to(tl.float16).to(tl.float32)
+        branch = tl.load(x_ptr + stream * HC_DIMENSION + hidden).to(tl.float32)
+        result += tl.sigmoid(gate) * branch
+    tl.store(out_ptr + hidden, result / HC_COUNT)
+
+
+def _runtime_ok(
+    x: torch.Tensor, down_weight: torch.Tensor, up_weight: torch.Tensor
+) -> bool:
+    return bool(
+        x.ndim == 2
+        and x.shape == (1, _HC_HIDDEN)
+        and down_weight.shape == (_HC_RANK + _HC_COUNT + 12, _HC_HIDDEN)
+        and up_weight.shape == (_HC_HIDDEN, _HC_RANK)
+        and x.dtype == torch.float16
+        and down_weight.dtype == torch.float16
+        and up_weight.dtype == torch.float16
+        and x.is_cuda
+        and down_weight.is_cuda
+        and up_weight.is_cuda
+        and x.is_contiguous()
+        and down_weight.is_contiguous()
+        and up_weight.is_contiguous()
+        and x.device == down_weight.device == up_weight.device
+    )
+
+
+def _qwen38_sm70_fp16_fused_hc(
+    x: torch.Tensor,
+    down_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not _runtime_ok(x, down_weight, up_weight):
+        # Preserve the ordinary projection and FP16 materialization boundaries
+        # for prefill and any unsupported runtime shape. This fallback lives
+        # inside the opaque op so a prefill-first dynamic compile cannot bake
+        # the M > 1 decision into subsequent decode graphs.
+        down_and_injection = torch.nn.functional.linear(x, down_weight)
+        lora = torch.ops.vllm.qwen4_exp_hc_silu(
+            down_and_injection[..., :_HC_RANK], _HC_COUNT
+        )
+        injection = down_and_injection[..., _HC_RANK : _HC_RANK + _HC_COUNT]
+        gate = torch.nn.functional.linear(lora, up_weight)
+        block = torch.ops.vllm.qwen4_exp_hc_gate_mix(x, gate, _HC_COUNT)
+        return block, injection
+    lora = x.new_empty((1, _HC_RANK))
+    injection = x.new_empty((1, _HC_COUNT))
+    block = x.new_empty((1, _HC_DIM))
+    _qwen38_hc_down_silu_inject_kernel[(_HC_RANK + _HC_COUNT,)](
+        x,
+        down_weight,
+        lora,
+        injection,
+        K=_HC_HIDDEN,
+        BLOCK_K=256,
+        RANK_VALUE=_HC_RANK,
+        HC_COUNT=_HC_COUNT,
+        num_warps=4,
+    )
+    _qwen38_hc_up_gate_mix_kernel[(_HC_DIM,)](
+        lora,
+        up_weight,
+        x,
+        block,
+        K=_HC_RANK,
+        HC_DIMENSION=_HC_DIM,
+        HC_COUNT=_HC_COUNT,
+        BLOCK_K=512,
+        num_warps=2,
+    )
+    logger.info_once("SM70 Qwen3.8 fused checkpoint-FP16 HC M=1 route enabled.")
+    return block, injection
+
+
+def _qwen38_sm70_fp16_fused_hc_fake(
+    x: torch.Tensor,
+    down_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del down_weight, up_weight
+    return (
+        x.new_empty((*x.shape[:-1], _HC_DIM)),
+        x.new_empty((*x.shape[:-1], _HC_COUNT)),
+    )
+
+
+direct_register_custom_op(
+    op_name="qwen38_sm70_fp16_fused_hc",
+    op_func=_qwen38_sm70_fp16_fused_hc,
+    fake_impl=_qwen38_sm70_fp16_fused_hc_fake,
+)
+
+
+def maybe_apply_qwen38_sm70_fp16_fused_hc(
+    down_layer: nn.Module,
+    up_layer: nn.Module,
+    x: torch.Tensor,
+    enabled: bool,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    if not enabled:
+        return None
+    down_weight = getattr(down_layer, "weight", None)
+    up_weight = getattr(up_layer, "weight", None)
+    if down_weight is None or up_weight is None:
+        return None
+    if down_weight.shape != (
+        _HC_RANK + _HC_COUNT + 12,
+        _HC_HIDDEN,
+    ) or up_weight.shape != (_HC_HIDDEN, _HC_RANK):
+        return None
+    return torch.ops.vllm.qwen38_sm70_fp16_fused_hc(x, down_weight, up_weight)
+
+
+def enable_qwen38_sm70_fp16_fused_hc(
+    module: nn.Module, dtype: torch.dtype, vllm_config=None
+) -> None:
+    """Mark exact base-model HC modules for the fused M=1 route."""
+    if (
+        not envs.VLLM_SM70_QWEN38_FUSED_HC_FP16
+        or envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
+        or dtype != torch.float16
+        or not current_platform.is_device_capability((7, 0))
+        or not _exact_runtime_contract(vllm_config)
+    ):
+        return
+
+    enabled_count = 0
+    for child in module.modules():
+        if not (
+            getattr(child, "use_combine", False)
+            and getattr(child, "lora_rank", None) == _HC_RANK
+            and getattr(child, "hc_count", None) == _HC_COUNT
+            and getattr(child, "hidden_size", None) == _HC_DIM
+            and hasattr(child, "input_mix_weight_down_block_inject")
+            and hasattr(child, "input_mix_weight_up")
+        ):
+            continue
+        child._sm70_qwen38_fp16_fused_hc = True
+        enabled_count += 1
+
+    if enabled_count:
+        logger.info_once(
+            "Prepared %d Qwen3.8 SM70 fused checkpoint-FP16 HC modules.",
+            enabled_count,
+        )
+
+
+__all__ = [
+    "enable_qwen38_sm70_fp16_fused_hc",
+    "maybe_apply_qwen38_sm70_fp16_fused_hc",
+]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -50,7 +50,7 @@ from vllm.v1.core.sched.request_queue import (
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -284,6 +284,22 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        # A Mamba state is materialized only when a scheduler chunk ends on
+        # the Mamba group's own block grid. The global cache block size can be
+        # much smaller in heterogeneous layouts (Qwen3.8 uses 16-token hashes
+        # with an 816-token recurrent-state block), so it is not a valid grid.
+        mamba_state_block_sizes = {
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        assert len(mamba_state_block_sizes) <= 1, (
+            "mamba align scheduling requires a single state block size, "
+            f"got {sorted(mamba_state_block_sizes)}"
+        )
+        self.mamba_state_block_size = (
+            next(iter(mamba_state_block_sizes)) if mamba_state_block_sizes else None
+        )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -400,45 +416,52 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        num_computed_tokens = (
+        start = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
             + num_external_computed_tokens
         )
-        # Perform block-aligned splitting at prefill phase, including:
-        # * non-resumed requests: num_computed_tokens < num_prompt_tokens + 0
-        # * resumed requests: num_computed_tokens < (
-        #                       num_prompt_tokens + num_output_tokens
-        #                     )
-        # NOTE: Use `request.num_tokens - 1` to bypass normal decoding.
-        if num_computed_tokens < max(request.num_prompt_tokens, request.num_tokens - 1):
-            # To enable block-aligned caching of the Mamba state, `num_new_tokens`
-            # must be a multiple of `block_size`.
-            # As an exception, if `num_new_tokens` is less than `block_size`, the
-            # state is simply not cached, requiring no special handling.
-            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
-            # matching block. To prevent this from causing a Mamba cache miss, the
-            # last chunk must be not smaller than `block_size`.
-            block_size = self.cache_config.block_size
-            last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
-            if self.use_eagle:
-                last_cache_position = max(last_cache_position - block_size, 0)
-            num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
-            if num_computed_tokens_after_sched < last_cache_position:
-                # align to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
-            elif (
-                num_computed_tokens
-                < last_cache_position
-                < num_computed_tokens_after_sched
-            ):
-                # force to cache the last chunk
-                num_new_tokens = last_cache_position - num_computed_tokens
-            else:
-                # prefill the last few tokens
-                pass
-        return num_new_tokens
+        # `request.num_tokens - 1` extends prefill handling to resumed requests
+        # replaying output tokens while leaving ordinary decode untouched.
+        prefill_end = max(request.num_prompt_tokens, request.num_tokens - 1)
+        if start >= prefill_end:
+            return num_new_tokens
+
+        block_size = (
+            self.mamba_state_block_size
+            if self.mamba_state_block_size is not None
+            else self.cache_config.block_size
+        )
+        # Prefix lookup is capped at n - 1. Flooring from n would register an
+        # unreachable state whenever the request length is block aligned.
+        last_token = request.num_tokens - 1
+        last_cache_position = last_token - last_token % block_size
+        if self.use_eagle:
+            last_cache_position = max(last_cache_position - block_size, 0)
+
+        end = start + num_new_tokens
+        if end < prefill_end:
+            max_prefill_tokens = self.max_num_scheduled_tokens
+            long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
+            if long_prefill_threshold > 0:
+                max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
+            aligned_end = end // block_size * block_size
+            if aligned_end > start or block_size <= max_prefill_tokens:
+                end = aligned_end
+
+        # The align allocator materializes one recurrent-state column per
+        # scheduler step. A step spanning multiple state blocks leaves the
+        # interior slots null, so every crossed boundary must end a chunk.
+        next_block_boundary = (start // block_size + 1) * block_size
+        end = min(
+            (
+                stop
+                for stop in (next_block_boundary, last_cache_position)
+                if start < stop < end
+            ),
+            default=end,
+        )
+        return max(end - start, 0)
 
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1170,6 +1170,13 @@ class MambaManager(SingleTypeKVCacheManager):
 
         block_size = kv_cache_spec.block_size
         max_num_blocks = max_length // block_size
+        if use_eagle and max_num_blocks > 0:
+            # EAGLE/MTP must recompute the final matched page because its
+            # recurrent snapshot may include draft tokens later rejected by
+            # verification. Mamba returns a null-padded list whose only real
+            # state is the rightmost block, so popping the result would remove
+            # the state itself; search one page earlier instead.
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(


### PR DESCRIPTION
## Purpose

Raise Qwen3.8-Flash-Next-NVFP4 TP4/V100 no-MTP pure decode from the matched
checkpoint-native baseline to 80 tokens/s without online QPN8, a top1-only
LM-head shortcut, or a task-quality regression.

Base SHA: `62ad1e02693f4c857f3b7547cef1860ee54e8053`
(`onecat/main`). The branch includes the Qwen3.8 correctness foundation from
#408. PR #398 remains the separate MTP4 owner.

## Scope and contract

- Model: `/data/models/RadixArk/Qwen3.8-Flash-Next-NVFP4`.
- Four V100-SXM2-32GB GPUs, TP4/PP1, V2 runner.
- ModelOpt checkpoint NVFP4 experts, FP16 activation/KV, online QPN8 off.
- Flash-V100/FlashQLA, full CUDA Graph, prefix caching, aligned Mamba state.
- Max length 262,144, max batched tokens 2,048, max sequences 1.
- Speed gate: input 8,192, output 512, greedy, `ignore_eos`, five
  prefix-cache-reset repetitions; pure decode excludes TTFT/prefill.
- Quality gate: frozen GSM8K indices 8-23, xhigh chat template,
  temperature/top-p/top-k `1.0/0.95/20`, seed 20260828, max output 4,096,
  natural EOS.

This is not the 2026-08-24 input-1,024/output-256 E4M3/QPN8 contract.

## Implementation

- Add an exact-topology, default-off SM70 checkpoint-FP16 row-GEMV route for
  eight audited Qwen3.8 projection roles.
- Fuse the exact batch-one HyperConnection projection/mix path.
- Fuse the exact non-interleaved GDN QKVZ and b/a projections and write
  qkv/z/b/a outputs directly.
- Replace QSA's eight-pass composite-key radix selection with four score
  passes plus exact increasing-index pivot-tie compaction.
- Keep unsupported shapes, prefill, other dtypes, online QPN8, and
  speculative decoding on the existing fallback.
- Remove unused fused-W13 and shared-expert prototypes from the retained
  source.

The opt-in controls are:

- `VLLM_SM70_QWEN38_FP16_GEMV=1`
- `VLLM_SM70_QWEN38_FUSED_HC_FP16=1`
- `VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16=1`

## Test result

### Matched pure decode

| Route | Five steady samples (tok/s) | Mean | Mean TPOT |
|---|---|---:|---:|
| control | 65.872, 65.882, 65.856, 65.855, 65.853 | 65.864 | 15.183 ms |
| candidate | 80.367, 80.451, 80.463, 81.560, 80.822 | **80.732** | **12.387 ms** |

The candidate improves throughput by 22.57% and reduces TPOT by 18.41%.
Every repetition exceeds 80 tok/s; population standard deviation is
0.442 tok/s, and all five candidate token arrays are identical. Warm 8K
prefill median is 2,766.4 ms versus 2,777.6 ms for control.

### Quality

- GSM8K: **15/16 raw, 15/16 strict**.
- Natural stopping: 16/16; closed thinking: 16/16.
- Length caps: 0; structurally invalid outputs: 0.
- Historical same-prompt MTP4 reference: 15/16 raw, 14/16 strict.
- The sole candidate miss is the same reference miss (item 12, predicted 12
  versus expected 13).
- Repository repetition/character health: 16/16 pass, zero replacement
  characters, maximum same-token run 3, maximum repeated 50-character window
  count 6 (failure threshold 40).
- The natural-output quality run reports weighted pure decode at
  80.935 tok/s.

The optimized FP16 reductions are deterministic but are not claimed
token-for-token identical to the control after all numerical decision
boundaries. Acceptance is based on real-weight operator bounds plus the
frozen natural-output task and health gates; the route remains default-off.

### Focused tests

- `25 passed`:
  `tests/models/qwen4_exp/test_qsa_ops.py` and
  `tests/models/qwen4_exp/test_sm70_fp16_gemv.py`.
- QSA GPU exactness/prefill-batch/CUDA-Graph replay: 3 passed on the retained
  QSA source.
- FP16 GDN operator screen: QKV/z bitwise 256/256; b/a bitwise 253/256 and
  254/256, worst absolute differences 0.00024414 and 0.00003052.
- Ruff format/check, shell syntax, and `git diff --check`: pass.

## Evidence

Full contracts, trace tables, operator results, rejected paths, quality
details, and local artifact paths are recorded in
`docs/design/sm70_qwen38_nvfp4_decode.md` and
`docs/design/sm70_v100_migration_control.md`.

AI assistance was used for profiling, implementation, tests, and
documentation. The source changes and reported results were reviewed locally.
