### PR TITLE
[Perf][SM70] Skip unused LM-head packing for raw top-1

### DIFF
--- a/tests/model_executor/layers/test_sm70_lm_head.py
+++ b/tests/model_executor/layers/test_sm70_lm_head.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.vocab_parallel_embedding as vocab_embedding
+from vllm import envs
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _FakeCudaTensor:
+    def __init__(self, shape, dtype=torch.float16):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.device = torch.device("cuda:0")
+        self.is_cuda = True
+
+    def reshape(self, *shape):
+        if shape and shape[0] == -1:
+            shape = (self.shape[0], *shape[1:])
+        self.shape = tuple(shape)
+        return self
+
+    def size(self, dim):
+        return self.shape[dim]
+
+    def is_contiguous(self):
+        return True
+
+    def stride(self, dim):
+        return 1 if dim == 1 else self.shape[1]
+
+
+def _set_lm_head_routes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    raw_top1: bool = False,
+    tc_top1: bool = False,
+    dense: bool = False,
+    qpn8: bool = False,
+) -> None:
+    monkeypatch.setenv("VLLM_SM70_LM_HEAD_TOP1", str(int(raw_top1)))
+    monkeypatch.setenv("VLLM_SM70_LM_HEAD_TOP1_TC", str(int(tc_top1)))
+    monkeypatch.setenv("VLLM_SM70_ENABLE_LM_HEAD_FASTPATH", str(int(dense)))
+    monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_QPN8_RERANK", qpn8)
+    monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_QPN8_RERANK_SHADOW", False)
+
+
+def test_raw_top1_does_not_prepare_packed_lm_head(monkeypatch) -> None:
+    _set_lm_head_routes(monkeypatch, raw_top1=True)
+    monkeypatch.setattr(
+        vocab_embedding,
+        "_is_sm70_lm_head_fastpath_eligible",
+        lambda _layer: True,
+    )
+    prepare = Mock(side_effect=AssertionError("raw top1 must not pack the LM head"))
+    monkeypatch.setattr(vocab_embedding.sm70_ops, "sm70_f16_prepare", prepare)
+    layer = SimpleNamespace(weight=object())
+
+    assert vocab_embedding.maybe_prepare_sm70_lm_head_top1(layer)
+    assert layer._sm70_f16_raw_top1_ready
+    assert not hasattr(layer, "_sm70_f16_prepared")
+    assert not hasattr(layer, "_sm70_f16_tm_weight")
+    prepare.assert_not_called()
+
+
+def test_raw_top1_dispatch_uses_original_weight(monkeypatch) -> None:
+    _set_lm_head_routes(monkeypatch, raw_top1=True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: (7, 0))
+    monkeypatch.setattr(
+        torch.ops._C,
+        "sm70_f16_lm_head_top1_out",
+        Mock(),
+        raising=False,
+    )
+    top1_out = Mock()
+    monkeypatch.setattr(
+        vocab_embedding.sm70_ops,
+        "sm70_f16_lm_head_top1_out",
+        top1_out,
+    )
+    monkeypatch.setattr(
+        vocab_embedding.torch,
+        "empty",
+        lambda shape, dtype, device: _FakeCudaTensor(shape, dtype),
+    )
+    weight = _FakeCudaTensor((64, 16))
+    layer = SimpleNamespace(
+        weight=weight,
+        _sm70_f16_raw_top1_ready=True,
+        shard_indices=SimpleNamespace(
+            org_vocab_start_index=32,
+            num_org_vocab_padding=0,
+        ),
+    )
+
+    result = vocab_embedding._maybe_sm70_lm_head_top1(
+        layer,
+        _FakeCudaTensor((1, 16)),
+    )
+
+    assert result is not None
+    top1_out.assert_called_once()
+    assert top1_out.call_args.args[3] is weight
+
+
+@pytest.mark.parametrize(
+    ("route", "tc_top1", "dense", "qpn8"),
+    [
+        ("tc_top1", True, False, False),
+        ("dense", False, True, False),
+        ("qpn8", False, False, True),
+    ],
+)
+def test_packed_lm_head_routes_still_prepare_layout(
+    monkeypatch,
+    route,
+    tc_top1,
+    dense,
+    qpn8,
+) -> None:
+    _set_lm_head_routes(
+        monkeypatch,
+        tc_top1=tc_top1,
+        dense=dense,
+        qpn8=qpn8,
+    )
+    monkeypatch.setattr(
+        vocab_embedding,
+        "_is_sm70_lm_head_fastpath_eligible",
+        lambda _layer: True,
+    )
+    packed_weight = object()
+    prepare = Mock(return_value=(packed_weight, torch.tensor([32])))
+    monkeypatch.setattr(torch.ops._C, "sm70_f16_prepare", Mock(), raising=False)
+    monkeypatch.setattr(vocab_embedding.sm70_ops, "sm70_f16_prepare", prepare)
+    prepare_qpn8 = Mock(return_value=qpn8)
+    monkeypatch.setattr(
+        vocab_embedding,
+        "_prepare_sm70_dflash2_qpn8_rerank",
+        prepare_qpn8,
+    )
+    layer = SimpleNamespace(weight=object())
+
+    assert vocab_embedding.maybe_prepare_sm70_lm_head_top1(layer), route
+    assert layer._sm70_f16_prepared
+    assert layer._sm70_f16_tm_weight is packed_weight
+    assert layer._sm70_f16_k_ld == 32
+    prepare.assert_called_once_with(layer.weight)
+    prepare_qpn8.assert_called_once_with(layer)
+
+
+def test_raw_top1_readiness_does_not_enable_dense_fastpath(monkeypatch) -> None:
+    _set_lm_head_routes(monkeypatch, raw_top1=True, dense=True)
+    layer = SimpleNamespace(_sm70_f16_raw_top1_ready=True)
+
+    assert (
+        vocab_embedding._maybe_sm70_lm_head_forward(
+            layer,
+            torch.empty((1, 16), dtype=torch.float16),
+        )
+        is None
+    )
+
+
+def test_disabled_lm_head_routes_prepare_nothing(monkeypatch) -> None:
+    _set_lm_head_routes(monkeypatch)
+    layer = SimpleNamespace(weight=object())
+
+    assert not vocab_embedding.maybe_prepare_sm70_lm_head_top1(layer)
+    assert not hasattr(layer, "_sm70_f16_raw_top1_ready")
+    assert not hasattr(layer, "_sm70_f16_prepared")

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -65,6 +65,14 @@ def _sm70_dflash2_qpn8_rerank_requested() -> bool:
     )
 
 
+def _sm70_lm_head_packed_layout_requested() -> bool:
+    return (
+        _sm70_env_bool("VLLM_SM70_ENABLE_LM_HEAD_FASTPATH", False)
+        or _sm70_env_bool("VLLM_SM70_LM_HEAD_TOP1_TC", False)
+        or _sm70_dflash2_qpn8_rerank_requested()
+    )
+
+
 def _sm70_dflash2_use_dense_order() -> bool:
     """Keep production on the scored full-vocabulary tie-order contract."""
     if envs.VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER:
@@ -105,9 +113,6 @@ def _is_sm70_lm_head_fastpath_eligible(layer: torch.nn.Module) -> bool:
         return False
     if not current_platform.is_cuda_alike():
         _trace_sm70_lm_head_skip("non_cuda_platform")
-        return False
-    if not hasattr(torch.ops._C, "sm70_f16_prepare"):
-        _trace_sm70_lm_head_skip("missing_sm70_f16_prepare_op")
         return False
     if layer.weight.dtype != torch.float16:
         _trace_sm70_lm_head_skip(f"weight_dtype={layer.weight.dtype}")
@@ -353,10 +358,25 @@ def _sm70_dflash2_candidate_order_topk(
 
 
 def maybe_prepare_sm70_lm_head_top1(layer: torch.nn.Module) -> bool:
-    if getattr(layer, "_sm70_f16_prepared", False):
-        return True
     if not _is_sm70_lm_head_fastpath_eligible(layer):
         return False
+
+    raw_top1_requested = _sm70_env_bool(
+        "VLLM_SM70_LM_HEAD_TOP1", _sm70_lm_head_top1_default()
+    )
+    packed_layout_requested = _sm70_lm_head_packed_layout_requested()
+    if raw_top1_requested:
+        layer._sm70_f16_raw_top1_ready = True
+
+    if not packed_layout_requested:
+        logger.info_once("SM70 raw-weight LM head top1 path prepared.")
+        return True
+
+    if not hasattr(torch.ops._C, "sm70_f16_prepare"):
+        _trace_sm70_lm_head_skip("missing_sm70_f16_prepare_op")
+        return raw_top1_requested
+    if getattr(layer, "_sm70_f16_prepared", False):
+        return True
     prepared = sm70_ops.sm70_f16_prepare(layer.weight)
     layer._sm70_f16_tm_weight = prepared[0]
     layer._sm70_f16_k_ld = int(prepared[1][0].item())
@@ -416,7 +436,9 @@ def _maybe_sm70_lm_head_top1(
         return None
     if bias is not None:
         return None
-    if not getattr(layer, "_sm70_f16_prepared", False):
+    raw_top1_ready = lm_head_top1 and getattr(layer, "_sm70_f16_raw_top1_ready", False)
+    packed_top1_ready = lm_head_top1_tc and getattr(layer, "_sm70_f16_prepared", False)
+    if not (raw_top1_ready or packed_top1_ready):
         _trace_sm70_lm_head_skip("top1_not_prepared")
         return None
     if not (
@@ -452,7 +474,7 @@ def _maybe_sm70_lm_head_top1(
 
     values = torch.empty((x_2d.size(0),), dtype=torch.float32, device=x_2d.device)
     indices = torch.empty((x_2d.size(0),), dtype=torch.int64, device=x_2d.device)
-    if lm_head_top1_tc and hasattr(torch.ops._C, "sm70_f16_lm_head_top1_tc_out"):
+    if packed_top1_ready and hasattr(torch.ops._C, "sm70_f16_lm_head_top1_tc_out"):
         tm_weight = getattr(layer, "_sm70_f16_tm_weight", None)
         k_ld = getattr(layer, "_sm70_f16_k_ld", None)
         if tm_weight is not None and k_ld is not None:
@@ -473,7 +495,7 @@ def _maybe_sm70_lm_head_top1(
     if num_rows != 1:
         return None
 
-    if not lm_head_top1 or not hasattr(torch.ops._C, "sm70_f16_lm_head_top1_out"):
+    if not raw_top1_ready or not hasattr(torch.ops._C, "sm70_f16_lm_head_top1_out"):
         return None
 
     sm70_ops.sm70_f16_lm_head_top1_out(


### PR DESCRIPTION
## Summary

- Track raw top-1 readiness separately from TurboMind packed-layout readiness.
- Keep the default fused greedy top-1 path on the original FP16 LM-head weight without creating an unused packed copy.
- Continue preparing the packed layout for Tensor Core top-1, dense SM70 GEMM, and DFlash2 QPN8 rerank/shadow consumers.

## Why

The default `sm70_f16_lm_head_top1_out` operator reads the original FP16 weight, but post-load preparation previously created and retained a second `62080 x 2560` FP16 TurboMind-layout copy. The copy costs 303.125 MiB per rank and is unused by the default raw top-1 route.

## QPN8 boundary

Qwen4Exp online QPN8 and DFlash2 QPN8 rerank are separate controls:

- `VLLM_SM70_QWEN4_EXP_ONLINE_QPN8=1` quantizes eligible dense projections and does not require a packed LM head, so it still benefits from this PR.
- `VLLM_SM70_DFLASH2_QPN8_RERANK=1` (or shadow mode) is an explicit packed-layout consumer, so the existing packed copy is retained when that route is requested.

## Validation

- Focused raw/TC/dense/DFlash2-rerank route matrix: 7 passed.
- 4x V100, TP4, MTP0, FP16 activation, online QPN8 disabled, full-and-piecewise CUDA Graph, applied after the QSA workspace-sharing PR:
  - model loading: 21.54 -> 21.24 GiB per rank
  - FP16 KV capacity: 365,137 -> 388,670 tokens (+6.45%)
  - calibrated E4M3 KV capacity: 671,395 -> 714,188 tokens (+6.37%)
- Greedy raw top-1 and seeded sampled dense-logits fallback requests both passed; the E4M3 arm loaded 24/24 calibrated scales.
- The combined full C1/C4/C8, 1K-128K matrix found no measurable same-dtype throughput regression over 16K+ cells:
  - FP16: prefill -0.09%, decode -0.12%, server E2E +0.07%
  - E4M3: prefill -0.14%, decode +0.06%, server E2E +0.06%

The full matrix validates the combined memory-optimization stack; it does not attribute an isolated throughput change to either PR.
