### PR TITLE
[Core][SM70] Allow DFlash2 candidate TopK over a quantized shared LM head

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -228,6 +228,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DFLASH2_FUSED_GEMMA_RMS: bool = False
     VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION: bool = False
     VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC: bool = False
+    VLLM_SM70_DFLASH2_QUANT_LM_HEAD: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE: bool = True
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
@@ -2082,6 +2083,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # production-weight TP4 microbenchmark.
     "VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC", "0"))
+    ),
+    # Allow DFlash2 candidate TopK when the shared target LM head is
+    # quantized (e.g. compressed-tensors NVFP4 checkpoints, whose
+    # unquantized-head guard predates this deployment). The dense-logit
+    # fallback (quant_method.apply over the full vocabulary) produces the
+    # candidates instead of the QPN8 fast path. Opt-in because draft
+    # acceptance may differ from the unquantized baseline; quality gates
+    # must follow before broad rollout.
+    "VLLM_SM70_DFLASH2_QUANT_LM_HEAD": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_QUANT_LM_HEAD", "0"))
     ),
     # Default-on SGLang-style push collective for the validated FP16 80-KiB
     # verifier and 8-KiB decode payloads on fully-connected SM70 TP4 CUDA

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -447,9 +447,19 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
             self.lm_head.quant_method,
             (UnquantizedEmbeddingMethod, UnquantizedLinearMethod),
         ):
-            raise ValueError(
-                "DFlash2 requires an unquantized target LM head for candidate TopK; "
-                f"got {type(self.lm_head.quant_method).__name__}."
+            if not envs.VLLM_SM70_DFLASH2_QUANT_LM_HEAD:
+                raise ValueError(
+                    "DFlash2 requires an unquantized target LM head for "
+                    "candidate TopK; got "
+                    f"{type(self.lm_head.quant_method).__name__}. Set "
+                    "VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1 to use the "
+                    "dense-logit fallback over the quantized head."
+                )
+            logger.info_once(
+                "VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1: DFlash2 candidate TopK "
+                "uses the dense-logit fallback over the quantized target "
+                "LM head (%s).",
+                type(self.lm_head.quant_method).__name__,
             )
 
         selector = self.model.candidate_selector


### PR DESCRIPTION
## Problem

Compressed-tensors NVFP4 checkpoints quantize `lm_head`, and `load_dflash_model` shares the target LM head with the DFlash2 draft. The unquantized-head guard in `compute_candidates` therefore hard-crashes the engine during profile_run on any SM70 NVFP4 + DFlash2 deployment:

```
ValueError: DFlash2 requires an unquantized target LM head for candidate TopK; got CompressedTensorsLinearMethod.
```

The guard predates quantized-head support. The dense-logit fallback in `compute_candidates` (`quant_method.apply` over the full vocabulary, then TopK) performs the same operation the target model itself uses when sampling over its quantized head, so candidate generation stays numerically consistent with acceptance scoring — no extra error source is introduced. (The QPN8 + FP16-rerank fast path is TP4-only and requires the dense packed head, so TP2 deployments already route through the fallback.)

## Change

- New opt-in env `VLLM_SM70_DFLASH2_QUANT_LM_HEAD` (default `0`): when set to `1`, the quantized-head check no longer raises; a one-time `logger.info_once` line records that the dense-logit fallback is in use.
- Default behavior is unchanged: unquantized heads and strict fail-closed semantics for quantized heads without the env are preserved.

## Validation

2x V100S-32GB (2 replicas, TP2), `unsloth/Qwen3.8-27B-NVFP4` + DFlash2 draft `incoai/Qwen3.8-27B-DFlash2`, 1.5.0 RC built from `6cfaaf5e82` + this patch, production traffic, 2/2 replicas ready with zero restarts:

- Engine starts; both workers log: `INFO [qwen3_dflash2.py:458] VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1: DFlash2 candidate TopK uses the dense-logit fallback over the quantized target LM head (CompressedTensorsLinearMethod).`
- Spec-decode acceptance over a ~10-minute live-traffic window: 0.5309 (delta-accepted 249 / delta-draft 469) vs 0.4908 on the previous AWQ-INT4 deployment — no regression.
- Output quality A/B vs AWQ-INT4: perplexity 4.5613 vs 4.5248 (0.81% relative difference); 10-prompt divergence suite shows only natural paraphrase-level drift, no garbage or format collapse.
- Caveat: validated on TP2 (dense fallback). On TP4 the same fallback applies whenever the QPN8 fast path is unavailable for the quantized head; the fast path itself is unchanged.

## Notes

- Strictly additive / opt-in; no kernel or scoring changes.
- Prepared with AI assistance; the diff and the validation steps above were reviewed by the deploying team before submission.
