### PR TITLE
[SM70] Extend v100-skinny provenance header to QPN4 and MXFP4-QPN kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,7 @@ Join the **1Cat-vLLM Open-Source Community Group 5** by scanning the latest QR c
 - [lmdeploy / TurboMind](https://github.com/InternLM/lmdeploy)
 - [flash-attention-v100](https://github.com/ai-bond/flash-attention-v100)
 - [marlin_v100](https://github.com/zhinianqin/marlin_v100)
+- [v100-skinny](https://github.com/dnv2003/v100-skinny) — QPN quadpair-N `m8n8k4` decode layout behind the SM70 QPN2 / QPN4 / QPN8 and MXFP4-QPN kernels (MIT; notice retained in `csrc/sm70_turbomind/ops/LICENSE.v100-skinny`)
 
 Special thanks to [@yangzhuxinyzx](https://github.com/yangzhuxinyzx) and [@1CatTCat](https://github.com/1CatTCat) for their outstanding contributions to the continued evolution and performance breakthroughs of **1Cat-vLLM**.
 

--- a/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
+++ b/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright contributors to the vLLM project
+//
+// The MXFP4 M=1 quadpair-N m8n8k4 layout is derived from dnv2003/v100-skinny (MIT).
+// See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
 #include <torch/all.h>
 

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Qwen3.8 NVFP4 M=1 decode kernels for NVIDIA Volta SM70.
+//
+// The QPN4 quadpair-N m8n8k4 layout is derived from dnv2003/v100-skinny (MIT).
+// See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
 #include <torch/all.h>
 #include <torch/library.h>


### PR DESCRIPTION

## Summary

`csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu` and `fp8_qpn8_sm70.cu` carry the header "derived from dnv2003/v100-skinny (MIT)", with the notice retained in `LICENSE.v100-skinny`. Two sibling kernels use the same layout without the header:

- `csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu`
- `csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu`

Both run `mma.sync.aligned.m8n8k4` with the quadpair-N decomposition that defines QPN: `quadpair = (lane >> 2) & 3`, each quadpair owning an 8-column slice of the warp's 32-column tile (`tile * 32`, `n >> 5`), the A-fragment row taken from lane position inside the quadpair (`(lane & 3) + ((lane & 16) ? 4 : 0)`), and split-K across warps reduced through `partials[SplitK][32]`. This is the layout documented in v100-skinny's `docs/qpn_race_notes.md` (kernels dated 2026-08-10), which `docs/design/sm70_qwen38_qpn8_decode.md` already cites.

## Changes

- Add the existing two-line provenance header to both files.
- Add v100-skinny to README Acknowledgements beside marlin_v100.

Comment and documentation only. No code change, no behaviour change.

Thanks for retaining the notice on QPN2/QPN8 — this brings the two later adaptations in line with the README's own note that adapted implementations preserve provenance in source.

— Dennis Vertzyas, author of v100-skinny
