### PR TITLE
platform: disable custom all-reduce on SM70 (Volta) — TP2 was hitting non-converging capture + Xid 62

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -486,6 +486,13 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def use_custom_allreduce(cls) -> bool:
+        # The custom all-reduce kernel is not supported on SM70 (Volta): with
+        # TP > 1 on V100 (PCIe or NVLink) it leads to non-converging piecewise
+        # CUDA-graph capture, decode throughput collapse, and Xid 62 faults on
+        # both GPUs. Returning False makes the parallel config fall back to
+        # NCCL, which is stable on this architecture.
+        if cls.has_device_capability(70) and not cls.has_device_capability(75):
+            return False
         return True
 
     @classmethod


### PR DESCRIPTION
## Summary

`CudaPlatform.use_custom_allreduce()` returned True unconditionally, so TP>1 on
V100 (SM70) silently took the custom all-reduce path even though it is
unsupported on this architecture (already noted in the README known-issues).
This PR returns False for Volta (capability 7.0-7.4) so the existing
parallel-config fallback to NCCL kicks in automatically with the standard
debug message — users no longer need to know they must pass
`--disable-custom-all-reduce`.

## Evidence (2x Tesla V100-SXM2-32GB, PCIe, TP2, Qwen3.8-27B AWQ, 262K ctx)

| | without flag (custom AR) | with NCCL fallback (this change) |
|---|---|---|
| piecewise capture | never converges (>45 min at 0/3) | ~3 min total, FULL graphs in ~1 s |
| decode (27B AWQ, single stream) | ~0.1 tok/s | 50.5 tok/s |
| aggregate 4-way | — | 157 tok/s |
| driver health | Xid 62 on both GPUs, D-state processes, host reboot required | 0 Xid over multi-hour runs |

Detailed timeline in issue #430.

## Why this is not duplicating an existing PR

Searched issues/PRs for `custom all-reduce SM70`: the closest are #262 (graph-capture
VMM-safety of the custom AR — orthogonal) and #299 (TP4 small-AR tuning — different
path). No PR wires the platform hook for Volta; today only the manual flag or the
undocumented hook exist.

## Tests run

- 2x V100 TP2 full benchmark plan (A/B/C/D scenarios, 1-4 concurrent, greedy,
  prompts up to ~108K tokens), multiple hours: 0 Xid, clean dmesg, stable decode.
- Engine starts and logs the fallback message
  (`Disabled the custom all-reduce kernel because it is not supported on current platform.`)
- `python -m py_compile vllm/platforms/cuda.py` passes; change is 7 lines gated to
  capability 7.0-7.4, other architectures unaffected.

## AI assistance disclosure

This change was prepared with AI coding assistance (OpenCode agent, SabaTech.dev
lab). The submitting human reviewed every line, reproduced the failure and the fix
on real hardware, and takes accountability for the change.