### PR TITLE
[CI/Build] Harden SM70 wheel assembly and API dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ Keep a custom `TMPDIR` short enough for Linux Unix-domain sockets; the default
 `/tmp` is safe. Very long cache-derived temporary paths can exceed ZeroMQ's IPC
 path limit before model loading starts.
 
+`max_tokens`/`max_completion_tokens` covers both reasoning and the final
+answer. For short JSON-schema responses and other machine-consumed calls,
+either give reasoning enough output budget or disable it for that request with
+`"chat_template_kwargs":{"enable_thinking":false}`. This keeps the server's
+reasoning default available for general requests while preventing a small
+completion budget from ending after reasoning but before the structured
+answer.
+
 ## OpenAI-Compatible Request Example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ python -m pip install -r requirements/common.txt
 python -m pip install cmake build
 ```
 
+The build requirements install `patchelf`. Do not remove it: SM70 wheel
+assembly fails closed when a bundled CUDA extension cannot have its
+build-machine RPATH removed.
+
 Build wheels:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -355,7 +355,9 @@ python -m pip install cmake build
 
 The build requirements install `patchelf`. Do not remove it: SM70 wheel
 assembly fails closed when a bundled CUDA extension cannot have its
-build-machine RPATH removed.
+build-machine RPATH removed. Re-running a build in the same worktree is
+supported; the downloaded Flash-Attention dependency is restored to its pinned
+commit before the SM70 patch set is reapplied.
 
 Build wheels:
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ concurrent service. That preserves capacity but intentionally leaves the B1
 also an authoritative rollback. Do not enable candidate-order reranking;
 dense-order reranking is the validated path.
 
+Keep a custom `TMPDIR` short enough for Linux Unix-domain sockets; the default
+`/tmp` is safe. Very long cache-derived temporary paths can exceed ZeroMQ's IPC
+path limit before model loading starts.
+
 ## OpenAI-Compatible Request Example
 
 ```bash

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -55,6 +55,10 @@ elseif(VLLM_FLASH_ATTN_SM70)
           COMMAND
             ${GIT_EXECUTABLE} -C <SOURCE_DIR> clean -fd
           COMMAND
+            ${GIT_EXECUTABLE} -C <SOURCE_DIR>/csrc/cutlass reset --hard
+          COMMAND
+            ${GIT_EXECUTABLE} -C <SOURCE_DIR>/csrc/cutlass clean -fd
+          COMMAND
             ${PATCH_EXECUTABLE} --batch --forward -p1 -l
             -i ${CMAKE_CURRENT_LIST_DIR}/../patches/sm70_flash_attn_d256_pipeline.patch
           COMMAND

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -36,15 +36,25 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn
   )
 elseif(VLLM_FLASH_ATTN_SM70)
+  set(VLLM_FLASH_ATTN_SM70_COMMIT c2eda5e6115b98c3ba4bfd181570668742eece22)
+  find_package(Git REQUIRED)
   find_program(PATCH_EXECUTABLE patch REQUIRED)
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/zhinianqin/flash-attention-v100.git
-          GIT_TAG c2eda5e6115b98c3ba4bfd181570668742eece22
+          GIT_TAG ${VLLM_FLASH_ATTN_SM70_COMMIT}
           GIT_PROGRESS TRUE
           GIT_SUBMODULES csrc/cutlass
           GIT_SUBMODULES_RECURSE TRUE
           PATCH_COMMAND
+            # FetchContent can rerun PATCH_COMMAND on reconfigure. Restore the
+            # pinned dependency first so an incremental wheel rebuild is
+            # deterministic instead of trying to patch an already-patched tree.
+            ${GIT_EXECUTABLE} -C <SOURCE_DIR> reset --hard
+            ${VLLM_FLASH_ATTN_SM70_COMMIT}
+          COMMAND
+            ${GIT_EXECUTABLE} -C <SOURCE_DIR> clean -fd
+          COMMAND
             ${PATCH_EXECUTABLE} --batch --forward -p1 -l
             -i ${CMAKE_CURRENT_LIST_DIR}/../patches/sm70_flash_attn_d256_pipeline.patch
           COMMAND

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44739,6 +44739,11 @@ Interpretation:
   fails closed if it is absent or cannot remove an RPATH. This converts a
   silent portability hazard into a build-time error and applies to source and
   precompiled-extension wheel assembly.
+- The first incremental rebuild also exposed a pre-existing FetchContent
+  failure: CMake reran the SM70 FA2 patch command against its already-patched
+  source checkout. The patch step now resets and cleans only the downloaded,
+  pinned dependency before reapplying the four repository patches. Explicit
+  `VLLM_FLASH_ATTN_SRC_DIR` development trees remain outside this reset path.
 - The rejected diagnostic wheel is
   `/data/minimax-h3/task-cache/v100-release150-wheel-20260831/dist/`
   `1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`, SHA256

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44742,8 +44742,9 @@ Interpretation:
 - The first incremental rebuild also exposed a pre-existing FetchContent
   failure: CMake reran the SM70 FA2 patch command against its already-patched
   source checkout. The patch step now resets and cleans only the downloaded,
-  pinned dependency before reapplying the four repository patches. Explicit
-  `VLLM_FLASH_ATTN_SRC_DIR` development trees remain outside this reset path.
+  pinned dependency and its CUTLASS submodule before reapplying the four
+  repository patches. Explicit `VLLM_FLASH_ATTN_SRC_DIR` development trees
+  remain outside this reset path.
 - The rejected diagnostic wheel is
   `/data/minimax-h3/task-cache/v100-release150-wheel-20260831/dist/`
   `1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`, SHA256

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44751,3 +44751,16 @@ Interpretation:
   `e09fd22f4030560a54ad59a783d82ee054e52ea6da014c5c755ee5e8a51a8fb1`.
   Do not publish it. A rebuilt wheel must show no absolute RPATH before its
   clean-environment and four-V100 runtime gates count.
+- The first RPATH-clean replacement, SHA256
+  `112888af049c66fecdc96aa1cee12ca16ede54aee62819dd8018762069352995`,
+  has no `RPATH` or `RUNPATH` in any of its nine native libraries and installs
+  in an isolated Python 3.12 environment. It is nevertheless also rejected:
+  its dependency metadata selects FastAPI `0.141.1` together with
+  `prometheus-fastapi-instrumentator` `7.1.0`. A real Uvicorn request then
+  fails with HTTP 500 because the metrics middleware reads `.path` from
+  FastAPI's `_IncludedRouter`.
+- The metrics dependency now requires `prometheus-fastapi-instrumentator`
+  `>=8.1.0,<9.0.0`. Upstream fixed `_IncludedRouter` handling in `8.0.1`, and
+  `8.1.0` also repairs nested-route resolution. A final wheel must resolve the
+  new dependency contract, pass `pip check`, and repeat the live plain-chat,
+  tool-call, and JSON-schema API gates before publication.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44753,7 +44753,7 @@ Interpretation:
   clean-environment and four-V100 runtime gates count.
 - The first RPATH-clean replacement, SHA256
   `112888af049c66fecdc96aa1cee12ca16ede54aee62819dd8018762069352995`,
-  has no `RPATH` or `RUNPATH` in any of its nine native libraries and installs
+  has no `RPATH` or `RUNPATH` in any of its ten native libraries and installs
   in an isolated Python 3.12 environment. It is nevertheless also rejected:
   its dependency metadata selects FastAPI `0.141.1` together with
   `prometheus-fastapi-instrumentator` `7.1.0`. A real Uvicorn request then
@@ -44764,3 +44764,46 @@ Interpretation:
   `8.1.0` also repairs nested-route resolution. A final wheel must resolve the
   new dependency contract, pass `pip check`, and repeat the live plain-chat,
   tool-call, and JSON-schema API gates before publication.
+
+### Final wheel proof
+
+- The final wheel was built from exact head
+  `c660086aa1aa264058b1fe54c1cd9f0620bb978d` and is stored at
+  `/data/minimax-h3/task-cache/v100-release150-wheel-20260831/dist-final/`
+  `1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`. Its size is `147,963,867`
+  bytes and SHA256 is
+  `9dbb1118d670f081563b202127e77af41f9261d9ec7f7a829ec1357f53037d71`.
+  It is a validated release candidate, not a published/tagged artifact.
+- The wheel contains ten expected native libraries. All ten have zero
+  `RPATH`/`RUNPATH`, no `/home/ymzx` string, and no unresolved dependency when
+  checked with the normal Torch/CUDA runtime library set. Wheel metadata is
+  version `1.5.0` and requires
+  `prometheus-fastapi-instrumentator>=8.1.0,<9.0.0`.
+- A source-independent Python 3.12 environment force-installed the final wheel
+  and passed `pip check` with FastAPI `0.141.1`, Starlette `1.6.0`, and
+  instrumentator `8.1.0`. On a V100-SXM2 it imported the core and SM70
+  extensions, FlashQLA, grouped-verifier q16 capability, QPN2 prepare/decode/
+  prefill dispatch, SM70 LM-head top20, and the Qwen3 Coder tool parser.
+- The wheel then started a real TP4/B1 server on four V100s with the README
+  profile. Startup logs resolved q7/probabilistic DFlash2, target and draft
+  Flash-V100, FP8 E5M2 target KV, prefix cache plus Mamba align, q4096,
+  QPN2-packed prefill, exact grouped verification, and the quality-audited
+  DFlash2 defaults without explicit fast-path environment variables.
+- `/v1/models` and `/metrics` both returned HTTP 200. Plain chat returned
+  `42`; non-streaming `get_weather` and streaming `read_file` calls returned
+  the correct function names and JSON arguments; JSON-schema output returned
+  exactly `{"name":"小林","age":27}`. The schema case passed with thinking
+  enabled at a 512-token budget and with per-request thinking disabled at a
+  128-token budget. A 128-token thinking budget ended in reasoning before the
+  final JSON, confirming normal shared-budget semantics rather than DFlash2
+  token corruption; the public README now calls out this request contract.
+- Two identical 10,017-token prefix requests returned the same `收到` output.
+  Wall time fell from `2.642 s` cold to `0.164 s` cached, and the server
+  reported a `47.3%` aggregate prefix-cache hit rate while hitting the
+  Flash-V100 prefix/chunked prefill and FP8-KV routes. Shutdown released GPUs
+  4-7 back to `5 MiB` each.
+- A completely cold Triton cache still JIT-compiled three small kernels on the
+  first inference (`_sm70_qwen35_gdn_split_kernel`,
+  `_prepare_dflash_inputs_kernel`, and `layer_norm_fwd_kernel`). The request
+  remained correct and completed in `0.547 s`; this is a bounded cold-start
+  warmup follow-up, not a steady-state or publication correctness blocker.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44725,3 +44725,23 @@ Interpretation:
   the matched four-V100 source-default proof. A built 1.5.0 wheel still needs
   install/import, grouped-verifier max-q, API tool/schema, and TP4 route smokes
   before tagging.
+
+## 2026-08-31 1.5.0 wheel RPATH release gate
+
+- The first post-merge 1.5.0 RC wheel built successfully from
+  `onecat/main@87c615a02ffcba08cc00a0e48ad1363a23cb29d6`, but the build
+  environment did not contain `patchelf`. Packaging only warned and retained
+  the build host's absolute Conda RPATH in both bundled Flash-V100 extensions.
+  `readelf -d` reported
+  `/home/ymzx/miniconda3/envs/1cat-vllm-1.3.0/lib`; that artifact is rejected
+  even though it can import on the build host.
+- The build dependency contract now installs `patchelf`, and wheel assembly
+  fails closed if it is absent or cannot remove an RPATH. This converts a
+  silent portability hazard into a build-time error and applies to source and
+  precompiled-extension wheel assembly.
+- The rejected diagnostic wheel is
+  `/data/minimax-h3/task-cache/v100-release150-wheel-20260831/dist/`
+  `1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`, SHA256
+  `e09fd22f4030560a54ad59a783d82ee054e52ea6da014c5c755ee5e8a51a8fb1`.
+  Do not publish it. A rebuilt wheel must show no absolute RPATH before its
+  clean-environment and four-V100 runtime gates count.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
+    "patchelf>=0.19.1.0",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools-scm>=8.0",
     "setuptools-rust>=1.9.0",

--- a/requirements/build/cuda.txt
+++ b/requirements/build/cuda.txt
@@ -2,6 +2,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
+patchelf>=0.19.1.0
 setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,7 +17,8 @@ openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.13.4, < 2.14.0
 prometheus_client >= 0.26.0
 pillow  # Required for image processing
-prometheus-fastapi-instrumentator >= 7.0.0, < 8.0.0
+# v8.0.1+ supports FastAPI's _IncludedRouter; v8.1 fixes nested-route resolution.
+prometheus-fastapi-instrumentator >= 8.1.0, < 9.0.0
 tiktoken >= 0.14.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
 llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le"

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -50,15 +50,12 @@ arctic-inference==0.2.0
     # via -r requirements/test/rocm.in
 argcomplete==3.6.3
     # via datamodel-code-generator
-arrow==1.4.0
-    # via isoduration
 astor==0.8.1
     # via depyf
 attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema
-    #   pytest-subtests
     #   referencing
 audioread==3.0.1
     # via librosa
@@ -73,9 +70,7 @@ azure-identity==1.25.3
 azure-storage-blob==12.28.0
     # via runai-model-streamer-azure
 backoff==2.2.1
-    # via
-    #   -r requirements/test/rocm.in
-    #   schemathesis
+    # via -r requirements/test/rocm.in
 bitsandbytes==0.50.1
     # via -r requirements/test/rocm.in
 black==26.3.1
@@ -138,7 +133,6 @@ colorama==0.4.6
     # via
     #   perceptron
     #   sacrebleu
-    #   schemathesis
 colorful==0.5.8
     # via ray
 colorlog==6.10.1
@@ -257,8 +251,6 @@ filelock==3.32.4
     #   virtualenv
 fonttools==4.62.1
     # via matplotlib
-fqdn==1.5.1
-    # via jsonschema
 frozendict==2.4.7
     # via einx
 frozenlist==1.8.0
@@ -331,7 +323,7 @@ h11==0.16.0
     #   uvicorn
 h2==4.3.0
     # via httpx
-harfile==0.4.0
+harfile==0.5.0
     # via schemathesis
 hf-xet==1.4.3
     # via huggingface-hub
@@ -356,7 +348,6 @@ httpx==0.27.2
     #   model-hosting-container-standards
     #   openai
     #   perceptron
-    #   schemathesis
 httpx-sse==0.4.3
     # via mcp
 huggingface-hub==1.10.2
@@ -379,18 +370,14 @@ hyperframe==6.1.0
 hypothesis==6.151.9
     # via
     #   hypothesis-graphql
-    #   hypothesis-jsonschema
     #   schemathesis
-hypothesis-graphql==0.12.0
-    # via schemathesis
-hypothesis-jsonschema==0.23.1
+hypothesis-graphql==0.13.1
     # via schemathesis
 idna==3.11
     # via
     #   anyio
     #   email-validator
     #   httpx
-    #   jsonschema
     #   requests
     #   yarl
 ijson==3.5.0
@@ -409,8 +396,6 @@ interegular==0.3.3
     # via lm-format-enforcer
 isodate==0.7.2
     # via azure-storage-blob
-isoduration==20.11.0
-    # via jsonschema
 isort==8.0.1
     # via datamodel-code-generator
 jinja2==3.1.6
@@ -436,19 +421,15 @@ joblib==1.5.3
     #   librosa
     #   nltk
     #   scikit-learn
-jsonpointer==3.1.0
-    # via jsonschema
 jsonschema==4.26.0
     # via
-    #   hypothesis-jsonschema
     #   mcp
     #   mistral-common
     #   ray
-    #   schemathesis
+jsonschema-rs==0.51.0
+    # via schemathesis
 jsonschema-specifications==2025.9.1
     # via jsonschema
-junit-xml==1.9
-    # via schemathesis
 kaldi-native-fbank==1.22.3
     # via -r requirements/test/rocm.in
 kaleido==1.0.0
@@ -792,7 +773,7 @@ prometheus-client==0.26.0
     #   opentelemetry-exporter-prometheus
     #   prometheus-fastapi-instrumentator
     #   ray
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.1.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -876,20 +857,22 @@ pydantic-settings==2.13.1
     #   fastapi
     #   mcp
 pygments==2.19.2
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pyjwt==2.12.1
     # via
     #   mcp
     #   msal
 pyparsing==3.3.2
     # via matplotlib
-pyrate-limiter==3.9.0
+pyrate-limiter==4.5.0
     # via schemathesis
 pystemmer==3.0.0
     # via mteb
 pytablewriter==1.2.1
     # via lm-eval
-pytest==8.3.5
+pytest==9.1.1
     # via
     #   -r requirements/test/rocm.in
     #   buildkite-test-collector
@@ -900,10 +883,9 @@ pytest==8.3.5
     #   pytest-mock
     #   pytest-rerunfailures
     #   pytest-shard
-    #   pytest-subtests
     #   pytest-timeout
     #   schemathesis
-pytest-asyncio==0.24.0
+pytest-asyncio==1.4.0
     # via -r requirements/test/rocm.in
 pytest-cov==6.3.0
     # via -r requirements/test/rocm.in
@@ -915,13 +897,10 @@ pytest-rerunfailures==14.0
     # via -r requirements/test/rocm.in
 pytest-shard==0.1.2
     # via -r requirements/test/rocm.in
-pytest-subtests==0.14.2
-    # via schemathesis
 pytest-timeout==2.3.1
     # via -r requirements/test/rocm.in
 python-dateutil==2.9.0.post0
     # via
-    #   arrow
     #   botocore
     #   matplotlib
     #   pandas
@@ -1018,16 +997,13 @@ requests==2.34.2
     #   tiktoken
 responses==0.26.0
     # via genai-perf
-rfc3339-validator==0.1.4
-    # via jsonschema
-rfc3987==1.3.8
-    # via jsonschema
 rich==14.3.3
     # via
     #   genai-perf
     #   mteb
     #   perceptron
     #   rich-toolkit
+    #   schemathesis
     #   typer
 rich-toolkit==0.19.7
     # via
@@ -1065,7 +1041,7 @@ safetensors==0.8.0
     #   segmentation-models-pytorch
     #   timm
     #   transformers
-schemathesis==3.39.15
+schemathesis==4.25.2
     # via -r requirements/test/rocm.in
 scikit-image==0.26.0
     # via albumentations
@@ -1119,10 +1095,8 @@ six==1.17.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
-    #   junit-xml
     #   opencensus
     #   python-dateutil
-    #   rfc3339-validator
     #   rouge-score
 smart-open==7.5.1
     # via ray
@@ -1151,13 +1125,12 @@ sqlitedict==2.1.0
     # via lm-eval
 sse-starlette==3.3.4
     # via mcp
-starlette==0.52.1
+starlette==1.6.0
     # via
     #   fastapi
     #   mcp
     #   model-hosting-container-standards
     #   prometheus-fastapi-instrumentator
-    #   schemathesis
     #   sse-starlette
     #   starlette-testclient
 starlette-testclient==0.4.1
@@ -1217,10 +1190,6 @@ tokenizers==0.22.2
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
     #   transformers
-tomli==2.4.0
-    # via schemathesis
-tomli-w==1.2.0
-    # via schemathesis
 torch-c-dlpack-ext==0.1.5
     # via tilelang
 tqdm==4.67.3
@@ -1305,8 +1274,10 @@ typing-extensions==4.16.0
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   pytest-asyncio
     #   referencing
     #   rich-toolkit
+    #   schemathesis
     #   sentence-transformers
     #   sqlalchemy
     #   starlette
@@ -1321,10 +1292,6 @@ typing-inspection==0.4.2
     #   mcp
     #   pydantic
     #   pydantic-settings
-tzdata==2025.3
-    # via arrow
-uri-template==1.3.0
-    # via jsonschema
 urllib3==2.6.3
     # via
     #   blobfile
@@ -1355,8 +1322,6 @@ watchfiles==1.1.1
     #   uvicorn
 wcwidth==0.6.0
     # via ftfy
-webcolors==25.10.0
-    # via jsonschema
 websockets==16.0
     # via uvicorn
 werkzeug==3.1.6
@@ -1374,9 +1339,7 @@ xxhash==3.6.0
     #   datasets
     #   evaluate
 yarl==1.23.0
-    # via
-    #   aiohttp
-    #   schemathesis
+    # via aiohttp
 z3-solver==4.15.4.0
     # via tilelang
 

--- a/setup.py
+++ b/setup.py
@@ -280,9 +280,11 @@ def bundle_flash_qla_sm70(build_lib: str, build_temp: str) -> None:
 def remove_rpath(path: Path) -> None:
     patchelf = which("patchelf")
     if patchelf is None:
-        logger.warning("patchelf not found; leaving RPATH unchanged for %s", path)
-        return
-    subprocess.run([patchelf, "--remove-rpath", str(path)], check=False)
+        raise RuntimeError(
+            "patchelf is required to build a portable 1Cat SM70 wheel; "
+            f"refusing to leave a build-host RPATH in {path}"
+        )
+    subprocess.run([patchelf, "--remove-rpath", str(path)], check=True)
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
## Purpose

Harden the 1.5.0 SM70 wheel release path so a wheel cannot appear healthy on the build host while failing after installation.

This PR closes three independently reproduced release blockers:

- fail closed when patchelf is missing or a bundled extension retains build-host RPATH/RUNPATH
- make the pinned Flash-Attention/CUTLASS patch flow repeatable across incremental wheel builds
- require prometheus-fastapi-instrumentator >=8.1,<9 so FastAPI 0.141 nested routes and /metrics do not fail the first API request

It also documents the request-level reasoning budget contract for short structured outputs.

Integration base: 87c615a02ffcba08cc00a0e48ad1363a23cb29d6

Head: 56db3c16ded5b741fc47f40d7ef8f79f71227ac5

## Test Plan

- run changed-file pre-commit and Python/CMake build checks
- deliberately build without visible patchelf and require wheel assembly to fail
- rebuild exact head with SM70/CUDA 12.8 and inspect every native library
- install the final wheel into a source-independent Python 3.12 environment and run pip check
- import SM70 native extensions and verify q16 grouped verifier, QPN2 decode/prefill, top20 sampler, FlashQLA, and Qwen3 Coder parser
- start a real TP4 V100 DFlash2 API from the installed wheel
- exercise /v1/models, /metrics, plain chat, non-streaming and streaming tool calls, JSON schema, and repeated-prefix requests

## Test Result

- changed-file pre-commit: passed
- fail-closed build without visible patchelf: passed (artifact refused)
- rejected nonportable RC SHA256: e09fd22f4030560a54ad59a783d82ee054e52ea6da014c5c755ee5e8a51a8fb1
- rejected RPATH-clean but API-broken RC SHA256: 112888af049c66fecdc96aa1cee12ca16ede54aee62819dd8018762069352995
- final RC SHA256: 9dbb1118d670f081563b202127e77af41f9261d9ec7f7a829ec1357f53037d71
- final size: 147,963,867 bytes; version 1.5.0; ten native libraries; zero RPATH/RUNPATH; zero build-host paths
- isolated install: pip check passed with FastAPI 0.141.1, Starlette 1.6.0, instrumentator 8.1.0
- native V100 import/capability gate: passed
- live API: /v1/models 200, /metrics 200, plain 42 passed, tool calls passed, streaming tool call passed, JSON schema passed
- repeated 10,017-token prefix: identical output; 2.642 s cold to 0.164 s cached; prefix/chunked Flash-V100 route hit
- GPUs 4-7 returned to 5 MiB after shutdown

The final wheel is a validated release candidate only; this PR does not publish or tag it.