### PR TITLE
[Core][SM70] Simplify DFlash2 release serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,9 @@ export TORCH_CUDA_ARCH_LIST="7.0"
 export FLASH_ATTN_V100_CUDA_ARCH_LIST="7.0"
 export MAX_JOBS=12
 export NVCC_THREADS=1
+# Use this for a pre-tag 1.5.0 release candidate. An exact v1.5.0 checkout
+# derives the same version from its Git tag and does not need the override.
+export VLLM_VERSION_OVERRIDE=1.5.0
 
 rm -rf build vllm.egg-info
 rm -rf .deps/*-build .deps/*-subbuild

--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ for long-context serving, and OpenAI-compatible API fixes for common clients.
   per prompt by default; video inputs remain opt-in.
 - **Tool calling and OpenAI API compatibility**: validated with OpenAI-style
   clients such as Cherry Studio, OpenClaw, and similar tools.
+- **Validated Qwen3.8 DFlash2 profile**: the four-V100 NVFP4/TP4/B1 profile
+  includes prefix caching, Mamba state alignment, tool/reasoning parsing,
+  FP8 E5M2 target KV, and guarded Flash-V100 grouped verification.
 - **Experimental FP8 work**: FP8 model and KV-cache paths are included for
   validation, but they are not production defaults.
-- **Experimental DFlash work**: included for continued research and validation.
+- **Experimental speculative research**: DFlash1/DDTree, lookup-augmented q16,
+  and n-gram chaining remain opt-in research paths.
 
 ## Recommended Model Providers
 
@@ -160,12 +164,14 @@ python - <<'PY'
 import torch, triton, vllm, sys
 import flash_attn_v100
 from flash_attn_v100 import flash_attn_v100_cuda, paged_kv_utils
+from flash_attn_v100 import flash_attn_grouped_verify_max_query_tokens
 print("python", sys.version.split()[0])
 print("torch", torch.__version__)
 print("torch_cuda", torch.version.cuda)
 print("triton", triton.__version__)
 print("vllm", vllm.__version__)
 print("flash_attn_v100", flash_attn_v100.__version__)
+print("dflash2_grouped_verify_max_q", flash_attn_grouped_verify_max_query_tokens())
 PY
 ```
 
@@ -214,6 +220,48 @@ python -m vllm.entrypoints.openai.api_server \
   --port 8000
 ```
 
+### Qwen3.8-27B-NVFP4 + DFlash2, TP4 low-latency profile
+
+This is the quality-audited four-V100 DFlash2 profile. The target checkpoint
+must use compressed-tensors NVFP4 with an unquantized/BF16-compatible LM head;
+the draft revision and selector top-K are part of the checkpoint contract.
+
+```bash
+python -m vllm.entrypoints.cli.main serve /path/to/Qwen3.8-27B-NVFP4 \
+  --served-model-name qwen3.8-27b-dflash2 \
+  --trust-remote-code \
+  --tensor-parallel-size 4 \
+  --attention-backend FLASH_ATTN_V100 \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-model-len 262144 \
+  --performance-mode interactivity \
+  --gpu-memory-utilization 0.80 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --default-chat-template-kwargs '{"enable_thinking":true}' \
+  --speculative-config '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","revision":"dedf8df68adfb1afeaf7b7480c0a0243108177b4","kv_cache_dtype":"auto"}' \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+On SM70, this command resolves the following values automatically unless an
+explicit override is present:
+
+- DFlash2 draft width `7`, from checkpoint block size `8`;
+- probabilistic draft sampling and the draft `FLASH_ATTN_V100` backend;
+- `max_num_seqs=1` and `max_num_batched_tokens=4096` for
+  `--performance-mode interactivity`;
+- prefix caching and Mamba `align` state caching for the API server;
+- the quality-audited NVFP4 DFlash2 fast paths when the exact TP4/B1,
+  selector-top16, q4096, and E5M2-KV contract is present.
+
+Use explicit `--max-num-seqs` and `--max-num-batched-tokens` values for a
+concurrent service. That preserves capacity but intentionally leaves the B1
+17-18 ms admission contract. Every `VLLM_SM70_DFLASH2_*` environment value is
+also an authoritative rollback. Do not enable candidate-order reranking;
+dense-order reranking is the validated path.
+
 ## OpenAI-Compatible Request Example
 
 ```bash
@@ -250,11 +298,12 @@ Example:
 --kv-cache-dtype fp8_e5m2
 ```
 
-### DFlash
+### Other DFlash modes
 
-DFlash is included as an experimental path for continued validation. Treat it
-as a research feature until you have validated speed and output quality on your
-own workload.
+The Qwen3.8 DFlash2 command above is the validated release profile. DFlash1,
+`dflash_ddtree`, lookup-augmented q16 verification, n-gram assist, and
+drafter-free chaining remain workload-dependent opt-in modes. Validate their
+acceptance, output quality, and end-to-end throughput before production use.
 
 ### MTP
 
@@ -310,7 +359,7 @@ Build wheels:
 export CUDA_HOME=/usr/local/cuda-12.8
 export PATH=$CUDA_HOME/bin:$PATH
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}
-export TORCH_CUDA_ARCH_LIST="7.0;8.0"
+export TORCH_CUDA_ARCH_LIST="7.0"
 export FLASH_ATTN_V100_CUDA_ARCH_LIST="7.0"
 export MAX_JOBS=12
 export NVCC_THREADS=1

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44694,3 +44694,34 @@ Interpretation:
   accompanies exact observed output parity rather than a changed prompt or
   sampling contract. PR #393 passes this prefill quality gate; the two page4
   environment variables remain its immediate rollback.
+
+## 2026-08-31 1.5.0 DFlash2 release usability audit
+
+- Integration base is public `onecat/main@187b932dbd11940f0bcf52fb3675dd47fd69f313`.
+  The audit does not change a CUDA kernel, sampler, rejection rule, or target
+  distribution. It closes configuration and documentation gaps around the
+  already accepted Qwen3.8 NVFP4 DFlash2 TP4/B1 profile.
+- Explicit SM70 DFlash now defaults its draft backend to `FLASH_ATTN_V100`.
+  `--performance-mode interactivity` selects the scored B1/q4096 capacity
+  values only when neither value was supplied. Balanced/concurrent services
+  and every explicit override retain their requested capacity.
+- Selector-based DFlash2 now derives seven draft tokens from the official
+  checkpoint's block size eight when the user omits the field. Config SHA256
+  `873e3556509b0da06e29654ba00d4944888d4b5e8a33afde25f7eb27d321e980`
+  at revision `dedf8df68adfb1afeaf7b7480c0a0243108177b4` resolves to block
+  size eight and selector top-K 16 in a source-only configuration load.
+- The practical-default admission now checks for an actual NVFP4 format,
+  including `nvfp4-pack-quantized` inside a mixed-precision compressed-tensors
+  config group. A same-shape non-NVFP4 compressed checkpoint no longer receives
+  the NVFP4-only default set. Legacy MTP-disable variables no longer suppress
+  explicit DFlash defaults, and SM75 no longer receives SM70 backends.
+- CPU gates pass: SM70 EngineArgs defaults `13 passed`, DFlash2 targeted suite
+  `84 passed, 12 CUDA-only skipped`, Qwen3 coder tool parser `104 passed`, and
+  changed-file pre-commit passes. Initial source-only pytest collection tried
+  to import the absent worktree `_C`; rerunning with host platform detection
+  disabled exercised the Python contracts without borrowing a stale binary.
+- No new throughput claim is made. The runtime values remain the accepted
+  `17.3767 ms` mean complete round and `4,039.49 token/s` cold 32K prefill from
+  the matched four-V100 source-default proof. A built 1.5.0 wheel still needs
+  install/import, grouped-verifier max-q, API tool/schema, and TP4 route smokes
+  before tagging.

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -227,6 +227,12 @@ class _FakeSM70Platform:
         return SimpleNamespace(major=7, minor=0)
 
 
+class _FakeSM75Platform(_FakeSM70Platform):
+    @staticmethod
+    def get_device_capability():
+        return SimpleNamespace(major=7, minor=5)
+
+
 def _fake_qwen_hybrid_model_config():
     return SimpleNamespace(
         hf_text_config=SimpleNamespace(
@@ -244,6 +250,8 @@ def _apply_sm70_defaults(
     speculative_config=None,
     enable_prefix_caching=None,
     max_num_seqs=None,
+    max_num_batched_tokens=None,
+    performance_mode="balanced",
 ):
     for key in (
         "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS",
@@ -265,6 +273,8 @@ def _apply_sm70_defaults(
         tensor_parallel_size=4,
         enable_prefix_caching=enable_prefix_caching,
         max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        performance_mode=performance_mode,
     )
     args.speculative_config = speculative_config
     args._maybe_apply_sm70_mtp_defaults(
@@ -398,9 +408,72 @@ def test_sm70_explicit_dflash_preserves_probabilistic_default(monkeypatch):
         "method": "dflash",
         "num_speculative_tokens": 7,
         "draft_sample_method": "probabilistic",
+        "attention_backend": "FLASH_ATTN_V100",
     }
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
+    assert args.max_num_seqs is None
+    assert args.max_num_batched_tokens is None
+
+
+def test_sm70_dflash_interactivity_defaults_to_audited_b1_profile(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+        performance_mode="interactivity",
+    )
+
+    assert args.speculative_config == {
+        "method": "dflash",
+        "num_speculative_tokens": 7,
+        "draft_sample_method": "probabilistic",
+        "attention_backend": "FLASH_ATTN_V100",
+    }
+    assert args.max_num_seqs == 1
+    assert args.max_num_batched_tokens == 4096
+
+
+def test_sm70_dflash_interactivity_preserves_capacity_overrides(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+        max_num_seqs=4,
+        max_num_batched_tokens=8192,
+        performance_mode="interactivity",
+    )
+
+    assert args.max_num_seqs == 4
+    assert args.max_num_batched_tokens == 8192
+
+
+def test_sm70_dflash_defaults_ignore_legacy_mtp_disable(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        env={"VLLM_1CAT_DISABLE_SM70_MTP_DEFAULTS": "1"},
+        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+        performance_mode="interactivity",
+    )
+
+    assert args.speculative_config["attention_backend"] == "FLASH_ATTN_V100"
+    assert args.speculative_config["draft_sample_method"] == "probabilistic"
+    assert args.max_num_seqs == 1
+    assert args.max_num_batched_tokens == 4096
+
+
+def test_sm70_speculative_defaults_do_not_apply_to_sm75(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _FakeSM75Platform())
+    args = EngineArgs(model="dummy", tensor_parallel_size=4)
+    args.speculative_config = {"method": "dflash", "num_speculative_tokens": 7}
+
+    args._maybe_apply_sm70_mtp_defaults(
+        UsageContext.OPENAI_API_SERVER,
+        _fake_qwen_hybrid_model_config(),
+    )
+
+    assert args.speculative_config == {
+        "method": "dflash",
+        "num_speculative_tokens": 7,
+    }
 
 
 def test_sm70_explicit_dflash_accepts_explicit_greedy(monkeypatch):

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -16,10 +16,14 @@ import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 import vllm.v1.worker.gpu.attn_utils as attn_utils
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
 from vllm import envs
-from vllm.config.speculative import SpeculativeConfig
+from vllm.config.speculative import (
+    SpeculativeConfig,
+    _get_dflash2_checkpoint_draft_tokens,
+)
 from vllm.config.vllm import (
     _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS,
     _apply_sm70_nvfp4_dflash2_practical_defaults,
+    _is_compressed_tensors_nvfp4,
     _is_sm70_nvfp4_dflash2_practical_contract,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -73,6 +77,15 @@ def _sm70_nvfp4_dflash2_practical_contract_args():
         architectures=("Qwen3_5ForConditionalGeneration",),
         quantization="compressed-tensors",
         dtype=torch.float16,
+        model_arch_config=SimpleNamespace(
+            quantization_config={
+                "format": "mixed-precision",
+                "config_groups": {
+                    "nvfp4": {"format": "nvfp4-pack-quantized"},
+                    "fp8": {"format": "float-quantized"},
+                },
+            }
+        ),
         hf_text_config=SimpleNamespace(
             hidden_size=5120,
             num_attention_heads=24,
@@ -105,6 +118,26 @@ def _sm70_nvfp4_dflash2_practical_contract_args():
         scheduler_config,
         cache_config,
     )
+
+
+def test_dflash2_checkpoint_draft_tokens_follow_block_contract():
+    hf_config = SimpleNamespace(dflash_config={"block_size": 8, "selector_top_k": 16})
+    assert _get_dflash2_checkpoint_draft_tokens(hf_config) == 7
+
+    hf_config.dflash_config["selector_top_k"] = 0
+    assert _get_dflash2_checkpoint_draft_tokens(hf_config) is None
+
+    hf_config.dflash_config = {"block_size": 1, "selector_top_k": 16}
+    assert _get_dflash2_checkpoint_draft_tokens(hf_config) is None
+
+
+def test_nvfp4_practical_contract_requires_nvfp4_quantization_group():
+    args = _sm70_nvfp4_dflash2_practical_contract_args()
+    assert _is_compressed_tensors_nvfp4(args[0])
+
+    args[0].model_arch_config.quantization_config = {"format": "float-quantized"}
+    assert not _is_compressed_tensors_nvfp4(args[0])
+    assert not _is_sm70_nvfp4_dflash2_practical_contract(*args)
 
 
 def test_sm70_nvfp4_dflash2_practical_contract_is_narrow():

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -82,6 +82,16 @@ RejectionSampleMethod = Literal["standard", "synthetic"]
 DraftSampleMethod = Literal["greedy", "probabilistic"]
 
 
+def _get_dflash2_checkpoint_draft_tokens(hf_config: Any) -> int | None:
+    """Return the checkpoint-native DFlash2 draft width when declared."""
+    dflash_config = getattr(hf_config, "dflash_config", None) or {}
+    selector_top_k = int(dflash_config.get("selector_top_k", 0) or 0)
+    block_size = int(dflash_config.get("block_size", 0) or 0)
+    if selector_top_k <= 0 or block_size <= 1:
+        return None
+    return block_size - 1
+
+
 def get_dflash_model_draft_tokens(speculative_config: Any) -> int:
     """Return the block width produced by the DFlash checkpoint itself.
 
@@ -96,10 +106,8 @@ def get_dflash_model_draft_tokens(speculative_config: Any) -> int:
 
     draft_model_config = getattr(speculative_config, "draft_model_config", None)
     hf_config = getattr(draft_model_config, "hf_config", None)
-    dflash_config = getattr(hf_config, "dflash_config", None) or {}
-    trained_tokens = int(dflash_config.get("block_size", 0) or 0) - 1
-    has_selector = int(dflash_config.get("selector_top_k", 0) or 0) > 0
-    if has_selector and 0 < trained_tokens < verify_tokens:
+    trained_tokens = _get_dflash2_checkpoint_draft_tokens(hf_config)
+    if trained_tokens is not None and trained_tokens < verify_tokens:
         return trained_tokens
     return verify_tokens
 
@@ -123,7 +131,8 @@ class SpeculativeConfig:
     # General speculative decoding control
     num_speculative_tokens: int = Field(default=None, gt=0)  # type: ignore[assignment]
     """The number of speculative tokens, if provided. It will default to the
-    number in the draft model config if present, otherwise, it is required."""
+    number in the draft model config if present; selector-based DFlash2 uses
+    checkpoint ``block_size - 1``. Otherwise, it is required."""
     model: str | None = None
     """The name of the draft model, eagle head, or additional weights, if
     provided."""
@@ -953,6 +962,18 @@ class SpeculativeConfig:
                         raise ValueError(
                             f"num_speculative_tokens:{self.num_speculative_tokens}"
                             f" must be divisible by {n_predict=}"
+                        )
+
+                if self.num_speculative_tokens is None and self.use_dflash():
+                    native_draft_tokens = _get_dflash2_checkpoint_draft_tokens(
+                        self.draft_model_config.hf_config
+                    )
+                    if native_draft_tokens is not None:
+                        self.num_speculative_tokens = native_draft_tokens
+                        logger.info_once(
+                            "Defaulting DFlash2 num_speculative_tokens to %d "
+                            "from checkpoint block_size.",
+                            native_draft_tokens,
                         )
 
                 if self.num_speculative_tokens is None:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -99,6 +99,26 @@ _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS = {
 }
 
 
+def _is_compressed_tensors_nvfp4(model_config: Any) -> bool:
+    """Recognize NVFP4, including mixed-precision config groups."""
+    if getattr(model_config, "quantization", None) != "compressed-tensors":
+        return False
+    model_arch_config = getattr(model_config, "model_arch_config", None)
+    quant_config = getattr(model_arch_config, "quantization_config", None)
+    if not isinstance(quant_config, Mapping):
+        return False
+
+    formats = [quant_config.get("format", "")]
+    config_groups = quant_config.get("config_groups", {})
+    if isinstance(config_groups, Mapping):
+        formats.extend(
+            group.get("format", "")
+            for group in config_groups.values()
+            if isinstance(group, Mapping)
+        )
+    return any("nvfp4" in str(format_name).lower() for format_name in formats)
+
+
 def _is_sm70_nvfp4_dflash2_practical_contract(
     model_config: Any,
     speculative_config: Any,
@@ -131,7 +151,7 @@ def _is_sm70_nvfp4_dflash2_practical_contract(
     architectures = set(getattr(model_config, "architectures", ()) or ())
     return bool(
         "Qwen3_5ForConditionalGeneration" in architectures
-        and getattr(model_config, "quantization", None) == "compressed-tensors"
+        and _is_compressed_tensors_nvfp4(model_config)
         and getattr(model_config, "dtype", None) == torch.float16
         and getattr(hf_text_config, "hidden_size", None) == 5120
         and getattr(hf_text_config, "num_attention_heads", None) == 24
@@ -568,7 +588,8 @@ class VllmConfig:
     performance_mode: PerformanceMode = "balanced"
     """Performance mode for runtime behavior, 'balanced' is the default.
     'interactivity' favors low end-to-end per-request latency at small batch
-    sizes (fine-grained CUDA graphs, latency-oriented kernels).
+    sizes (fine-grained CUDA graphs, latency-oriented kernels). For explicit
+    DFlash on SM70, it also selects the audited B1/q4096 capacity defaults.
     'throughput' favors aggregate tokens/sec at high concurrency (larger CUDA
     graphs, more aggressive batching, throughput-oriented kernels)."""
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1746,11 +1746,15 @@ class EngineArgs:
         usage_context: UsageContext | None,
         model_config: ModelConfig,
     ) -> None:
-        """Apply the 1Cat SM70 MTP baseline knobs that affect decode speed."""
-        if (
+        """Apply the 1Cat SM70 speculative serving defaults."""
+        mtp_defaults_disabled = (
             envs.VLLM_1CAT_DISABLE_SM70_MTP_DEFAULTS
             or envs.VLLM_1CAT_DISABLE_QWEN35_MTP_DEFAULTS
-        ):
+        )
+        explicit_dflash = isinstance(self.speculative_config, dict) and (
+            self.speculative_config.get("method") == "dflash"
+        )
+        if mtp_defaults_disabled and not explicit_dflash:
             return
         if not current_platform.is_cuda_alike():
             return
@@ -1758,7 +1762,7 @@ class EngineArgs:
             cap = current_platform.get_device_capability()
         except Exception:
             return
-        if cap is None or cap.major != 7:
+        if cap is None or (cap.major, cap.minor) != (7, 0):
             return
 
         text_config = model_config.hf_text_config
@@ -1827,9 +1831,25 @@ class EngineArgs:
                 f"speculative_config.draft_sample_method={draft_sample_method}"
             )
 
-        if spec_method != "mtp":
+        if "attention_backend" not in self.speculative_config:
+            self.speculative_config["attention_backend"] = "FLASH_ATTN_V100"
+            profile_updates.append(
+                "speculative_config.attention_backend=FLASH_ATTN_V100"
+            )
+
+        if spec_method == "dflash":
+            # The quality-audited Qwen3.8 DFlash2 latency profile is B1 with a
+            # 4096-token prefill chunk. Apply it only when the user explicitly
+            # asks for interactivity and has not supplied either capacity knob.
+            if self.performance_mode == "interactivity":
+                if self.max_num_seqs is None:
+                    self.max_num_seqs = 1
+                    profile_updates.append("max_num_seqs=1")
+                if self.max_num_batched_tokens is None:
+                    self.max_num_batched_tokens = 4096
+                    profile_updates.append("max_num_batched_tokens=4096")
             if profile_updates:
-                logger.info(
+                logger.info_once(
                     "Applied SM70 speculative defaults: %s",
                     ", ".join(profile_updates),
                 )
@@ -1838,12 +1858,6 @@ class EngineArgs:
         if "use_local_argmax_reduction" not in self.speculative_config:
             self.speculative_config["use_local_argmax_reduction"] = True
             profile_updates.append("speculative_config.use_local_argmax_reduction=True")
-
-        if "attention_backend" not in self.speculative_config:
-            self.speculative_config["attention_backend"] = "FLASH_ATTN_V100"
-            profile_updates.append(
-                "speculative_config.attention_backend=FLASH_ATTN_V100"
-            )
 
         if self.max_num_seqs is None:
             self.max_num_seqs = 4 if self.tensor_parallel_size >= 4 else 1


### PR DESCRIPTION
## Purpose

Prepare the quality-audited Qwen3.8 NVFP4 DFlash2 path for the 1.5.0 wheel without changing kernel arithmetic or sampling semantics.

- default explicit SM70 DFlash to the draft `FLASH_ATTN_V100` backend
- make `--performance-mode interactivity` select the accepted B1/q4096 capacity values only when the user did not set them
- derive DFlash2 draft width from checkpoint block size (`8 -> 7`) when omitted
- require a real NVFP4 format group before enabling the NVFP4-only practical defaults
- keep legacy MTP-disable flags from suppressing explicit DFlash defaults and exclude SM75 from SM70 policy
- publish the validated TP4 launch command, automatic values, rollback boundary, and SM70-only wheel build arch

Integration base: `187b932dbd11940f0bcf52fb3675dd47fd69f313`

Head: `8d3a63711d77e7a9bae152f47e56525c72b8f517`

## Test Plan

- run focused SM70 EngineArgs default tests
- run the full CPU DFlash2 targeted suite with CUDA-only cases skipped
- run the Qwen3 coder tool parser suite
- load the fixed official DFlash2 config revision without `num_speculative_tokens` and confirm q7/top16
- load the local mixed-precision NVFP4 config and confirm the nested NVFP4 group gate
- run changed-file pre-commit, compileall, and diff checks
- after the 1.5.0 wheel is built, install it in a clean Python 3.12 environment and run grouped-verifier capability, API tool/schema, and TP4 route smokes

## Test Result

- SM70 EngineArgs: `13 passed, 76 deselected`
- DFlash2 targeted CPU suite: `84 passed, 12 skipped`
- Qwen3 coder tool parser: `104 passed`
- official `incoai/Qwen3.8-27B-DFlash2@dedf8df68adfb1afeaf7b7480c0a0243108177b4` config resolves block size 8, selector top-K 16, and default draft width 7
- official config SHA256: `873e3556509b0da06e29654ba00d4944888d4b5e8a33afde25f7eb27d321e980`
- local mixed compressed-tensors checkpoint resolves `nvfp4-pack-quantized` correctly; a same-shape float-only config is rejected by the practical gate
- changed-file pre-commit: passed
- `python -m compileall`: passed
- `git diff --check`: passed

No new GPU throughput claim is made. This PR selects already measured values; the retained matched result is 17.3767 ms per complete DFlash2 round and 4039.49 token/s cold 32K prefill. Final wheel install/runtime smoke remains a pre-tag gate.

