### PR TITLE
[Perf] Pre-Ampere tile profiles for the QSA prefill dispatch (#441)

### DIFF
--- a/vllm/models/qwen4_exp/amd/ops/qsa.py
+++ b/vllm/models/qwen4_exp/amd/ops/qsa.py
@@ -819,6 +819,20 @@ def qsa_select_paged_tokens(
     return out
 
 
+_SHARED_MEM_OPTIN: dict[int, int] = {}
+
+
+def _max_shared_mem(device: torch.device) -> int:
+    """Per-block shared memory the device can actually grant (opt-in limit)."""
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    if idx not in _SHARED_MEM_OPTIN:
+        props = torch.cuda.get_device_properties(idx)
+        _SHARED_MEM_OPTIN[idx] = getattr(
+            props, "shared_memory_per_block_optin", props.shared_memory_per_block
+        )
+    return _SHARED_MEM_OPTIN[idx]
+
+
 def qsa_sparse_paged_attention(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -881,8 +895,39 @@ def qsa_sparse_paged_attention(
         block_n, target_splits, partial_warps = 64, 4, 2
     else:
         block_n, target_splits, partial_warps = 64, 1, 2
+    # Pre-Ampere retune (measured on V100 sm70 and RTX 8000 sm75, see
+    # issue #441): the wide GB300 prefill tiles are 19.3x (V100,
+    # 527 -> 27.3 ms) and 4.2x (RTX 8000 after the shared-memory clamp,
+    # 199.7 -> 47.9 ms) slower than narrow 4-warp tiles on 2048-row
+    # chunks -- two warps cannot hide the emulated-bf16 latency on these
+    # parts. The decode/verify branches (base_programs < 32) already run
+    # the optimal narrow profiles and stay untouched.
+    if base_programs >= 32 and not current_platform.is_rocm():
+        if torch.cuda.get_device_capability(q.device)[0] < 8:
+            if base_programs <= 256:
+                block_n, target_splits, partial_warps = 16, 8, 4
+            elif base_programs <= 512:
+                block_n, target_splits, partial_warps = 16, 4, 4
+            else:
+                block_n, target_splits, partial_warps = 16, 1, 4
     # gfx942 and gfx950 have a 64 KiB LDS limit. One software-pipelining
     # stage keeps the wide TP4 tile within that shared-memory budget.
+    # On CUDA, the profiles above were tuned on GB300, whose 228 KiB of
+    # shared memory per block hides the cost of the widest tile. A tile
+    # holds K and V for the full head dimension plus the fp32 accumulator:
+    #     2 * BLOCK_N * HEAD_DIM * itemsize + BLOCK_M * HEAD_DIM * 4
+    # bytes -- 80 KiB at BLOCK_N 64 and HEAD_DIM 256. Turing grants only
+    # 64 KiB (Volta 96 KiB), so narrow the tile to the widest one the
+    # device can actually hold rather than asking the platform for its
+    # name. ROCm keeps its measured single-stage behaviour untouched.
+    if not current_platform.is_rocm():
+        shared_budget = _max_shared_mem(q.device)
+        accumulator_bytes = block_m * head_dim * 4
+        while block_n > 16 and (
+            2 * block_n * head_dim * q.element_size() + accumulator_bytes
+            > shared_budget
+        ):
+            block_n //= 2
     partial_stages = 1 if current_platform.is_rocm() else 2
 
     num_tiles = triton.cdiv(logical_indices.shape[1], block_n)


### PR DESCRIPTION
Follow-up to #441 as requested — the QSA prefill retune we run in production on a mixed Volta/Turing box (2× Quadro RTX 8000 sm75, 3× Tesla V100 sm70).

## What

The dispatch table in `qwen4_exp/amd/ops/qsa.py` ("Tuned on GB300") is used unchanged on pre-Ampere cards, where two warps cannot hide the emulated-bf16 latency. This PR adds, ahead of that table:

1. a capability branch selecting narrow 4-warp tiles (`16/8/4`, `16/4/4`, `16/1/4` by `base_programs`) for `compute_capability < 8` on the prefill branch (`base_programs >= 32`). The decode/verify branches already run the optimal narrow profiles and are untouched.
2. a shared-memory clamp that sizes the tile against the device's actual opt-in limit (`2 * BLOCK_N * HEAD_DIM * itemsize + BLOCK_M * HEAD_DIM * 4`) instead of assuming the GB300 budget — Turing grants 64 KiB, Volta 96 KiB.

Both are CUDA-only; ROCm keeps its measured single-stage behaviour exactly as before. Pure insertions, no existing profile changes for sm80+.

## Measurements

2048-token prefill chunk, production geometry (H12/KV1/D256, TOPK 2048), harness `tools/qsa_bench.py` in our fork:

| Card | GB300 profile | pre-Ampere profile | factor |
|---|---:|---:|---:|
| V100 (96 KB smem) | 527 ms (N64/S1/W2) | **27.3 ms** (N16/S1/W4) | **19.3×** |
| RTX 8000 (64 KB) | 199.7 ms (clamped N32/W2) | **47.9 ms** (N16/S4/W4) | **4.2×** |

End to end on Qwen3.8-Flash-Next-180B (TP2×PP2, 262k context): prefill 392–448 → 1482–1696 tok/s, cold-turn TTFT 67 → 25 s, coherence 3/3 (caveats on the absolute prefill number as discussed in #441; the ratio is the load-bearing part).

Numerics: 9.77e-04 max deviation against the production path, while the kernel already scatters 4.88e-04 against itself across split reduction orders — one to two ULP in bf16. An A/B with identical prompts showed no quality difference.

## Notes

- Per `qwen4_exp/__init__.py`, pre-Ampere takes the `amd/` branch, so only that file is touched; the `nvidia/` twin is dead code on these cards.
- Happy to extend the clamp to ROCm if you have gfx942 numbers — we could not measure it and did not want to change behaviour blind.

Fixes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
