### PR TITLE
[Core][SM70] Generalize DFlash2 verifier defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ PY
 
 # ▶ Qwen3.8-27B-NVFP4 + DFlash2
 
-## Recommended TP4 serving command
+## Example TP4 + E5M2 serving command
 
 ```bash
 vllm serve /path/to/Qwen3.8-27B-NVFP4 \
@@ -978,14 +978,17 @@ Representative automatic values:
 official draft block size = 8
 draft width               = 7
 selector Top-K            = 16
-target KV                 = FP8 E5M2
+example target KV         = FP8 E5M2 (optional)
 draft attention backend   = FLASH_ATTN_V100
 verification fast paths   = automatic
 ```
 
-The SM70 verification fast paths are independent of target quantization, KV
-dtype, TP degree, and service capacity. Each operator capability-checks its
-local dtype/shape and falls back independently. Set `--max-num-seqs`,
+Enabling the SM70 DFlash2 verifier defaults is independent of target
+quantization, KV dtype, TP degree, and service capacity. Each operator then
+capability-checks its local dtype/shape and falls back independently. For
+example, the current one-pass grouped Attention operator is E5M2-specific and
+the compact LM-head rerank is TP4-specific; a different KV dtype or TP degree
+retains DFlash2 and only falls back for those operators. Set `--max-num-seqs`,
 `--max-num-batched-tokens`, or `--performance-mode` for the desired concurrency
 and prefill policy; these options do not opt a compatible single-request
 verifier out of its fast path.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
+<!-- markdownlint-disable MD041 -->
+
 <p align="center">
   <img src="./assets/1cat-vllm-logo.png" alt="1Cat-vLLM logo" width="420">
 </p>
 
 # 1Cat-vLLM
 
-## Make Volta Fast Again.
+## Make Volta Fast Again
 
-### Modern LLM inference for NVIDIA Tesla V100 / SM70.
+### Modern LLM inference for NVIDIA Tesla V100 / SM70
 
-**4× Tesla V100 16GB · Qwen3.8-27B-NVFP4 + DFlash2 · ≈260 tok/s**
+<strong>4× Tesla V100 16GB · Qwen3.8-27B-NVFP4 + DFlash2 · ≈260 tok/s</strong>
 
 > Tesla V100 was released in 2017.
 >
@@ -356,7 +358,7 @@ Representative gates include:
 
 ## We are not just “making FlashAttention compile on V100.”
 
-## We are rebuilding the dataflow for Volta.
+## We are rebuilding the dataflow for Volta
 
 FlashAttention is fundamentally an **IO and scheduling problem**:
 
@@ -462,7 +464,7 @@ The corresponding operator gain reaches roughly **21%–26.5%** on representativ
 
 ---
 
-# Layer 2 — Rewrite D=256 Attention as a Volta-Native Pipeline
+## Layer 2 — Rewrite D=256 Attention as a Volta-Native Pipeline
 
 After reducing data-movement overhead, the Attention body itself is restructured.
 

--- a/README.md
+++ b/README.md
@@ -960,7 +960,6 @@ vllm serve /path/to/Qwen3.8-27B-NVFP4 \
   --attention-backend FLASH_ATTN_V100 \
   --kv-cache-dtype fp8_e5m2 \
   --max-model-len 262144 \
-  --performance-mode interactivity \
   --gpu-memory-utilization 0.80 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder \
@@ -981,8 +980,15 @@ draft width               = 7
 selector Top-K            = 16
 target KV                 = FP8 E5M2
 draft attention backend   = FLASH_ATTN_V100
-performance mode          = interactivity
+verification fast paths   = automatic
 ```
+
+The SM70 verification fast paths are independent of target quantization, KV
+dtype, TP degree, and service capacity. Each operator capability-checks its
+local dtype/shape and falls back independently. Set `--max-num-seqs`,
+`--max-num-batched-tokens`, or `--performance-mode` for the desired concurrency
+and prefill policy; these options do not opt a compatible single-request
+verifier out of its fast path.
 
 ---
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44837,6 +44837,13 @@ Interpretation:
   `18.972 ms`, two independent steady requests measure `17.391 ms` and
   `17.394 ms`; the historical B1 controls were `17.396 ms` and `17.386 ms`.
   This recovers about `1.13 ms` without constraining service concurrency.
+- The probabilistic dense draft-logit fallback is about `1.66 GiB` per rank at
+  capacity 256. It was previously allocated before the model-loading memory
+  profile, allowing KV sizing to overcommit that already-resident memory. Its
+  allocation is now deferred until draft weights load, while the compact
+  rejection cache and dense compatibility semantics are unchanged. This is a
+  startup/OOM accounting fix, not a speed claim: its isolated latency result
+  remained about `18.52 ms` before the QPN2 admission repair.
 - The focused NVFP4 QPN2 module reports `5 passed`. A live forced-tool request
   returns `get_weather` with `{"city":"北京"}`, and a JSON-schema request
   returns exactly `{"name":"小明","age":18}`. The change introduces no new

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44807,3 +44807,39 @@ Interpretation:
   `_prepare_dflash_inputs_kernel`, and `layer_norm_fwd_kernel`). The request
   remained correct and completed in `0.547 s`; this is a bounded cold-start
   warmup follow-up, not a steady-state or publication correctness blocker.
+
+## 2026-09-01 DFlash2 default-capacity 17 ms root cause
+
+- A matched four-V100 audit held the model, TP4, q8 verifier, E5M2 target KV,
+  256K maximum length, prefix cache, Mamba align, tool/reasoning parsers, and
+  graph policy fixed. Changing only `max_num_seqs` from the source default 256
+  to 1 moved the steady complete round from about `18.52 ms` to
+  `17.39 ms`. Changing graph capture sizes, available KV memory, and dense
+  draft-logit allocation order did not recover the gap.
+- The CUDA Graph descriptor and attention metadata are not capacity-expanded.
+  For the single live q8 request both configurations capture `num_reqs=1` and
+  `num_tokens=8`; Mamba/GDN state indices and Flash-V100 metadata are sliced to
+  that descriptor. Node traces placed the difference inside the target q8
+  graph, while the DFlash graph remained unchanged.
+- The causal branch was a model-load predicate in the NVFP4 scheme. The
+  DFlash2 QPN2 contract required `scheduler_config.max_num_seqs == 1`, so a
+  default-capacity server retained TurboMind for every compatible target MLP
+  even when the live verifier width was eight. The old default-capacity log
+  had no QPN2 route hit; the B1 log reported `QPN2 M<=8 route enabled`.
+- Scheduler capacity is not an operator capability. The opaque C++ dispatcher
+  already selects the byte-preserving QPN2 layout only for live `M<=8` and
+  falls back to the retained TurboMind layout for larger dynamic M. The model-
+  load contract now keeps TP4, q7/top16, PP1, no-DBO, dtype, tensor-shape, and
+  operator-availability checks, but no longer reads `max_num_seqs`. Explicit
+  `VLLM_SM70_NVFP4_QPN2=0` and prefill rollback controls remain authoritative.
+- With source-default capacity 256, the repaired launch now reports both QPN2
+  decode and QPN2-packed prefill routes. After one first-request warmup at
+  `18.972 ms`, two independent steady requests measure `17.391 ms` and
+  `17.394 ms`; the historical B1 controls were `17.396 ms` and `17.386 ms`.
+  This recovers about `1.13 ms` without constraining service concurrency.
+- The focused NVFP4 QPN2 module reports `5 passed`. A live forced-tool request
+  returns `get_weather` with `{"city":"北京"}`, and a JSON-schema request
+  returns exactly `{"name":"小明","age":18}`. The change introduces no new
+  arithmetic path: it makes default capacity select the same previously
+  quality-audited, checkpoint-code-preserving B1 operator path. Test services
+  were stopped after collection and all four V100s returned to idle memory.

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -470,23 +470,7 @@ def test_fp8_qpn8_shape_gate_uses_checkpoint_native_layout():
     assert not _is_sm70_fp8_qpn8_layer(layer)
 
 
-def test_fp8_qpn8_runtime_gate_uses_engine_contract_only(monkeypatch):
-    vllm_config = SimpleNamespace(
-        scheduler_config=SimpleNamespace(max_num_seqs=8),
-        speculative_config=None,
-    )
-    monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.fp8.get_current_vllm_config",
-        lambda: vllm_config,
-    )
-
-    assert _is_sm70_fp8_qpn8_runtime_contract()
-    vllm_config.scheduler_config.max_num_seqs = 16
-    assert not _is_sm70_fp8_qpn8_runtime_contract()
-    vllm_config.scheduler_config.max_num_seqs = 8
-    vllm_config.speculative_config = object()
-    assert not _is_sm70_fp8_qpn8_runtime_contract()
-    monkeypatch.setenv("VLLM_SM70_FP8_QPN8", "1")
+def test_fp8_qpn8_runtime_gate_is_capacity_and_speculation_independent():
     assert _is_sm70_fp8_qpn8_runtime_contract()
 
 

--- a/tests/quantization/test_sm70_nvfp4_qpn2.py
+++ b/tests/quantization/test_sm70_nvfp4_qpn2.py
@@ -106,9 +106,10 @@ def test_nvfp4_qpn2_dflash2_default_contract(monkeypatch):
         monkeypatch.setattr(
             nvfp4_scheme,
             "get_current_vllm_config",
-            lambda: _runtime_config(max_num_seqs=2),
+            lambda: _runtime_config(max_num_seqs=256),
         )
-        assert not nvfp4_scheme._sm70_nvfp4_qpn2_prefill_enabled()
+        assert nvfp4_scheme._sm70_nvfp4_qpn2_enabled()
+        assert nvfp4_scheme._sm70_nvfp4_qpn2_prefill_enabled()
     finally:
         envs.disable_envs_cache()
 

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -457,6 +457,7 @@ def test_selector_edges_match_sequential_reference():
 
 def _stub_base(monkeypatch: pytest.MonkeyPatch, draft_logits):
     def init_base(self, _vllm_config, device):
+        self.device = device
         self.draft_model_config = SimpleNamespace(
             hf_config=SimpleNamespace(dflash_config={"selector_top_k": 16})
         )
@@ -467,6 +468,9 @@ def _stub_base(monkeypatch: pytest.MonkeyPatch, draft_logits):
         self.vocab_size = 31
         self.draft_tokens = torch.empty((2, 7), dtype=torch.int64, device=device)
         self.draft_logits = draft_logits
+        self._draft_logits_init = (
+            None if draft_logits is None else (torch.float32, -float("inf"))
+        )
 
     monkeypatch.setattr(DFlashSpeculator, "__init__", init_base)
 
@@ -478,7 +482,7 @@ def test_selector_leaves_greedy_without_proposal_logits(monkeypatch):
 
 
 def test_selector_default_path_does_not_allocate_sparse_score_cache(monkeypatch):
-    allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
+    allocated = torch.full((2, 7, 31), -float("inf"), dtype=torch.float32)
     _stub_base(monkeypatch, allocated)
     monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION", False)
     monkeypatch.setattr(envs, "VLLM_SPEC_DUMP_ALIGNMENT", False)
@@ -490,7 +494,7 @@ def test_selector_default_path_does_not_allocate_sparse_score_cache(monkeypatch)
 
 
 def test_selector_opt_in_allocates_sparse_score_cache(monkeypatch):
-    allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
+    allocated = torch.full((2, 7, 31), -float("inf"), dtype=torch.float32)
     _stub_base(monkeypatch, allocated)
     monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION", True)
     speculator = DFlash2Speculator(None, torch.device("cpu"))
@@ -503,7 +507,7 @@ def test_selector_opt_in_allocates_sparse_score_cache(monkeypatch):
 
 
 def test_selector_alignment_shadow_is_explicit_and_keeps_full_lattice(monkeypatch):
-    allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
+    allocated = torch.full((2, 7, 31), -float("inf"), dtype=torch.float32)
     _stub_base(monkeypatch, allocated)
     monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION", True)
     monkeypatch.setattr(envs, "VLLM_SPEC_DUMP_ALIGNMENT", True)
@@ -542,6 +546,20 @@ def test_selector_uses_checkpoint_top16_and_fp32_proposal_cache(monkeypatch):
     assert speculator.selector_top_k == 16
     assert dtype is torch.float32
     assert fill == float("-inf")
+
+
+def test_probabilistic_dense_fallback_is_allocated_after_initialization(monkeypatch):
+    _stub_base(monkeypatch, None)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    speculator._draft_logits_init = (torch.float32, -float("inf"))
+
+    assert speculator.draft_logits is None
+    speculator._allocate_draft_logits()
+
+    assert speculator.draft_logits is not None
+    assert speculator.draft_logits.shape == (2, 7, 31)
+    assert speculator.draft_logits.dtype is torch.float32
+    assert torch.isneginf(speculator.draft_logits).all()
 
 
 def _sparse_sampling_contract_fixture():

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -21,10 +21,9 @@ from vllm.config.speculative import (
     _get_dflash2_checkpoint_draft_tokens,
 )
 from vllm.config.vllm import (
-    _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS,
-    _apply_sm70_nvfp4_dflash2_practical_defaults,
-    _is_compressed_tensors_nvfp4,
-    _is_sm70_nvfp4_dflash2_practical_contract,
+    _SM70_DFLASH2_VERIFIER_DEFAULTS,
+    _apply_sm70_dflash2_verifier_defaults,
+    _is_sm70_dflash2_verifier_contract,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
@@ -72,7 +71,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
 )
 
 
-def _sm70_nvfp4_dflash2_practical_contract_args():
+def _sm70_dflash2_verifier_contract_args():
     model_config = SimpleNamespace(
         architectures=("Qwen3_5ForConditionalGeneration",),
         quantization="compressed-tensors",
@@ -106,18 +105,7 @@ def _sm70_nvfp4_dflash2_practical_contract_args():
         enable_dbo=False,
         ubatch_size=0,
     )
-    scheduler_config = SimpleNamespace(
-        max_num_seqs=1,
-        max_num_batched_tokens=4096,
-    )
-    cache_config = SimpleNamespace(cache_dtype="fp8_e5m2")
-    return (
-        model_config,
-        speculative_config,
-        parallel_config,
-        scheduler_config,
-        cache_config,
-    )
+    return model_config, speculative_config, parallel_config
 
 
 def test_dflash2_checkpoint_draft_tokens_follow_block_contract():
@@ -131,49 +119,50 @@ def test_dflash2_checkpoint_draft_tokens_follow_block_contract():
     assert _get_dflash2_checkpoint_draft_tokens(hf_config) is None
 
 
-def test_nvfp4_practical_contract_requires_nvfp4_quantization_group():
-    args = _sm70_nvfp4_dflash2_practical_contract_args()
-    assert _is_compressed_tensors_nvfp4(args[0])
-
-    args[0].model_arch_config.quantization_config = {"format": "float-quantized"}
-    assert not _is_compressed_tensors_nvfp4(args[0])
-    assert not _is_sm70_nvfp4_dflash2_practical_contract(*args)
-
-
-def test_sm70_nvfp4_dflash2_practical_contract_is_narrow():
-    args = _sm70_nvfp4_dflash2_practical_contract_args()
-    assert _is_sm70_nvfp4_dflash2_practical_contract(*args)
+def test_sm70_dflash2_verifier_contract_is_narrow():
+    args = _sm70_dflash2_verifier_contract_args()
+    assert _is_sm70_dflash2_verifier_contract(*args)
 
     for config_index, attribute, incompatible_value in (
-        (0, "quantization", "fp8"),
+        (0, "dtype", torch.bfloat16),
         (1, "num_speculative_tokens", 5),
-        (2, "tensor_parallel_size", 2),
-        (3, "max_num_seqs", 2),
-        (3, "max_num_batched_tokens", 8192),
-        (4, "cache_dtype", "auto"),
+        (2, "pipeline_parallel_size", 2),
+        (2, "enable_dbo", True),
+        (2, "ubatch_size", 2),
     ):
-        incompatible_args = _sm70_nvfp4_dflash2_practical_contract_args()
+        incompatible_args = _sm70_dflash2_verifier_contract_args()
         setattr(incompatible_args[config_index], attribute, incompatible_value)
-        assert not _is_sm70_nvfp4_dflash2_practical_contract(*incompatible_args)
+        assert not _is_sm70_dflash2_verifier_contract(*incompatible_args)
 
-    incompatible_args = _sm70_nvfp4_dflash2_practical_contract_args()
+    incompatible_args = _sm70_dflash2_verifier_contract_args()
     incompatible_args[1].draft_model_config.hf_config.dflash_config[
         "selector_top_k"
     ] = 8
-    assert not _is_sm70_nvfp4_dflash2_practical_contract(*incompatible_args)
+    assert not _is_sm70_dflash2_verifier_contract(*incompatible_args)
 
 
-def test_sm70_nvfp4_dflash2_practical_defaults_preserve_overrides(monkeypatch):
-    for name in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS:
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("quantization", [None, "fp8", "compressed-tensors"])
+def test_sm70_dflash2_verifier_contract_is_tp_and_quantization_independent(
+    tensor_parallel_size, quantization
+):
+    args = _sm70_dflash2_verifier_contract_args()
+    args[0].quantization = quantization
+    args[2].tensor_parallel_size = tensor_parallel_size
+    assert _is_sm70_dflash2_verifier_contract(*args)
+
+
+def test_sm70_dflash2_verifier_defaults_preserve_overrides(monkeypatch):
+    for name in _SM70_DFLASH2_VERIFIER_DEFAULTS:
         monkeypatch.delenv(name, raising=False)
     overridden_name = "VLLM_SM70_DFLASH2_QPN8_RERANK"
     monkeypatch.setenv(overridden_name, "0")
 
-    applied = _apply_sm70_nvfp4_dflash2_practical_defaults()
+    applied = _apply_sm70_dflash2_verifier_defaults()
 
     assert overridden_name not in applied
     assert os.environ[overridden_name] == "0"
-    for name, expected_value in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS.items():
+    for name, expected_value in _SM70_DFLASH2_VERIFIER_DEFAULTS.items():
         if name != overridden_name:
             assert name in applied
             assert os.environ[name] == expected_value

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -84,6 +84,10 @@ _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
 _SM70_MTP_CUDAGRAPH_REQUEST_SIZES = (1, 2, 4, 6, 8, 12, 16)
 
 _SM70_DFLASH2_VERIFIER_DEFAULTS = {
+    # This is the target projection's memory-neutral FP8 layout, not the
+    # rejected draft-MLP QPN8 experiment. Per-layer TP/shape checks retain the
+    # original layout whenever the exact operator contract is unavailable.
+    "VLLM_SM70_FP8_QPN8": "1",
     "VLLM_SM70_DFLASH2_QPN8_RERANK": "1",
     "VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER": "1",
     "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER": "0",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -83,7 +83,7 @@ DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
 _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
 _SM70_MTP_CUDAGRAPH_REQUEST_SIZES = (1, 2, 4, 6, 8, 12, 16)
 
-_SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS = {
+_SM70_DFLASH2_VERIFIER_DEFAULTS = {
     "VLLM_SM70_DFLASH2_QPN8_RERANK": "1",
     "VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER": "1",
     "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER": "0",
@@ -99,42 +99,24 @@ _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS = {
 }
 
 
-def _is_compressed_tensors_nvfp4(model_config: Any) -> bool:
-    """Recognize NVFP4, including mixed-precision config groups."""
-    if getattr(model_config, "quantization", None) != "compressed-tensors":
-        return False
-    model_arch_config = getattr(model_config, "model_arch_config", None)
-    quant_config = getattr(model_arch_config, "quantization_config", None)
-    if not isinstance(quant_config, Mapping):
-        return False
-
-    formats = [quant_config.get("format", "")]
-    config_groups = quant_config.get("config_groups", {})
-    if isinstance(config_groups, Mapping):
-        formats.extend(
-            group.get("format", "")
-            for group in config_groups.values()
-            if isinstance(group, Mapping)
-        )
-    return any("nvfp4" in str(format_name).lower() for format_name in formats)
-
-
-def _is_sm70_nvfp4_dflash2_practical_contract(
+def _is_sm70_dflash2_verifier_contract(
     model_config: Any,
     speculative_config: Any,
     parallel_config: Any,
-    scheduler_config: Any,
-    cache_config: Any,
 ) -> bool:
-    """Admit only the scored Qwen3.8 NVFP4 DFlash2 TP4/B1 contract."""
+    """Admit the quality-audited Qwen3.8 DFlash2 verifier contract.
+
+    Target quantization, KV dtype, TP degree, and service capacity are
+    intentionally not part of this admission. Each fast operator capability-
+    checks its local weight, cache dtype, and live batch shape, then falls back
+    independently when it cannot handle that contract.
+    """
     if any(
         config is None
         for config in (
             model_config,
             speculative_config,
             parallel_config,
-            scheduler_config,
-            cache_config,
         )
     ):
         return False
@@ -151,7 +133,6 @@ def _is_sm70_nvfp4_dflash2_practical_contract(
     architectures = set(getattr(model_config, "architectures", ()) or ())
     return bool(
         "Qwen3_5ForConditionalGeneration" in architectures
-        and _is_compressed_tensors_nvfp4(model_config)
         and getattr(model_config, "dtype", None) == torch.float16
         and getattr(hf_text_config, "hidden_size", None) == 5120
         and getattr(hf_text_config, "num_attention_heads", None) == 24
@@ -161,19 +142,15 @@ def _is_sm70_nvfp4_dflash2_practical_contract(
         and int(getattr(speculative_config, "num_speculative_tokens", 0) or 0) == 7
         and selector_top_k == 16
         and getattr(parallel_config, "pipeline_parallel_size", 0) == 1
-        and getattr(parallel_config, "tensor_parallel_size", 0) == 4
         and not getattr(parallel_config, "enable_dbo", False)
         and int(getattr(parallel_config, "ubatch_size", 0) or 0) <= 1
-        and getattr(scheduler_config, "max_num_seqs", 0) == 1
-        and getattr(scheduler_config, "max_num_batched_tokens", 0) == 4096
-        and str(getattr(cache_config, "cache_dtype", "")).lower() == "fp8_e5m2"
     )
 
 
-def _apply_sm70_nvfp4_dflash2_practical_defaults() -> tuple[str, ...]:
+def _apply_sm70_dflash2_verifier_defaults() -> tuple[str, ...]:
     """Set quality-audited defaults while preserving every explicit override."""
     applied = []
-    for env_name, env_value in _SM70_NVFP4_DFLASH2_PRACTICAL_DEFAULTS.items():
+    for env_name, env_value in _SM70_DFLASH2_VERIFIER_DEFAULTS.items():
         if env_name not in os.environ:
             os.environ[env_name] = env_value
             applied.append(env_name)
@@ -1623,17 +1600,15 @@ class VllmConfig:
                         env_name,
                         env_value,
                     )
-            if _is_sm70_nvfp4_dflash2_practical_contract(
+            if _is_sm70_dflash2_verifier_contract(
                 self.model_config,
                 self.speculative_config,
                 self.parallel_config,
-                self.scheduler_config,
-                self.cache_config,
             ):
-                for env_name in _apply_sm70_nvfp4_dflash2_practical_defaults():
+                for env_name in _apply_sm70_dflash2_verifier_defaults():
                     logger.info_once(
                         "Auto-setting %s=%s for the quality-audited SM70 "
-                        "Qwen3.8 NVFP4 DFlash2 TP4/B1 practical baseline. "
+                        "Qwen3.8 DFlash2 verification baseline. "
                         "Set it explicitly to override.",
                         env_name,
                         os.environ[env_name],

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -53,10 +53,16 @@ def _is_sm70_nvfp4_qpn4_runtime_contract() -> bool:
 
 
 def _is_sm70_dflash2_nvfp4_qpn2_runtime_contract() -> bool:
-    """Admit the quality-audited single-request DFlash2 TP4 route."""
+    """Admit the quality-audited DFlash2 TP4 operator contract.
+
+    Scheduler capacity is intentionally not part of this model-load decision.
+    The opaque dispatcher selects QPN2 only from the live ``M <= 8`` shape and
+    retains the existing TurboMind path for larger dynamic M.  A server that
+    can hold many requests must therefore load the same small-M layout as a
+    server configured with ``max_num_seqs=1``.
+    """
     vllm_config = get_current_vllm_config()
     parallel_config = vllm_config.parallel_config
-    scheduler_config = vllm_config.scheduler_config
     speculative_config = getattr(vllm_config, "speculative_config", None)
     draft_model_config = getattr(speculative_config, "draft_model_config", None)
     draft_hf_config = getattr(draft_model_config, "hf_config", None)
@@ -72,7 +78,6 @@ def _is_sm70_dflash2_nvfp4_qpn2_runtime_contract() -> bool:
         and selector_top_k == 16
         and parallel_config.pipeline_parallel_size == 1
         and parallel_config.tensor_parallel_size == 4
-        and scheduler_config.max_num_seqs == 1
         and not getattr(parallel_config, "enable_dbo", False)
         and int(getattr(parallel_config, "ubatch_size", 0) or 0) <= 1
     )

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -163,7 +163,6 @@ _SM70_FP8_QPN8_REQUIRED_OPS = (
     "fp8_qpn8_gemm_sm70_out",
     "fp8_qpn8_gated_pair_sm70_out",
 )
-_SM70_FP8_QPN8_MAX_NUM_SEQS = 8
 # Layers retain only data_ptr(), so this cache owns each allocation's lifetime.
 _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 _sm70_fp8_qpn8_pp2_tp4_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
@@ -279,18 +278,15 @@ def _is_sm70_fp8_qpn8_layer(layer: torch.nn.Module) -> bool:
 
 
 def _is_sm70_fp8_qpn8_runtime_contract() -> bool:
-    """Admit only the no-MTP M range with a measured native decode kernel."""
-    vllm_config = get_current_vllm_config()
-    scheduler_config = getattr(vllm_config, "scheduler_config", None)
-    max_num_seqs = int(getattr(scheduler_config, "max_num_seqs", 1))
-    speculative_config = getattr(vllm_config, "speculative_config", None)
-    if max_num_seqs > _SM70_FP8_QPN8_MAX_NUM_SEQS:
-        return False
-    if speculative_config is None:
-        return True
-    # Speculative workloads require an explicit operator opt-in; admission is
-    # still based only on bounded concurrency and the layer tensor contract.
-    return os.getenv("VLLM_SM70_FP8_QPN8") is not None
+    """Keep scheduler capacity out of the QPN8 weight-layout contract.
+
+    The opaque dispatcher selects the measured QPN8 decode kernel from the
+    live ``M <= 8`` shape and the exact dense-prefill fallback for larger M.
+    Model-level capacity and speculative decoding therefore do not need an
+    explicit environment opt-in; layer shape and operator availability remain
+    the actual admission gates.
+    """
+    return True
 
 
 def _sm70_fp8_qpn8_pp2_tp4_enabled() -> bool:

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -352,7 +352,7 @@ class DFlash2Speculator(DFlashSpeculator):
         )
         self._cached_candidate_scores = None
         if (
-            self.draft_logits is not None
+            self._draft_logits_init is not None
             and envs.VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION
         ):
             self._cached_candidate_scores = torch.full(
@@ -388,10 +388,6 @@ class DFlash2Speculator(DFlashSpeculator):
                 device=device,
             )
         self._use_sm70_tail = _requires_sm70_tail(device, self.draft_block)
-        if self.draft_logits is not None:
-            # The cache kernel writes only K columns; all other vocabulary
-            # columns must remain impossible.
-            self.draft_logits.fill_(-float("inf"))
 
         self._ngram_assist: DFlash2NgramAssist | None = None
         self._ngram_num_hits = 0

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -131,19 +131,17 @@ class DraftModelSpeculator(BaseSpeculator):
         )
 
         self.draft_logits: torch.Tensor | None = None
+        self._draft_logits_init: tuple[torch.dtype, float] | None = None
         if self.speculative_config.draft_sample_method == "probabilistic":
             # Temperature-applied logits, cached from the previous decode step.
-            dtype, fill = self.draft_logits_spec(vllm_config)
-            self.draft_logits = torch.full(
-                (
-                    self.max_num_reqs,
-                    self.num_speculative_steps,
-                    self.vocab_size,
-                ),
-                fill,
-                dtype=dtype,
-                device=device,
-            )
+            # Defer this potentially multi-GiB compatibility buffer into the
+            # model-loading memory profile. The compact DFlash2 rejection path
+            # does not read the dense tensor, but structured output and
+            # unsupported sampling contracts still need the exact dense
+            # fallback. Deferring allocation preserves that fallback while
+            # ensuring its capacity-scaled memory is deducted before KV cache
+            # sizing.
+            self._draft_logits_init = self.draft_logits_spec(vllm_config)
 
         self.supports_mm_inputs = False
 
@@ -164,6 +162,7 @@ class DraftModelSpeculator(BaseSpeculator):
         )
 
         self.model = self.load_draft_model(target_model, target_attn_layer_names)
+        self._allocate_draft_logits()
         self._validate_local_argmax_reduction()
 
         all_attn_layers = set[str](
@@ -185,6 +184,21 @@ class DraftModelSpeculator(BaseSpeculator):
                 "Embeddings from the target model will not be passed to the "
                 "drafter; using text-only draft inputs instead.",
                 type(self.model).__name__,
+            )
+
+    def _allocate_draft_logits(self) -> None:
+        """Allocate the dense compatibility buffer after model weights."""
+        if self._draft_logits_init is not None and self.draft_logits is None:
+            dtype, fill = self._draft_logits_init
+            self.draft_logits = torch.full(
+                (
+                    self.max_num_reqs,
+                    self.num_speculative_steps,
+                    self.vocab_size,
+                ),
+                fill,
+                dtype=dtype,
+                device=self.device,
             )
 
     @property


### PR DESCRIPTION
## Purpose

Make the quality-audited SM70 Qwen3.8 DFlash2 verifier fast paths automatic without coupling global DFlash2 admission to target quantization, KV dtype, TP degree, or scheduler capacity.

- admit shared verifier defaults from the DFlash2 model/q7/top16 contract
- let each operator capability-check its local weight, KV dtype, TP shape, and live batch shape, then fall back independently
- remove the stale `max_num_seqs == 1` model-load gate from the TP4 NVFP4 QPN2 operator; its opaque dispatcher already uses QPN2 only for live M<=8 and TurboMind for larger M
- make the exact target QPN8 layout automatic for compatible layers without scheduler-capacity gating
- account the probabilistic dense draft-logit compatibility buffer during model loading, before KV sizing
- preserve explicit environment rollback controls and document local operator constraints separately from the DFlash2 route

Base: `onecat/main@9e860996550c692d42b6f7ca57ced1bffbd8dfe5`

## Test Plan

- run focused SM70 EngineArgs, NVFP4 QPN2, and DFlash2 CPU suites
- start the current Qwen3.8-27B-NVFP4 + DFlash2 TP4 service on four V100s with source-default scheduler capacity and no private verifier environment overrides
- prove the default-capacity launch loads QPN2 and compare its single-request complete round with the historical B1 control
- run live tool-call and JSON-schema quality smokes
- verify startup memory profiling includes the dense probabilistic fallback and cleanly release the four GPUs

## Test Result

- existing focused CPU suites: `111 passed, 9 CUDA-only skipped, 76 deselected`
- NVFP4 QPN2 focused module after the capacity fix: `5 passed`
- deferred dense-fallback/selector tests: `5 passed, 103 deselected`
- Ruff, compileall, and `git diff --check`: passed
- static/Nsight audit: both configurations capture the same q8 `num_reqs=1`, `num_tokens=8` target graph; the latency delta was inside the target graph, not DFlash, GDN capacity padding, graph-count, or KV-memory pressure
- route proof: source-default `max_num_seqs=256` now logs `SM70 NVFP4 QPN2 M<=8 route enabled` and the QPN2-packed prefill dispatcher; the old default-capacity log had no QPN2 hit
- performance: after one first-request warmup at `18.972 ms`, source-default capacity measures `17.391 ms` and `17.394 ms` per complete round. Historical B1 controls were `17.396 ms` and `17.386 ms`; the old default-capacity steady result was about `18.52 ms`
- quality smokes: forced tool call returned `get_weather({"city":"北京"})`; JSON-schema output returned exactly `{"name":"小明","age":18}`
- startup/OOM accounting: the roughly 1.66-GiB/rank probabilistic dense fallback is included in model-loading memory before KV sizing; the 256K service started successfully
- cleanup: port 8000 was stopped and GPUs 0-3 returned to 6 MiB each
