### PR TITLE
[CI/Build][SM70] Close wheel build inputs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -344,6 +344,7 @@ WORKDIR /workspace
 COPY pyproject.toml setup.py CMakeLists.txt ./
 COPY cmake cmake/
 COPY csrc csrc/
+COPY flash_qla flash_qla/
 COPY vllm/envs.py vllm/envs.py
 COPY vllm/__init__.py vllm/__init__.py
 

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -24,8 +24,8 @@ fastsafetensors >= 0.3.3
 nvidia-cutlass-dsl[cu13]==4.7.0
 quack-kernels>=0.3.3
 
-# Tokenspeed_MLA for faster mla with spec decode
-tokenspeed-mla==0.2.5
+# TokenSpeed MLA is optional. Version 0.2.5 pins apache-tvm-ffi==0.1.13,
+# which cannot coexist with the TileLang version pinned above.
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.2

--- a/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
@@ -30,8 +30,9 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
         return device_capability.major == 10
 
     _INSTALL_HINT = (
-        "tokenspeed_mla package is not installed. "
-        "Install it with: `uv pip install tokenspeed-mla`"
+        "tokenspeed_mla is an optional package and is not installed. "
+        "Its apache-tvm-ffi requirement must be compatible with the installed "
+        "TileLang version."
     )
 
     @classmethod

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -101,8 +101,9 @@ class TokenspeedMLABackend(MLACommonBackend):
             import tokenspeed_mla  # noqa: F401
         except ImportError:
             return (
-                "tokenspeed_mla package is not installed. "
-                "Install it with: `uv pip install tokenspeed-mla`"
+                "tokenspeed_mla is an optional package and is not installed. "
+                "Its apache-tvm-ffi requirement must be compatible with the "
+                "installed TileLang version."
             )
 
         # tokenspeed_mla CuTe DSL kernel is shape-specialized for DeepSeek R1


### PR DESCRIPTION
## Purpose

Close two independently reproduced SM70 wheel-build blockers originally reported in #409 and #411:

- remove mandatory `tokenspeed-mla==0.2.5`, whose `apache-tvm-ffi==0.1.13` requirement conflicts with the repository TileLang pin at `0.1.10`; TokenSpeed remains an optional Blackwell backend;
- copy the tracked `flash_qla/` source tree into the Docker csrc wheel stage consumed by `setup.py`.

Base SHA: `5ef2ddc2d3b9810969a873a5ee0eaef1d1ce708c`.

This reimplementation provides the DCO sign-off missing from the original candidate commits and credits their report.

## Test Plan

- resolve the CUDA requirement set for Python 3.12 / manylinux x86_64 with no cache;
- verify `apache-tvm-ffi==0.1.10` remains and TokenSpeed MLA is absent;
- verify the FlashQLA SM70 source exists, `setup.py` consumes it, and the Docker csrc stage copies it;
- run changed-file pre-commit and Python byte compilation.

## Test Result

- `uv pip compile`: 192 packages resolved in 53.40 s; `apache-tvm-ffi==0.1.10`; no `tokenspeed-mla`;
- FlashQLA source/setup/Docker static closure: passed;
- all changed-file pre-commit hooks: passed;
- Python byte compilation and `git diff --check`: passed.

Reported-by: #409 and #411.