### PR TITLE
[Model][SM70] Enable Qwen4Exp multimodal inference

### DIFF
--- a/tests/models/qwen4_exp/test_config.py
+++ b/tests/models/qwen4_exp/test_config.py
@@ -53,7 +53,8 @@ def test_sm70_v2_route_accepts_prefix_caching(
     assert "mrope_interleaved" not in vllm_config.model_config.hf_config.rope_parameters
 
 
-def test_initial_sm70_route_rejects_multimodal_tower(
+@pytest.mark.skip_global_cleanup
+def test_sm70_route_accepts_multimodal_tower_and_preserves_mrope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -79,8 +80,9 @@ def test_initial_sm70_route_rejects_multimodal_tower(
         speculative_config=None,
     )
 
-    with pytest.raises(NotImplementedError, match="--language-model-only"):
-        Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+    Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+    assert text_config.rope_parameters == {"mrope_section": [11, 11, 10]}
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -607,13 +607,7 @@ class Qwen4ExpForConditionalGenerationConfig(Qwen3_5ForConditionalGenerationConf
 
         model_config = vllm_config.model_config
         multimodal_config = model_config.multimodal_config
-        if multimodal_config is not None:
-            if not multimodal_config.language_model_only:
-                raise NotImplementedError(
-                    "Qwen4Exp multimodal inference is not enabled in the initial "
-                    "SM70 route; pass --language-model-only while the vision "
-                    "tower remains outside the TP4 memory and quality gates"
-                )
+        if multimodal_config is not None and multimodal_config.language_model_only:
             _strip_qwen4_exp_mrope(model_config)
 
         spec_config = vllm_config.speculative_config

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -937,8 +937,11 @@ class Qwen4ExpForConditionalGeneration(
             self._tower_model_names = []
         else:
             self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
-            self._init_video_pruning(multimodal_config)
             self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+            self.video_pruning_rate = multimodal_config.video_pruning_rate
+            self.is_multimodal_pruning_enabled = (
+                multimodal_config.is_multimodal_pruning_enabled()
+            )
 
             with self._mark_tower_model(vllm_config, {"image", "video"}):
                 self.visual = Qwen3_VisionTransformer(


### PR DESCRIPTION
## Summary

- Remove the provisional guard that rejected full Qwen4Exp image and video inference on the SM70 route.
- Preserve MRoPE for full multimodal requests while continuing to strip it in language-model-only mode.
- Replace the removed video-pruning helper in the NVIDIA implementation with the current Qwen3-VL initialization contract.
- Add a config regression test for multimodal admission and MRoPE preservation.

## Scope

This is a Qwen4Exp model-integration fix for the 1Cat V100/SM70 route. It does not change QSA kernels, FP8 KV conversion, or attention dispatch. The same initialization issue affected FP16 KV and calibrated E4M3 QSA KV runs.

## Duplicate check

I searched open and closed 1Cat PRs and open vLLM PRs for Qwen4Exp multimodal, MRoPE, and video-pruning fixes. No equivalent PR is open. 1Cat PRs #359 and #374 repaired adjacent Qwen4Exp integration paths but did not enable the multimodal tower or replace this removed helper.

## Validation

- Focused config regressions: 2 passed.
- Python compile check passed for the changed config, NVIDIA model, and test files.
- All changed-file pre-commit hooks passed, including Ruff, format, mypy, SPDX, forbidden-import, accelerator API, and configuration checks.
- End-to-end validation used four Tesla V100 PCIe 32GB GPUs with TP4, MTP0, FP16 activations, eager execution, and prefix caching disabled.
- Five image cases and four video cases were each repeated twice under both FP16 KV and calibrated E4M3 main QSA KV: 18/18 successful requests and 18/18 semantically correct responses per arm, with 9/9 exact repeat stability and no runtime or request errors.

A full local test-file run was not used as acceptance evidence because this CPU environment lacks torchvision and its global teardown tries to access an unavailable accelerator. The two changed config contracts were rerun directly with the repository cleanup boundary disabled and passed.

## AI assistance

OpenAI Codex assisted with implementation, test execution, duplicate checks, and PR preparation. The human submitter reviewed the three-file diff and the reported V100 runtime evidence.