### PR TITLE
[Core][SM70] Preserve DFlash2 decode across NVFP4 prefill

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -255,6 +255,13 @@ void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
                                   int64_t tm_group_size, int64_t tm_k_ld,
                                   int64_t tm_q_ld, bool gated_silu);
 
+void nvfp4_qpn2_prefill_dispatch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_weight,
+    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
+    int64_t tm_q_ld, bool gated_silu, int64_t min_prefill_m);
+
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -4,6 +4,10 @@
 #include <torch/all.h>
 #include <torch/library.h>
 
+#ifdef VLLM_QPN4_STANDALONE
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/stack.h>
+#endif
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <cuda_fp16.h>
@@ -607,9 +611,9 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
   TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
                   out.scalar_type() == torch::kFloat16,
               "nvfp4_qpn4_prefill_sm70_out: input and output must be FP16");
-  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && dense_weight_ptr != 0 &&
-                  input.is_contiguous() && out.is_contiguous(),
-              "nvfp4_qpn4_prefill_sm70_out: invalid input or workspace");
+  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && input.is_contiguous() &&
+                  out.is_contiguous(),
+              "nvfp4_qpn4_prefill_sm70_out: invalid input or output");
   const int64_t m = input.size(0);
   const int64_t k = input.size(1);
   TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k,
@@ -618,8 +622,16 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
   TORCH_CHECK(out.size(0) == m && out.size(1) == (gated_silu ? n / 2 : n),
               "nvfp4_qpn4_prefill_sm70_out: output shape mismatch");
 
-  auto dense_weight = torch::from_blob(
-      reinterpret_cast<void*>(dense_weight_ptr), {k, n}, input.options());
+  // A zero pointer requests an operator-local workspace. This keeps the
+  // 85 MiB dense FP16 buffer out of model load, AOT profile, and decode CUDA
+  // graph capture. The caching allocator reuses the allocation across layers
+  // during real prefill, while the worker's pre-capture empty_cache releases
+  // the profiling allocation before decode graphs are recorded.
+  auto dense_weight =
+      dense_weight_ptr == 0
+          ? torch::empty({k, n}, input.options())
+          : torch::from_blob(reinterpret_cast<void*>(dense_weight_ptr), {k, n},
+                             input.options());
   nvfp4_qpn4_dequantize_sm70_out(dense_weight, codes, scales, global_scale,
                                  use_scale_code);
   if (!gated_silu) {
@@ -635,6 +647,63 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
       reinterpret_cast<const half*>(gate_up.data_ptr<at::Half>()),
       static_cast<int>(m), static_cast<int>(n / 2));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+#ifndef VLLM_QPN4_STANDALONE
+void nvfp4_qpn2_dispatch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_weight,
+    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
+    int64_t tm_q_ld, bool gated_silu);
+#endif
+
+void nvfp4_qpn2_prefill_dispatch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_weight,
+    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
+    int64_t tm_q_ld, bool gated_silu, int64_t min_prefill_m) {
+  TORCH_CHECK(min_prefill_m > 8,
+              "QPN2-packed prefill threshold must exceed M=8");
+  if (input.size(0) >= min_prefill_m) {
+    const int64_t k = input.size(1);
+    const int64_t n = gated_silu ? out.size(1) * 2 : out.size(1);
+    auto prefill_codes = codes.view({k, n / 2});
+    auto prefill_scales = scales.view({k / 16, n});
+    nvfp4_qpn4_prefill_sm70_out(out, 0, input, prefill_codes, prefill_scales,
+                                global_scale, true, gated_silu);
+    return;
+  }
+
+#ifndef VLLM_QPN4_STANDALONE
+  nvfp4_qpn2_dispatch_sm70_out(
+      out, input, codes, scales, global_scale, split_k, accumulator_chains,
+      tm_weight, tm_scales, tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
+#else
+  // Source overlays retain the validated decode extension. Route small M
+  // through its existing opaque dispatch without exposing an M-dependent
+  // branch to Dynamo; only the large-M branch is supplied by this sidecar.
+  static const auto qpn2_dispatch =
+      c10::Dispatcher::singleton().findSchemaOrThrow(
+          "_C::nvfp4_qpn2_dispatch_sm70_out", "");
+  torch::jit::Stack stack;
+  stack.reserve(13);
+  stack.emplace_back(out);
+  stack.emplace_back(input);
+  stack.emplace_back(codes);
+  stack.emplace_back(scales);
+  stack.emplace_back(global_scale);
+  stack.emplace_back(split_k);
+  stack.emplace_back(accumulator_chains);
+  stack.emplace_back(tm_weight);
+  stack.emplace_back(tm_scales);
+  stack.emplace_back(tm_group_size);
+  stack.emplace_back(tm_k_ld);
+  stack.emplace_back(tm_q_ld);
+  stack.emplace_back(gated_silu);
+  qpn2_dispatch.callBoxed(&stack);
+#endif
 }
 
 void nvfp4_qpn4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
@@ -1019,6 +1088,14 @@ TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "use_scale_code, bool gated_silu) -> ()");
   ops.impl("nvfp4_qpn4_prefill_sm70_out", torch::kCUDA,
            &nvfp4_qpn4_prefill_sm70_out);
+  ops.def(
+      "nvfp4_qpn2_prefill_dispatch_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor scales, float global_scale, int split_k, "
+      "int accumulator_chains, Tensor tm_weight, Tensor tm_scales, "
+      "int tm_group_size, int tm_k_ld, int tm_q_ld, bool gated_silu, "
+      "int min_prefill_m) -> ()");
+  ops.impl("nvfp4_qpn2_prefill_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_prefill_dispatch_sm70_out);
   ops.def(
       "nvfp4_qpn4_dispatch_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
       "Tensor input, Tensor codes, Tensor scales, float global_scale, bool "

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -5,8 +5,8 @@
 #include <torch/library.h>
 
 #ifdef VLLM_QPN4_STANDALONE
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <ATen/core/stack.h>
+  #include <ATen/core/dispatch/Dispatcher.h>
+  #include <ATen/core/stack.h>
 #endif
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -650,12 +650,14 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
 }
 
 #ifndef VLLM_QPN4_STANDALONE
-void nvfp4_qpn2_dispatch_sm70_out(
-    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
-    torch::Tensor scales, double global_scale, int64_t split_k,
-    int64_t accumulator_chains, torch::Tensor tm_weight,
-    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
-    int64_t tm_q_ld, bool gated_silu);
+void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
+                                  torch::Tensor codes, torch::Tensor scales,
+                                  double global_scale, int64_t split_k,
+                                  int64_t accumulator_chains,
+                                  torch::Tensor tm_weight,
+                                  torch::Tensor tm_scales,
+                                  int64_t tm_group_size, int64_t tm_k_ld,
+                                  int64_t tm_q_ld, bool gated_silu);
 #endif
 
 void nvfp4_qpn2_prefill_dispatch_sm70_out(
@@ -677,9 +679,9 @@ void nvfp4_qpn2_prefill_dispatch_sm70_out(
   }
 
 #ifndef VLLM_QPN4_STANDALONE
-  nvfp4_qpn2_dispatch_sm70_out(
-      out, input, codes, scales, global_scale, split_k, accumulator_chains,
-      tm_weight, tm_scales, tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
+  nvfp4_qpn2_dispatch_sm70_out(out, input, codes, scales, global_scale, split_k,
+                               accumulator_chains, tm_weight, tm_scales,
+                               tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
 #else
   // Source overlays retain the validated decode extension. Route small M
   // through its existing opaque dispatch without exposing an M-dependent

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -368,6 +368,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &nvfp4_qpn2_dispatch_sm70_out);
 
   ops.def(
+      "nvfp4_qpn2_prefill_dispatch_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor scales, float global_scale, int split_k, "
+      "int accumulator_chains, Tensor tm_weight, Tensor tm_scales, "
+      "int tm_group_size, int tm_k_ld, int tm_q_ld, bool gated_silu, "
+      "int min_prefill_m) -> ()");
+  ops.impl("nvfp4_qpn2_prefill_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_prefill_dispatch_sm70_out);
+
+  ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
       "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "

--- a/docs/design/sm70_dflash2_nvfp4_prefill_promotion.md
+++ b/docs/design/sm70_dflash2_nvfp4_prefill_promotion.md
@@ -99,3 +99,46 @@ target-only versus DFlash2 PPL comparison of `5.4993116/5.4993622`. This PR
 does not change that operator or the verifier/sampler path. Its newly promoted
 large-M route reuses the previously bitwise-equal packed prefill operator, and
 the latest-main long-prefill run preserved the retained output hash.
+
+## 2026-08-29 opaque dispatch and practical defaults
+
+A release audit on `onecat/main` at
+`cda10f1220f78cb1fe9d62b0001912d0a0b59c95` found that the first integration
+used a Python `M >= 1024` branch around the prefill operator. AOTInductor
+captured that dynamic branch into the decode graph: the graph pool grew from
+`0.13` to `0.28 GiB`, and a complete DFlash2 round regressed from about
+`17.4` to `41.98 ms`. Sidecar loading alone did not fix the graph because the
+Python shape branch remained visible.
+
+The retained implementation exposes one opaque
+`nvfp4_qpn2_prefill_dispatch_sm70_out` operator for all M. Its C++ dispatcher
+keeps M below the threshold on the established QPN2/TurboMind path and sends
+large M to the QPN2-packed prefill kernel. The prefill kernel creates and
+releases its bounded FP16 dense workspace within the operator; no large
+persistent workspace is captured by the decode graph. Production wheels link
+the dispatcher into `_C`; a separately loaded fragment is supported only for
+source-overlay validation against an already accepted native extension.
+
+The route passed exact V100 screens for M8/M16, normal/gated output, and
+pointer-zero ephemeral versus explicit workspace (`max_abs=0` throughout).
+The focused CPU contract suite passes seven tests, including strict admission
+and explicit rollback.
+
+For the practical NVFP4 DFlash2 service contract, source configuration now
+also defaults the already quality-audited verifier/GDN metadata paths and the
+QPN8 dense-order rerank. Admission requires Qwen3.8-27B compressed-tensors
+NVFP4, FP16 execution, TP4/PP1/B1, q7/top16 DFlash2, FP8 E5M2 target KV,
+`max_num_batched_tokens=4096`, no DBO, and Flash-V100 on SM70. Every explicit
+environment value wins. Candidate-order rerank remains off because its FP16
+tie-cutoff changes candidate sets; dense-order is the quality release path.
+
+The four-V100 source-default proof removed all QPN2/prefill booleans and all
+DFlash2 fastpath booleans from the launch file. Logs showed automatic defaults,
+opaque QPN2 prefill, QPN8 `dense_order=True`, and a `0.13 GiB` graph pool.
+Three 512-token single-request runs measured complete rounds of
+`17.4035/17.3569/17.3697 ms` (mean `17.3767 ms`). One cold 32K token-ID prefill
+measured `4039.49 tok/s`; the following decode measured `17.3640 ms/round`, so
+the large-M route did not poison or slow the decode graph. Three distinct
+function-call schemas and one strict JSON-schema response also passed on the
+same source-default service. Raw evidence is in
+`/data/minimax-h3/task-cache/v100-dflash2-release-audit-20260829/remote-18ms-restart/source-default-validation.json`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44543,3 +44543,27 @@ Interpretation:
   long-context limiter. The next trace must be taken at 256K and separate the
   context-growing QSA indexer/attention work from the now-fixed MoE projection
   cost; 128K-only traces are no longer sufficient acceptance evidence.
+
+## 2026-08-29 DFlash2 18-ms source-default and prefill closure
+
+- The first NVFP4 QPN2-prefill integration exposed `M >= 1024` in Python.
+  AOT decode captured the wrong branch, grew the graph pool from 0.13 to
+  0.28 GiB, and regressed a complete DFlash2 round from about 17.4 to
+  41.98 ms. Sidecar-only and persistent-workspace variants are rejected.
+- One opaque C++ dispatcher now selects established QPN2/TurboMind for small M
+  and the QPN2-packed bounded prefill kernel for large M. The latter owns an
+  ephemeral FP16 workspace inside the operator. M8/M16 normal/gated and
+  explicit/ephemeral workspace comparisons are bitwise equal.
+- The exact quality-audited NVFP4 DFlash2 TP4/B1 q7/top16, E5M2-KV, q4096
+  contract now source-defaults the accepted verifier/GDN fast paths and QPN8
+  dense-order rerank. Explicit overrides remain authoritative. Candidate-order
+  stays off because its candidate-set tie cutoff is not quality-equivalent.
+- A four-V100 restart with the corresponding booleans absent from the launch
+  file logged automatic admission, opaque prefill, `dense_order=True`, and a
+  0.13-GiB graph pool. Three 512-token single-request runs measured
+  `17.4035/17.3569/17.3697 ms` per complete round (mean `17.3767 ms`). Cold
+  32K prefill was `4039.49 tok/s`; post-prefill decode remained
+  `17.3640 ms/round`.
+- Evidence:
+  `docs/design/sm70_dflash2_nvfp4_prefill_promotion.md` and
+  `/data/minimax-h3/task-cache/v100-dflash2-release-audit-20260829/remote-18ms-restart/source-default-validation.json`.

--- a/tests/quantization/test_sm70_nvfp4_qpn2.py
+++ b/tests/quantization/test_sm70_nvfp4_qpn2.py
@@ -190,12 +190,6 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
     monkeypatch.setattr(nvfp4_scheme, "_is_qpn2_layer", lambda layer: True)
     monkeypatch.setattr(nvfp4_scheme, "_missing_qpn2_ops", lambda: [])
     monkeypatch.setattr(nvfp4_scheme, "_missing_qpn2_prefill_ops", lambda: [])
-    workspace = torch.empty((1,), dtype=torch.float16)
-    monkeypatch.setattr(
-        nvfp4_scheme.sm70_tm,
-        "get_nvfp4_qpn4_dense_workspace",
-        lambda _weight: workspace,
-    )
     monkeypatch.setitem(nvfp4_scheme._SM70_NVFP4_QPN2_CONFIGS, (64, 64, False), (8, 2))
     monkeypatch.setitem(nvfp4_scheme._SM70_NVFP4_QPN2_CONFIGS, (64, 64, True), (8, 2))
     monkeypatch.setattr(
@@ -229,16 +223,16 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
     monkeypatch.setattr(
         nvfp4_scheme.sm70_ops, "nvfp4_qpn2_dispatch_sm70_out", fake_dispatch
     )
-    prefill_calls = []
+    combined_calls = []
 
-    def fake_prefill(*args):
-        prefill_calls.append(args)
-        args[0].fill_(5)
+    def fake_combined_dispatch(*args):
+        combined_calls.append(args)
+        args[0].fill_(5 if args[1].shape[0] >= args[-1] else 3)
 
     monkeypatch.setattr(
         nvfp4_scheme.sm70_ops,
-        "nvfp4_qpn4_prefill_sm70_out",
-        fake_prefill,
+        "nvfp4_qpn2_prefill_dispatch_sm70_out",
+        fake_combined_dispatch,
     )
 
     try:
@@ -246,17 +240,7 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
         assert layer.sm70_nvfp4_qpn2
         assert layer.sm70_nvfp4_qpn2_gated_silu
         assert layer.sm70_nvfp4_qpn2_global_scale == 0.5
-        assert layer.sm70_nvfp4_qpn2_prefill_dense_weight_ptr == workspace.data_ptr()
-        assert layer.sm70_nvfp4_qpn2_prefill_codes.shape == (64, 32)
-        assert layer.sm70_nvfp4_qpn2_prefill_scales.shape == (4, 64)
-        assert (
-            layer.sm70_nvfp4_qpn2_prefill_codes.data_ptr()
-            == layer.sm70_nvfp4_qpn2_codes.data_ptr()
-        )
-        assert (
-            layer.sm70_nvfp4_qpn2_prefill_scales.data_ptr()
-            == layer.sm70_nvfp4_qpn2_scales.data_ptr()
-        )
+        assert layer.sm70_nvfp4_qpn2_prefill_enabled
         assert layer.weight.numel() == 0
         assert layer.weight_scale.numel() == 0
 
@@ -267,8 +251,9 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
         assert fused is not None and fused.shape == (8, 32)
         assert torch.equal(raw, torch.full_like(raw, 3))
         assert torch.equal(fused, torch.full_like(fused, 3))
-        assert calls[0][-1] is False
-        assert calls[1][-1] is True
+        assert not calls
+        assert combined_calls[0][-2:] == (False, 9)
+        assert combined_calls[1][-2:] == (True, 9)
 
         large_x = torch.ones((9, 64), dtype=torch.float16)
         large_raw = scheme.apply_weights(layer, large_x)
@@ -276,9 +261,7 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
         assert torch.equal(large_raw, torch.full_like(large_raw, 5))
         assert large_fused is not None
         assert torch.equal(large_fused, torch.full_like(large_fused, 5))
-        assert prefill_calls[0][-2:] == (True, False)
-        assert prefill_calls[1][-2:] == (True, True)
-        assert prefill_calls[0][3].shape == (64, 32)
-        assert prefill_calls[0][4].shape == (4, 64)
+        assert combined_calls[2][-2:] == (False, 9)
+        assert combined_calls[3][-2:] == (True, 9)
     finally:
         envs.disable_envs_cache()

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -16,6 +17,11 @@ import vllm.v1.worker.gpu.attn_utils as attn_utils
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
 from vllm import envs
 from vllm.config.speculative import SpeculativeConfig
+from vllm.config.vllm import (
+    _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS,
+    _apply_sm70_nvfp4_dflash2_practical_defaults,
+    _is_sm70_nvfp4_dflash2_practical_contract,
+)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     _is_dflash2_spec_config,
@@ -60,6 +66,84 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
     _requires_sm70_tail,
     _selector_walk_kernel,
 )
+
+
+def _sm70_nvfp4_dflash2_practical_contract_args():
+    model_config = SimpleNamespace(
+        architectures=("Qwen3_5ForConditionalGeneration",),
+        quantization="compressed-tensors",
+        dtype=torch.float16,
+        hf_text_config=SimpleNamespace(
+            hidden_size=5120,
+            num_attention_heads=24,
+            num_key_value_heads=4,
+            head_dim=256,
+        ),
+    )
+    speculative_config = SimpleNamespace(
+        method="dflash",
+        num_speculative_tokens=7,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(dflash_config={"selector_top_k": 16})
+        ),
+    )
+    parallel_config = SimpleNamespace(
+        pipeline_parallel_size=1,
+        tensor_parallel_size=4,
+        enable_dbo=False,
+        ubatch_size=0,
+    )
+    scheduler_config = SimpleNamespace(
+        max_num_seqs=1,
+        max_num_batched_tokens=4096,
+    )
+    cache_config = SimpleNamespace(cache_dtype="fp8_e5m2")
+    return (
+        model_config,
+        speculative_config,
+        parallel_config,
+        scheduler_config,
+        cache_config,
+    )
+
+
+def test_sm70_nvfp4_dflash2_practical_contract_is_narrow():
+    args = _sm70_nvfp4_dflash2_practical_contract_args()
+    assert _is_sm70_nvfp4_dflash2_practical_contract(*args)
+
+    for config_index, attribute, incompatible_value in (
+        (0, "quantization", "fp8"),
+        (1, "num_speculative_tokens", 5),
+        (2, "tensor_parallel_size", 2),
+        (3, "max_num_seqs", 2),
+        (3, "max_num_batched_tokens", 8192),
+        (4, "cache_dtype", "auto"),
+    ):
+        incompatible_args = _sm70_nvfp4_dflash2_practical_contract_args()
+        setattr(incompatible_args[config_index], attribute, incompatible_value)
+        assert not _is_sm70_nvfp4_dflash2_practical_contract(*incompatible_args)
+
+    incompatible_args = _sm70_nvfp4_dflash2_practical_contract_args()
+    incompatible_args[1].draft_model_config.hf_config.dflash_config[
+        "selector_top_k"
+    ] = 8
+    assert not _is_sm70_nvfp4_dflash2_practical_contract(*incompatible_args)
+
+
+def test_sm70_nvfp4_dflash2_practical_defaults_preserve_overrides(monkeypatch):
+    for name in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS:
+        monkeypatch.delenv(name, raising=False)
+    overridden_name = "VLLM_SM70_DFLASH2_QPN8_RERANK"
+    monkeypatch.setenv(overridden_name, "0")
+
+    applied = _apply_sm70_nvfp4_dflash2_practical_defaults()
+
+    assert overridden_name not in applied
+    assert os.environ[overridden_name] == "0"
+    for name, expected_value in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS.items():
+        if name != overridden_name:
+            assert name in applied
+            assert os.environ[name] == expected_value
 
 
 def test_dflash2_gdn_fastpaths_are_default_off(monkeypatch):

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -35,6 +35,44 @@ def _maybe_load_fp8_qpn8_library() -> None:
 _maybe_load_fp8_qpn8_library()
 
 
+def _nvfp4_qpn2_prefill_library_path() -> str | None:
+    library_path = os.getenv("VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY")
+    if library_path is not None:
+        return library_path
+    bundled = sorted(
+        Path(__file__).resolve().parent.glob("_sm70_nvfp4_qpn2_prefill_C*.so")
+    )
+    return str(bundled[-1]) if bundled else None
+
+
+def has_deferred_nvfp4_qpn2_prefill_library() -> bool:
+    """Return whether a separate large-M prefill fragment is configured."""
+    return _nvfp4_qpn2_prefill_library_path() is not None
+
+
+def load_deferred_nvfp4_qpn2_prefill_library() -> bool:
+    """Load an isolated large-M QPN2-packed prefill fragment.
+
+    Source-overlay deployments can retain a previously validated decode
+    extension while adding the newer, large-M-only QPN2-packed prefill op.
+    The op owns its temporary dense workspace, so registration before AOT
+    prefill compilation does not retain the large buffer during decode graph
+    capture.
+    Production wheels normally link the op into ``vllm._C``; a bundled
+    fragment is only used when the main extension does not provide it.
+    """
+    if hasattr(torch.ops._C, "nvfp4_qpn4_prefill_sm70_out"):
+        return True
+
+    library_path = _nvfp4_qpn2_prefill_library_path()
+    if library_path is not None:
+        torch.ops.load_library(library_path)
+    return hasattr(torch.ops._C, "nvfp4_qpn4_prefill_sm70_out")
+
+
+load_deferred_nvfp4_qpn2_prefill_library()
+
+
 def _maybe_load_nvfp4_qpn_m1_library() -> None:
     """Load the narrow Qwen3.8 NVFP4 experiment in spawned TP workers."""
     library_path = os.getenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY")
@@ -1237,6 +1275,63 @@ if hasattr(torch.ops._C, "nvfp4_qpn2_dispatch_sm70_out"):
         tm_k_ld: int,
         tm_q_ld: int,
         gated_silu: bool,
+    ) -> None:
+        return None
+
+
+def nvfp4_qpn2_prefill_dispatch_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    split_k: int,
+    accumulator_chains: int,
+    tm_weight: torch.Tensor,
+    tm_scales: torch.Tensor,
+    tm_group_size: int,
+    tm_k_ld: int,
+    tm_q_ld: int,
+    gated_silu: bool,
+    min_prefill_m: int,
+) -> None:
+    """Keep QPN2 decode and QPN2-packed prefill behind one opaque op."""
+    _op("nvfp4_qpn2_prefill_dispatch_sm70_out")(
+        out,
+        input,
+        codes,
+        scales,
+        global_scale,
+        split_k,
+        accumulator_chains,
+        tm_weight,
+        tm_scales,
+        tm_group_size,
+        tm_k_ld,
+        tm_q_ld,
+        gated_silu,
+        min_prefill_m,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn2_prefill_dispatch_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn2_prefill_dispatch_sm70_out")
+    def _nvfp4_qpn2_prefill_dispatch_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+        split_k: int,
+        accumulator_chains: int,
+        tm_weight: torch.Tensor,
+        tm_scales: torch.Tensor,
+        tm_group_size: int,
+        tm_k_ld: int,
+        tm_q_ld: int,
+        gated_silu: bool,
+        min_prefill_m: int,
     ) -> None:
         return None
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import is_dataclass
 from datetime import datetime
@@ -82,6 +82,82 @@ DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
 )
 _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
 _SM70_MTP_CUDAGRAPH_REQUEST_SIZES = (1, 2, 4, 6, 8, 12, 16)
+
+_SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS = {
+    "VLLM_SM70_DFLASH2_QPN8_RERANK": "1",
+    "VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER": "1",
+    "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER": "0",
+    "VLLM_SM70_DFLASH2_VERIFY_FASTPATH": "1",
+    "VLLM_SM70_DFLASH2_FUSED_GDN_METADATA": "1",
+    "VLLM_SM70_DFLASH2_FUSED_GDN_NORM": "1",
+    "VLLM_SM70_DFLASH2_FUSED_GDN_SPLIT": "1",
+    "VLLM_SM70_DFLASH2_FUSED_GEMMA_RMS": "1",
+    "VLLM_SM70_DFLASH2_FUSED_SMALLQ_METADATA": "1",
+    "VLLM_SM70_DFLASH2_GROUPED_SMALLQ_METADATA": "1",
+    "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION": "1",
+    "VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC": "1",
+}
+
+
+def _is_sm70_nvfp4_dflash2_practical_contract(
+    model_config: Any,
+    speculative_config: Any,
+    parallel_config: Any,
+    scheduler_config: Any,
+    cache_config: Any,
+) -> bool:
+    """Admit only the scored Qwen3.8 NVFP4 DFlash2 TP4/B1 contract."""
+    if any(
+        config is None
+        for config in (
+            model_config,
+            speculative_config,
+            parallel_config,
+            scheduler_config,
+            cache_config,
+        )
+    ):
+        return False
+
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    draft_hf_config = getattr(draft_model_config, "hf_config", None)
+    dflash_config = getattr(draft_hf_config, "dflash_config", None) or {}
+    selector_top_k = (
+        int(dflash_config.get("selector_top_k", 0) or 0)
+        if isinstance(dflash_config, Mapping)
+        else 0
+    )
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    architectures = set(getattr(model_config, "architectures", ()) or ())
+    return bool(
+        "Qwen3_5ForConditionalGeneration" in architectures
+        and getattr(model_config, "quantization", None) == "compressed-tensors"
+        and getattr(model_config, "dtype", None) == torch.float16
+        and getattr(hf_text_config, "hidden_size", None) == 5120
+        and getattr(hf_text_config, "num_attention_heads", None) == 24
+        and getattr(hf_text_config, "num_key_value_heads", None) == 4
+        and getattr(hf_text_config, "head_dim", None) == 256
+        and getattr(speculative_config, "method", None) == "dflash"
+        and int(getattr(speculative_config, "num_speculative_tokens", 0) or 0) == 7
+        and selector_top_k == 16
+        and getattr(parallel_config, "pipeline_parallel_size", 0) == 1
+        and getattr(parallel_config, "tensor_parallel_size", 0) == 4
+        and not getattr(parallel_config, "enable_dbo", False)
+        and int(getattr(parallel_config, "ubatch_size", 0) or 0) <= 1
+        and getattr(scheduler_config, "max_num_seqs", 0) == 1
+        and getattr(scheduler_config, "max_num_batched_tokens", 0) == 4096
+        and str(getattr(cache_config, "cache_dtype", "")).lower() == "fp8_e5m2"
+    )
+
+
+def _apply_sm70_nvfp4_dflash2_practical_defaults() -> tuple[str, ...]:
+    """Set quality-audited defaults while preserving every explicit override."""
+    applied = []
+    for env_name, env_value in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS.items():
+        if env_name not in os.environ:
+            os.environ[env_name] = env_value
+            applied.append(env_name)
+    return tuple(applied)
 
 
 def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
@@ -1512,6 +1588,21 @@ class VllmConfig:
                         "baseline. Set it explicitly to override.",
                         env_name,
                         env_value,
+                    )
+            if _is_sm70_nvfp4_dflash2_practical_contract(
+                self.model_config,
+                self.speculative_config,
+                self.parallel_config,
+                self.scheduler_config,
+                self.cache_config,
+            ):
+                for env_name in _apply_sm70_nvfp4_dflash2_practical_defaults():
+                    logger.info_once(
+                        "Auto-setting %s=%s for the quality-audited SM70 "
+                        "Qwen3.8 NVFP4 DFlash2 TP4/B1 practical baseline. "
+                        "Set it explicitly to override.",
+                        env_name,
+                        os.environ[env_name],
                     )
         sm70_flash_0dot3_compile_graph = envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
         sm70_flash_no_compile_graph = (

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -176,6 +176,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
     VLLM_SM70_NVFP4_QPN2_PREFILL: bool = False
+    VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY: str | None = None
     VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M: int = 1024
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
@@ -1749,6 +1750,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # QPN2. This stays opt-in until full-model speed and quality gates pass.
     "VLLM_SM70_NVFP4_QPN2_PREFILL": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QPN2_PREFILL", "0"))
+    ),
+    "VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY": lambda: os.getenv(
+        "VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY"
     ),
     "VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M": lambda: int(
         os.getenv("VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M", "1024")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -128,7 +128,7 @@ _SM70_NVFP4_QPN2_REQUIRED_OPS = (
     "nvfp4_qpn2_gated_sm70_out",
     "nvfp4_qpn2_dispatch_sm70_out",
 )
-_SM70_NVFP4_QPN2_PREFILL_REQUIRED_OPS = ("nvfp4_qpn4_prefill_sm70_out",)
+_SM70_NVFP4_QPN2_PREFILL_REQUIRED_OPS = ("nvfp4_qpn2_prefill_dispatch_sm70_out",)
 
 
 def _is_qpn2_layer(layer: torch.nn.Module) -> bool:
@@ -355,7 +355,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                     layer.weight.data, layer.weight_scale.data
                 )
                 qpn2_global_scale = float(layer.weight_global_scale.item())
-                qpn2_prefill_workspace = None
+                qpn2_prefill_enabled = False
                 if _sm70_nvfp4_qpn2_prefill_enabled():
                     missing_prefill_ops = _missing_qpn2_prefill_ops()
                     if missing_prefill_ops:
@@ -365,15 +365,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                             f"large M. Missing ops: {missing_prefill_ops}."
                         )
                     else:
-                        qpn2_prefill_workspace = sm70_tm.get_nvfp4_qpn4_dense_workspace(
-                            layer.weight
-                        )
-                        if qpn2_prefill_workspace is None:
-                            logger.warning_once(
-                                "Insufficient memory for the bounded SM70 "
-                                "NVFP4 QPN2-packed prefill workspace; "
-                                "retaining TurboMind for large M."
-                            )
+                        qpn2_prefill_enabled = True
 
             use_gated_silu = bool(
                 envs.VLLM_SM70_NVFP4_DENSE_GATED_SILU and is_qpn4_gate and not use_qpn2
@@ -398,26 +390,15 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 layer.sm70_nvfp4_qpn2_split_k = split_k
                 layer.sm70_nvfp4_qpn2_nacc = nacc
                 layer.sm70_nvfp4_qpn2_gated_silu = suffix == "gate_up_proj"
-                layer.sm70_nvfp4_qpn2_prefill_dense_weight_ptr = (
-                    0
-                    if qpn2_prefill_workspace is None
-                    else qpn2_prefill_workspace.data_ptr()
-                )
-                if qpn2_prefill_workspace is not None:
-                    # QPN2 and QPN4 use the same physical tile order, but
-                    # expose checkpoint-native [N, K/2] and GEMM-native
-                    # [K, N/2] shapes respectively.  Keep zero-copy views so
-                    # prefill does not retain a third multi-GB weight layout.
-                    layer.sm70_nvfp4_qpn2_prefill_codes = qpn2_codes.view(k, n // 2)
-                    layer.sm70_nvfp4_qpn2_prefill_scales = qpn2_scales.view(k // 16, n)
+                layer.sm70_nvfp4_qpn2_prefill_enabled = qpn2_prefill_enabled
                 logger.info_once(
                     "SM70 NVFP4 QPN2 M<=8 route enabled for a compatible "
                     "TP4 projection contract."
                 )
-                if qpn2_prefill_workspace is not None:
+                if qpn2_prefill_enabled:
                     logger.info_once(
-                        "SM70 NVFP4 QPN2-packed bounded FP16 prefill route "
-                        "enabled for M>=%d.",
+                        "SM70 NVFP4 opaque QPN2 decode plus QPN2-packed "
+                        "ephemeral FP16 prefill dispatch enabled for M>=%d.",
                         envs.VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M,
                     )
             elif use_gated_silu:
@@ -490,26 +471,6 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         )
         if x_2d.shape[0] == 0:
             return out_2d.reshape(*x.shape[:-1], output_size)
-        prefill_dense_weight_ptr = int(
-            getattr(layer, "sm70_nvfp4_qpn2_prefill_dense_weight_ptr", 0)
-        )
-        if (
-            x_2d.shape[0] >= envs.VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M
-            and prefill_dense_weight_ptr
-        ):
-            sm70_ops.nvfp4_qpn4_prefill_sm70_out(
-                out_2d,
-                prefill_dense_weight_ptr,
-                x_2d,
-                layer.sm70_nvfp4_qpn2_prefill_codes,
-                layer.sm70_nvfp4_qpn2_prefill_scales,
-                float(layer.sm70_nvfp4_qpn2_global_scale),
-                True,
-                gated_silu,
-            )
-            if bias is not None:
-                out_2d.add_(bias)
-            return out_2d.reshape(*x.shape[:-1], output_size)
         state = getattr(layer, sm70_tm.STATE_ATTR)
         split_k = int(layer.sm70_nvfp4_qpn2_split_k)
         nacc = int(layer.sm70_nvfp4_qpn2_nacc)
@@ -517,21 +478,39 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             split_k, nacc = _SM70_NVFP4_QPN2_CONFIGS[
                 (x_2d.shape[1], output_size * 2, True)
             ]
-        sm70_ops.nvfp4_qpn2_dispatch_sm70_out(
-            out_2d,
-            x_2d,
-            layer.sm70_nvfp4_qpn2_codes,
-            layer.sm70_nvfp4_qpn2_scales,
-            float(layer.sm70_nvfp4_qpn2_global_scale),
-            split_k,
-            nacc,
-            state.weight,
-            state.scales,
-            state.group_size,
-            state.k_ld,
-            state.q_ld,
-            gated_silu,
-        )
+        if getattr(layer, "sm70_nvfp4_qpn2_prefill_enabled", False):
+            sm70_ops.nvfp4_qpn2_prefill_dispatch_sm70_out(
+                out_2d,
+                x_2d,
+                layer.sm70_nvfp4_qpn2_codes,
+                layer.sm70_nvfp4_qpn2_scales,
+                float(layer.sm70_nvfp4_qpn2_global_scale),
+                split_k,
+                nacc,
+                state.weight,
+                state.scales,
+                state.group_size,
+                state.k_ld,
+                state.q_ld,
+                gated_silu,
+                envs.VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M,
+            )
+        else:
+            sm70_ops.nvfp4_qpn2_dispatch_sm70_out(
+                out_2d,
+                x_2d,
+                layer.sm70_nvfp4_qpn2_codes,
+                layer.sm70_nvfp4_qpn2_scales,
+                float(layer.sm70_nvfp4_qpn2_global_scale),
+                split_k,
+                nacc,
+                state.weight,
+                state.scales,
+                state.group_size,
+                state.k_ld,
+                state.q_ld,
+                gated_silu,
+            )
         if bias is not None:
             out_2d.add_(bias)
         return out_2d.reshape(*x.shape[:-1], output_size)


### PR DESCRIPTION
## Purpose

- keep the accepted SM70 NVFP4 QPN2 decode graph opaque while adding the QPN2-packed large-M prefill route
- replace the Python M-dependent branch and persistent 85 MiB workspace with one C++ dispatcher and an operator-local ephemeral workspace
- source-default the quality-audited 18 ms NVFP4 DFlash2 TP4/B1 practical path, preserving every explicit override and keeping candidate-order disabled

## Test Plan

- focused CPU contract and dispatch tests
- exact V100 normal/gated M8/M16 operator comparisons
- restart the four-V100 256K practical API with QPN2/prefill/DFlash2 fastpath booleans removed from the launch file
- measure three 512-token single-request decode runs, cold 32K prefill, and post-prefill decode
- smoke tool calls and strict JSON schema output

## Test Result

- `7 passed` focused pytest; ruff, compileall, and `git diff --check` pass
- V100 operator comparison: `max_abs=0` for normal/gated and explicit/ephemeral workspace cases
- CUDA Graph pool: `0.13 GiB`
- complete DFlash2 round: `17.4035 / 17.3569 / 17.3697 ms`, mean `17.3767 ms`
- cold 32K pure prefill: `4039.49 tok/s`
- post-32K complete round: `17.3640 ms`
- tool calling: `3/3`; strict JSON schema: `1/1`

Detailed evidence is recorded in `docs/design/sm70_dflash2_nvfp4_prefill_promotion.md`.