### PR TITLE
fix: handle developer role in HF chat templates

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -688,20 +688,110 @@ STRICT_ROLE_TEMPLATE = (
     "{% endif %}"
 )
 
+COMMENT_ONLY_DEVELOPER_TEMPLATE = "{# role == 'developer' #}" + STRICT_ROLE_TEMPLATE
+
+REJECT_DEVELOPER_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'developer' %}"
+    "{{ raise_exception('developer role is unsupported') }}"
+    "{% else %}"
+    "{{ message['content'] }}"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+ROLE_LIST_DEVELOPER_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] in ('system', 'developer') %}"
+    "{{ message['content'] }}"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+CONDITIONAL_DEVELOPER_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'developer' and enable_developer %}"
+    "{{ message['content'] }}"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+NESTED_CONDITIONAL_DEVELOPER_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if enable_developer %}"
+    "{% if message['role'] == 'developer' %}{{ message['content'] }}{% endif %}"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+UNREACHABLE_DEVELOPER_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] in ('user', 'developer') %}"
+    "{{ raise_exception('developer role is unsupported') }}"
+    "{% elif message['role'] == 'developer' %}"
+    "{{ message['content'] }}"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+OUTER_CONDITIONAL_DEVELOPER_TEMPLATE = (
+    "{% if enable_developer %}"
+    "{% for message in messages %}"
+    "{% if message['role'] == 'developer' %}{{ message['content'] }}{% endif %}"
+    "{% endfor %}"
+    "{% endif %}"
+)
+
+FILTERED_DEVELOPER_LOOP_TEMPLATE = (
+    "{% for message in messages if message['role'] != 'developer' %}"
+    "{% if message['role'] == 'developer' %}{{ message['content'] }}{% endif %}"
+    "{% endfor %}"
+)
+
 
 class TestDetectDeveloperRoleSupport:
     def test_absent_in_chatml(self):
         assert _detect_developer_role_support(CHATML_TEMPLATE) is False
 
     def test_present_double_quotes(self):
-        assert _detect_developer_role_support(TEMPLATE_WITH_DEVELOPER) is True
+        template = TEMPLATE_WITH_DEVELOPER.replace("'developer'", '"developer"')
+        assert _detect_developer_role_support(template) is True
 
     def test_present_single_quotes(self):
-        template = TEMPLATE_WITH_DEVELOPER.replace('"developer"', "'developer'")
-        assert _detect_developer_role_support(template) is True
+        assert _detect_developer_role_support(TEMPLATE_WITH_DEVELOPER) is True
 
     def test_absent_in_strict_template(self):
         assert _detect_developer_role_support(STRICT_ROLE_TEMPLATE) is False
+
+    def test_absent_when_only_jinja_comment_mentions_developer(self):
+        assert _detect_developer_role_support(COMMENT_ONLY_DEVELOPER_TEMPLATE) is False
+
+    def test_rejecting_developer_branch_is_not_support(self):
+        assert _detect_developer_role_support(REJECT_DEVELOPER_TEMPLATE) is False
+
+    def test_role_membership_branch_is_support(self):
+        assert _detect_developer_role_support(ROLE_LIST_DEVELOPER_TEMPLATE) is True
+
+    def test_conditionally_enabled_developer_branch_is_not_support(self):
+        assert _detect_developer_role_support(CONDITIONAL_DEVELOPER_TEMPLATE) is False
+
+    def test_nested_conditionally_enabled_branch_is_not_support(self):
+        assert (
+            _detect_developer_role_support(NESTED_CONDITIONAL_DEVELOPER_TEMPLATE)
+            is False
+        )
+
+    def test_unreachable_developer_branch_is_not_support(self):
+        assert _detect_developer_role_support(UNREACHABLE_DEVELOPER_TEMPLATE) is False
+
+    def test_outer_conditional_loop_is_not_support(self):
+        assert (
+            _detect_developer_role_support(OUTER_CONDITIONAL_DEVELOPER_TEMPLATE)
+            is False
+        )
+
+    def test_loop_filter_excluding_developer_is_not_support(self):
+        assert _detect_developer_role_support(FILTERED_DEVELOPER_LOOP_TEMPLATE) is False
 
 
 class TestSafeApplyChatTemplateDeveloperRole:
@@ -809,6 +899,28 @@ class TestSafeApplyChatTemplateDeveloperRole:
         assert "Be concise." in result
         assert "What is 2+2?" in result
 
+    def test_codex_system_and_multiple_developer_messages_consolidated(
+        self, model_config, tokenizer
+    ):
+        conversation = [
+            {"role": "system", "content": "Base instructions."},
+            {"role": "developer", "content": "Follow AGENTS.md."},
+            {"role": "developer", "content": "Use the sandbox policy."},
+            {"role": "user", "content": "Fix the issue."},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=SYSTEM_FIRST_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert result.count("<|im_start|>system") == 1
+        assert "Base instructions.\n\nFollow AGENTS.md." in result
+        assert "Follow AGENTS.md.\n\nUse the sandbox policy." in result
+        assert "<|im_start|>developer" not in result
+
     def test_developer_only_no_prior_system(self, model_config, tokenizer):
         conversation = [
             {"role": "user", "content": "Hello"},
@@ -889,20 +1001,51 @@ class TestConsolidateSystemMessages:
         assert result[1]["role"] == "user"
 
     def test_list_content_handled(self):
+        system_content = [
+            {"type": "text", "text": "Rule 1."},
+            {"type": "text", "text": "Rule 2."},
+        ]
         conversation = [
             {"role": "user", "content": "Hello"},
             {
                 "role": "system",
-                "content": [
-                    {"type": "text", "text": "Rule 1."},
-                    {"type": "text", "text": "Rule 2."},
-                ],
+                "content": system_content,
             },
         ]
         result = _consolidate_system_messages(conversation)
         assert result[0]["role"] == "system"
-        assert result[0]["content"] == "Rule 1.\nRule 2."
+        assert result[0]["content"] == system_content
         assert result[1]["role"] == "user"
+
+    def test_structured_content_preserved_when_merged(self):
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        conversation = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Inspect this image."},
+                    image_part,
+                ],
+            },
+            {"role": "user", "content": "Start."},
+            {"role": "developer", "content": "Be concise."},
+        ]
+        result = _consolidate_system_messages(
+            _convert_developer_to_system(conversation)
+        )
+        assert result[0] == {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Inspect this image."},
+                image_part,
+                {"type": "text", "text": "\n\n"},
+                {"type": "text", "text": "Be concise."},
+            ],
+        }
+        assert result[1] == {"role": "user", "content": "Start."}
 
     def test_does_not_mutate_original(self):
         conversation = [

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -452,7 +452,168 @@ def _detect_content_format(
 
 @lru_cache(maxsize=32)
 def _detect_developer_role_support(chat_template: str) -> bool:
-    return '"developer"' in chat_template or "'developer'" in chat_template
+    """Detect an unconditional, reachable developer-role rendering branch."""
+    jinja_ast = _try_extract_ast(chat_template)
+    if jinja_ast is None:
+        return False
+
+    for loop_ast, message_varname in _iter_nodes_assign_messages_item(jinja_ast):
+        if _has_conditional_ancestor(jinja_ast, loop_ast):
+            continue
+        if loop_ast.test is not None:
+            loop_test, _ = _evaluate_condition_for_developer(
+                loop_ast.test, message_varname
+            )
+            if loop_test is not True:
+                continue
+
+        for node in loop_ast.body:
+            if not isinstance(node, jinja2.nodes.If):
+                continue
+
+            body = _select_developer_role_body(node, message_varname)
+            if body is None:
+                continue
+            if _body_calls_raise_exception(body):
+                return False
+            if _body_renders_output(body):
+                return True
+
+    return False
+
+
+def _has_conditional_ancestor(
+    root: jinja2.nodes.Node,
+    target: jinja2.nodes.Node,
+) -> bool:
+    pending = [(root, False)]
+    while pending:
+        node, is_conditional = pending.pop()
+        for child in node.iter_child_nodes():
+            child_is_conditional = is_conditional or isinstance(
+                node, jinja2.nodes.If | jinja2.nodes.CondExpr
+            )
+            if child is target:
+                return child_is_conditional
+            pending.append((child, child_is_conditional))
+    return False
+
+
+def _select_developer_role_body(
+    if_node: jinja2.nodes.If,
+    message_varname: str,
+) -> list[jinja2.nodes.Node] | None:
+    developer_condition_seen = False
+    for branch in [if_node, *if_node.elif_]:
+        value, mentions_developer = _evaluate_condition_for_developer(
+            branch.test, message_varname
+        )
+        developer_condition_seen |= mentions_developer
+        if value is None:
+            return None
+        if value:
+            return branch.body if developer_condition_seen else None
+
+    return if_node.else_ if developer_condition_seen else None
+
+
+def _evaluate_condition_for_developer(
+    node: jinja2.nodes.Node,
+    message_varname: str,
+) -> tuple[bool | None, bool]:
+    """Evaluate a condition with role=developer; None means not provable."""
+    if isinstance(node, jinja2.nodes.And | jinja2.nodes.Or):
+        left, left_mentions = _evaluate_condition_for_developer(
+            node.left, message_varname
+        )
+        right, right_mentions = _evaluate_condition_for_developer(
+            node.right, message_varname
+        )
+        mentions_developer = left_mentions or right_mentions
+        if isinstance(node, jinja2.nodes.And):
+            if left is False or right is False:
+                return False, mentions_developer
+            if left is True and right is True:
+                return True, mentions_developer
+        else:
+            if left is True or right is True:
+                return True, mentions_developer
+            if left is False and right is False:
+                return False, mentions_developer
+        return None, mentions_developer
+
+    if isinstance(node, jinja2.nodes.Not):
+        value, mentions_developer = _evaluate_condition_for_developer(
+            node.node, message_varname
+        )
+        return (None if value is None else not value), mentions_developer
+
+    if not isinstance(node, jinja2.nodes.Compare) or len(node.ops) != 1:
+        if isinstance(node, jinja2.nodes.Const) and isinstance(node.value, bool):
+            return node.value, False
+        return None, False
+
+    operand = node.ops[0]
+    left = node.expr
+    right = operand.expr
+    if _is_attr_access(left, message_varname, "role") and isinstance(
+        right, jinja2.nodes.Const
+    ):
+        mentions_developer = right.value == "developer"
+        if operand.op == "eq":
+            return right.value == "developer", mentions_developer
+        if operand.op == "ne":
+            return right.value != "developer", mentions_developer
+
+    if isinstance(left, jinja2.nodes.Const) and _is_attr_access(
+        right, message_varname, "role"
+    ):
+        mentions_developer = left.value == "developer"
+        if operand.op == "eq":
+            return left.value == "developer", mentions_developer
+        if operand.op == "ne":
+            return left.value != "developer", mentions_developer
+
+    if not _is_attr_access(left, message_varname, "role") or not isinstance(
+        right, jinja2.nodes.List | jinja2.nodes.Tuple
+    ):
+        return None, False
+
+    values = [
+        item.value for item in right.items if isinstance(item, jinja2.nodes.Const)
+    ]
+    if len(values) != len(right.items):
+        return None, "developer" in values
+
+    mentions_developer = "developer" in values
+    if operand.op == "in":
+        return mentions_developer, mentions_developer
+    if operand.op == "notin":
+        return not mentions_developer, mentions_developer
+    return None, mentions_developer
+
+
+def _body_calls_raise_exception(body: list[jinja2.nodes.Node]) -> bool:
+    for node in body:
+        calls = itertools.chain(
+            [node] if isinstance(node, jinja2.nodes.Call) else [],
+            node.find_all(jinja2.nodes.Call),
+        )
+        for call in calls:
+            if _is_var_access(call.node, "raise_exception"):
+                return True
+    return False
+
+
+def _body_renders_output(body: list[jinja2.nodes.Node]) -> bool:
+    for node in body:
+        if isinstance(node, jinja2.nodes.Output):
+            for child in node.nodes:
+                if not isinstance(child, jinja2.nodes.TemplateData):
+                    return True
+                if child.data.strip():
+                    return True
+    return False
 
 
 def _convert_developer_to_system(
@@ -479,7 +640,7 @@ def _consolidate_system_messages(
     very first message.  After developer-to-system conversion, system messages
     may appear at non-first positions; this merges them into a single message.
     """
-    system_contents: list[str] = []
+    system_contents: list[str | list[dict[str, Any]]] = []
     non_system: list[ConversationMessage] = []
     needs_consolidation = False
     for i, msg in enumerate(conversation):
@@ -487,14 +648,6 @@ def _consolidate_system_messages(
             if i > 0 or system_contents:
                 needs_consolidation = True
             content = msg.get("content", "")
-            if isinstance(content, list):
-                parts = []
-                for part in content:
-                    if isinstance(part, dict) and "text" in part:
-                        parts.append(part["text"])
-                    elif isinstance(part, str):
-                        parts.append(part)
-                content = "\n".join(parts)
             if content:
                 system_contents.append(content)
         else:
@@ -503,9 +656,30 @@ def _consolidate_system_messages(
     if not needs_consolidation:
         return conversation
 
+    if any(isinstance(content, list) for content in system_contents):
+        merged_parts: list[dict[str, Any]] = []
+        for content in system_contents:
+            if isinstance(content, str):
+                parts: list[dict[str, Any]] = [{"type": "text", "text": content}]
+            else:
+                parts = [
+                    {"type": "text", "text": part}
+                    if isinstance(part, str)
+                    else copy.deepcopy(part)
+                    for part in content
+                ]
+            if not parts:
+                continue
+            if merged_parts:
+                merged_parts.append({"type": "text", "text": "\n\n"})
+            merged_parts.extend(parts)
+        merged_content: str | list[dict[str, Any]] = merged_parts
+    else:
+        merged_content = "\n\n".join(cast(list[str], system_contents))
+
     merged: ConversationMessage = {
         "role": "system",
-        "content": "\n\n".join(system_contents),
+        "content": merged_content,
     }
     return [merged, *non_system]
 


### PR DESCRIPTION
## Summary

Codex CLI requests sent through the Responses API can include messages with
`role: "developer"`. HF chat templates that do not explicitly support that
role either reject the request with `Unexpected message role` or fail after
conversion when a later `system` message violates templates that require the
system prompt to be first.

This ports the upstream vLLM handling into the HF renderer path:

- detect whether a chat template explicitly supports the `developer` role
- map unsupported `developer` messages to `system`
- remove the developer-only `tools` payload before rendering
- merge all `system` messages into a single first message so strict templates
  keep their ordering invariant

## Upstream context

- vLLM issue: https://github.com/vllm-project/vllm/issues/42407
- vLLM fix PR: https://github.com/vllm-project/vllm/pull/43590

This is not a duplicate of an open upstream PR in 1Cat-vLLM. The duplicate-work
check found no dedicated open 1CatAI/1Cat-vLLM PR for the developer-role chat
template fix. Search did return draft PR #238, but that is a broad v1.3.0
replay patch set rather than this focused renderer compatibility fix.

## Tests

- `git diff --check` passed
- `.venv/bin/python -m py_compile vllm/renderers/hf.py tests/renderers/test_hf.py` passed
- `/Users/fl/data0/sourceCode/1Cat-vLLM/.venv/bin/python -m pytest tests/renderers/test_hf.py -q` could not run because that venv did not have `pytest`
- `uv run pytest tests/renderers/test_hf.py -q` could not collect tests locally because uv resolved the macOS environment as unsatisfiable for the pinned torch CPU dependency

## AI assistance

This PR was prepared with assistance from OpenAI Codex. The submitting human
should review every changed line and rerun the targeted renderer tests in a
supported Linux/CUDA development environment before merging.