### PR TITLE
[Core][SM70] Allow compressed-tensors KV method on the fp8_e5m2 unit-scale override path

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -173,15 +173,29 @@ def _init_kv_cache_quant(
                 and not current_platform.has_device_capability(75)
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             )
+            # Lazy import: the quantization package imports Attention at module
+            # scope, so importing it here avoids a circular import.
+            from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+                CompressedTensorsKVCacheMethod,
+            )
             uses_base_scale_processing = (
                 type(quant_method).process_weights_after_loading
                 is BaseKVCacheMethod.process_weights_after_loading
+            )
+            # CompressedTensorsKVCacheMethod overrides process_weights_after_loading
+            # to load checkpoint KV scales, but its override also implements the
+            # SM70 unit-scale override (its _force_unit_fp8_e5m2_kv_scales branch),
+            # so it is compatible with the unit-scale override path.
+            is_compressed_tensors_kv = isinstance(
+                quant_method, CompressedTensorsKVCacheMethod
             )
             has_checkpoint_kv_scheme = (
                 getattr(quant_method.quant_config, "kv_cache_scheme", None) is not None
             )
             unit_scale_compatible = (
-                uses_base_scale_processing or not has_checkpoint_kv_scheme
+                uses_base_scale_processing
+                or is_compressed_tensors_kv
+                or not has_checkpoint_kv_scheme
             )
             if not sm70_flash_v100 or not unit_scale_compatible:
                 raise ValueError(


### PR DESCRIPTION
## Problem

The SM70 Flash-V100 fp8_e5m2 KV guard in `_init_kv_cache_quant` (`attention.py`) only accepted quant methods that keep `BaseKVCacheMethod.process_weights_after_loading`. NVFP4 checkpoints put their KV quantization in a `CompressedTensorsKVCacheMethod` (which carries a `kv_cache_scheme` and *overrides* `process_weights_after_loading` to load checkpoint KV scales), so the class-identity check fails and the engine crashes at init:

```
ValueError: fp8_e5m2 kv-cache is not supported with checkpoint KV scales outside the SM70 Flash-V100 unit-scale override path.
```

However, `CompressedTensorsKVCacheMethod`'s override already implements the SM70 unit-scale override (its `_force_unit_fp8_e5m2_kv_scales` branch) — exactly the mechanism the guard exists to protect. The whitelist rejected a method that is already compatible with the unit-scale path.

## Change

- Add `CompressedTensorsKVCacheMethod` to the `unit_scale_compatible` check (lazy import, since the quantization package imports `Attention` at module scope).
- No kernel or scale-math changes: checkpoint KV/q/prob scales are still ignored and unit scales are used, identical to the base-method path; the existing one-time log line documents it.

## Validation

Deployed on 2x V100S-32GB (2 replicas, TP2) with `unsloth/Qwen3.8-27B-NVFP4` + `--kv-cache-dtype fp8_e5m2` + `VLLM_SM70_FLASH_ATTN_V100=1` (1.5.0 RC built from `6cfaaf5e82` + this patch), production traffic, 2/2 replicas ready with zero restarts:

- Both workers log: `INFO [attention.py:206] Using explicit fp8_e5m2 KV cache with a quantized checkpoint on SM70 Flash-V100; checkpoint KV/q/prob scales, when present, will be ignored and unit scales will be used.`
- FP8 KV decode path confirmed active on both ranks: `INFO [flash_attn_v100.py:1159] FLASH_ATTN_V100 FP8 KV cache decode path active (kv_dtype=fp8_e5m2, route=xqa_paged).`
- 256K-token context fits: KV footprint ~4.2 GB/rank (vs ~8.34 GB with fp16 KV); two concurrent 256K prefills complete without OOM.
- A/B vs the previous AWQ-INT4 deployment (same model family, same topology): single-stream 69.1 vs 50.6 tok/s; 256K serial prefill 311.7s vs 320.3s; perplexity 4.5613 vs 4.5248 (0.81% relative difference).

## Notes

- Strictly additive: the affected combination previously crashed at init, so no previously-working configuration changes behavior.
- Prepared with AI assistance; the diff and the validation steps above were reviewed by the deploying team before submission.
