### PR TITLE
[Bugfix] Only filter by safetensors index when a shard stores unindexed tensors

### DIFF
--- a/tests/model_executor/model_loader/test_safetensors_index_filter.py
+++ b/tests/model_executor/model_loader/test_safetensors_index_filter.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import os
 
 import pytest
 import torch
@@ -13,17 +14,22 @@ from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 pytestmark = pytest.mark.skip_global_cleanup
 
 
-@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
-@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
-def test_default_loader_only_yields_tensors_assigned_by_index(
-    tmp_path, load_format: str, load_strategy: str | None
-) -> None:
+def _write_index(tmp_path, weight_map: dict[str, str]) -> None:
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+
+def _write_reused_shard_checkpoint(tmp_path) -> None:
+    """A checkpoint whose second shard is reused from another model.
+
+    The index assigns ``main.weight`` to the first shard and ``ple.weight`` to
+    the second, but the second shard also stores a stale ``main.weight`` and an
+    entirely unindexed tensor.
+    """
     main_shard = tmp_path / "model-00001-of-00002.safetensors"
     reused_shard = tmp_path / "model-00002-of-00002.safetensors"
-    save_file(
-        {"main.weight": torch.tensor([1.0])},
-        main_shard,
-    )
+    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
     save_file(
         {
             "ple.weight": torch.tensor([2.0]),
@@ -32,17 +38,41 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
         },
         reused_shard,
     )
-    (tmp_path / "model.safetensors.index.json").write_text(
-        json.dumps(
-            {
-                "metadata": {},
-                "weight_map": {
-                    "main.weight": main_shard.name,
-                    "ple.weight": reused_shard.name,
-                },
-            }
-        )
+    _write_index(
+        tmp_path,
+        {"main.weight": main_shard.name, "ple.weight": reused_shard.name},
     )
+
+
+def _write_ordinary_checkpoint(tmp_path) -> None:
+    """A normal sharded checkpoint: each shard stores exactly its index entry."""
+    first_shard = tmp_path / "model-00001-of-00002.safetensors"
+    second_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"main.weight": torch.tensor([1.0])}, first_shard)
+    save_file({"ple.weight": torch.tensor([2.0])}, second_shard)
+    _write_index(
+        tmp_path,
+        {"main.weight": first_shard.name, "ple.weight": second_shard.name},
+    )
+
+
+def _prepare(tmp_path, **load_config_kwargs):
+    loader = DefaultModelLoader(LoadConfig(**load_config_kwargs))
+    return loader._prepare_weights(
+        str(tmp_path),
+        None,
+        None,
+        fall_back_to_pt=False,
+        allow_patterns_overrides=None,
+    )
+
+
+@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
+@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
+def test_default_loader_only_yields_tensors_assigned_by_index(
+    tmp_path, load_format: str, load_strategy: str | None
+) -> None:
+    _write_reused_shard_checkpoint(tmp_path)
 
     loader = DefaultModelLoader(
         LoadConfig(
@@ -66,28 +96,7 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
 
 @pytest.mark.skip_global_cleanup
 def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> None:
-    main_shard = tmp_path / "model-00001-of-00002.safetensors"
-    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
-    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
-    save_file(
-        {
-            "ple.weight": torch.tensor([2.0]),
-            "main.weight": torch.tensor([99.0]),
-            "unindexed.weight": torch.tensor([3.0]),
-        },
-        reused_shard,
-    )
-    (tmp_path / "model.safetensors.index.json").write_text(
-        json.dumps(
-            {
-                "metadata": {},
-                "weight_map": {
-                    "main.weight": main_shard.name,
-                    "ple.weight": reused_shard.name,
-                },
-            }
-        )
-    )
+    _write_reused_shard_checkpoint(tmp_path)
 
     loader = DefaultModelLoader(
         LoadConfig(
@@ -107,3 +116,38 @@ def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> N
     assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
     torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
     torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
+
+
+def test_prepare_weights_skips_filtering_for_ordinary_checkpoint(tmp_path) -> None:
+    # Every shard stores exactly what the index assigns to it, so no allowlist
+    # is produced and the accelerated backends stay available.
+    _write_ordinary_checkpoint(tmp_path)
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file is None
+
+
+def test_prepare_weights_engages_filtering_for_reused_shard(tmp_path) -> None:
+    # The reused shard stores tensors the index did not assign to it, so the
+    # per-file allowlist is produced.
+    _write_reused_shard_checkpoint(tmp_path)
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file == {
+        os.path.normpath(str(tmp_path / "model-00001-of-00002.safetensors")): {
+            "main.weight"
+        },
+        os.path.normpath(str(tmp_path / "model-00002-of-00002.safetensors")): {
+            "ple.weight"
+        },
+    }
+
+
+def test_prepare_weights_skips_filtering_without_index(tmp_path) -> None:
+    save_file({"main.weight": torch.tensor([1.0])}, tmp_path / "model.safetensors")
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file is None

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -208,7 +208,9 @@ class DefaultModelLoader(BaseModelLoader):
             )
 
         indexed_weights_by_file = (
-            get_safetensors_index_weights_by_file(hf_folder, index_file)
+            get_safetensors_index_weights_by_file(
+                hf_folder, index_file, hf_weights_files
+            )
             if use_safetensors
             else None
         )
@@ -248,17 +250,19 @@ class DefaultModelLoader(BaseModelLoader):
             )
         elif use_safetensors:
             # fastsafetensors/instanttensor iterators cannot filter tensors
-            # inside a reused shard, so indexed-subset checkpoints must take
-            # the standard filtered iterator to honor the index assignments.
+            # inside a reused shard. `indexed_weights_by_file` is only set when
+            # a shard really does store unindexed tensors, so ordinary indexed
+            # checkpoints keep using these accelerated backends and only
+            # reused-shard checkpoints take the standard filtered iterator.
             use_special_format = self.load_config.load_format in (
                 "fastsafetensors",
                 "instanttensor",
             )
             if use_special_format and indexed_weights_by_file is not None:
                 logger.warning(
-                    "Checkpoint index assigns a subset of stored tensors; "
-                    "falling back from %s to the filtered safetensors "
-                    "iterator.",
+                    "Checkpoint shards store tensors the index does not "
+                    "assign to them; falling back from %s to the filtered "
+                    "safetensors iterator so the index is honored.",
                     self.load_config.load_format,
                 )
                 use_special_format = False

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -679,15 +679,22 @@ def filter_duplicate_safetensors_files(
 
 
 def get_safetensors_index_weights_by_file(
-    hf_folder: str, index_file: str
+    hf_folder: str, index_file: str, hf_weights_files: list[str]
 ) -> dict[str, set[str]] | None:
-    """Return the exact tensor names assigned to each indexed shard.
+    """Return per-shard tensor allowlists, but only when the index needs them.
 
     A safetensors shard can contain tensors that are not referenced by the
     checkpoint index (for example, when a checkpoint reuses part of another
     model's shard).  The index is authoritative in that case: loading every
     tensor from an otherwise referenced file can inject stale or incompatible
     weights into the model.
+
+    Almost every checkpoint stores in each shard exactly the tensors the index
+    assigns to it, and for those this returns ``None`` so that all loader paths
+    keep their current behavior, including the accelerated backends that cannot
+    filter within a shard.  An allowlist is returned only when a shard actually
+    stores tensors the index did not assign to it.  Detecting this reads
+    safetensors headers, not tensor data.
     """
     index_file_name = os.path.join(hf_folder, index_file)
     if not os.path.isfile(index_file_name):
@@ -700,7 +707,18 @@ def get_safetensors_index_weights_by_file(
     for weight_name, filename in weight_map.items():
         shard_path = os.path.normpath(os.path.join(hf_folder, filename))
         weights_by_file[shard_path].add(weight_name)
-    return dict(weights_by_file)
+
+    for st_file in hf_weights_files:
+        indexed_weights = weights_by_file.get(os.path.normpath(st_file))
+        if indexed_weights is None:
+            # Shard is not covered by the index, so there is nothing to
+            # enforce. Leave the existing behavior untouched.
+            return None
+        with safe_open(st_file, framework="pt") as f:
+            stored_weights = set(f.keys())
+        if stored_weights - indexed_weights:
+            return dict(weights_by_file)
+    return None
 
 
 def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[str]:


### PR DESCRIPTION
## Purpose

Follow-up to #407. That PR is correct about honoring the index, but it engages the filtering too broadly.

`get_safetensors_index_weights_by_file` currently returns a per-file allowlist whenever `model.safetensors.index.json` exists — which is nearly every sharded model. Two consequences on `main` today:

1. `--load-format fastsafetensors` and `--load-format instanttensor` are silently disabled for **all** ordinary sharded checkpoints, falling back to the standard CPU iterator. These are exactly the large checkpoints those backends exist for.
2. The fallback logs `"Checkpoint index assigns a subset of stored tensors"`, which is untrue for those checkpoints and misleads anyone debugging a slow load.

Neither affects correctness, but the accelerated-loader regression is real and applies to every sharded model.

**Fix:** decide whether the allowlist is needed before building it. `get_safetensors_index_weights_by_file` now takes the selected shard list and returns `None` unless some shard actually stores tensors the index did not assign to it. Detection reads safetensors headers via `safe_open(...).keys()`, never tensor data, and returns as soon as the first mismatching shard is found.

- Ordinary sharded checkpoints and checkpoints with no index get `None`, so `fastsafetensors`/`instanttensor` stay in use and every other loader path is unchanged.
- Only genuine reused-shard checkpoints — the Qwen3.8 Flash Next AWQ case #407 was written for — produce an allowlist and take the filtered iterator. The fallback warning is now accurate and reworded.

The same fix was applied upstream in vllm-project/vllm#54230 after review raised this exact point, so the fork stays aligned.

**AI assistance:** Claude assisted with the fix, tests, and PR preparation. I reviewed every changed line and ran the tests below.

## Test Plan

```bash
.venv/bin/python -m pytest \
  --confcutdir=tests/model_executor/model_loader \
  tests/model_executor/model_loader/test_safetensors_index_filter.py \
  tests/model_executor/model_loader/test_registry.py -vv

.venv/bin/pre-commit run --files \
  vllm/model_executor/model_loader/default_loader.py \
  vllm/model_executor/model_loader/weight_utils.py \
  tests/model_executor/model_loader/test_safetensors_index_filter.py
```

Three tests pin when filtering engages: an ordinary sharded checkpoint and a checkpoint with no index must both produce no allowlist, while the reused-shard checkpoint must produce the expected per-shard sets. The existing reused-shard and multithread tests are unchanged apart from having their duplicated fixture pulled into a helper.

## Test Result

- `test_safetensors_index_filter.py` + `test_registry.py`: `12 passed`.
- Pre-commit on all changed files: passed (ruff, ruff format, mypy, SPDX).
- Negative control: against current `main`, `test_prepare_weights_skips_filtering_for_ordinary_checkpoint` fails with `assert indexed_weights_by_file is None`, confirming the test pins this regression rather than passing vacuously.
- Validation ran on CPU; no compute path changed and no GPU was required.
