### PR TITLE
[Bugfix][V1] Reject hybrid prefills from uniform decode

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1721,6 +1721,66 @@ def test_is_uniform_decode() -> None:
     )
 
 
+def test_compute_force_uniform_decode_rejects_hybrid_prefills() -> None:
+    runner = SimpleNamespace(
+        model_config=SimpleNamespace(is_hybrid=True),
+        requests={"req_a": SimpleNamespace(num_prompt_tokens=8)},
+    )
+    compute = GPUModelRunner._compute_force_uniform_decode
+
+    # Exact 1+K shape aliases for MTP0, MTP2, and MTP4 are prefills.
+    for prompt_len in (1, 3, 5):
+        scheduled = _schedule_new_request("req_new")
+        new_req = scheduled.scheduled_new_reqs[0]
+        new_req.prompt_token_ids = list(range(prompt_len))
+        scheduled.num_scheduled_tokens["req_new"] = prompt_len
+        scheduled.total_num_scheduled_tokens = prompt_len
+        force_uniform_decode = compute(runner, scheduled)
+        assert force_uniform_decode is False
+        assert not GPUModelRunner._is_uniform_decode(
+            max_num_scheduled_tokens=prompt_len,
+            uniform_decode_query_len=prompt_len,
+            num_tokens=prompt_len,
+            num_reqs=1,
+            force_uniform_decode=force_uniform_decode,
+        )
+
+    # A fully prefix-cached new request has finished its prompt and can defer
+    # to the normal uniform-decode shape heuristic.
+    prefix_hit = _schedule_new_request("req_new")
+    prefix_hit.scheduled_new_reqs[0].num_computed_tokens = 3
+    assert compute(runner, prefix_hit) is None
+
+    # A later chunk is still prefill until all prompt tokens are computed.
+    chunked_prefill = _schedule_cached_requests(
+        req_ids=["req_a"],
+        num_scheduled_tokens={"req_a": 3},
+        new_token_ids=[[]],
+        num_computed_tokens=[5],
+        num_output_tokens=[0],
+    )
+    assert compute(runner, chunked_prefill) is False
+
+    decode = _schedule_cached_requests(
+        req_ids=["req_a"],
+        num_scheduled_tokens={"req_a": 1},
+        new_token_ids=[[7]],
+        num_computed_tokens=[8],
+        num_output_tokens=[1],
+    )
+    assert compute(runner, decode) is None
+
+    mixed = _schedule_new_request("req_new")
+    mixed.scheduled_cached_reqs = decode.scheduled_cached_reqs
+    mixed.num_scheduled_tokens["req_a"] = 1
+    mixed.total_num_scheduled_tokens += 1
+    assert compute(runner, mixed) is False
+
+    # The guard is intentionally limited to stateful hybrid models.
+    runner.model_config.is_hybrid = False
+    assert compute(runner, _schedule_new_request("req_new")) is None
+
+
 @pytest.mark.skipif(
     current_platform.is_rocm() or current_platform.is_device_capability((7, 0)),
     reason="Attention backend FLASHINFER is not supported on ROCm or SM70.",

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -8133,6 +8133,44 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    def _compute_force_uniform_decode(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> bool | None:
+        """Reject uniform-decode dispatch for hybrid-model prefills.
+
+        A prefill can have the same shape as a uniform decode batch, notably
+        when its scheduled token count equals ``1 + num_speculative_tokens``.
+        Hybrid backends keep recurrent state and must run that row through the
+        prefill path. Derive the phase from this iteration's scheduler output
+        rather than ``input_batch`` so the early PP+SP caller observes the
+        current step as well.
+
+        ``None`` preserves the normal shape heuristic. ``False`` is only
+        returned when a hybrid batch contains an unfinished prompt.
+        """
+        if not self.model_config.is_hybrid:
+            return None
+
+        for new_req in scheduler_output.scheduled_new_reqs:
+            num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
+                new_req.prompt_token_ids,
+                new_req.prompt_embeds,
+            )
+            if new_req.num_computed_tokens < num_prompt_tokens:
+                return False
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for req_id, num_computed_tokens in zip(
+            cached_reqs.req_ids,
+            cached_reqs.num_computed_tokens,
+            strict=True,
+        ):
+            if num_computed_tokens < self.requests[req_id].num_prompt_tokens:
+                return False
+
+        return None
+
     def _determine_batch_execution_and_padding(
         self,
         num_tokens: int,
@@ -8575,6 +8613,9 @@ class GPUModelRunner(
                 num_scheduled_tokens_np=num_scheduled_tokens_np,
                 max_num_scheduled_tokens=max_num_scheduled_tokens,
                 use_cascade_attn=cascade_attn_prefix_lens is not None,
+                force_uniform_decode=self._compute_force_uniform_decode(
+                    scheduler_output
+                ),
                 num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
             )
             if trace_log:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1015,6 +1015,11 @@ class Worker(WorkerBase):
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     max_num_scheduled_tokens=num_scheduled_tokens_np.max(),
                     use_cascade_attn=False,  # TODO(lucas): Handle cascade attention
+                    force_uniform_decode=(
+                        self.model_runner._compute_force_uniform_decode(
+                            scheduler_output
+                        )
+                    ),
                 )
             )
             all_gather_tensors = {


### PR DESCRIPTION
## Summary

- reject uniform-decode dispatch when a hybrid batch still contains unfinished prefill work
- derive the phase from the current `SchedulerOutput`, so the normal runner and the early PP+SP caller make the same decision
- preserve the existing shape heuristic for decode-only batches, full prefix-cache hits, non-hybrid models, and explicit CUDA-graph capture overrides

## Why this is not a duplicate

No open 1Cat PR currently carries this fix. The same upstream bug is tracked by vllm-project/vllm#53051, with alternative open implementations in vllm-project/vllm#39945, #47123, and #53059.

This PR is a narrow 1Cat carry based on current `main`: it combines the hybrid-only scope with current-step scheduler state, including the PP+SP call site. It does not include the separate Qwen3.8/MTP batch-invariance experiment or any kernel workaround. Once vLLM lands and 1Cat imports a canonical upstream fix, this carry can be replaced by that commit.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_model_runner.py \
  -k 'test_is_uniform_decode or test_compute_force_uniform_decode_rejects_hybrid_prefills' \
  --confcutdir=tests/v1/worker -q
# 2 passed, 36 deselected

pre-commit run --files \
  vllm/v1/worker/gpu_model_runner.py \
  vllm/v1/worker/gpu_worker.py \
  tests/v1/worker/test_gpu_model_runner.py
# all applicable hooks passed
```

The regression test covers the MTP0/MTP2/MTP4 `1+K` aliases (1, 3, and 5 tokens), chunked prefill, mixed prefill/decode, complete prefix-cache hits, normal decode, and the non-hybrid no-op path.

No model E2E result is claimed here: the current Qwen4-Exp route requires MRV2 and does not exercise this MRV1 dispatch path.

## AI assistance

AI assistance was used for implementation review, upstream comparison, test construction, and documentation. The human submitter reviewed the complete three-file diff and reproduced the reported tests.
