### PR TITLE
[Core][SM70] Qualify GLM-5.3 DFlash2 TP4/PP2 256K

### DIFF
--- a/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
+++ b/benchmarks/kernels/benchmark_glm53_fp16_gemv.py
@@ -630,7 +630,7 @@ def main() -> None:
                 [torch.nn.functional.linear(x8[i : i + 1], weight) for i in range(8)]
             )
             fp32_reference8 = torch.nn.functional.linear(x8.float(), weight.float())
-            for half2_rows in (-4, -3, -2, 4, 0, 1, 2, 8, 16):
+            for half2_rows in (-5, -4, -3, -2, 4, 0, 1, 2, 8, 16):
                 try:
                     result = _benchmark_cuda_chunk_parallel_kernel(
                         x8,

--- a/csrc/sm70_turbomind/ops/glm53_fp16_gemv_sm70.cu
+++ b/csrc/sm70_turbomind/ops/glm53_fp16_gemv_sm70.cu
@@ -284,7 +284,8 @@ __device__ __forceinline__ int glm53_staged_partial_index(int row, int chunk,
   return ((row * kChunkCount + chunk) * kLanesPerRow + lane);
 }
 
-template <int kBatch, int kRowsPerBlock, bool kSwizzled>
+template <int kBatch, int kRowsPerBlock, bool kSwizzled,
+          bool kBroadcastInput = true>
 __global__ void glm53_fp16_gemv_half2_broadcast_staged_sm70_kernel(
     half* __restrict__ output, const half* __restrict__ input,
     const half* __restrict__ weight) {
@@ -309,11 +310,16 @@ __global__ void glm53_fp16_gemv_half2_broadcast_staged_sm70_kernel(
 #pragma unroll
     for (int batch = 0; batch < kBatch; ++batch) {
       unsigned input_packed = 0;
-      if (row_in_block == 0) {
+      if constexpr (!kBroadcastInput) {
+        input_packed = __ldg(reinterpret_cast<const unsigned*>(
+            input + static_cast<size_t>(batch) * kGlm53K + k));
+      } else if (row_in_block == 0) {
         input_packed = __ldg(reinterpret_cast<const unsigned*>(
             input + static_cast<size_t>(batch) * kGlm53K + k));
       }
-      input_packed = __shfl_sync(0xffffffffu, input_packed, lane_pair);
+      if constexpr (kBroadcastInput) {
+        input_packed = __shfl_sync(0xffffffffu, input_packed, lane_pair);
+      }
       const half2 x = *reinterpret_cast<half2*>(&input_packed);
       const float2 input_value = __half22float2(x);
       chunk_sum[batch].x =
@@ -414,8 +420,17 @@ void sm70_glm53_fp16_gemv_out(torch::Tensor output, torch::Tensor input,
   const cudaStream_t stream =
       at::cuda::getCurrentCUDAStream(input.device().index());
   const char* variant_raw = std::getenv("VLLM_SM70_GLM53_EXACT_KDA_HALF2_ROWS");
-  const int variant = variant_raw == nullptr ? -3 : std::atoi(variant_raw);
+  const int variant = variant_raw == nullptr ? -5 : std::atoi(variant_raw);
   if (input.size(0) == 8 && variant != 0) {
+    if (variant == -5) {
+      glm53_fp16_gemv_half2_broadcast_staged_sm70_kernel<8, 4, true, false>
+          <<<kGlm53N / 4, 256, 0, stream>>>(
+              reinterpret_cast<half*>(output.data_ptr<at::Half>()),
+              reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+              reinterpret_cast<const half*>(weight.data_ptr<at::Half>()));
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      return;
+    }
     if (variant == -3) {
       glm53_fp16_gemv_half2_broadcast_staged_sm70_kernel<8, 4, true>
           <<<kGlm53N / 4, 256, 0, stream>>>(
@@ -468,7 +483,7 @@ void sm70_glm53_fp16_gemv_out(torch::Tensor output, torch::Tensor input,
       default:
         TORCH_CHECK(false,
                     "VLLM_SM70_GLM53_EXACT_KDA_HALF2_ROWS must be one of "
-                    "-4, -3, -2, 0, 1, 2, 4, 8, or 16");
+                    "-5, -4, -3, -2, 0, 1, 2, 4, 8, or 16");
     }
 #undef VLLM_LAUNCH_GLM53_GEMV_HALF2
     C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45168,3 +45168,72 @@ Interpretation:
   `q8_tp8pp1_10seed_topponly8_fusedfg1024_control2_warm128_20260902.json`,
   `q8_tp8pp1_fusedfg1024_topponly8_round_nodes.json`, and
   `q8_tp8pp1_gsm8k128_topponly8_fusedfg1024_source_default_prop09_top095_official_quality_20260902.json`.
+
+## 2026-09-03 GLM-5.3 DFlash2 TP4/PP2 256K cache and verifier audit
+
+- Draft PR #456 is stacked on verifier PR #454. The frozen contract is eight
+  V100-SXM2-32GB GPUs, TP4/PP2 with layer partition `24,21`, GLM-5.3-Flash
+  NVFP4 target execution in FP16, E4M3 target KV, official probabilistic q7
+  DFlash2, one live request, CUDA Graph, and AOT compile. No INT8 dense or KDA
+  path is admitted.
+- GLM's target Mamba state forces a 2,304-token MLA manager block. Charging
+  each DFlash sliding-window layer at that block size wasted about 1.6 GiB on
+  every PP1 rank. The cache planner now reblocks the draft attention to the
+  largest aligned divisor whose real page fits an MLA tensor slot: 1,152
+  tokens and 1,198,080 padded bytes for this model. Draft pages share the
+  unused MLA slot for the same globally exclusive block ID; no cache value,
+  scale, dtype, attention window, or block-owner lifetime changes.
+- At `gpu_memory_utilization=0.93`, every run reports 333,796 logical KV
+  tokens, or 1.27 concurrent 262,144-token requests. PP0 has 2.20 GiB
+  available and needs 1.05 GiB; PP1 has 1.14-1.16 GiB available and needs
+  0.89 GiB. The pool block is 7,644,672 bytes on PP0 and 6,370,560 bytes on
+  PP1. Model loading is 24.95 GiB/rank on PP0 and 25.85 GiB/rank on PP1,
+  where the approximately 0.90-GiB difference is the resident drafter.
+- The exact boundary run uses 262,136 prompt tokens plus eight output tokens
+  at `max_model_len=262144`. It finishes normally with no cache corruption.
+  Prefill takes 1,160.21 seconds and boundary decode is 1.825 token/s because
+  the real 256K sparse-attention work is included; this is a capacity proof,
+  not the short-context verifier speed result.
+- Three 128-question audits at the 256K service configuration record
+  `122/128`, `119/128`, and `123/128` accuracy. The fixed-seed runs have zero
+  invalid answers and 128 natural stops. The official unseeded run records
+  one length stop, `0.78125%` invalid answers, and `5.81257` mean completion
+  tokens per verification step, above the 5.78 release threshold. Pooled
+  acceptance is 5.46934-5.53801 on the fixed-seed routes, above the 4.85
+  implementation threshold.
+- Robust full-round cost is 43.440, 43.709, and 44.160 ms when each complete
+  128-request audit sums decode time and divides by all verification rounds.
+  Mean steady accepted-token throughput is 130.589-132.127 token/s. Two
+  deterministic dataset-0 AOT1 runs have identical 207-token output arrays
+  and measure 42.643 and 42.836 ms/round. Single unrelated stochastic
+  requests ranged more widely and are not used as a stable speed claim.
+- Temporary V2 CUDA-event probes localize a representative 42.486-ms round:
+  PP0 target forward 19.281 ms, PP1 target forward 16.109 ms, target logits
+  plus rejection sampling 1.282 ms, request-state update 0.034 ms, DFlash
+  proposal 3.456 ms, PP broadcast GPU work 0.124 ms, and about 2.200 ms of
+  remaining CPU scheduler/PP handoff. The two sequential target stages alone
+  are 35.390 ms. Resident NCCL wait kernels are dependency waits and are not
+  added again as communication service.
+- The retained exact KDA candidate lets every row lane directly load the
+  cached input half2 and removes the row-0 warp shuffle while preserving the
+  FP32 FMA and reduction order. The q8 microbenchmark is bitwise equal and
+  moves 126.222 to 114.924 microseconds (`+9.8%` effective bandwidth). Rows-8
+  CTA and forced 32-register launch-bound variants regress to 132.407 and
+  131.568 microseconds and were removed. The full-model output remains exact;
+  endpoint movement is below run-to-run noise, so only the operator result is
+  claimed.
+- Shared-expert side-stream execution remains enabled. A retained serialized
+  trace is about 1.23 ms/round slower. TP4 shared+routed `all_reduce_sum2` was
+  also left off: unmatched route smokes did not establish a benefit and were
+  not promoted. The quality-rejected TP4 push collective remains off.
+- Strict TP4/PP2 does not meet the requested 32-ms full-round ceiling. It
+  would require at least 10.5 ms, about 24.7%, below the stable 42.5-ms short
+  round, while the sequential target forwards already exceed 32 ms before
+  sampling and drafting. The same packed-cache code gives TP8/PP1 309,806 KV
+  tokens (1.18x 256K) and a 31.093-ms q8 round, but that is an explicitly
+  different topology and must not be reported as TP4/PP2.
+- Nsight Compute hardware-counter collection remains unavailable with
+  `ERR_NVGPUCTRPERM`. The host also rejects application-clock changes for the
+  current user; V100 application clocks remain 877/1290 MHz rather than the
+  supported 877/1530-MHz maximum. Neither unavailable counter values nor a
+  locked-clock speed projection is used as measured evidence.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45226,6 +45226,12 @@ Interpretation:
   trace is about 1.23 ms/round slower. TP4 shared+routed `all_reduce_sum2` was
   also left off: unmatched route smokes did not establish a benefit and were
   not promoted. The quality-rejected TP4 push collective remains off.
+- The latest SGLang PP work does not provide a mergeable latency escape hatch.
+  GLM-5 speculative decoding plus PP issue #23162 is a closed RFC with no
+  linked implementation and keeps target PP stages serial. Parallel-spec
+  roadmap #27462 lists DFlash's hidden-state data plane and the PP handshake
+  as future/unvalidated work. Cross-round enumeration is not quality-neutral
+  for this hidden-state-conditioned drafter without that data plane.
 - Strict TP4/PP2 does not meet the requested 32-ms full-round ceiling. It
   would require at least 10.5 ms, about 24.7%, below the stable 42.5-ms short
   round, while the sequential target forwards already exceed 32 ms before

--- a/tests/v1/core/test_glm5_kv_cache_layout.py
+++ b/tests/v1/core/test_glm5_kv_cache_layout.py
@@ -118,7 +118,7 @@ def test_glm53_pp2_kpool_tail_shares_indexer_storage(monkeypatch):
         assert tensor.shared_by == [idx_name, tail_name]
 
 
-def test_glm53_dflash_keeps_compressed_layout_and_allocates_draft_pages():
+def test_glm53_dflash_packs_only_draft_pages_that_fit_mla_slots():
     vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(
             max_model_len=4096,
@@ -176,20 +176,107 @@ def test_glm53_dflash_keeps_compressed_layout_and_allocates_draft_pages():
     assert len(auxiliary_groups[0].layer_names) == 5
 
     _, _, mla_names, idx_names, mla_page, idx_page, _, _ = layout
-    bytes_per_block = mla_page + idx_page + 5 * draft_spec.page_size_bytes
+    auxiliary_spec = auxiliary_groups[0].kv_cache_spec
+    assert auxiliary_spec.block_size == 32
+    assert auxiliary_spec.page_size_bytes == mla_page
+    bytes_per_block = mla_page + idx_page + 4 * mla_page
     assert kv_cache_utils._pool_bytes_per_block(groups) == bytes_per_block
 
     cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
         vllm_config, groups, bytes_per_block * 100
     )
     assert cache_config.num_blocks == 100
-    assert len(cache_config.kv_cache_tensors) == len(mla_names) + len(idx_names) + 5
+    assert len(cache_config.kv_cache_tensors) == len(mla_names) + len(idx_names) + 4
+    packed_draft_tensors = [
+        tensor
+        for tensor in cache_config.kv_cache_tensors
+        if tensor.shared_by[0] in mla_names
+        and any(name.startswith("speculator.") for name in tensor.shared_by)
+    ]
+    assert len(packed_draft_tensors) == 1
     draft_tensors = [
         tensor
         for tensor in cache_config.kv_cache_tensors
         if tensor.shared_by[0].startswith("speculator.")
     ]
-    assert len(draft_tensors) == 5
-    assert all(
-        tensor.size == draft_spec.page_size_bytes * 100 for tensor in draft_tensors
+    assert len(draft_tensors) == 4
+    assert all(tensor.size == mla_page * 100 for tensor in draft_tensors)
+
+
+def test_glm53_dflash_tp4_reblocks_and_packs_all_draft_pages():
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            max_model_len=262144,
+            get_total_num_hidden_layers=lambda: 21,
+        ),
+        parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+        cache_config=SimpleNamespace(
+            mamba_cache_mode="none",
+            num_gpu_blocks_override=None,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=128,
+            disable_hybrid_kv_cache_manager=False,
+        ),
+        speculative_config=SimpleNamespace(use_dflash=lambda: True),
     )
+    target_block_size = 2304
+    specs = {}
+    for layer_idx in range(5):
+        prefix = f"model.layers.{4 * layer_idx + 3}.self_attn"
+        specs[f"{prefix}.mla_attn"] = MLAAttentionSpec(
+            block_size=target_block_size,
+            num_kv_heads=1,
+            head_size=512,
+            dtype=torch.uint8,
+            cache_dtype_str="fp8_e4m3",
+            model_version="glm5_next",
+        )
+        specs[f"{prefix}.indexer.k_cache"] = MLAAttentionSpec(
+            block_size=target_block_size,
+            num_kv_heads=1,
+            head_size=132,
+            dtype=torch.uint8,
+            compress_ratio=4,
+        )
+        specs[f"model.layers.{4 * layer_idx}.self_attn"] = MambaSpec(
+            block_size=262144,
+            shapes=((1198080,),),
+            dtypes=(torch.uint8,),
+            num_speculative_blocks=7,
+        )
+        specs[f"speculator.model.layers.{layer_idx}.self_attn.attn"] = (
+            SlidingWindowSpec(
+                block_size=target_block_size,
+                num_kv_heads=2,
+                head_size=128,
+                head_size_v=128,
+                dtype=torch.float16,
+                sliding_window=2048,
+            )
+        )
+
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, specs)
+    layout = kv_cache_utils._glm5_next_tensor_layout(groups)
+    assert layout is not None
+    _, _, mla_names, idx_names, mla_page, idx_page, _, _ = layout
+    auxiliary_group = kv_cache_utils._glm5_next_auxiliary_attention_groups(groups)[0]
+    assert auxiliary_group.kv_cache_spec.block_size == 1152
+    assert auxiliary_group.kv_cache_spec.page_size_bytes == mla_page == 1198080
+
+    bytes_per_block = len(mla_names) * mla_page + len(idx_names) * idx_page
+    assert bytes_per_block == 6370560
+    assert kv_cache_utils._pool_bytes_per_block(groups) == bytes_per_block
+
+    cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, bytes_per_block * 200
+    )
+    assert cache_config.num_blocks == 200
+    assert len(cache_config.kv_cache_tensors) == len(mla_names) + len(idx_names)
+    for layer_idx, mla_name in enumerate(mla_names):
+        tensor = next(
+            tensor
+            for tensor in cache_config.kv_cache_tensors
+            if mla_name in tensor.shared_by
+        )
+        assert f"speculator.model.layers.{layer_idx}.self_attn.attn" in tensor.shared_by

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -916,10 +916,13 @@ def _pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int:
         return kv_cache_groups[0].kv_cache_spec.page_size_bytes
     if (glm5 := _glm5_next_tensor_layout(kv_cache_groups)) is not None:
         _, _, mla_names, idx_names, mla_page, idx_page, _, _ = glm5
+        _, standalone_auxiliary = _glm5_next_auxiliary_tensor_plan(
+            kv_cache_groups, len(mla_names), mla_page
+        )
         return (
             len(mla_names) * mla_page
             + len(idx_names) * idx_page
-            + _glm5_next_auxiliary_page_bytes(kv_cache_groups)
+            + sum(page_size for _, page_size in standalone_auxiliary)
         )
     if layout := _get_csa_linear_tensor_layout(kv_cache_groups):
         return layout.bytes_per_block
@@ -1421,6 +1424,42 @@ def _get_kv_cache_groups_glm5_next(
     )
     assert uniform_spec is not None
 
+    # The target's Mamba state makes its MLA manager block much wider than the
+    # draft model needs. Keeping that block size on DFlash attention would add
+    # every draft layer's large page to every shared-pool block, even though a
+    # sliding-window draft owns only a few block ids. Reblock the draft to the
+    # largest 16-token-aligned divisor whose page fits in one MLA tensor slot.
+    # The padded page can then share that slot safely: block ids are globally
+    # unique across cache groups, so target, Mamba, and draft owners never alias
+    # the same physical page at the same time.
+    if auxiliary_attn_specs:
+        target_block_size = uniform_spec.block_size
+        fitted_auxiliary_specs: dict[str, KVCacheSpec] | None = None
+        for candidate in range(target_block_size, 15, -1):
+            if target_block_size % candidate != 0 or candidate % 16 != 0:
+                continue
+            candidate_specs = {
+                name: replace(spec, block_size=candidate, page_size_padded=None)
+                for name, spec in auxiliary_attn_specs.items()
+            }
+            if all(
+                cast(FullAttentionSpec, spec).real_page_size_bytes <= mla_page
+                for spec in candidate_specs.values()
+            ):
+                fitted_auxiliary_specs = {
+                    name: replace(spec, page_size_padded=mla_page)
+                    for name, spec in candidate_specs.items()
+                }
+                break
+        if fitted_auxiliary_specs is not None:
+            auxiliary_attn_specs = fitted_auxiliary_specs
+            logger.info_once(
+                "GLM-5.3 DFlash auxiliary attention uses block_size=%d and "
+                "shares padded %d-byte MLA tensor slots.",
+                next(iter(auxiliary_attn_specs.values())).block_size,
+                mla_page,
+            )
+
     # Keep all indexer tails in one group and pad their pages to the indexer
     # page size so each tail can share its sibling indexer's storage.
     tail_group = None
@@ -1479,13 +1518,22 @@ def _glm5_next_auxiliary_attention_groups(
     ]
 
 
-def _glm5_next_auxiliary_page_bytes(
+def _glm5_next_auxiliary_tensor_plan(
     kv_cache_groups: list[KVCacheGroupSpec],
-) -> int:
-    return sum(
-        len(group.layer_names) * group.kv_cache_spec.page_size_bytes
-        for group in _glm5_next_auxiliary_attention_groups(kv_cache_groups)
-    )
+    num_mla_slots: int,
+    mla_page: int,
+) -> tuple[list[list[str]], list[tuple[str, int]]]:
+    """Plan DFlash auxiliary tensors over globally exclusive pool block ids."""
+    shared_by_mla_slot: list[list[str]] = [[] for _ in range(num_mla_slots)]
+    standalone: list[tuple[str, int]] = []
+    for group in _glm5_next_auxiliary_attention_groups(kv_cache_groups):
+        page_size = group.kv_cache_spec.page_size_bytes
+        for index, layer_name in enumerate(group.layer_names):
+            if index < num_mla_slots and page_size == mla_page:
+                shared_by_mla_slot[index].append(layer_name)
+            else:
+                standalone.append((layer_name, page_size))
+    return shared_by_mla_slot, standalone
 
 
 def _glm5_next_tensor_layout(
@@ -1671,11 +1719,13 @@ def get_kv_cache_config_from_groups(
         ) = glm5n
         if tail_names:
             assert len(idx_names) == len(tail_names)
-        auxiliary_groups = _glm5_next_auxiliary_attention_groups(kv_cache_groups)
+        shared_auxiliary, standalone_auxiliary = _glm5_next_auxiliary_tensor_plan(
+            kv_cache_groups, len(mla_names), mla_page
+        )
         per_block = (
             len(mla_names) * mla_page
             + len(idx_names) * idx_page
-            + _glm5_next_auxiliary_page_bytes(kv_cache_groups)
+            + sum(page_size for _, page_size in standalone_auxiliary)
         )
         num_blocks = may_override_num_blocks(vllm_config, available_memory // per_block)
         kv_cache_tensors = [
@@ -1686,7 +1736,8 @@ def get_kv_cache_config_from_groups(
                     group.layer_names[i]
                     for group in mamba_groups
                     if i < len(group.layer_names)
-                ],
+                ]
+                + shared_auxiliary[i],
             )
             for i, mla_name in enumerate(mla_names)
         ] + [
@@ -1698,11 +1749,10 @@ def get_kv_cache_config_from_groups(
         ]
         kv_cache_tensors.extend(
             KVCacheTensor(
-                size=group.kv_cache_spec.page_size_bytes * num_blocks,
+                size=page_size * num_blocks,
                 shared_by=[layer_name],
             )
-            for group in auxiliary_groups
-            for layer_name in group.layer_names
+            for layer_name, page_size in standalone_auxiliary
         )
     elif csa_config := _get_kv_cache_config_csa_linear(
         vllm_config, kv_cache_groups, available_memory
@@ -2559,10 +2609,13 @@ def _max_memory_usage_bytes_from_groups(
             # Tail: 1 block/req (KpoolTailSpec.max_admission_blocks_per_request
             # == 1), drawn from the shared pool.
             blocks_needed += 1
+        _, standalone_auxiliary = _glm5_next_auxiliary_tensor_plan(
+            kv_cache_groups, len(mla_names), mla_page
+        )
         return blocks_needed * (
             len(mla_names) * mla_page
             + len(idx_names) * idx_page
-            + _glm5_next_auxiliary_page_bytes(kv_cache_groups)
+            + sum(page_size for _, page_size in standalone_auxiliary)
         )
 
     # General case: group_size pools, each shared by one layer per group
@@ -2810,9 +2863,32 @@ def get_kv_cache_configs(
         )
 
     # Check if the available memory is enough per worker.
-    for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
+    for worker_index, (groups, avail_mem) in enumerate(
+        zip(projected_groups_per_worker, available_memory)
+    ):
         if not groups:
             continue
+        if _glm5_next_tensor_layout(groups) is not None:
+            group_ledger = []
+            for group in groups:
+                spec = group.kv_cache_spec
+                pages = cdiv(
+                    spec.max_memory_usage_bytes(vllm_config), spec.page_size_bytes
+                )
+                group_ledger.append(
+                    f"{type(spec).__name__}(layers={len(group.layer_names)},"
+                    f"block={spec.block_size},page={spec.page_size_bytes},"
+                    f"pages={pages})"
+                )
+            logger.info(
+                "GLM-5.3 KV ledger worker=%d available=%s GiB required=%s GiB "
+                "pool_block_bytes=%d groups=[%s]",
+                worker_index,
+                format_gib(avail_mem),
+                format_gib(_max_memory_usage_bytes_from_groups(vllm_config, groups)),
+                _pool_bytes_per_block(groups),
+                ", ".join(group_ledger),
+            )
         _check_enough_kv_cache_memory(
             avail_mem,
             partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),


### PR DESCRIPTION
## Purpose

- Stack on Draft PR #454 and qualify GLM-5.3-Flash NVFP4 DFlash2 on eight V100s with TP4/PP2.
- Reach at least 256K total context with E4M3 FP8 KV without reducing output quality.
- Optimize the complete q8 verification round toward 32 ms without INT8 dense/KDA or quality-changing fallbacks.

## Frozen Contract

- Target: `LibertAIDAI/GLM-5.3-Flash-NVFP4`, FP16 execution.
- Draft: `incoai/GLM-5.3-Flash-DFlash2`, q7 probabilistic DFlash2.
- Hardware/topology: 8x V100-SXM2-32GB, strict TP4/PP2 with partition `24,21`.
- Target KV: FP8 E4M3; required total context: 262,144 tokens.
- CUDA Graph and Flash-V100/FlashQLA fast paths retained.

## Implementation

- Reblock DFlash sliding-window attention from the target manager 2,304-token block to 1,152 tokens.
- Pack its 1,198,080-byte padded pages into unused MLA tensor slots under the global exclusive block-ID pool.
- Add a bitwise-exact q8 KDA GEMV variant that directly loads the cached input per row and removes the row-0 warp shuffle.
- Add focused tests and record the full audit in the migration control document.

## Results

- Strict TP4/PP2 capacity: 333,796 logical tokens, or 1.27x a 262,144-token request.
- Exact 262,136 prompt + 8 output boundary request finishes without cache corruption.
- PP0: 24.95 GiB model, 2.20 GiB cache budget, 1.05 GiB required for 256K.
- PP1: 25.85 GiB model, 1.14-1.16 GiB cache budget, 0.89 GiB required for 256K.
- Stable full q8 round across three 128-request audits: 43.440-44.160 ms; accepted-token decode: 130.589-132.127 token/s.
- Two deterministic dataset-0 AOT1 runs have identical 207-token arrays and measure 42.643/42.836 ms per round.
- Event decomposition: PP0 target 19.281 ms, PP1 target 16.109 ms, sampling 1.282 ms, state 0.034 ms, draft 3.456 ms, PP broadcast 0.124 ms, residual scheduler/handoff about 2.200 ms.
- KDA micro: 126.222 -> 114.924 us, bitwise equal. Full endpoint movement is below run-to-run noise.
- Quality audits: fixed-seed 122/128 and 123/128 with zero invalid answers; official unseeded 119/128 with one length stop and 5.81257 mean completion tokens/verification step, above the 5.78 release gate.

## Acceptance Status

- 256K strict TP4/PP2 capacity: PASS.
- FP8 E4M3 KV and output-quality gates: PASS.
- 32 ms strict TP4/PP2 round: OPEN. The two sequential target stages alone are 35.390 ms; stable complete rounds are about 43.8 ms.
- TP8/PP1 is separate evidence: it reaches 309,806 logical tokens and 31.093 ms at 256K, but is not reported as TP4/PP2.

## Validation

- `pytest -q tests/v1/core/test_glm5_kv_cache_layout.py`: 4 passed.
- `pytest -q tests/models/glm5next/test_sm70_kda.py`: 31 passed on V100.
- Ruff check/format, Python compilation, and `git diff --check`: passed.
- Broader KV suite previously recorded 66 passed and one parent-reproducible DeepSeek-V4 fixture failure.
- Nsight Compute counters are unavailable (`ERR_NVGPUCTRPERM`); application-clock changes are denied to the current user.

## Dependency

- Base SHA: `dec040e68ef156bd6a252493048b8812c48e0475`.
- Base branch: `codex/v100-glm53-dflash2-verifier30-20260901-165322` / Draft PR #454.
- Current head: `72fecc32aa`.