### PR TITLE
[Bugfix] Harden API failures and SM70 shutdown cleanup

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44852,6 +44852,7 @@ Interpretation:
   `/home/ymzx/1cat-vllm-deploy/logs/`
   `nvfp4-dflash2-pr432-011adcf8ce-256k.log` and
   `/home/ymzx/1cat-vllm-deploy/test-artifacts/pr432-011adcf8ce/`.
+
 ## 2026-09-01 DFlash2 default-capacity 17 ms root cause
 
 - A matched four-V100 audit held the model, TP4, q8 verifier, E5M2 target KV,

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44807,3 +44807,48 @@ Interpretation:
   `_prepare_dflash_inputs_kernel`, and `layer_norm_fwd_kernel`). The request
   remained correct and completed in `0.547 s`; this is a bounded cold-start
   warmup follow-up, not a steady-state or publication correctness blocker.
+
+## 2026-08-31 API failure and in-process cleanup gate
+
+- Draft PR #432 is based on `onecat/main@9e860996550c692d42b6f7ca57ced1bffbd8dfe5`;
+  tested head is `011adcf8ce`. It changes no DFlash2 proposal, selector,
+  rejection, sampling, verifier, or attention arithmetic.
+- Historical assistant tool calls now preserve object arguments, decode valid
+  JSON objects, and coerce malformed, null, or non-object arguments to an empty
+  object. This prevents one truncated tool call from making every later turn
+  in the conversation fail during template rendering.
+- Async multimodal items are stored as deferred factories, so per-prompt limit
+  validation happens before a coroutine exists. Resolution gathers with
+  `return_exceptions=True`, drains sibling fetches, then re-raises the first
+  failure. The two-image-over-limit API probe returned the expected HTTP 400
+  and produced no `coroutine ... was never awaited` warning, including after
+  server shutdown.
+- MRV2 shutdown now drops the target and draft CUDA Graph managers, detaches
+  target and draft layer KV/state views, removes Dynamo bytecode hooks, releases
+  `model_state` and `speculator`, and clears process-global Flash-V100, FP8, and
+  NVFP4 workspace owners. The multimodal language-model lookup cache is weak
+  keyed so it no longer pins models for the interpreter lifetime.
+- Focused Python gates pass `15 passed`; changed-file Ruff formatting/checks
+  and `git diff --check` pass. The broader pre-existing multimodal suite was
+  stopped while downloading its external model/assets and is not counted.
+- Remote TP4 proof used four V100-SXM2-32GB GPUs, Qwen3.8-27B NVFP4 target,
+  FP8 E5M2 target KV, FP16 draft KV, q7 probabilistic DFlash2, 256K maximum
+  context, q4096 chunked prefill, prefix cache plus Mamba align, Flash-V100,
+  and target/draft CUDA Graphs. Startup hit exact grouped verification and the
+  quality-audited fast-path defaults.
+- A malformed historical tool call returned HTTP 200 and continued with `OK`;
+  forced `get_weather` returned valid Guangzhou arguments; JSON Schema returned
+  exactly `{"name":"Alice","age":30}`. A no-thinking coding smoke naturally
+  stopped with valid typed binary-search code and three assertions. Its 176
+  completion tokens took `0.889 s` wall time (about 198 completion token/s),
+  which is a route smoke rather than a new performance baseline.
+- Graceful termination removed the API, engine, and all four worker processes;
+  GPU 0-3 memory fell from `26,259 MiB` to `9 MiB` each. No recent `/dev/shm`
+  file, port listener, or unawaited-coroutine warning remained. Python's
+  multiprocessing resource tracker still reported semaphore/shared-memory
+  cleanup warnings while removing them; this is retained as a logging cleanup
+  follow-up, not evidence of a surviving process, file, or GPU allocation.
+- Retained remote log and request/response artifacts are under
+  `/home/ymzx/1cat-vllm-deploy/logs/`
+  `nvfp4-dflash2-pr432-011adcf8ce-256k.log` and
+  `/home/ymzx/1cat-vllm-deploy/test-artifacts/pr432-011adcf8ce/`.

--- a/tests/entrypoints/test_chat_utils_failure_lifecycle.py
+++ b/tests/entrypoints/test_chat_utils_failure_lifecycle.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import gc
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.entrypoints.chat_utils import (
+    AsyncMultiModalContentParser,
+    AsyncMultiModalItemTracker,
+    _postprocess_messages,
+)
+
+
+def _assistant_tool_call(arguments, name: str = "write"):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            ],
+        }
+    ]
+
+
+def test_tool_call_arguments_malformed_json_is_recoverable(caplog):
+    messages = _assistant_tool_call('{"cmd": "unterminated', name="exec")
+
+    _postprocess_messages(messages)
+
+    arguments = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert arguments == {}
+    assert len(caplog.records) == 1
+    assert "exec" in caplog.records[0].message
+    assert "coercing to an empty object" in caplog.records[0].message
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [({"path": "a"}, {"path": "a"}), ('{"path": "a"}', {"path": "a"}), (None, {})],
+)
+def test_tool_call_argument_objects_are_preserved(arguments, expected):
+    messages = _assistant_tool_call(arguments)
+
+    _postprocess_messages(messages)
+
+    normalized = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert normalized == expected
+
+
+@pytest.mark.parametrize("arguments", ["[]", "42", "true", '"text"', "null", []])
+def test_tool_call_arguments_must_be_an_object(arguments):
+    messages = _assistant_tool_call(arguments)
+
+    _postprocess_messages(messages)
+
+    normalized = messages[0]["tool_calls"][0]["function"]["arguments"]
+    assert normalized == {}
+
+
+def test_async_parser_does_not_create_coroutine_before_limit_validation():
+    class RejectingTracker:
+        def add(self, *_args, **_kwargs):
+            raise ValueError("too many image items")
+
+    parser = object.__new__(AsyncMultiModalContentParser)
+    parser._tracker = RejectingTracker()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        with pytest.raises(ValueError, match="too many image items"):
+            parser.parse_image("https://example.com/image.png")
+        gc.collect()
+
+    unawaited = [
+        warning for warning in caught if "was never awaited" in str(warning.message)
+    ]
+    assert not unawaited
+
+
+def test_resolve_items_drains_siblings_after_partial_failure():
+    completed = 0
+
+    async def fetch(should_fail: bool, delay: float):
+        nonlocal completed
+        await asyncio.sleep(delay)
+        if should_fail:
+            raise ValueError("simulated fetch failure")
+        completed += 1
+        return "decoded", None
+
+    async def run_test():
+        tracker = AsyncMultiModalItemTracker(MagicMock())
+        tracker._items_by_modality["image"] = [
+            lambda: fetch(True, 0.01),
+            lambda: fetch(False, 0.05),
+            lambda: fetch(False, 0.05),
+        ]
+
+        tasks_before = asyncio.all_tasks()
+        with pytest.raises(ValueError, match="simulated fetch failure"):
+            await tracker.resolve_items()
+
+        leaked_tasks = asyncio.all_tasks() - tasks_before
+        assert not leaked_tasks
+        assert completed == 2
+
+    asyncio.run(run_test())

--- a/tests/models/test_language_model_cache_is_weak.py
+++ b/tests/models/test_language_model_cache_is_weak.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+import weakref
+
+import pytest
+import torch.nn as nn
+
+from vllm.model_executor.models.interfaces import _language_model_by_module
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _LanguageModel(nn.Module):
+    def embed_input_ids(self, input_ids):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _MultiModalModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.language_model = _LanguageModel()
+
+
+def test_language_model_cache_is_weak_keyed():
+    assert isinstance(_language_model_by_module, weakref.WeakKeyDictionary)
+
+
+def test_language_model_cache_does_not_pin_model():
+    model = _MultiModalModel()
+    _language_model_by_module[model] = model.language_model
+    model_ref = weakref.ref(model)
+
+    del model
+    gc.collect()
+
+    assert model_ref() is None

--- a/tests/v1/worker/test_release_cleanup.py
+++ b/tests/v1/worker/test_release_cleanup.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+from vllm.v1.worker.utils import clear_layer_kv_caches
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _AttentionLayer(nn.Module):
+    def __init__(self, kv_cache):
+        super().__init__()
+        self.kv_cache = kv_cache
+        self.impl = SimpleNamespace(
+            _k_scale_cache=torch.ones(1),
+            _v_scale_cache=torch.ones(1),
+        )
+
+
+def test_clear_layer_kv_caches_detaches_tensor_and_scale_views():
+    tensor_layer = _AttentionLayer(torch.ones(4))
+    list_layer = _AttentionLayer([torch.ones(4)])
+
+    clear_layer_kv_caches([tensor_layer, list_layer])
+
+    assert isinstance(tensor_layer.kv_cache, torch.Tensor)
+    assert tensor_layer.kv_cache.numel() == 0
+    assert list_layer.kv_cache == []
+    assert tensor_layer.impl._k_scale_cache is None
+    assert tensor_layer.impl._v_scale_cache is None
+
+
+def test_compile_wrapper_cleanup_is_idempotent():
+    wrapper = object.__new__(TorchCompileWithNoGuardsWrapper)
+    handle = MagicMock()
+    wrapper._bytecode_hook_handle = handle
+
+    wrapper.cleanup()
+    wrapper.cleanup()
+
+    handle.remove.assert_called_once_with()
+    assert wrapper._bytecode_hook_handle is None
+
+
+def test_sm70_workspace_cleanup_releases_all_tensor_owners():
+    from vllm.model_executor.layers.quantization import fp8, sm70_turbomind
+    from vllm.v1.attention.backends import flash_attn_v100
+    from vllm.v1.worker.gpu.shutdown import _clear_loaded_gpu_workspaces
+
+    tensor = torch.ones(1)
+    flash_attn_v100._sm70_fa2_cu_seqlens_cache[(0, 0, 0, 0)] = (tensor, tensor)
+    flash_attn_v100._fp8_prefill_bridge_workspaces[(0, 0, 0, 0)] = (
+        tensor,
+        tensor,
+        tensor,
+    )
+    flash_attn_v100._fp8_prefill_bridge_tail_workspaces[(0, 0, tensor.dtype, 0, 0)] = (
+        tensor,
+        tensor,
+    )
+    flash_attn_v100._prefill_gather_dense_workspaces[(0, 0, tensor.dtype, 0, 0, 0)] = (
+        tensor,
+        tensor,
+    )
+    flash_attn_v100._prefill_dense_splitkv3_workspaces[(0, 0, tensor.dtype)] = (
+        tensor,
+        tensor,
+        tensor,
+    )
+    fp8._sm70_fp8_prefill_dense_workspaces[(0, tensor.dtype)] = tensor
+    fp8._sm70_fp8_qpn8_pp2_tp4_workspaces[(0, tensor.dtype)] = tensor
+    sm70_turbomind._nvfp4_qpn4_dense_workspaces[(0, tensor.dtype)] = tensor
+
+    _clear_loaded_gpu_workspaces()
+
+    assert not flash_attn_v100._sm70_fa2_cu_seqlens_cache
+    assert not flash_attn_v100._fp8_prefill_bridge_workspaces
+    assert not flash_attn_v100._fp8_prefill_bridge_tail_workspaces
+    assert not flash_attn_v100._prefill_gather_dense_workspaces
+    assert not flash_attn_v100._prefill_dense_splitkv3_workspaces
+    assert not fp8._sm70_fp8_prefill_dense_workspaces
+    assert not fp8._sm70_fp8_qpn8_pp2_tp4_workspaces
+    assert not sm70_turbomind._nvfp4_qpn4_dense_workspaces
+
+
+def test_mrv2_shutdown_drops_target_draft_graph_and_model_refs(monkeypatch):
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+    from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+    target_model = nn.Sequential(_AttentionLayer(torch.ones(4)))
+    draft_model = nn.Sequential(_AttentionLayer(torch.ones(4)))
+    draft_graph_manager = object()
+    speculator = SimpleNamespace(
+        model=draft_model,
+        query_cudagraph_manager=draft_graph_manager,
+    )
+
+    runner = object.__new__(GPUModelRunner)
+    runner.vllm_config = MagicMock()
+    runner._ple_offload_connector = None
+    runner.cudagraph_manager = object()
+    runner.kv_caches = [torch.ones(4)]
+    runner.attn_groups = [object()]
+    runner.kv_cache_config = object()
+    runner.model_state = SimpleNamespace(model=target_model)
+    runner.speculator = speculator
+    runner.model = target_model
+
+    monkeypatch.setattr(
+        model_runner_module.torch.accelerator, "synchronize", MagicMock()
+    )
+    monkeypatch.setattr(
+        model_runner_module.torch.accelerator, "empty_cache", MagicMock()
+    )
+    monkeypatch.setattr(model_runner_module, "free_before_shutdown", MagicMock())
+    monkeypatch.setattr(model_runner_module.gc, "collect", MagicMock())
+
+    runner.shutdown()
+
+    assert runner.cudagraph_manager is None
+    assert speculator.query_cudagraph_manager is None
+    assert runner.speculator is None
+    assert not hasattr(runner, "model_state")
+    assert not hasattr(runner, "model")
+    assert runner.kv_caches == []
+    assert runner.attn_groups == []
+    assert target_model[0].kv_cache.numel() == 0
+    assert draft_model[0].kv_cache.numel() == 0

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -154,7 +154,9 @@ class TorchCompileWithNoGuardsWrapper:
             )
 
         if envs.VLLM_USE_BYTECODE_HOOK and mode != CompilationMode.STOCK_TORCH_COMPILE:
-            torch._dynamo.convert_frame.register_bytecode_hook(self.bytecode_hook)
+            self._bytecode_hook_handle = (
+                torch._dynamo.convert_frame.register_bytecode_hook(self.bytecode_hook)
+            )
             self._compiled_bytecode: CodeType | None = None
 
     def aot_compile(self, *args: Any, **kwargs: Any) -> Any:
@@ -260,6 +262,13 @@ class TorchCompileWithNoGuardsWrapper:
                 f"(please search for the usage of the function `update`):\n{src}"
             )
             raise RuntimeError(msg)
+
+    def cleanup(self) -> None:
+        """Remove the Dynamo bytecode hook registered by this instance."""
+        handle = getattr(self, "_bytecode_hook_handle", None)
+        if handle is not None:
+            handle.remove()
+            self._bytecode_hook_handle = None
 
     @contextmanager
     def _dispatch_to_compiled_code(self) -> Generator[None, None, None]:

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -405,6 +405,7 @@ ModalityStr = Literal[
     "prompt_embeds",
 ]
 _T = TypeVar("_T")
+_AsyncMultiModalItem: TypeAlias = Callable[[], Awaitable[tuple[object, str | None]]]
 
 
 # Backward compatibility for single item input
@@ -798,19 +799,24 @@ class MultiModalItemTracker(BaseMultiModalItemTracker[tuple[object, str | None]]
         return MultiModalContentParser(self, mm_processor_kwargs=mm_processor_kwargs)
 
 
-class AsyncMultiModalItemTracker(
-    BaseMultiModalItemTracker[Awaitable[tuple[object, str | None]]]
-):
+class AsyncMultiModalItemTracker(BaseMultiModalItemTracker[_AsyncMultiModalItem]):
     async def resolve_items(
         self,
     ) -> tuple[MultiModalDataDict | None, MultiModalUUIDDict | None]:
         if not self._items_by_modality:
             return None, None
 
-        resolved_items_by_modality = {
-            modality: await asyncio.gather(*coros)
-            for modality, coros in self._items_by_modality.items()
-        }
+        resolved_items_by_modality: dict[str, list[Any]] = {}
+        for modality, items in self._items_by_modality.items():
+            results = await asyncio.gather(
+                *(item() for item in items), return_exceptions=True
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    # Drain every fetch in this modality before propagating an
+                    # error so no network/thread-pool work is left detached.
+                    raise result
+            resolved_items_by_modality[modality] = results
 
         mm_processor = (
             self.mm_processor if self._model_config.is_multimodal_model else None
@@ -1062,6 +1068,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
     def model_config(self) -> ModelConfig:
         return self._tracker.model_config
 
+    async def _item_with_uuid_async(self, item: object, uuid: str | None):
+        return item, uuid
+
     @override
     def parse_prompt_embeds(self, data: str) -> None:
         """Schedule async prompt embeds decode and store the coroutine in the tracker.
@@ -1073,8 +1082,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         if not self.model_config.enable_prompt_embeds:
             raise ValueError(_ENABLE_PROMPT_EMBEDS_ERROR)
 
-        coro = self._load_prompt_embeds_async(data.encode())
-        self._tracker.add("prompt_embeds", coro)
+        self._tracker.add(
+            "prompt_embeds", partial(self._load_prompt_embeds_async, data.encode())
+        )
         self._add_placeholder("prompt_embeds", PROMPT_EMBEDS_PLACEHOLDER_TOKEN)
 
     async def _load_prompt_embeds_async(
@@ -1092,9 +1102,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return image, uuid
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
-        coro = self._image_with_uuid_async(image_url, uuid)
-
-        placeholder = self._tracker.add("image", coro)
+        placeholder = self._tracker.add(
+            "image", partial(self._image_with_uuid_async, image_url, uuid)
+        )
         self._add_placeholder("image", placeholder)
 
     def parse_image_embeds(
@@ -1108,25 +1118,19 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
                 "You must set `--enable-mm-embeds` to input `image_embeds`"
             )
 
-        future = asyncio.Future[
-            tuple[torch.Tensor | dict[str, torch.Tensor] | None, str | None]
-        ]()
-
         if isinstance(image_embeds, dict):
             embeds = {
                 k: self._connector.fetch_image_embedding(v)
                 for k, v in image_embeds.items()
             }
-            future.set_result((embeds, uuid))
+        elif isinstance(image_embeds, str):
+            embeds = self._connector.fetch_image_embedding(image_embeds)
+        else:
+            embeds = None
 
-        if isinstance(image_embeds, str):
-            embedding = self._connector.fetch_image_embedding(image_embeds)
-            future.set_result((embedding, uuid))
-
-        if image_embeds is None:
-            future.set_result((None, uuid))
-
-        placeholder = self._tracker.add("image_embeds", future)
+        placeholder = self._tracker.add(
+            "image_embeds", partial(self._item_with_uuid_async, embeds, uuid)
+        )
         self._add_placeholder("image", placeholder)
 
     def parse_audio_embeds(
@@ -1140,25 +1144,19 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
                 "You must set `--enable-mm-embeds` to input `audio_embeds`"
             )
 
-        future = asyncio.Future[
-            tuple[torch.Tensor | dict[str, torch.Tensor] | None, str | None]
-        ]()
-
         if isinstance(audio_embeds, dict):
             embeds = {
                 k: self._connector.fetch_audio_embedding(v)
                 for k, v in audio_embeds.items()
             }
-            future.set_result((embeds, uuid))
+        elif isinstance(audio_embeds, str):
+            embeds = self._connector.fetch_audio_embedding(audio_embeds)
+        else:
+            embeds = None
 
-        if isinstance(audio_embeds, str):
-            embedding = self._connector.fetch_audio_embedding(audio_embeds)
-            future.set_result((embedding, uuid))
-
-        if audio_embeds is None:
-            future.set_result((None, uuid))
-
-        placeholder = self._tracker.add("audio_embeds", future)
+        placeholder = self._tracker.add(
+            "audio_embeds", partial(self._item_with_uuid_async, embeds, uuid)
+        )
         self._add_placeholder("audio", placeholder)
 
     def parse_image_pil(
@@ -1166,13 +1164,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         image_pil: Image.Image | None,
         uuid: str | None = None,
     ) -> None:
-        future = asyncio.Future[tuple[Image.Image | None, str | None]]()
-        if image_pil:
-            future.set_result((image_pil, uuid))
-        else:
-            future.set_result((None, uuid))
-
-        placeholder = self._tracker.add("image", future)
+        placeholder = self._tracker.add(
+            "image", partial(self._item_with_uuid_async, image_pil, uuid)
+        )
         self._add_placeholder("image", placeholder)
 
     async def _audio_with_uuid_async(self, audio_url: str | None, uuid: str | None):
@@ -1182,9 +1176,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return audio, uuid
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
-        coro = self._audio_with_uuid_async(audio_url, uuid)
-
-        placeholder = self._tracker.add("audio", coro)
+        placeholder = self._tracker.add(
+            "audio", partial(self._audio_with_uuid_async, audio_url, uuid)
+        )
         self._add_placeholder("audio", placeholder)
 
     def parse_input_audio(
@@ -1210,9 +1204,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return video, uuid
 
     def parse_video(self, video_url: str | None, uuid: str | None = None) -> None:
-        coro = self._video_with_uuid_async(video_url, uuid)
-
-        placeholder = self._tracker.add("video", coro)
+        placeholder = self._tracker.add(
+            "video", partial(self._video_with_uuid_async, video_url, uuid)
+        )
         self._add_placeholder("video", placeholder)
 
         # Extract audio from video if use_audio_in_video is True
@@ -1221,8 +1215,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
             and self._mm_processor_kwargs
             and self._mm_processor_kwargs.get("use_audio_in_video", False)
         ):
-            audio_coro = self._audio_with_uuid_async(video_url, uuid)
-            audio_placeholder = self._tracker.add("audio", audio_coro)
+            audio_placeholder = self._tracker.add(
+                "audio", partial(self._audio_with_uuid_async, video_url, uuid)
+            )
             self._add_placeholder("audio", audio_placeholder)
 
 
@@ -1834,10 +1829,39 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                         parameter="tool_calls",
                     )
 
-                # if arguments is None or empty string, set to {}
+                # Chat templates require tool arguments to be JSON objects.
                 if content := function.get("arguments"):
-                    if not isinstance(content, (dict, list)):
-                        function["arguments"] = json.loads(content)
+                    if isinstance(content, dict):
+                        parsed = content
+                    else:
+                        if isinstance(content, str):
+                            try:
+                                parsed = json.loads(content)
+                            except json.JSONDecodeError:
+                                # Historical malformed calls must not make all
+                                # subsequent conversation turns unrecoverable.
+                                logger.warning(
+                                    "Tool call %r has arguments that are not valid "
+                                    "JSON (%d chars); coercing to an empty object "
+                                    "so the conversation can continue.",
+                                    function.get("name"),
+                                    len(content),
+                                )
+                                parsed = None
+                        else:
+                            parsed = content
+
+                        if not isinstance(parsed, dict):
+                            if parsed is not None:
+                                logger.warning(
+                                    "Tool call %r arguments decoded to %s, not a "
+                                    "JSON object; coercing to an empty object.",
+                                    function.get("name"),
+                                    type(parsed).__name__,
+                                )
+                            parsed = {}
+
+                    function["arguments"] = parsed
                 else:
                     function["arguments"] = {}
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -169,6 +169,12 @@ _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] 
 _sm70_fp8_qpn8_pp2_tp4_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
+def clear_sm70_fp8_workspaces() -> None:
+    """Release process-global SM70 FP8 prefill and QPN8 workspaces."""
+    _sm70_fp8_prefill_dense_workspaces.clear()
+    _sm70_fp8_qpn8_pp2_tp4_workspaces.clear()
+
+
 def _is_sm70_fp8_pp2_tp4_shared_gate_layer(layer: torch.nn.Module) -> bool:
     """Match the exact PP2 x TP4 shared-expert gate/up tensor."""
     prefix = str(getattr(layer, "prefix", ""))

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -38,6 +38,11 @@ class SM70TurboMindLinearState:
 _nvfp4_qpn4_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
+def clear_sm70_turbomind_workspaces() -> None:
+    """Release process-global NVFP4 QPN4 dense workspaces."""
+    _nvfp4_qpn4_dense_workspaces.clear()
+
+
 def quant_backend() -> SM70QuantBackend:
     return envs.get_sm70_quant_backend()
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import weakref
 from collections.abc import (
     AsyncGenerator,
     Callable,
@@ -104,8 +105,11 @@ def _require_is_multimodal(is_multimodal: Tensor | None) -> Tensor:
     return is_multimodal
 
 
-# Cache results of `SupportsMultiModal.get_language_model`
-_language_model_by_module = dict[nn.Module, VllmModel]()
+# Cache results of `SupportsMultiModal.get_language_model` without pinning the
+# outer model (and therefore its weights/KV cache) for the interpreter lifetime.
+_language_model_by_module: weakref.WeakKeyDictionary[nn.Module, VllmModel] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 @runtime_checkable

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -578,6 +578,15 @@ _prefill_dense_splitkv3_workspaces: dict[
 ] = {}
 
 
+def clear_flash_attn_v100_workspaces() -> None:
+    """Release process-global Flash-V100 tensors during engine shutdown."""
+    _sm70_fa2_cu_seqlens_cache.clear()
+    _fp8_prefill_bridge_workspaces.clear()
+    _fp8_prefill_bridge_tail_workspaces.clear()
+    _prefill_gather_dense_workspaces.clear()
+    _prefill_dense_splitkv3_workspaces.clear()
+
+
 def _normalize_flash_v100_kv_cache_dtype(kv_cache_dtype: str) -> str:
     # Newer vLLM resolves an explicit FP16 cache to "float16". The vendored
     # Flash-V100 extension uses "auto" for the same unquantized FP16 layout.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -116,9 +116,20 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer
+from vllm.v1.worker.utils import KVBlockZeroer, clear_layer_kv_caches
 
 logger = init_logger(__name__)
+
+
+def _detach_model_runtime_state(model: nn.Module) -> None:
+    """Drop layer KV views and compilation hooks that can pin a model."""
+    clear_layer_kv_caches(model.modules())
+
+    from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+    for module in model.modules():
+        if isinstance(module, TorchCompileWithNoGuardsWrapper):
+            module.cleanup()
 
 
 class GPUModelRunner(LoRAModelRunnerMixin):
@@ -1654,9 +1665,24 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
+        # CUDA graph managers own graph pools, captured outputs, and persistent
+        # attention metadata. Drop both target and draft managers first.
+        self.cudagraph_manager = None
         if self._ple_offload_connector is not None:
             self._ple_offload_connector.close()
             self._ple_offload_connector = None
+
+        target_model = getattr(self, "model", None)
+        speculator = getattr(self, "speculator", None)
+        if speculator is not None:
+            if hasattr(speculator, "query_cudagraph_manager"):
+                speculator.query_cudagraph_manager = None
+            draft_model = getattr(speculator, "model", None)
+            if isinstance(draft_model, nn.Module):
+                _detach_model_runtime_state(draft_model)
+        if isinstance(target_model, nn.Module):
+            _detach_model_runtime_state(target_model)
+
         if hasattr(self, "kv_caches"):
             self.kv_caches.clear()
         if hasattr(self, "attn_groups"):
@@ -1664,6 +1690,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if hasattr(self, "kv_cache_config"):
             del self.kv_cache_config
         free_before_shutdown(self.vllm_config)
+        if hasattr(self, "model_state"):
+            del self.model_state
+        if speculator is not None:
+            self.speculator = None
         if hasattr(self, "model"):
             del self.model
 

--- a/vllm/v1/worker/gpu/shutdown.py
+++ b/vllm/v1/worker/gpu/shutdown.py
@@ -1,9 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
+
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def _clear_loaded_gpu_workspaces() -> None:
+    """Clear fork-specific GPU caches without importing unused backends."""
+    cleanup_functions = (
+        (
+            "vllm.v1.attention.backends.flash_attn_v100",
+            "clear_flash_attn_v100_workspaces",
+        ),
+        (
+            "vllm.model_executor.layers.quantization.fp8",
+            "clear_sm70_fp8_workspaces",
+        ),
+        (
+            "vllm.model_executor.layers.quantization.sm70_turbomind",
+            "clear_sm70_turbomind_workspaces",
+        ),
+    )
+    for module_name, function_name in cleanup_functions:
+        module = sys.modules.get(module_name)
+        if module is not None:
+            getattr(module, function_name)()
 
 
 def free_before_shutdown(vllm_config: VllmConfig) -> None:
@@ -18,3 +42,4 @@ def free_before_shutdown(vllm_config: VllmConfig) -> None:
 
     _ROPE_DICT.clear()
     reset_workspace_manager()
+    _clear_loaded_gpu_workspaces()

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -674,6 +674,27 @@ def bind_kv_cache(
         forward_context[layer_name].bind_kv_cache(kv_cache)
 
 
+def clear_layer_kv_caches(layers: Iterable[Any]) -> None:
+    """Detach KV/state tensors installed on model layers by ``bind_kv_cache``.
+
+    Models can outlive their runner through compilation hooks or external
+    references. Clearing only the runner-owned list would otherwise leave the
+    same allocations reachable from attention and Mamba layers.
+    """
+    for layer in layers:
+        if not hasattr(layer, "kv_cache"):
+            continue
+        kv_cache = layer.kv_cache
+        layer.kv_cache = torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+
+        impl = getattr(layer, "impl", None)
+        if impl is not None:
+            if hasattr(impl, "_k_scale_cache"):
+                impl._k_scale_cache = None
+            if hasattr(impl, "_v_scale_cache"):
+                impl._v_scale_cache = None
+
+
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:


### PR DESCRIPTION
## Purpose

Fix confirmed release blockers without changing DFlash2 proposal, selector, rejection, sampling, verifier, or attention arithmetic:

- normalize malformed historical tool-call arguments safely;
- defer async multimodal work until item-count validation and drain sibling fetches on failure;
- release MRV2 target/draft model, layer KV/state, compilation-hook, and CUDA Graph references during in-process shutdown;
- clear fork-specific Flash-V100, FP8, and NVFP4 process-global workspaces.

Base: `9e860996550c692d42b6f7ca57ced1bffbd8dfe5`

Tested implementation: `011adcf8ce`

Current head: `a4a92bfb44`

## Implementation

- Tool arguments preserve dictionaries, decode JSON-object strings, and coerce malformed/null/non-object values to `{}` with bounded warnings.
- Async multimodal trackers store zero-argument factories rather than already-created coroutines. Resolution uses `gather(..., return_exceptions=True)` so same-modality siblings finish before the first failure is propagated.
- The multimodal language-model cache now uses weak keys.
- MRV2 shutdown clears target and draft graph managers, detaches layer KV/state and quant-scale views, removes Dynamo bytecode hooks, releases `model_state`/`speculator`, and clears loaded SM70 workspace registries without importing unused backends.

## Test Plan and Result

- Focused Python regressions: **15 passed**.
- Changed-file Ruff format/check: **passed**.
- `git diff --check`: **passed**.
- Markdown lint for the retained worklog: **passed**.
- The broader pre-existing multimodal test group was stopped while fetching external model/assets and is not counted.

Remote TP4 V100 contract:

- 4× V100-SXM2-32GB, Qwen3.8-27B NVFP4 target, FP8 E5M2 target KV, FP16 draft KV;
- q7 probabilistic DFlash2, Flash-V100 target/draft attention, target and draft CUDA Graphs;
- 256K maximum context, q4096 chunked prefill, prefix cache, Mamba align, tool and reasoning parsers.

Results:

- malformed historical tool arguments: HTTP 200, conversation continued with `OK`;
- forced tool call: valid `get_weather({"city":"广州"})`;
- JSON Schema: exact `{"name":"Alice","age":30}`;
- two-image limit rejection: expected HTTP 400 and no unawaited-coroutine warning, including after shutdown;
- coding route smoke: valid typed binary search plus three assertions, 176 completion tokens in 0.889 s (~198 completion tok/s; route smoke, not a new baseline);
- graceful shutdown: API/engine/four workers gone, GPU 0–3 dropped from 26,259 MiB to 9 MiB each, no listener, recent `/dev/shm` file, or coroutine warning remained.

## Artifacts

- Remote log: `/home/ymzx/1cat-vllm-deploy/logs/nvfp4-dflash2-pr432-011adcf8ce-256k.log`
- Requests/responses: `/home/ymzx/1cat-vllm-deploy/test-artifacts/pr432-011adcf8ce/`
- Worklog: `docs/design/sm70_v100_migration_control.md`

## Risks and follow-ups

- Python's multiprocessing resource tracker still printed semaphore/shared-memory cleanup warnings, although it removed the resources and no process/file/GPU allocation survived. Treat this as a logging-cleanup follow-up.
- The all-files pre-commit workflow currently also sees pre-existing root `README.md` markdownlint errors on the base branch; this PR does not modify that unrelated file.