### PR TITLE
[Kernel][Bugfix] Validate QUASAR NVFP4 DFlash2 on V100

### DIFF
--- a/benchmarks/benchmark_dsv4_dspark_long_context.py
+++ b/benchmarks/benchmark_dsv4_dspark_long_context.py
@@ -81,8 +81,9 @@ def _build_messages(unit_count: int, marker: str) -> list[dict[str, str]]:
         {
             "role": "system",
             "content": (
-                "Follow the final user instruction exactly. Long repeated context "
-                "must not cause repetition, garbling, or loss of the suffix."
+                f"This request is isolated by {marker}. Follow the final user "
+                "instruction exactly. Long repeated context must not cause "
+                "repetition, garbling, or loss of the suffix."
             ),
         },
         {"role": "user", "content": filler + instruction},
@@ -155,6 +156,8 @@ def _metrics_snapshot(host: str, port: int, timeout: int) -> dict[str, Any]:
         "rounds": _metric_total(text, "vllm:spec_decode_num_drafts_total"),
         "proposed": _metric_total(text, "vllm:spec_decode_num_draft_tokens_total"),
         "accepted": _metric_total(text, "vllm:spec_decode_num_accepted_tokens_total"),
+        "prompt_tokens": _metric_total(text, "vllm:prompt_tokens_total"),
+        "prefill_seconds": _metric_total(text, "vllm:request_prefill_time_seconds_sum"),
         "positions": positions,
     }
 
@@ -399,6 +402,8 @@ def _run_case(
     rounds = after["rounds"] - before["rounds"]
     proposed = after["proposed"] - before["proposed"]
     accepted = after["accepted"] - before["accepted"]
+    computed_prompt_tokens = after["prompt_tokens"] - before["prompt_tokens"]
+    prefill_seconds = after["prefill_seconds"] - before["prefill_seconds"]
     accepted_per_position = [
         after["positions"].get(position, 0.0) - before["positions"].get(position, 0.0)
         for position in range(num_speculative_tokens)
@@ -446,6 +451,15 @@ def _run_case(
                     value / rounds if rounds else None
                     for value in accepted_per_position
                 ],
+            },
+            "prefill_metrics": {
+                "computed_prompt_tokens": computed_prompt_tokens,
+                "prefill_seconds": prefill_seconds,
+                "tokens_per_second": (
+                    computed_prompt_tokens / prefill_seconds
+                    if prefill_seconds > 0
+                    else None
+                ),
             },
             "verifier_profile": verifier_profile,
         }

--- a/benchmarks/benchmark_sm70_dflash2_gsm8k.py
+++ b/benchmarks/benchmark_sm70_dflash2_gsm8k.py
@@ -8,6 +8,7 @@ import argparse
 import hashlib
 import json
 import math
+import os
 import random
 import subprocess
 import time
@@ -17,17 +18,31 @@ from pathlib import Path
 from typing import Any
 
 import regex as re
-from benchmark_sm70_decode import (
-    _diff_spec_metrics,
-    _hash_ids,
-    _json_safe,
-    _module_file,
-    _module_realpath,
-    _parse_extra_engine_args,
-    _request_metrics_dict,
-    _spec_metrics_snapshot,
-    _tracked_env,
-)
+
+if __package__:
+    from benchmarks.benchmark_sm70_decode import (
+        _diff_spec_metrics,
+        _hash_ids,
+        _json_safe,
+        _module_file,
+        _module_realpath,
+        _parse_extra_engine_args,
+        _request_metrics_dict,
+        _spec_metrics_snapshot,
+        _tracked_env,
+    )
+else:
+    from benchmark_sm70_decode import (
+        _diff_spec_metrics,
+        _hash_ids,
+        _json_safe,
+        _module_file,
+        _module_realpath,
+        _parse_extra_engine_args,
+        _request_metrics_dict,
+        _spec_metrics_snapshot,
+        _tracked_env,
+    )
 
 INVALID_ANSWER = -9_999_999
 _NUMBER_RE = re.compile(r"(?<![\w.])[-+]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?(?![\w.])")
@@ -138,6 +153,43 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _git_sha(path: Path) -> str | None:
+    """Return repository provenance without making benchmark data disposable."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=path,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _append_partial_case(
+    path: Path,
+    *,
+    dataset_index: int,
+    request_seed: int | None,
+    output: Any,
+) -> None:
+    """Durably retain a completed case before a long quality run finishes."""
+    result = output.outputs[0]
+    record = {
+        "dataset_index": dataset_index,
+        "request_seed": request_seed,
+        "output_tokens": len(result.token_ids),
+        "finish_reason": result.finish_reason,
+        "stop_reason": result.stop_reason,
+        "text": result.text,
+        "token_ids": list(result.token_ids),
+    }
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(record, sort_keys=True) + "\n")
+        file.flush()
+        os.fsync(file.fileno())
 
 
 def _request_seeds(args: argparse.Namespace) -> list[int | None]:
@@ -367,6 +419,9 @@ def main() -> int:
     outputs = []
     request_spec_metrics = []
     case_inputs = []
+    partial_path = args.out.with_suffix(args.out.suffix + ".partial.jsonl")
+    partial_path.parent.mkdir(parents=True, exist_ok=True)
+    partial_path.write_text("", encoding="utf-8")
     for seed_base in request_seeds:
         if args.sequential:
             seed_outputs = []
@@ -385,12 +440,19 @@ def main() -> int:
                     skip_special_tokens=False,
                 )
                 request_spec_before = _spec_metrics_snapshot(llm)
-                seed_outputs.append(llm.generate([prompt], sampling, use_tqdm=False)[0])
+                generated = llm.generate([prompt], sampling, use_tqdm=False)[0]
+                seed_outputs.append(generated)
                 request_spec_after = _spec_metrics_snapshot(llm)
                 seed_spec_metrics.append(
                     _diff_spec_metrics(request_spec_before, request_spec_after)
                 )
                 actual_seeds.append(request_seed)
+                _append_partial_case(
+                    partial_path,
+                    dataset_index=dataset_index,
+                    request_seed=request_seed,
+                    output=generated,
+                )
         else:
             sampling = SamplingParams(
                 temperature=args.temperature,
@@ -403,6 +465,15 @@ def main() -> int:
             seed_outputs = llm.generate(prompts, sampling, use_tqdm=False)
             seed_spec_metrics = [None] * len(seed_outputs)
             actual_seeds = [seed_base] * len(seed_outputs)
+            for (dataset_index, _row), generated in zip(
+                rows, seed_outputs, strict=True
+            ):
+                _append_partial_case(
+                    partial_path,
+                    dataset_index=dataset_index,
+                    request_seed=seed_base,
+                    output=generated,
+                )
         outputs.extend(seed_outputs)
         request_spec_metrics.extend(seed_spec_metrics)
         case_inputs.extend(
@@ -501,11 +572,8 @@ def main() -> int:
     c_stable_extension = Path(vllm_c_stable.__file__).resolve()
     payload = {
         "contract": {
-            "source_sha": subprocess.check_output(
-                ["git", "rev-parse", "HEAD"],
-                cwd=Path(__file__).resolve().parents[1],
-                text=True,
-            ).strip(),
+            "source_sha": _git_sha(Path(__file__).resolve().parents[1]),
+            "partial_result_file": str(partial_path),
             "mode": args.mode,
             "dataset": str(args.dataset),
             "dataset_sha256": _sha256_file(args.dataset),

--- a/benchmarks/benchmark_sm70_serving_quality.py
+++ b/benchmarks/benchmark_sm70_serving_quality.py
@@ -20,19 +20,35 @@ from pathlib import Path
 from typing import Any
 
 import regex as re
-from benchmark_sm70_model_tokens import (
-    _parse_extra_engine_args,
-    _sm70_attention_policy,
-    _sm70_comm_policy,
-    _sm70_gdn_fla_policy,
-    _sm70_graph_policy,
-    _sm70_moe_policy,
-    _sm70_sampling_policy,
-    _sm70_tune_policy,
-    _sm70_turbomind_policy,
-    _tracked_env,
-)
-from run_sm70_release_matrix import _fixed_quality_contract_failures
+
+if __package__:
+    from benchmarks.benchmark_sm70_model_tokens import (
+        _parse_extra_engine_args,
+        _sm70_attention_policy,
+        _sm70_comm_policy,
+        _sm70_gdn_fla_policy,
+        _sm70_graph_policy,
+        _sm70_moe_policy,
+        _sm70_sampling_policy,
+        _sm70_tune_policy,
+        _sm70_turbomind_policy,
+        _tracked_env,
+    )
+    from benchmarks.run_sm70_release_matrix import _fixed_quality_contract_failures
+else:
+    from benchmark_sm70_model_tokens import (
+        _parse_extra_engine_args,
+        _sm70_attention_policy,
+        _sm70_comm_policy,
+        _sm70_gdn_fla_policy,
+        _sm70_graph_policy,
+        _sm70_moe_policy,
+        _sm70_sampling_policy,
+        _sm70_tune_policy,
+        _sm70_turbomind_policy,
+        _tracked_env,
+    )
+    from run_sm70_release_matrix import _fixed_quality_contract_failures
 
 DEFAULT_PROMPTS = [
     "Write one sentence about deterministic validation.",
@@ -172,12 +188,16 @@ def _counter_delta(
     accepted_tokens = delta.get("vllm:spec_decode_num_accepted_tokens_total", 0.0)
     generation_tokens = delta.get("vllm:generation_tokens_total", 0.0)
     prompt_tokens = delta.get("vllm:prompt_tokens_total", 0.0)
+    position_prefix = "vllm:spec_decode_num_accepted_tokens_per_pos_total:position_"
+    position_indices = [
+        int(key.removeprefix(position_prefix))
+        for key in delta
+        if key.startswith(position_prefix)
+        and key.removeprefix(position_prefix).isdigit()
+    ]
     per_position = [
-        delta.get(
-            f"vllm:spec_decode_num_accepted_tokens_per_pos_total:position_{pos}",
-            0.0,
-        )
-        for pos in range(4)
+        delta.get(f"{position_prefix}{pos}", 0.0)
+        for pos in range(max(position_indices, default=-1) + 1)
     ]
     return {
         "raw": delta,
@@ -415,9 +435,17 @@ def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | N
     total_accepted_tokens = sum(
         float(item["num_accepted_tokens"]) for item in per_request
     )
+    num_positions = max(
+        (len(item["accepted_tokens_per_pos"]) for item in per_request), default=0
+    )
     per_position = [
-        sum(float(item["accepted_tokens_per_pos"][pos]) for item in per_request)
-        for pos in range(4)
+        sum(
+            float(item["accepted_tokens_per_pos"][pos])
+            if pos < len(item["accepted_tokens_per_pos"])
+            else 0.0
+            for item in per_request
+        )
+        for pos in range(num_positions)
     ]
     return {
         "num_drafts": total_drafts,

--- a/benchmarks/benchmark_sm70_tool_protocol.py
+++ b/benchmarks/benchmark_sm70_tool_protocol.py
@@ -894,6 +894,7 @@ def _run_json_schema_bench_sample(
     schema_dir: Path,
     limit: int,
     max_schema_bytes: int,
+    max_tokens: int,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     candidates = sorted(
@@ -933,7 +934,7 @@ def _run_json_schema_bench_sample(
             "return_token_ids": True,
             "temperature": 0.0,
             "seed": seed,
-            "max_tokens": 2048,
+            "max_tokens": max_tokens,
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -1191,6 +1192,10 @@ def _run_structured(base_url: str, model: str, seed: int) -> dict[str, Any]:
             "temperature": 0.0,
             "seed": seed,
             "max_tokens": 512,
+            # This is a protocol/escaping gate, not a reasoning-budget gate.
+            # Thinking is covered separately with a sufficiently large output
+            # budget so it cannot consume this fixed 512-token contract.
+            "chat_template_kwargs": {"enable_thinking": False},
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -1227,6 +1232,7 @@ def main() -> None:
     parser.add_argument("--json-schema-dir", type=Path)
     parser.add_argument("--json-schema-limit", type=int, default=0)
     parser.add_argument("--json-schema-max-bytes", type=int, default=16384)
+    parser.add_argument("--json-schema-max-tokens", type=int, default=2048)
     parser.add_argument(
         "--only-datasets",
         action="store_true",
@@ -1267,6 +1273,7 @@ def main() -> None:
             args.json_schema_dir,
             args.json_schema_limit,
             args.json_schema_max_bytes,
+            args.json_schema_max_tokens,
         )
     result_keys = {
         "tool_chain",

--- a/benchmarks/kernels/benchmark_sm70_quasar_nvfp4_oracle.py
+++ b/benchmarks/kernels/benchmark_sm70_quasar_nvfp4_oracle.py
@@ -1,0 +1,539 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Audit SM70 TurboMind against real QUASAR NVFP4 projection shards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+
+@dataclass(frozen=True)
+class Projection:
+    name: str
+    packed: torch.Tensor
+    scales: torch.Tensor
+    weight_global_divisor: float
+    input_global_divisor: float
+
+
+QPN2_CONFIGS = {
+    # (K, physical N): (split K, independent accumulator chains)
+    (1536, 5120): (8, 2),
+    (4352, 5120): (16, 2),
+    (5120, 3584): (16, 2),
+    (5120, 4128): (16, 2),
+    (5120, 8704): (8, 2),
+}
+
+
+class Checkpoint:
+    def __init__(self, model: Path):
+        self.model = model
+        index_path = model / "model.safetensors.index.json"
+        self.weight_map = json.loads(index_path.read_text())["weight_map"]
+
+    def tensor(self, name: str) -> torch.Tensor:
+        shard = self.model / self.weight_map[name]
+        with safe_open(shard, framework="pt", device="cpu") as tensors:
+            return tensors.get_tensor(name)
+
+
+def _projection_keys(prefix: str) -> tuple[str, str, str, str]:
+    return tuple(
+        f"{prefix}.{suffix}"
+        for suffix in (
+            "weight_packed",
+            "weight_scale",
+            "weight_global_scale",
+            "input_global_scale",
+        )
+    )  # type: ignore[return-value]
+
+
+def _load_column_parallel(
+    checkpoint: Checkpoint,
+    name: str,
+    prefixes: tuple[str, ...],
+    tp_rank: int,
+    tp_size: int,
+) -> Projection:
+    packed_parts: list[torch.Tensor] = []
+    scale_parts: list[torch.Tensor] = []
+    weight_divisors: list[float] = []
+    input_divisors: list[float] = []
+    for prefix in prefixes:
+        packed_key, scale_key, weight_key, input_key = _projection_keys(prefix)
+        packed = checkpoint.tensor(packed_key)
+        scales = checkpoint.tensor(scale_key)
+        if packed.shape[0] % tp_size:
+            raise ValueError(f"{prefix}: output rows do not divide TP{tp_size}")
+        rows = packed.shape[0] // tp_size
+        start = tp_rank * rows
+        packed_parts.append(packed[start : start + rows].contiguous())
+        scale_parts.append(scales[start : start + rows].contiguous())
+        weight_divisors.append(float(checkpoint.tensor(weight_key).flatten()[0]))
+        input_divisors.append(float(checkpoint.tensor(input_key).flatten()[0]))
+    if len(set(weight_divisors)) != 1 or len(set(input_divisors)) != 1:
+        raise ValueError(
+            f"{name}: fused logical projections have different global scales"
+        )
+    return Projection(
+        name=name,
+        packed=torch.cat(packed_parts),
+        scales=torch.cat(scale_parts),
+        weight_global_divisor=weight_divisors[0],
+        input_global_divisor=input_divisors[0],
+    )
+
+
+def _load_row_parallel(
+    checkpoint: Checkpoint,
+    name: str,
+    prefix: str,
+    tp_rank: int,
+    tp_size: int,
+) -> Projection:
+    packed_key, scale_key, weight_key, input_key = _projection_keys(prefix)
+    packed = checkpoint.tensor(packed_key)
+    scales = checkpoint.tensor(scale_key)
+    if packed.shape[1] % tp_size or scales.shape[1] % tp_size:
+        raise ValueError(f"{prefix}: input columns do not divide TP{tp_size}")
+    packed_cols = packed.shape[1] // tp_size
+    scale_cols = scales.shape[1] // tp_size
+    packed_start = tp_rank * packed_cols
+    scale_start = tp_rank * scale_cols
+    return Projection(
+        name=name,
+        packed=packed[:, packed_start : packed_start + packed_cols].contiguous(),
+        scales=scales[:, scale_start : scale_start + scale_cols].contiguous(),
+        weight_global_divisor=float(checkpoint.tensor(weight_key).flatten()[0]),
+        input_global_divisor=float(checkpoint.tensor(input_key).flatten()[0]),
+    )
+
+
+def _load_projections(model: Path, tp_rank: int, tp_size: int) -> list[Projection]:
+    checkpoint = Checkpoint(model)
+    root = "model.language_model.layers"
+    gdn = f"{root}.0.linear_attn"
+    attn = f"{root}.3.self_attn"
+    mlp = f"{root}.0.mlp"
+    return [
+        _load_column_parallel(
+            checkpoint,
+            "gdn_qkvzba",
+            (
+                f"{gdn}.in_proj_qkv",
+                f"{gdn}.in_proj_z",
+                f"{gdn}.in_proj_b",
+                f"{gdn}.in_proj_a",
+            ),
+            tp_rank,
+            tp_size,
+        ),
+        _load_row_parallel(checkpoint, "gdn_out", f"{gdn}.out_proj", tp_rank, tp_size),
+        _load_column_parallel(
+            checkpoint,
+            "attention_qkv",
+            (f"{attn}.q_proj", f"{attn}.k_proj", f"{attn}.v_proj"),
+            tp_rank,
+            tp_size,
+        ),
+        _load_row_parallel(
+            checkpoint, "attention_out", f"{attn}.o_proj", tp_rank, tp_size
+        ),
+        _load_column_parallel(
+            checkpoint,
+            "mlp_gate_up",
+            (f"{mlp}.gate_proj", f"{mlp}.up_proj"),
+            tp_rank,
+            tp_size,
+        ),
+        _load_row_parallel(
+            checkpoint, "mlp_down", f"{mlp}.down_proj", tp_rank, tp_size
+        ),
+    ]
+
+
+def _unpack_codes(packed: torch.Tensor) -> torch.Tensor:
+    return (
+        torch.stack((packed & 0xF, packed >> 4), dim=-1)
+        .flatten(start_dim=-2)
+        .t()
+        .contiguous()
+    )
+
+
+def _dequantize_weight(projection: Projection, device: torch.device) -> torch.Tensor:
+    packed = projection.packed.to(device)
+    nibbles = torch.stack((packed & 0xF, packed >> 4), dim=-1).flatten(start_dim=-2)
+    magnitudes = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        dtype=torch.float32,
+        device=device,
+    )
+    weight = magnitudes[(nibbles & 7).long()]
+    weight = torch.where((nibbles & 8) != 0, -weight, weight)
+    effective_scales = (
+        projection.scales.float().to(device) / projection.weight_global_divisor
+    )
+    return weight * effective_scales.repeat_interleave(16, dim=1)
+
+
+def _quality(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, object]:
+    actual_f = actual.float()
+    expected_f = expected.float()
+    delta = actual_f - expected_f
+    denominator = torch.linalg.vector_norm(expected_f).clamp_min(1e-12)
+    return {
+        "finite": bool(torch.isfinite(actual).all()),
+        "max_abs": float(delta.abs().max()),
+        "mean_abs": float(delta.abs().mean()),
+        "relative_l2": float(torch.linalg.vector_norm(delta) / denominator),
+        "cosine": float(
+            torch.nn.functional.cosine_similarity(actual_f, expected_f, dim=1)
+            .mean()
+            .item()
+        ),
+    }
+
+
+def _graph_latency_us(call, warmup: int = 20, repeats: int = 100) -> float:
+    for _ in range(3):
+        call()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        call()
+    for _ in range(warmup):
+        graph.replay()
+    torch.accelerator.synchronize()
+    samples = []
+    for _ in range(5):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(repeats):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000 / repeats)
+    return statistics.median(samples)
+
+
+def _run_projection(
+    projection: Projection,
+    m: int,
+    device: torch.device,
+    generator: torch.Generator,
+    sweep_qpn2: bool,
+) -> dict[str, object]:
+    from vllm import _sm70_ops
+
+    qweight = _unpack_codes(projection.packed).to(device)
+    effective_scales = (
+        (projection.scales.t().float() / projection.weight_global_divisor)
+        .half()
+        .contiguous()
+        .to(device)
+    )
+    x = (
+        torch.randn(
+            (m, qweight.shape[0]),
+            dtype=torch.float16,
+            device=device,
+            generator=generator,
+        )
+        * 0.1
+    )
+    tm_weight, tm_scales, meta = _sm70_ops.nvfp4_sm70_prepare(
+        qweight, effective_scales, 16, False
+    )
+    out = torch.empty((m, qweight.shape[1]), dtype=torch.float16, device=device)
+    _sm70_ops.nvfp4_gemm_sm70_out(
+        out,
+        x,
+        tm_weight,
+        tm_scales,
+        16,
+        int(meta[0]),
+        int(meta[1]),
+        False,
+    )
+    weight = _dequantize_weight(projection, device)
+    expected = x.float().matmul(weight.t())
+    torch.accelerator.synchronize(device)
+    result: dict[str, object] = {
+        "name": projection.name,
+        "m": m,
+        "n": int(qweight.shape[1]),
+        "k": int(qweight.shape[0]),
+        "weight_global_divisor": projection.weight_global_divisor,
+        "input_global_divisor": projection.input_global_divisor,
+        "quality": _quality(out, expected),
+    }
+    production_out = out
+    production_tm_weight = tm_weight
+    production_tm_scales = tm_scales
+    production_meta = meta
+    if qweight.shape[1] % 16:
+        padded_n = (qweight.shape[1] + 15) // 16 * 16
+        padded_weight = torch.zeros(
+            (qweight.shape[0], padded_n), dtype=qweight.dtype, device=device
+        )
+        padded_scales = torch.zeros(
+            (effective_scales.shape[0], padded_n),
+            dtype=effective_scales.dtype,
+            device=device,
+        )
+        padded_weight[:, : qweight.shape[1]].copy_(qweight)
+        padded_scales[:, : qweight.shape[1]].copy_(effective_scales)
+        padded_tm_weight, padded_tm_scales, padded_meta = _sm70_ops.nvfp4_sm70_prepare(
+            padded_weight, padded_scales, 16, False
+        )
+        padded_out = torch.empty((m, padded_n), dtype=torch.float16, device=device)
+        _sm70_ops.nvfp4_gemm_sm70_out(
+            padded_out,
+            x,
+            padded_tm_weight,
+            padded_tm_scales,
+            16,
+            int(padded_meta[0]),
+            int(padded_meta[1]),
+            False,
+        )
+        torch.accelerator.synchronize(device)
+        result["padded_n"] = padded_n
+        result["padded_quality"] = _quality(padded_out[:, : qweight.shape[1]], expected)
+        production_out = padded_out
+        production_tm_weight = padded_tm_weight
+        production_tm_scales = padded_tm_scales
+        production_meta = padded_meta
+
+    logical_n = projection.packed.shape[0]
+    physical_n = (logical_n + 31) // 32 * 32
+    qpn2_packed = projection.packed.to(device)
+    qpn2_weight_scales = projection.scales.to(device)
+    if physical_n != logical_n:
+        physical_packed = torch.zeros(
+            (physical_n, qpn2_packed.shape[1]), dtype=torch.uint8, device=device
+        )
+        physical_weight_scales = torch.zeros(
+            (physical_n, qpn2_weight_scales.shape[1]),
+            dtype=qpn2_weight_scales.dtype,
+            device=device,
+        )
+        physical_packed[:logical_n].copy_(qpn2_packed)
+        physical_weight_scales[:logical_n].copy_(qpn2_weight_scales)
+        qpn2_packed = physical_packed
+        qpn2_weight_scales = physical_weight_scales
+    qpn2_codes, qpn2_scales = _sm70_ops.nvfp4_qpn2_prepare_sm70(
+        qpn2_packed, qpn2_weight_scales
+    )
+    qpn2_out = torch.empty((m, physical_n), dtype=torch.float16, device=device)
+    split_k, accumulator_chains = QPN2_CONFIGS[(x.shape[1], physical_n)]
+
+    def run_qpn2() -> None:
+        _sm70_ops.nvfp4_qpn2_gemm_sm70_out(
+            qpn2_out,
+            x,
+            qpn2_codes,
+            qpn2_scales,
+            1.0 / projection.weight_global_divisor,
+            split_k,
+            accumulator_chains,
+        )
+
+    def run_turbomind() -> None:
+        _sm70_ops.nvfp4_gemm_sm70_out(
+            production_out,
+            x,
+            production_tm_weight,
+            production_tm_scales,
+            16,
+            int(production_meta[0]),
+            int(production_meta[1]),
+            False,
+        )
+
+    result["qpn2_physical_n"] = physical_n
+    turbomind_graph_us = _graph_latency_us(run_turbomind)
+    result["turbomind_graph_us"] = turbomind_graph_us
+    if m > 8:
+        # Exercise the production large-M implementation independently of its
+        # tuned M threshold. The branch is shape-invariant once selected, so a
+        # small real-weight M keeps this oracle cheap while covering every
+        # QUASAR attention/GDN/MLP projection.
+        prefill_out = torch.empty_like(qpn2_out)
+
+        def run_qpn2_prefill() -> None:
+            _sm70_ops.nvfp4_qpn2_prefill_dispatch_sm70_out(
+                prefill_out,
+                x,
+                qpn2_codes,
+                qpn2_scales,
+                1.0 / projection.weight_global_divisor,
+                split_k,
+                accumulator_chains,
+                production_tm_weight,
+                production_tm_scales,
+                16,
+                int(production_meta[0]),
+                int(production_meta[1]),
+                False,
+                9,
+            )
+
+        run_qpn2_prefill()
+        torch.accelerator.synchronize(device)
+        result["qpn2_prefill_quality"] = _quality(prefill_out[:, :logical_n], expected)
+        result["qpn2_prefill_vs_turbomind"] = _quality(
+            prefill_out[:, :logical_n], production_out[:, :logical_n]
+        )
+        qpn2_prefill_graph_us = _graph_latency_us(run_qpn2_prefill)
+        result["qpn2_prefill_graph_us"] = qpn2_prefill_graph_us
+        result["qpn2_prefill_speedup"] = turbomind_graph_us / qpn2_prefill_graph_us
+        torch.accelerator.empty_cache()
+        return result
+
+    run_qpn2()
+    torch.accelerator.synchronize(device)
+    result["qpn2_quality"] = _quality(qpn2_out[:, :logical_n], expected)
+    result["qpn2_vs_turbomind"] = _quality(
+        qpn2_out[:, :logical_n], production_out[:, :logical_n]
+    )
+    if projection.name == "mlp_gate_up":
+        qpn2_gated_out = torch.empty(
+            (m, physical_n // 2), dtype=torch.float16, device=device
+        )
+        _sm70_ops.nvfp4_qpn2_gated_sm70_out(
+            qpn2_gated_out,
+            x,
+            qpn2_codes,
+            qpn2_scales,
+            1.0 / projection.weight_global_divisor,
+            split_k,
+            accumulator_chains,
+        )
+        torch.accelerator.synchronize(device)
+        logical_half = logical_n // 2
+        expected_gated = (
+            torch.nn.functional.silu(expected[:, :logical_half])
+            * (expected[:, logical_half:logical_n])
+        )
+        turbomind_gated = (
+            torch.nn.functional.silu(production_out[:, :logical_half].float())
+            * production_out[:, logical_half:logical_n].float()
+        )
+        result["qpn2_gated_quality"] = _quality(
+            qpn2_gated_out[:, :logical_half], expected_gated
+        )
+        result["qpn2_gated_vs_turbomind"] = _quality(
+            qpn2_gated_out[:, :logical_half], turbomind_gated
+        )
+    qpn2_graph_us = _graph_latency_us(run_qpn2)
+    result["qpn2_graph_us"] = qpn2_graph_us
+    result["qpn2_speedup"] = turbomind_graph_us / qpn2_graph_us
+    if sweep_qpn2:
+        candidates = []
+        for candidate_split_k in (8, 16, 32):
+            if (x.shape[1] // 16) % candidate_split_k:
+                continue
+            for candidate_accumulator_chains in (1, 2):
+
+                def run_candidate(
+                    split_k: int = candidate_split_k,
+                    accumulator_chains: int = candidate_accumulator_chains,
+                ) -> None:
+                    _sm70_ops.nvfp4_qpn2_gemm_sm70_out(
+                        qpn2_out,
+                        x,
+                        qpn2_codes,
+                        qpn2_scales,
+                        1.0 / projection.weight_global_divisor,
+                        split_k,
+                        accumulator_chains,
+                    )
+
+                run_candidate()
+                torch.accelerator.synchronize(device)
+                candidate = {
+                    "split_k": candidate_split_k,
+                    "accumulator_chains": candidate_accumulator_chains,
+                    "graph_us": _graph_latency_us(run_candidate),
+                    "quality": _quality(qpn2_out[:, :logical_n], expected),
+                    "vs_turbomind": _quality(
+                        qpn2_out[:, :logical_n], production_out[:, :logical_n]
+                    ),
+                }
+                if projection.name == "mlp_gate_up" and candidate_split_k <= 16:
+                    gated_out = torch.empty(
+                        (m, physical_n // 2), dtype=torch.float16, device=device
+                    )
+
+                    def run_gated_candidate(
+                        split_k: int = candidate_split_k,
+                        accumulator_chains: int = candidate_accumulator_chains,
+                        output: torch.Tensor = gated_out,
+                    ) -> None:
+                        _sm70_ops.nvfp4_qpn2_gated_sm70_out(
+                            output,
+                            x,
+                            qpn2_codes,
+                            qpn2_scales,
+                            1.0 / projection.weight_global_divisor,
+                            split_k,
+                            accumulator_chains,
+                        )
+
+                    candidate["gated_graph_us"] = _graph_latency_us(run_gated_candidate)
+                candidates.append(candidate)
+        result["qpn2_sweep"] = candidates
+    torch.accelerator.empty_cache()
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--m", type=int, nargs="+", default=(1, 8))
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--sweep-qpn2", action="store_true")
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This audit requires an exact SM70 GPU")
+    generator = torch.Generator(device=device).manual_seed(20260902)
+    projections = _load_projections(args.model, args.tp_rank, args.tp_size)
+    rows = [
+        _run_projection(projection, m, device, generator, args.sweep_qpn2)
+        for projection in projections
+        for m in args.m
+    ]
+    payload = {
+        "model": str(args.model),
+        "tp_rank": args.tp_rank,
+        "tp_size": args.tp_size,
+        "device": torch.cuda.get_device_name(device),
+        "rows": rows,
+    }
+    encoded = json.dumps(payload, indent=2)
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(encoded + "\n")
+    print(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/sm70_quasar_nvfp4_dflash2_acceptance.md
+++ b/docs/design/sm70_quasar_nvfp4_dflash2_acceptance.md
@@ -1,0 +1,289 @@
+# SM70 QUASAR NVFP4 DFlash2 acceptance
+
+> Status: implementation, matched target/DFlash acceptance, and fresh-wheel
+> release validation complete. All numerical, performance, quality, protocol,
+> packaging, and memory findings below are measured on the four-V100 release
+> host.
+
+## Scope and frozen contract
+
+This work admits the fully quantized
+`QUASAR-QAT/Qwen3.8-27B-QUASAR-NVFP4` checkpoint on four V100 GPUs without
+narrowing DFlash2 to `max_num_seqs=1`, a 512-token prefill budget, or one target
+KV dtype. The measured practical contract is TP4, FP16 execution, Flash-V100,
+FP8 E5M2 target KV, FP16 draft KV, prefix caching, Mamba alignment, a 256K
+declared context, `max_num_batched_tokens=4096`, `max_num_seqs=4`, seven model
+drafts, selector top-16, probabilistic draft sampling, and full target/draft
+CUDA graphs. The final wheel gate measures cold prefill only through 64K, as
+required by the release test plan.
+
+The checkpoint differs materially from the earlier mixed NVFP4 baseline. All
+attention, GDN, and MLP linears are checkpoint-native NVFP4. On Volta, the
+accepted QPN2 and TurboMind kernels execute those weights as W4A16: they retain
+the checkpoint's FP4 weights and group scales but consume FP16 activations.
+They do not emulate the checkpoint's W4A4 activation quantizer. This is an
+existing SM70 execution contract, not a property of speculative decoding, and
+is why dataset scores rather than route logs are a mandatory release gate.
+
+## Correctness root cause
+
+The initial target-only smoke for `17 + 25` emitted a long run of `!`. A real
+checkpoint oracle covered all six TP-local projection shapes. Five shapes
+matched a dense dequantized-weight reference, while the GDN fused input
+projection did not:
+
+| Projection | TP-local shape | Old result |
+|---|---:|---:|
+| GDN `in_proj_qkvz` | K=5120, N=4120 | relative L2 about 0.5 |
+| GDN output | K=1536, N=5120 | within FP16 tolerance |
+| attention QKV | K=5120, N=3584 | within FP16 tolerance |
+| attention output | K=1536, N=5120 | within FP16 tolerance |
+| MLP gate/up | K=5120, N=8704 | within FP16 tolerance |
+| MLP down | K=4352, N=5120 | within FP16 tolerance |
+
+N=4120 is divisible by eight but not by the TurboMind converter's required
+16-column physical layout. The converter silently produced corrupt values.
+Padding weights and scales with zero rows to N=4128, executing the physical
+shape, and cropping before bias reduced relative L2 to about `3e-4` with cosine
+similarity rounding to 1.0 on every TP rank. The exact arithmetic smoke then
+returned `42`.
+
+The implementation records logical and physical output widths in the prepared
+linear state, uses the physical width for warmup and execution, and crops to
+the logical width before bias, reshape, or a row-parallel collective consumes
+the result. Padded fused gate-SiLU remains rejected because no current model
+needs that unsupported layout.
+
+## QPN2 all-projection verification path
+
+The same real-weight oracle was extended to the six QUASAR projection shapes
+at M=1 and M=8 on all four TP shards. QPN2 passed every cell. In the final M=8
+run, the worst observed relative L2 was `5.20e-4`; cosine similarity was at
+least `0.99999988`. Depending on the projection and TP shard, QPN2 was
+`1.29x--3.94x` faster than the corrected TurboMind path. The N=4120 GDN fused
+input projection used a physical N=4128 buffer on all four ranks. A forced
+M=16 run separately covered the ephemeral dense-prefill algorithm; its output
+differed from the established TurboMind reference by at most one FP16 ULP.
+M=16 timing is deliberately not a production claim because the actual
+large-M threshold is 1024.
+
+The runtime admission is intentionally exact: compressed-tensors NVFP4,
+recognized Qwen3.8 TP4 projection suffix and packed shape, DFlash block 8,
+selector top-16, PP1, and no DBO. It does not require one resident sequence,
+E5M2 target KV, or a particular prefill chunk. Unsupported shapes retain the
+corrected TurboMind path.
+
+A production-shape Split-K/accumulator sweep found only about 0.15 ms of
+additional whole-model opportunity. That reduction-order change is not being
+promoted: the practical round is already below the target and preserving the
+current quality candidate is more valuable than a marginal timing claim.
+
+## Scheduler and prefill isolation
+
+MRV2 DFlash owns a separate K+1 query batch. Its K mask slots must size the
+draft `InputBuffers`, hidden-state buffer, context-position buffer, and
+per-group slot mappings; they must not be subtracted from the target
+scheduler's prefill budget. A target-only scheduled-token property now returns
+zero extra target slots for `method=dflash` while retaining the old accounting
+for Eagle, MTP, and `dflash_ddtree`.
+
+The DFlash speculator independently raises draft buffer capacity to at least
+`max_num_seqs * (draft_block + 1)`. Its runtime and captured CUDA graph also
+use a DFlash-owned persistent slot-mapping buffer rather than borrowing the
+target `BlockTables` allocation. This closes the out-of-bounds case where
+`max_num_seqs * 8` exceeds `max_num_batched_tokens`. The SM70 interactivity
+defaults no longer force `max_num_seqs=1` or
+`max_num_batched_tokens=4096`; normal server defaults and every explicit user
+override survive.
+
+With prefix caching and Mamba alignment enabled, two cold token-ID repetitions
+measured 4,138/4,155 token/s at 32K and 3,612/3,607 token/s at 63,488 tokens.
+A later cold chat-contract confirmation, with a marker before the repeated
+body to prevent accidental cross-case prefix reuse, measured:
+
+| Prompt | Prefill throughput |
+|---:|---:|
+| 32,724 tokens | 4,049 token/s |
+| 63,482 tokens | 3,607 token/s |
+
+These are slightly above the same-machine mixed-NVFP4 DFlash2 history of about
+4,039 and 3,567 token/s, so enabling DFlash2 no longer removes the accepted
+large-M QPN2-packed prefill path.
+
+## Complete-round evidence
+
+Graph-node tracing is diagnostic overhead, not a release timing. Under the
+same Nsight instrumentation, the old mixed target and QUASAR all-QPN2 target
+had nearly identical stable target-replay intervals (about 21.31 and 21.16 ms)
+and rank-max GPU service (about 19.39 and 19.19 ms). This establishes that the
+additional checkpoint-native NVFP4 projections are no longer an unexplained
+gap.
+
+The profiler-free practical service then ran five identical, warmed,
+single-request measurements on the final candidate:
+
+`17.543, 17.545, 17.517, 17.624, 17.532 ms/round`
+
+The mean is `17.552 ms`, with a `17.517--17.624 ms` range. The requested
+sub-20-ms gate therefore passes without binding server capacity to B1.
+
+## Quality gates
+
+The following gates were applied before packaging:
+
+1. target-only and DFlash2 use the same QUASAR checkpoint, sampling contract,
+   dataset order, seed policy, 16K output cap, practical cache settings, and
+   score harness;
+2. executable MBPP with long xhigh reasoning and token-level WikiText
+   likelihood must not show a meaningful loss versus target-only;
+3. BFCL-style simple, multiple, parallel, and irrelevance cases plus strict
+   JSON Schema cases must be compared with the target-only service;
+4. prefix-hit follow-ups and mixed-length batch 1/2/4 runs must show no stale
+   GDN state, KV corruption, graph residue, or memory growth;
+5. the DFlash2 seven-position acceptance vector must be reported in full.
+
+Target-only and DFlash both pass six of eight fixed BFCL cases. Both misses are
+the same two parallel fixtures, where each arm emits one valid call instead of
+the fixture's expected two calls; simple, multiple, and irrelevance cases all
+pass. Target-only passes all four fixed JSON Schema cases at a 2K budget.
+DFlash passes three at 2K; the remaining complex schema consumes the 2K budget
+in valid reasoning and emits no content, then passes and stops naturally at
+2,655 tokens with a 4K budget. This is a budget-sensitive reasoning trajectory,
+not malformed JSON or a speculative-decoding protocol error.
+
+The first matched MBPP-32 run uses temperature 1.0, top-p 0.95, top-k 20,
+`xhigh` reasoning, request seed 0, and a 16K natural-EOS cap. Target-only
+passes 32/32 independent tests; accelerated DFlash2 passes 31/32. EvalPlus
+excludes the one row without an independent contract and scores target-only
+versus DFlash2 Base `31/31` versus `30/31` and Plus `29/31` versus `27/31`.
+The only base discordance is one valid but incorrectly terminating comb-sort
+implementation. With one discordant pair, the exact McNemar p-value is 1.0;
+this run is evidence to investigate rather than evidence of a population
+regression.
+
+A full same-seed QPN2 rollback arm isolates the newly widened target operator
+from the rest of DFlash2. It also scores 31/32, EvalPlus Base 30/31, and Plus
+27/31, but fails a different row after a 16K reasoning-length termination.
+Thus disabling QPN2 does not recover aggregate quality. It reduces mean steady
+decode from 251.93 to 225.44 token/s and aggregate output throughput from
+228.75 to 208.06 token/s. Disabling QPN2 therefore does not repair the sampled
+failure but costs about 11.8% steady decode throughput.
+
+At request seed `20260925`, target-only and all-QPN2 DFlash2 both score MBPP
+32/32, EvalPlus Base 31/31, and Plus 28/31, with identical Plus failure rows.
+Across the two predeclared seeds, target-only scores Base 62/62 and Plus 57/62;
+DFlash scores Base 61/62 and Plus 55/62. There is only one paired discordance
+for each score class, which is not significant evidence of a population
+regression. The second seed's exact score and failure agreement also rejects
+the hypothesis that QPN2 systematically degrades code quality.
+
+On eight matched 2,048-token WikiText prompts, target-only and DFlash emit the
+same first output token and text in every case. The maximum prompt PPL
+difference is `0.00851`; the maximum per-token prompt/output log-probability
+difference is `0.938/0.190`, within the predeclared model-quality bounds of
+`1.0/0.25/0.01` for prompt logprob, output logprob, and PPL.
+
+Structured-output batch gates pass target-only and DFlash at B1/B2/B4
+(`42/42` each). The final DFlash protocol suite passes tool-chain 6/6, nested
+and escaped JSON schemas, and stream/non-stream parity 3/3. Explicit-history
+Responses replay passes; server-side Responses storage remains disabled
+because the current store has no eviction policy and is not required for tool
+calling. Prefix-state follow-ups pass 5/5 with and without thinking for both
+arms.
+
+A 96-request mixed B4 structured-output stress passes 96/96. V100 memory is
+28,855 MiB per rank before and after the run; the subsequent first long-prefill
+allocation leaves only a stable 4 MiB one-time increase. Logs contain no OOM,
+illegal access, traceback, stale-buffer symptom, or graph replay corruption.
+
+The earlier gross repeated-punctuation failure is closed by the N=4120
+physical-layout repair. No quality conclusion is inferred from that smoke or
+from greedy token equality.
+
+## Rollback and diagnostics
+
+- `VLLM_SM70_NVFP4_QPN2=0` retains corrected TurboMind execution.
+- `VLLM_SM70_NVFP4_QPN2_PREFILL=0` retains the established large-M fallback.
+- `VLLM_SM70_DFLASH2_VERIFY_FASTPATH=0` remains a diagnostic rollback, not a
+  production quality workaround.
+- Missing QPN2 operators or an unrecognized shape fall back explicitly; no
+  padded logical width may silently reach a converter that cannot represent
+  it.
+
+The real-checkpoint oracle is
+`benchmarks/kernels/benchmark_sm70_quasar_nvfp4_oracle.py`. The serving-quality
+reporter now discovers every speculative position dynamically instead of
+truncating DFlash2 at four positions. Long quality runs also retain each
+completed response in an fsync'd partial JSONL sidecar before final summary
+metadata is assembled.
+
+## Fresh 1.5.0 wheel release proof
+
+The CPython 3.12 SM70 wheel is
+`1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`, size `147,980,225` bytes,
+SHA256 `2a4d6bee4e19d315b142f2c563059f3064ddeeca563a6bdc828c33e1073c825b`.
+It was built with the CUDA 12.8 toolkit and version metadata `1.5.0`. All ten
+native libraries have empty RPATH/RUNPATH and resolve their Torch/CUDA
+dependencies with the normal runtime library set. The wheel retains the
+release dependency bound
+`prometheus-fastapi-instrumentator>=8.1.0,<9.0.0`.
+
+On the four-V100 host, the prior environment was cloned to a distinct Conda
+prefix, the old package was uninstalled, and this wheel was installed without
+dependencies or a source/PYTHONPATH overlay. `pip check` passes after satisfying
+the package's existing `setuptools>=77.0.3,<81.0.0` bound, and `vllm.__file__`
+resolves inside the new prefix. The core extension, QPN2 operators, SM70
+compact sampler, Flash-V100, and FlashQLA all load from that prefix.
+
+The source-independent TP4 server used FP16 execution, a 262,144-token declared
+context, E5M2 target KV, automatic FP16 draft KV, prefix caching with Mamba
+alignment, `max_num_batched_tokens=4096`, `max_num_seqs=4`, tool/reasoning
+parsers, and target plus draft CUDA graphs. No private fast-path environment
+variables were supplied. Startup logs automatically enabled the quality-audited
+DFlash2 defaults, loaded all checkpoint-native NVFP4 projections, selected
+QPN2 for compatible decode projections and QPN2-packed ephemeral prefill for
+M>=1024, and activated the exact q8 grouped verifier.
+
+The final targeted CPU contract suite passes 159 tests under the wheel's
+Torch 2.10/CUDA 12.8 ABI. Ruff lint, Ruff format, and `git diff --check` pass
+for every changed Python source and test file.
+
+The first 1K request against an empty Triton cache compiled seven bounded
+request-shape kernels and measured `23.055 ms/round`. With the cache warm, four
+identical requests measured `17.641`, `17.663`, `17.638`, and `17.637`
+ms/round: mean `17.645 ms`, range `17.637--17.663 ms`. The first and steady
+runs had the same 512 output tokens, 203 draft rounds, and `2.522` emitted
+tokens per round; the cold-only difference is compilation latency rather than
+an acceptance or execution-route change.
+
+Unique cold long-context requests measured:
+
+| Prompt | Prefill | Complete round | Pure decode | Emitted/round |
+|---:|---:|---:|---:|---:|
+| 32,724 tokens | 4,038.5 token/s | 18.827 ms | 134.9 token/s | 2.540 |
+| 63,482 tokens | 3,596.5 token/s | 20.358 ms | 105.7 token/s | 2.186 |
+
+Both requests contained the required suffix marker, had no replacement
+characters, and passed repetition/output-health checks. Their prefill rates are
+within about 0.3% of the accepted source measurements, so the wheel does not
+lose the promoted prefill path. These ordinary technical-writing prompts have
+lower acceptance than the historical easy prompt; complete-round latency, not
+their task-dependent decode throughput, is the release comparison.
+
+Two identical 9,994-token prefix requests returned the same healthy output.
+Wall time fell from `2.624 s` cold to `0.311 s` cached and TTFT from `2.506 s`
+to `0.210 s`; the server recorded 9,888 cached prompt tokens. A four-way
+concurrent strict-JSON test passed 16/16 requests. Per-rank GPU memory changed
+by at most 2 MiB, and the log contained no traceback, OOM, illegal access,
+assertion failure, stale-buffer symptom, or graph corruption. Graceful shutdown
+returned GPUs 0--3 to 6 MiB each.
+
+Fresh-wheel protocol probes returned `42.0`, emitted the requested
+`get_weather({"city":"Guangzhou"})` call, and produced a schema-valid
+`{"name":"小林","age":27}` object. The full client also passed the six-step
+tool chain, nested/escaped structured output, stream/non-stream parity, and
+explicit-history Responses replay. Its aggregate flag remains false only for
+`previous_response_id`: server-side Responses storage is intentionally disabled
+because the current store has no eviction policy. The first stored response is
+valid and the expected follow-up receives HTTP 404; ordinary Chat Completions
+tool calling and explicit-history Responses are unaffected.

--- a/tests/benchmarks/test_benchmark_sm70_decode.py
+++ b/tests/benchmarks/test_benchmark_sm70_decode.py
@@ -1,9 +1,56 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+import subprocess
 import types
 
-from benchmarks import benchmark_sm70_decode, benchmark_sm70_model_tokens
+from benchmarks import (
+    benchmark_sm70_decode,
+    benchmark_sm70_dflash2_gsm8k,
+    benchmark_sm70_model_tokens,
+    benchmark_sm70_serving_quality,
+)
+
+
+def test_dflash_quality_git_provenance_is_optional(monkeypatch, tmp_path):
+    def fail(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(128, ["git", "rev-parse", "HEAD"])
+
+    monkeypatch.setattr(benchmark_sm70_dflash2_gsm8k.subprocess, "check_output", fail)
+
+    assert benchmark_sm70_dflash2_gsm8k._git_sha(tmp_path) is None
+
+
+def test_dflash_quality_persists_completed_case(tmp_path):
+    path = tmp_path / "quality.partial.jsonl"
+    output = types.SimpleNamespace(
+        outputs=[
+            types.SimpleNamespace(
+                token_ids=[3, 5, 8],
+                finish_reason="stop",
+                stop_reason=None,
+                text="answer",
+            )
+        ]
+    )
+
+    benchmark_sm70_dflash2_gsm8k._append_partial_case(
+        path,
+        dataset_index=7,
+        request_seed=42,
+        output=output,
+    )
+
+    assert json.loads(path.read_text()) == {
+        "dataset_index": 7,
+        "finish_reason": "stop",
+        "output_tokens": 3,
+        "request_seed": 42,
+        "stop_reason": None,
+        "text": "answer",
+        "token_ids": [3, 5, 8],
+    }
 
 
 def test_sm70_fa2_d256_prefill_status_reports_import_error(monkeypatch):
@@ -104,6 +151,40 @@ def test_spec_decoding_delta_reports_one_sequential_prompt():
     assert metrics["num_accepted_tokens"] == 7
     assert metrics["accepted_tokens_per_pos"] == [3, 2, 2]
     assert metrics["mean_acceptance_length"] == 2.75
+
+
+def test_serving_quality_preserves_all_dflash_positions():
+    prefix = "vllm:spec_decode_num_accepted_tokens_per_pos_total:position_"
+    before = {
+        "vllm:spec_decode_num_drafts_total": 10.0,
+        "vllm:spec_decode_num_draft_tokens_total": 70.0,
+        "vllm:spec_decode_num_accepted_tokens_total": 35.0,
+        **{f"{prefix}{pos}": float(10 - pos) for pos in range(7)},
+    }
+    after = {
+        "vllm:spec_decode_num_drafts_total": 12.0,
+        "vllm:spec_decode_num_draft_tokens_total": 84.0,
+        "vllm:spec_decode_num_accepted_tokens_total": 42.0,
+        **{f"{prefix}{pos}": float(12 - pos) for pos in range(7)},
+    }
+
+    delta = benchmark_sm70_serving_quality._counter_delta(before, after)
+
+    assert delta is not None
+    assert delta["accepted_tokens_per_pos"] == [2.0] * 7
+    summary = benchmark_sm70_serving_quality._summarize_spec_metrics(
+        [
+            {"serving_metrics_delta": delta},
+            {
+                "serving_metrics_delta": {
+                    **delta,
+                    "accepted_tokens_per_pos": [1.0, 1.0, 1.0],
+                }
+            },
+        ]
+    )
+    assert summary is not None
+    assert summary["accepted_tokens_per_pos"] == [3.0, 3.0, 3.0, 2.0, 2.0, 2.0, 2.0]
 
 
 def test_sm70_policy_records_generic_mtp_moe_tuning(monkeypatch):

--- a/tests/benchmarks/test_dsv4_quality_tools.py
+++ b/tests/benchmarks/test_dsv4_quality_tools.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 
+from benchmarks.benchmark_dsv4_dspark_long_context import _build_messages
 from benchmarks.benchmark_dsv4_gsm8k_api import _last_integer
 from benchmarks.compare_dsv4_quality_results import (
     _compare_gsm8k,
@@ -16,6 +17,15 @@ def test_last_integer_normalizes_signed_integral_decimal() -> None:
     assert _last_integer("answer: 12.0") == 12
     assert _last_integer("answer: 12.5") is None
     assert _last_integer("no numeric answer") is None
+
+
+def test_long_context_cases_diverge_before_the_cached_filler() -> None:
+    left = _build_messages(4, "CASE-32K")
+    right = _build_messages(4, "CASE-64K")
+
+    assert left[0]["content"] != right[0]["content"]
+    assert "CASE-32K" in left[0]["content"]
+    assert "CASE-64K" in right[0]["content"]
 
 
 def _gsm8k_artifact(predictions: list[int | None]) -> dict:

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -416,7 +416,7 @@ def test_sm70_explicit_dflash_preserves_probabilistic_default(monkeypatch):
     assert args.max_num_batched_tokens is None
 
 
-def test_sm70_dflash_interactivity_defaults_to_audited_b1_profile(monkeypatch):
+def test_sm70_dflash_interactivity_preserves_capacity_defaults(monkeypatch):
     args = _apply_sm70_defaults(
         monkeypatch,
         speculative_config={"method": "dflash", "num_speculative_tokens": 7},
@@ -429,8 +429,8 @@ def test_sm70_dflash_interactivity_defaults_to_audited_b1_profile(monkeypatch):
         "draft_sample_method": "probabilistic",
         "attention_backend": "FLASH_ATTN_V100",
     }
-    assert args.max_num_seqs == 1
-    assert args.max_num_batched_tokens == 4096
+    assert args.max_num_seqs is None
+    assert args.max_num_batched_tokens is None
 
 
 def test_sm70_dflash_interactivity_preserves_capacity_overrides(monkeypatch):
@@ -456,8 +456,8 @@ def test_sm70_dflash_defaults_ignore_legacy_mtp_disable(monkeypatch):
 
     assert args.speculative_config["attention_backend"] == "FLASH_ATTN_V100"
     assert args.speculative_config["draft_sample_method"] == "probabilistic"
-    assert args.max_num_seqs == 1
-    assert args.max_num_batched_tokens == 4096
+    assert args.max_num_seqs is None
+    assert args.max_num_batched_tokens is None
 
 
 def test_sm70_speculative_defaults_do_not_apply_to_sm75(monkeypatch):

--- a/tests/quantization/test_sm70_nvfp4_qpn2.py
+++ b/tests/quantization/test_sm70_nvfp4_qpn2.py
@@ -141,15 +141,85 @@ def test_nvfp4_qpn2_shape_gate_is_exact_tp4():
     layer.tp_size = 2
     assert not nvfp4_scheme._is_qpn2_layer(layer)
     layer.tp_size = 4
-    layer.prefix = "model.language_model.layers.0.self_attn.qkv_proj"
-    assert not nvfp4_scheme._is_qpn2_layer(layer)
-    layer.prefix = "model.language_model.layers.0.mlp.down_proj"
-    layer.input_size_per_partition = 4352
-    layer.output_size_per_partition = 5120
-    layer.weight = SimpleNamespace(shape=(5120, 2176))
-    assert nvfp4_scheme._is_qpn2_layer(layer)
+    compatible = (
+        ("linear_attn.in_proj_qkvz", 5120, 4120, (4120, 2560)),
+        ("linear_attn.out_proj", 1536, 5120, (5120, 768)),
+        ("self_attn.qkv_proj", 5120, 3584, (3584, 2560)),
+        ("self_attn.o_proj", 1536, 5120, (5120, 768)),
+        ("mlp.down_proj", 4352, 5120, (5120, 2176)),
+    )
+    for suffix, k, n, weight_shape in compatible:
+        layer.prefix = f"model.language_model.layers.0.{suffix}"
+        layer.input_size_per_partition = k
+        layer.output_size_per_partition = n
+        layer.weight = SimpleNamespace(shape=weight_shape)
+        assert nvfp4_scheme._is_qpn2_layer(layer)
+
     layer.input_size_per_partition = 4096
     assert not nvfp4_scheme._is_qpn2_layer(layer)
+
+
+def test_nvfp4_qpn2_output_padding_is_zero_filled():
+    weight = torch.full((56, 32), 7, dtype=torch.uint8)
+    scales = torch.full((56, 4), 2, dtype=torch.float8_e4m3fn)
+    padded_weight, padded_scales, physical_n = nvfp4_scheme._pad_qpn2_output_rows(
+        weight, scales
+    )
+    assert physical_n == 64
+    assert padded_weight.shape == (64, 32)
+    assert padded_scales.shape == (64, 4)
+    assert torch.equal(padded_weight[:56], weight)
+    assert torch.equal(padded_scales[:56], scales)
+    assert not torch.count_nonzero(padded_weight[56:])
+    assert not torch.count_nonzero(padded_scales[56:].float())
+
+
+def test_nvfp4_qpn2_dispatch_crops_padded_output_before_bias(monkeypatch):
+    layer = SimpleNamespace(
+        output_size_per_partition=56,
+        sm70_nvfp4_qpn2_output_size=64,
+        sm70_nvfp4_qpn2_split_k=8,
+        sm70_nvfp4_qpn2_nacc=2,
+        sm70_nvfp4_qpn2_global_scale=0.5,
+        sm70_nvfp4_qpn2_prefill_enabled=False,
+        sm70_nvfp4_qpn2_codes=torch.empty((64, 32), dtype=torch.uint8),
+        sm70_nvfp4_qpn2_scales=torch.empty((64, 4), dtype=torch.uint8),
+    )
+    setattr(
+        layer,
+        sm70_tm.STATE_ATTR,
+        sm70_tm.SM70TurboMindLinearState(
+            weight=torch.empty((1,), dtype=torch.int32),
+            scales=torch.empty((1,), dtype=torch.float16),
+            group_size=16,
+            k_ld=64,
+            q_ld=64,
+            output_size=56,
+            padded_output_size=64,
+            op_kind="nvfp4",
+        ),
+    )
+    seen_shapes = []
+
+    def fake_dispatch(*args):
+        seen_shapes.append(tuple(args[0].shape))
+        args[0].fill_(3)
+
+    monkeypatch.setattr(
+        nvfp4_scheme.sm70_ops, "nvfp4_qpn2_dispatch_sm70_out", fake_dispatch
+    )
+    bias = torch.arange(56, dtype=torch.float16)
+    output = CompressedTensorsW4A4Fp4._apply_qpn2(
+        layer, torch.ones((8, 64), dtype=torch.float16), bias, gated_silu=False
+    )
+    assert seen_shapes == [(8, 64)]
+    assert output.shape == (8, 56)
+    assert torch.equal(output[0], bias + 3)
+
+    empty = CompressedTensorsW4A4Fp4._apply_qpn2(
+        layer, torch.ones((0, 64), dtype=torch.float16), None, gated_silu=False
+    )
+    assert empty.shape == (0, 56)
 
 
 def _make_small_layer() -> torch.nn.Module:

--- a/tests/quantization/test_sm70_turbomind_adapter.py
+++ b/tests/quantization/test_sm70_turbomind_adapter.py
@@ -83,6 +83,78 @@ def test_mxfp4_unpack_flattens_last_two_block_dims_like_lmdeploy():
     assert weight.tolist() == [[0, 4], [1, 5], [2, 6], [3, 7]]
 
 
+def test_nvfp4_prepare_pads_output_to_converter_alignment(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(
+        torch.zeros((24, 16), dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones((24, 2), dtype=torch.float16), requires_grad=False
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        torch.tensor(0.25, dtype=torch.float32), requires_grad=False
+    )
+
+    from vllm import _sm70_ops as sm70_ops
+
+    prepared = []
+
+    def fake_prepare(qweight, scales, group_size, interleave_gated_silu):
+        prepared.append(
+            (
+                tuple(qweight.shape),
+                tuple(scales.shape),
+                group_size,
+                interleave_gated_silu,
+            )
+        )
+        return (
+            torch.empty((32, 4), dtype=torch.int32),
+            torch.empty((2, 32), dtype=torch.float16),
+            torch.tensor([32, 32], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_sm70_prepare", fake_prepare)
+
+    tm.prepare_nvfp4_linear(layer)
+
+    state = getattr(layer, tm.STATE_ATTR)
+    assert prepared == [((32, 32), (2, 32), 16, False)]
+    assert state.output_size == 24
+
+
+def test_nvfp4_apply_crops_converter_padding(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    state = tm.SM70TurboMindLinearState(
+        weight=torch.empty((32, 4), dtype=torch.int32),
+        scales=torch.empty((2, 32), dtype=torch.float16),
+        group_size=16,
+        k_ld=32,
+        q_ld=32,
+        output_size=24,
+        op_kind="nvfp4",
+        padded_output_size=32,
+    )
+    setattr(layer, tm.STATE_ATTR, state)
+
+    from vllm import _sm70_ops as sm70_ops
+
+    def fake_gemm(out, *args):
+        del args
+        out.copy_(torch.arange(32, dtype=out.dtype).view(1, 32))
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_gemm_sm70_out", fake_gemm)
+
+    output = tm.apply_prepared_linear(
+        layer, torch.ones((1, 32), dtype=torch.float16), bias=None
+    )
+
+    assert output.shape == (1, 24)
+    assert output.tolist() == [list(map(float, range(24)))]
+
+
 def test_symmetric_int4_zero_points_are_eight():
     tm = _load_adapter()
     scales = torch.ones((2, 3), dtype=torch.float32)

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -237,6 +237,35 @@ def test_fp8_warmup_supports_modelopt_turbomind_layout(monkeypatch):
     assert all(call[3:] == (128, 128, 64) for call in calls)
 
 
+def test_nvfp4_warmup_uses_converter_padded_output_size(monkeypatch):
+    state = SimpleNamespace(
+        weight=torch.empty((32, 4), dtype=torch.int32),
+        scales=torch.empty((2, 32), dtype=torch.float16),
+        group_size=16,
+        k_ld=32,
+        q_ld=32,
+        output_size=24,
+        padded_output_size=32,
+        op_kind="nvfp4",
+        gated_silu=False,
+    )
+    calls = []
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_gemm_sm70_out_meta", object(), raising=False
+    )
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "nvfp4_gemm_sm70_out",
+        lambda *args: calls.append(args),
+    )
+
+    count = warmup._warmup_fp4_dense_layers([state], [1, 4])
+
+    assert count == 2
+    assert [tuple(call[0].shape) for call in calls] == [(1, 32), (4, 32)]
+    assert [tuple(call[1].shape) for call in calls] == [(1, 32), (4, 32)]
+
+
 def _nvfp4_moe_layer() -> nn.Module:
     layer = nn.Module()
     layer.sm70_nvfp4_moe = True

--- a/tests/v1/spec_decode/test_dflash_mrv2_config.py
+++ b/tests/v1/spec_decode/test_dflash_mrv2_config.py
@@ -15,9 +15,13 @@ from vllm.config.speculative import (
 )
 from vllm.config.vllm import VllmConfig
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import (
+    _prepare_dflash_inputs_to_capture,
+)
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     get_eagle3_aux_layers_from_config,
 )
@@ -49,8 +53,69 @@ def test_dflash_and_ddtree_routes_are_disjoint() -> None:
 
 def test_mrv2_dflash_reserves_all_mask_slots() -> None:
     assert _config("dflash").max_num_new_slots_for_drafting == 7
+    assert _config("dflash").max_num_new_target_slots_for_drafting == 0
     # The retained DDTree path keeps its existing flat-parallel slot contract.
     assert _config("dflash_ddtree").max_num_new_slots_for_drafting == 6
+    assert _config("dflash_ddtree").max_num_new_target_slots_for_drafting == 6
+
+
+def test_mrv2_dflash_preserves_target_scheduler_token_budget() -> None:
+    scheduler = SimpleNamespace(
+        max_num_seqs=512,
+        max_num_batched_tokens=4096,
+        max_num_scheduled_tokens=None,
+    )
+    config = SimpleNamespace(
+        speculative_config=_config("dflash"),
+        scheduler_config=scheduler,
+    )
+
+    VllmConfig._set_max_num_scheduled_tokens(config)
+
+    assert scheduler.max_num_scheduled_tokens == 4096
+
+
+def test_dflash_capture_uses_its_own_persistent_slot_mapping(monkeypatch) -> None:
+    query_slots = torch.zeros((2, 16), dtype=torch.int64)
+    seen: dict[str, torch.Tensor] = {}
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.spec_decode.dflash.cudagraph.InputBatch.make_dummy",
+        lambda *args: SimpleNamespace(),
+    )
+
+    def fake_build_slot_mappings(slot_mappings, kv_cache_config):
+        del kv_cache_config
+        seen["slot_mappings"] = slot_mappings
+        return {"draft.layer": slot_mappings[1]}
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.spec_decode.dflash.cudagraph.build_slot_mappings_by_layer",
+        fake_build_slot_mappings,
+    )
+    block_tables = SimpleNamespace(
+        cp_size=1,
+        get_dummy_block_tables=lambda num_reqs: (),
+    )
+
+    state = _prepare_dflash_inputs_to_capture(
+        num_reqs=1,
+        num_tokens=8,
+        input_buffers=object(),
+        block_tables=block_tables,
+        query_slot_mappings=query_slots,
+        attn_groups=[],
+        kv_cache_config=object(),
+        max_model_len=1024,
+        skip_attn=True,
+        causal=False,
+    )
+
+    captured = seen["slot_mappings"]
+    assert captured.shape == (2, 8)
+    assert captured.data_ptr() == query_slots.data_ptr()
+    assert torch.all(query_slots == PAD_SLOT_ID)
+    assert state.slot_mappings["draft.layer"].data_ptr() == query_slots[1].data_ptr()
 
 
 @pytest.mark.parametrize(
@@ -158,6 +223,7 @@ def test_adaptive_lookup_rejects_explicit_async_scheduling(monkeypatch) -> None:
 def test_dflash_forces_v2_and_rejects_explicit_v1(monkeypatch) -> None:
     fake = SimpleNamespace(
         speculative_config=SimpleNamespace(use_dflash=lambda: True),
+        model_config=None,
     )
     monkeypatch.setattr("vllm.config.vllm.envs.VLLM_USE_V2_MODEL_RUNNER", None)
     assert VllmConfig.use_v2_model_runner.fget(fake)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1365,6 +1365,19 @@ class SpeculativeConfig:
             slots_per_req += 1
         return slots_per_req
 
+    @property
+    def max_num_new_target_slots_for_drafting(self) -> int:
+        """Return extra slots inserted into the target runner's input batch.
+
+        MRV2 DFlash builds its K+1 query batch in a separate ``InputBuffers``
+        instance. Its K draft slots therefore consume draft-runner capacity,
+        not the target scheduler's prefill budget. Other proposers retain the
+        existing shared-batch accounting.
+        """
+        if self.use_dflash():
+            return 0
+        return self.max_num_new_slots_for_drafting
+
     def use_gemma4_mtp(self) -> bool:
         return (
             self.method == "mtp"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2355,7 +2355,7 @@ class VllmConfig:
         """
         if self.speculative_config is not None:
             scheduled_token_delta = (
-                self.speculative_config.max_num_new_slots_for_drafting
+                self.speculative_config.max_num_new_target_slots_for_drafting
                 * self.scheduler_config.max_num_seqs
             )
             max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
@@ -2373,7 +2373,10 @@ class VllmConfig:
                     " to accommodate the additional draft token slots, or decrease"
                     " num_speculative_tokens or max_num_seqs."
                 )
-            if self.scheduler_config.max_num_scheduled_tokens < 8192:
+            if (
+                scheduled_token_delta > 0
+                and self.scheduler_config.max_num_scheduled_tokens < 8192
+            ):
                 logger.warning_once(
                     "max_num_scheduled_tokens is set to"
                     f" {self.scheduler_config.max_num_scheduled_tokens} based on"
@@ -2385,7 +2388,7 @@ class VllmConfig:
 
             max_num_scheduled_tokens = self.scheduler_config.max_num_scheduled_tokens
             if max_num_batched_tokens < max_num_scheduled_tokens + (
-                self.speculative_config.max_num_new_slots_for_drafting
+                self.speculative_config.max_num_new_target_slots_for_drafting
                 * self.scheduler_config.max_num_seqs
             ):
                 raise ValueError(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1838,16 +1838,9 @@ class EngineArgs:
             )
 
         if spec_method == "dflash":
-            # The quality-audited Qwen3.8 DFlash2 latency profile is B1 with a
-            # 4096-token prefill chunk. Apply it only when the user explicitly
-            # asks for interactivity and has not supplied either capacity knob.
-            if self.performance_mode == "interactivity":
-                if self.max_num_seqs is None:
-                    self.max_num_seqs = 1
-                    profile_updates.append("max_num_seqs=1")
-                if self.max_num_batched_tokens is None:
-                    self.max_num_batched_tokens = 4096
-                    profile_updates.append("max_num_batched_tokens=4096")
+            # MRV2 owns a separate K+1 draft query batch, so DFlash does not
+            # require B1 or a reduced prefill chunk. Preserve the server's
+            # normal capacity defaults and every explicit user override.
             if profile_updates:
                 logger.info_once(
                     "Applied SM70 speculative defaults: %s",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -118,12 +118,21 @@ __all__ = ["CompressedTensorsW4A4Fp4"]
 
 _SM70_NVFP4_QPN2_CONFIGS = {
     # (K, N, fused gated-SiLU): (split-K, independent accumulator chains)
+    (1536, 5120, False): (8, 2),
+    (5120, 3584, False): (16, 2),
+    # Qwen3.8 GDN qkvzba is logically N=4120 on TP4.  QPN2 consumes the
+    # zero-padded physical N=4128 layout and the caller crops the result.
+    (5120, 4128, False): (16, 2),
     (5120, 8704, False): (8, 2),
     (5120, 8704, True): (8, 2),
     (4352, 5120, False): (16, 2),
 }
 _SM70_NVFP4_QPN2_SHAPES = {
     # Checkpoint-native packed tensors are [N, K/2].
+    "in_proj_qkvz": (4120, 2560),
+    "qkv_proj": (3584, 2560),
+    "out_proj": (5120, 768),
+    "o_proj": (5120, 768),
     "gate_up_proj": (8704, 2560),
     "down_proj": (5120, 2176),
 }
@@ -148,6 +157,21 @@ def _is_qpn2_layer(layer: torch.nn.Module) -> bool:
         getattr(layer, "input_size_per_partition", 0) == expected_packed_k * 2
         and getattr(layer, "output_size_per_partition", 0) == expected_n
     )
+
+
+def _pad_qpn2_output_rows(
+    weight: torch.Tensor, scales: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad checkpoint-native output rows to QPN2's 32-column contract."""
+    logical_n = weight.shape[0]
+    physical_n = (logical_n + 31) // 32 * 32
+    if physical_n == logical_n:
+        return weight, scales, physical_n
+    padded_weight = weight.new_zeros((physical_n, weight.shape[1]))
+    padded_scales = scales.new_zeros((physical_n, scales.shape[1]))
+    padded_weight[:logical_n].copy_(weight)
+    padded_scales[:logical_n].copy_(scales)
+    return padded_weight, padded_scales, physical_n
 
 
 def _missing_qpn2_ops() -> list[str]:
@@ -356,8 +380,11 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                     )
                     use_qpn2 = False
             if use_qpn2:
+                qpn2_weight, qpn2_weight_scale, qpn2_output_size = (
+                    _pad_qpn2_output_rows(layer.weight.data, layer.weight_scale.data)
+                )
                 qpn2_codes, qpn2_scales = sm70_ops.nvfp4_qpn2_prepare_sm70(
-                    layer.weight.data, layer.weight_scale.data
+                    qpn2_weight, qpn2_weight_scale
                 )
                 qpn2_global_scale = float(layer.weight_global_scale.item())
                 qpn2_prefill_enabled = False
@@ -382,7 +409,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             if use_qpn2:
                 suffix = layer.prefix.rsplit(".", 1)[-1]
                 k = layer.input_size_per_partition
-                n = layer.output_size_per_partition
+                n = qpn2_output_size
                 split_k, nacc = _SM70_NVFP4_QPN2_CONFIGS[(k, n, False)]
                 layer.register_buffer(
                     "sm70_nvfp4_qpn2_codes", qpn2_codes, persistent=False
@@ -392,6 +419,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 )
                 layer.sm70_nvfp4_qpn2 = True
                 layer.sm70_nvfp4_qpn2_global_scale = qpn2_global_scale
+                layer.sm70_nvfp4_qpn2_output_size = qpn2_output_size
                 layer.sm70_nvfp4_qpn2_split_k = split_k
                 layer.sm70_nvfp4_qpn2_nacc = nacc
                 layer.sm70_nvfp4_qpn2_gated_silu = suffix == "gate_up_proj"
@@ -468,20 +496,26 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x_2d = x.reshape(-1, x.shape[-1])
         if x_2d.stride(-1) != 1:
             x_2d = x_2d.contiguous()
-        output_size = layer.output_size_per_partition
+        logical_output_size = layer.output_size_per_partition
+        kernel_output_size = int(
+            getattr(layer, "sm70_nvfp4_qpn2_output_size", logical_output_size)
+        )
         if gated_silu:
-            output_size //= 2
+            logical_output_size //= 2
+            kernel_output_size //= 2
         out_2d = torch.empty(
-            (x_2d.shape[0], output_size), dtype=x.dtype, device=x.device
+            (x_2d.shape[0], kernel_output_size), dtype=x.dtype, device=x.device
         )
         if x_2d.shape[0] == 0:
-            return out_2d.reshape(*x.shape[:-1], output_size)
+            return out_2d[:, :logical_output_size].reshape(
+                *x.shape[:-1], logical_output_size
+            )
         state = getattr(layer, sm70_tm.STATE_ATTR)
         split_k = int(layer.sm70_nvfp4_qpn2_split_k)
         nacc = int(layer.sm70_nvfp4_qpn2_nacc)
         if gated_silu:
             split_k, nacc = _SM70_NVFP4_QPN2_CONFIGS[
-                (x_2d.shape[1], output_size * 2, True)
+                (x_2d.shape[1], kernel_output_size * 2, True)
             ]
         if getattr(layer, "sm70_nvfp4_qpn2_prefill_enabled", False):
             sm70_ops.nvfp4_qpn2_prefill_dispatch_sm70_out(
@@ -516,6 +550,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 state.q_ld,
                 gated_silu,
             )
+        if kernel_output_size != logical_output_size:
+            out_2d = out_2d[:, :logical_output_size]
         if bias is not None:
             out_2d.add_(bias)
-        return out_2d.reshape(*x.shape[:-1], output_size)
+        return out_2d.reshape(*x.shape[:-1], logical_output_size)

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -14,6 +14,7 @@ GPTQ_GROUP_SIZES = (128,)
 COMPRESSED_UINT4_GROUP_SIZES = (32, 128)
 MXFP4_GROUP_SIZE = 32
 NVFP4_GROUP_SIZE = 16
+NVFP4_OUTPUT_ALIGNMENT = 16
 NVFP4_QPN4_DENSE_WORKSPACE_ELEMENTS = 5120 * 8704
 STATE_ATTR = "_sm70_turbomind_linear"
 SM70QuantBackend = Literal["auto", "marlin", "turbomind"]
@@ -32,6 +33,7 @@ class SM70TurboMindLinearState:
     dense_weight_ptr: int = 0
     global_scale: float = 0.0
     use_scale_code: bool = False
+    padded_output_size: int = 0
 
 
 # States retain only data_ptr(), so this cache owns the bounded allocation.
@@ -163,6 +165,7 @@ def _store_state(
     dense_weight_ptr: int = 0,
     global_scale: float = 0.0,
     use_scale_code: bool = False,
+    padded_output_size: int = 0,
 ) -> None:
     state = SM70TurboMindLinearState(
         weight=weight,
@@ -176,6 +179,7 @@ def _store_state(
         dense_weight_ptr=dense_weight_ptr,
         global_scale=global_scale,
         use_scale_code=use_scale_code,
+        padded_output_size=padded_output_size,
     )
     setattr(layer, STATE_ATTR, state)
 
@@ -302,6 +306,29 @@ def prepare_nvfp4_linear(
         .to(torch.float16)
         .contiguous()
     )
+    output_size = qweight.size(1)
+    padded_output_size = (
+        (output_size + NVFP4_OUTPUT_ALIGNMENT - 1) // NVFP4_OUTPUT_ALIGNMENT
+    ) * NVFP4_OUTPUT_ALIGNMENT
+    if padded_output_size != output_size:
+        if interleave_gated_silu:
+            raise RuntimeError(
+                "SM70 TurboMind NVFP4 gated-SiLU does not support output padding."
+            )
+        padded_qweight = torch.zeros(
+            (qweight.size(0), padded_output_size),
+            dtype=qweight.dtype,
+            device=qweight.device,
+        )
+        padded_scales = torch.zeros(
+            (scales.size(0), padded_output_size),
+            dtype=scales.dtype,
+            device=scales.device,
+        )
+        padded_qweight[:, :output_size].copy_(qweight)
+        padded_scales[:, :output_size].copy_(scales)
+        qweight = padded_qweight
+        scales = padded_scales
     tm_weight, tm_scales, meta = sm70_ops.nvfp4_sm70_prepare(
         qweight, scales, NVFP4_GROUP_SIZE, interleave_gated_silu
     )
@@ -311,9 +338,10 @@ def prepare_nvfp4_linear(
         tm_scales,
         meta,
         NVFP4_GROUP_SIZE,
-        qweight.size(1),
+        output_size,
         "nvfp4",
         interleave_gated_silu,
+        padded_output_size=padded_output_size,
     )
 
 
@@ -389,8 +417,9 @@ def apply_prepared_linear(
     state = getattr(layer, STATE_ATTR)
     reshaped_x = x.reshape(-1, x.shape[-1])
     out_shape = x.shape[:-1] + (state.output_size,)
+    kernel_output_size = state.padded_output_size or state.output_size
     out = torch.empty(
-        (reshaped_x.shape[0], state.output_size),
+        (reshaped_x.shape[0], kernel_output_size),
         dtype=x.dtype,
         device=x.device,
     )
@@ -445,6 +474,8 @@ def apply_prepared_linear(
         )
     else:
         raise AssertionError(f"unknown SM70 TurboMind op kind: {state.op_kind}")
+    if kernel_output_size != state.output_size:
+        out = out[:, : state.output_size]
     if state.gated_silu and state.op_kind == "nvfp4":
         out_features = state.output_size // 2
         out = (

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -556,7 +556,8 @@ def _warmup_fp4_dense_layers(
         device = state.weight.device
         k_dim = int(state.weight.shape[0])
         gated_silu = bool(state.gated_silu)
-        n_dim = int(state.output_size) // (2 if gated_silu else 1)
+        kernel_output_size = int(state.padded_output_size or state.output_size)
+        n_dim = kernel_output_size // (2 if gated_silu else 1)
         for m_dim in m_values:
             x = torch.empty((m_dim, k_dim), dtype=torch.float16, device=device)
             out = torch.empty((m_dim, n_dim), dtype=torch.float16, device=device)

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 import torch
 
 from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import (
     build_attn_metadata,
@@ -26,6 +27,7 @@ def _prepare_dflash_inputs_to_capture(
     num_tokens: int,
     input_buffers: InputBuffers,
     block_tables: BlockTables,
+    query_slot_mappings: torch.Tensor,
     attn_groups: list[list[AttentionGroup]],
     kv_cache_config: KVCacheConfig,
     max_model_len: int,
@@ -34,7 +36,11 @@ def _prepare_dflash_inputs_to_capture(
 ) -> CapturedAttentionState:
     input_batch = InputBatch.make_dummy(num_reqs, num_tokens, input_buffers)
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
-    slot_mappings = block_tables.get_dummy_slot_mappings(num_tokens)
+    # DFlash owns a K+1 query batch which can be wider than the target token
+    # budget. Keep its persistent graph input independent from the target
+    # BlockTables slot-mapping allocation.
+    query_slot_mappings.fill_(PAD_SLOT_ID)
+    slot_mappings = query_slot_mappings[:, :num_tokens]
     slot_mappings_by_layer = build_slot_mappings_by_layer(
         slot_mappings, kv_cache_config
     )
@@ -81,6 +87,7 @@ class DFlashCudaGraphManager(CudaGraphManager):
         forward_fn: Callable,
         input_buffers: InputBuffers,
         block_tables: BlockTables,
+        query_slot_mappings: torch.Tensor,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
@@ -102,6 +109,7 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 num_tokens,
                 input_buffers,
                 block_tables,
+                query_slot_mappings,
                 attn_groups,
                 kv_cache_config,
                 max_model_len,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -47,10 +47,6 @@ class DFlashSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
 
-        self.hidden_states = torch.zeros(
-            self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
-        )
-
         # Multimodal inputs not currently supported.
         self.supports_mm_inputs = False
 
@@ -59,6 +55,20 @@ class DFlashSpeculator(DraftModelSpeculator):
         # remaining target-verification positions.
         self.draft_block = get_dflash_model_draft_tokens(self.speculative_config)
         self.num_query_per_req = 1 + self.draft_block
+        draft_query_capacity = self.max_num_reqs * self.num_query_per_req
+        if draft_query_capacity > self.max_num_tokens:
+            # The target's token budget and the draft query batch are disjoint.
+            # Size only the draft-owned buffers up for K+1 queries per request
+            # instead of reducing the target prefill budget.
+            self.max_num_tokens = draft_query_capacity
+            self.input_buffers = InputBuffers(
+                max_num_reqs=self.max_num_reqs,
+                max_num_tokens=self.max_num_tokens,
+                device=device,
+            )
+        self.hidden_states = torch.zeros(
+            self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
+        )
         if self.draft_block < self.num_speculative_steps:
             logger.info(
                 "%s emits %d model drafts and lookup may fill %d additional "
@@ -122,6 +132,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
         self._context_only_prefill_logged = False
+        self._query_slot_mappings: torch.Tensor | None = None
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
@@ -172,6 +183,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             self._generate_draft,
             self.input_buffers,
             self.block_tables,
+            self._require_query_slot_mappings(),
             self.attn_groups,
             self.kv_cache_config,
             self.max_model_len,
@@ -207,6 +219,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         ]
         assert self.draft_kv_cache_group_ids, "No draft attention groups found."
         self.draft_kv_cache_group_id = self.draft_kv_cache_group_ids[0]
+        self._query_slot_mappings = torch.full(
+            (len(kv_cache_config.kv_cache_groups), self.max_num_tokens),
+            PAD_SLOT_ID,
+            dtype=torch.int64,
+            device=self.device,
+        )
 
         # Per-group context slot buffers for the precompute (one row per group).
         self._context_slot_mappings = torch.zeros(
@@ -240,6 +258,11 @@ class DFlashSpeculator(DraftModelSpeculator):
                         layer_names, self.model.get_draft_attn_causal()
                     )
                 }
+
+    def _require_query_slot_mappings(self) -> torch.Tensor:
+        if self._query_slot_mappings is None:
+            raise RuntimeError("DFlash attention buffers have not been initialized.")
+        return self._query_slot_mappings
 
     @torch.inference_mode()
     def _run_model(
@@ -434,15 +457,17 @@ class DFlashSpeculator(DraftModelSpeculator):
             )
             return self.draft_tokens[:num_reqs]
 
-        # The query slot mapping is written into the shared BlockTables slot_mappings.
-        # That buffer's address is what the captured CUDA graph reads from at replay.
+        # Query slots live in a DFlash-owned persistent buffer. Its address is
+        # captured by the draft CUDA graph and its capacity is independent of
+        # the target runner's max_num_batched_tokens allocation.
         assert self.draft_kv_cache_group_id >= 0
+        query_slot_mappings = self._require_query_slot_mappings()
         # Support multiple draft KV cache groups by preparing inputs once for each
         with record_function_or_nullcontext("dflash: prepare inputs"):
             for i, gid in enumerate(self.draft_kv_cache_group_ids):
                 prepare_dflash_inputs(
                     self.input_buffers,
-                    self.block_tables.slot_mappings[gid],
+                    query_slot_mappings[gid],
                     self.context_positions,
                     self._context_slot_mappings[i],
                     self.sample_indices,
@@ -543,7 +568,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 causal=self._group_causal,
             )
             draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
-                self.block_tables.slot_mappings[:, :num_tokens_padded],
+                query_slot_mappings[:, :num_tokens_padded],
                 self.kv_cache_config,
             )
 


### PR DESCRIPTION
## Purpose

- Admit the fully quantized `QUASAR-QAT/Qwen3.8-27B-QUASAR-NVFP4` checkpoint on SM70 with DFlash2 without narrowing the server to B1, a 512-token prefill budget, TP2, or one target KV dtype.
- Fix the checkpoint's TP-local GDN `N=4120` projection by separating logical and zero-padded physical output widths (`4128`) before TurboMind/QPN2 execution.
- Extend the quality-audited QPN2 path to all compatible QUASAR projections and retain the promoted M>=1024 packed-prefill route.
- Stop MRV2 DFlash K+1 draft slots and slot mappings from consuming/borrowing target scheduler buffers.
- Add durable real-checkpoint, serving-quality, protocol, and long-context release evidence.

## Test Plan

- Run focused scheduler, DFlash buffer, NVFP4 layout/QPN2, warmup, and benchmark contract tests.
- Compare target-only and DFlash2 on two fixed MBPP/EvalPlus seeds and matched WikiText likelihood.
- Exercise tool calls, strict JSON Schema, streaming parity, prefix-state replay, B1/B2/B4 structured output, and mixed B4 stress.
- Build an SM70 CPython 3.12 wheel, install it into a distinct source-independent Conda prefix on 4x V100, and rerun route, protocol, concurrency, prefill, prefix-cache, and complete-round gates.

## Test Result

- `159 passed, 16 warnings`; Ruff lint/format and `git diff --check` pass.
- Real QUASAR projection oracle: all TP ranks pass; M=8 worst relative L2 about `5.20e-4`, cosine at least `0.99999988`; corrected N=4120 uses physical N=4128. QPN2 is `1.29x-3.94x` faster than corrected TurboMind by projection/rank.
- Quality: seed 20260925 is exactly tied (MBPP 32/32, EvalPlus Base 31/31, Plus 28/31). Across two seeds target/DFlash are Base 62/62 vs 61/62 and Plus 57/62 vs 55/62 with one paired discordance per class. Matched WikiText max PPL delta is `0.00851`.
- Protocol: tool chain, nested/escaped JSON, stream parity, explicit-history Responses, prefix state, and B1/B2/B4 structured output pass. Fresh-wheel arithmetic returns `42.0`, tool call is `get_weather({"city":"Guangzhou"})`, and strict schema emits `{"name":"小林","age":27}`. Server-side Responses storage remains intentionally disabled because it has no eviction policy.
- Source stress: 96/96 mixed B4 requests pass without memory growth. Fresh wheel: 16/16 four-way concurrent strict-JSON requests pass; no traceback, OOM, illegal access, stale buffer, or graph corruption.
- Fresh wheel steady 1K complete-round mean: `17.645 ms` (range `17.637-17.663`). Empty-cache first request is `23.055 ms` due to seven bounded Triton JITs with identical tokens/acceptance.
- Unique cold prefill: 32,724 tokens at `4,038.5 tok/s`; 63,482 tokens at `3,596.5 tok/s`. Both pass output-health checks.
- Identical 9,994-token prefix: wall `2.624s -> 0.311s`, TTFT `2.506s -> 0.210s`, 9,888 cached tokens.
- Wheel: `1cat_vllm-1.5.0-cp312-cp312-linux_x86_64.whl`, SHA256 `2a4d6bee4e19d315b142f2c563059f3064ddeeca563a6bdc828c33e1073c825b`; ten native libraries, empty RPATH/RUNPATH, `pip check` clean in the fresh environment.

Detailed evidence and rollback controls are in `docs/design/sm70_quasar_nvfp4_dflash2_acceptance.md`.