### PR TITLE
[Perf][SM70] Share Qwen4Exp QSA top-k workspace

### DIFF
--- a/tests/models/qwen4_exp/test_model_forward.py
+++ b/tests/models/qwen4_exp/test_model_forward.py
@@ -1,9 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import torch
+from types import SimpleNamespace
 
-from vllm.models.qwen4_exp.nvidia.model import Qwen4ExpDecoderLayer
+import torch
+from torch import nn
+
+from vllm.models.qwen4_exp.nvidia import model as qwen4_exp_model
+from vllm.models.qwen4_exp.nvidia.model import (
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpModel,
+)
 
 
 class _AttentionHyperConnection:
@@ -61,3 +68,82 @@ def test_linear_attention_forwards_preallocated_output_buffer() -> None:
 
     assert gdn.output is not None
     torch.testing.assert_close(mlp_out, hidden_states + 1)
+
+
+def test_qsa_model_shares_one_topk_indices_buffer(monkeypatch) -> None:
+    class FakeEmbedding(nn.Module):
+        def __init__(self, *_args, **_kwargs) -> None:
+            super().__init__()
+
+    class FakeDecoderLayer(nn.Module):
+        def __init__(
+            self,
+            _vllm_config,
+            layer_type: str,
+            prefix: str = "",
+            topk_indices_buffer: torch.Tensor | None = None,
+        ) -> None:
+            super().__init__()
+            self.layer_type = layer_type
+            self.prefix = prefix
+            self.topk_indices_buffer = topk_indices_buffer
+
+    def fake_make_layers(num_layers, get_layer, prefix):
+        layers = nn.ModuleList(
+            get_layer(f"{prefix}.{layer_idx}") for layer_idx in range(num_layers)
+        )
+        return 0, num_layers, layers
+
+    monkeypatch.setattr(qwen4_exp_model, "VocabParallelEmbedding", FakeEmbedding)
+    monkeypatch.setattr(qwen4_exp_model, "Qwen4ExpDecoderLayer", FakeDecoderLayer)
+    monkeypatch.setattr(qwen4_exp_model, "make_layers", fake_make_layers)
+    monkeypatch.setattr(
+        qwen4_exp_model,
+        "make_empty_intermediate_tensors_factory",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        qwen4_exp_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=False),
+    )
+
+    config = SimpleNamespace(
+        vocab_size=32,
+        hidden_size=16,
+        hc_count=2,
+        num_hidden_layers=4,
+        layer_types=[
+            "linear_attention",
+            "full_attention",
+            "linear_attention",
+            "full_attention",
+        ],
+        indexer_n_heads=4,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=config,
+            dtype=torch.float16,
+        ),
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0)
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        compilation_config=SimpleNamespace(mode=0),
+        speculative_config=None,
+    )
+
+    model = Qwen4ExpModel(vllm_config=vllm_config)
+
+    assert model.topk_indices_buffer.shape == (16, 11)
+    assert model.topk_indices_buffer.dtype == torch.int32
+    qsa_layers = [
+        layer for layer in model.layers if layer.layer_type == "full_attention"
+    ]
+    assert len(qsa_layers) == 2
+    assert all(
+        layer.topk_indices_buffer is model.topk_indices_buffer for layer in qsa_layers
+    )

--- a/tests/models/qwen4_exp/test_qsa_cache.py
+++ b/tests/models/qwen4_exp/test_qsa_cache.py
@@ -4,10 +4,12 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import torch
 
 from vllm.models.qwen4_exp.common.qsa_cache import QSAKeyStateCache
 from vllm.models.qwen4_exp.nvidia.qsa import (
+    Qwen4ExpQSAAttention,
     Qwen4ExpQSAFlashAttentionBackend,
     Qwen4ExpQSAFlashAttentionImpl,
 )
@@ -16,6 +18,50 @@ from vllm.v1.worker.utils import bind_kv_cache
 
 def test_qsa_does_not_claim_batch_invariant_reductions() -> None:
     assert not Qwen4ExpQSAFlashAttentionBackend.supports_batch_invariance()
+
+
+def _bare_qsa_attention(output_width: int) -> Qwen4ExpQSAAttention:
+    attention = object.__new__(Qwen4ExpQSAAttention)
+    torch.nn.Module.__init__(attention)
+    attention.indexer = SimpleNamespace(output_width=output_width)
+    return attention
+
+
+def test_qsa_attention_reuses_shared_topk_indices_buffer() -> None:
+    attention = _bare_qsa_attention(output_width=7)
+    shared = torch.empty(16, 7, dtype=torch.int32)
+
+    attention._set_topk_indices_buffer(
+        max_tokens=16,
+        topk_indices_buffer=shared,
+    )
+
+    assert attention.topk_indices_buffer is shared
+    assert "topk_indices_buffer" not in attention._buffers
+
+
+def test_qsa_attention_keeps_private_buffer_fallback() -> None:
+    attention = _bare_qsa_attention(output_width=7)
+
+    attention._set_topk_indices_buffer(
+        max_tokens=16,
+        topk_indices_buffer=None,
+    )
+
+    assert attention.topk_indices_buffer.shape == (16, 7)
+    assert attention.topk_indices_buffer.dtype == torch.int32
+    assert "topk_indices_buffer" in attention._buffers
+
+
+def test_qsa_attention_rejects_invalid_shared_topk_indices_buffer() -> None:
+    attention = _bare_qsa_attention(output_width=7)
+    invalid = torch.empty(16, 6, dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="shared top-k buffer"):
+        attention._set_topk_indices_buffer(
+            max_tokens=16,
+            topk_indices_buffer=invalid,
+        )
 
 
 def test_bind_qsa_key_cache_builds_key_and_mrope_views() -> None:

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -220,6 +220,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
         vllm_config: VllmConfig,
         layer_type: str,
         prefix: str = "",
+        topk_indices_buffer: torch.Tensor | None = None,
     ) -> None:
         super().__init__()
         config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
@@ -274,6 +275,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
                     layer_id=self.layer_idx,
                     quant_config=quant_config,
                     prefix=f"{prefix}.self_attn",
+                    topk_indices_buffer=topk_indices_buffer,
                 )
         else:
             raise ValueError(f"Invalid layer_type {layer_type}")
@@ -468,6 +470,17 @@ class Qwen4ExpModel(nn.Module):
             if layer_type == "full_attention"
             and getattr(config, "indexer_n_heads", None) is not None
         )
+        topk_indices_buffer: torch.Tensor | None = None
+        if self._qsa_layer_ids:
+            topk_indices_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                int(config.indexer_budget) + int(config.indexer_compress_ratio) - 1,
+                dtype=torch.int32,
+            )
+            # QSA layers execute serially and consume their selected indices
+            # before the next layer overwrites them, so one model-level
+            # workspace is sufficient for every QSA layer.
+            self.topk_indices_buffer = topk_indices_buffer
         self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
 
         def get_layer(prefix: str) -> Qwen4ExpDecoderLayer:
@@ -476,6 +489,7 @@ class Qwen4ExpModel(nn.Module):
                 vllm_config,
                 layer_type=config.layer_types[layer_idx],
                 prefix=prefix,
+                topk_indices_buffer=topk_indices_buffer,
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -200,6 +200,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         prefix: str = "",
+        topk_indices_buffer: torch.Tensor | None = None,
     ) -> None:
         nn.Module.__init__(self)
         cache_config = vllm_config.cache_config
@@ -338,20 +339,48 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             prefix=f"{prefix}.indexer",
         )
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        self.register_buffer(
-            "topk_indices_buffer",
-            torch.empty(
-                max_tokens,
-                self.indexer.output_width,
-                dtype=torch.int32,
-            ),
-            persistent=False,
+        self._set_topk_indices_buffer(
+            max_tokens=max_tokens,
+            topk_indices_buffer=topk_indices_buffer,
         )
 
         static_context = vllm_config.compilation_config.static_forward_context
         if self.layer_name in static_context:
             raise ValueError(f"Duplicate layer name: {self.layer_name}")
         static_context[self.layer_name] = self
+
+    def _set_topk_indices_buffer(
+        self,
+        *,
+        max_tokens: int,
+        topk_indices_buffer: torch.Tensor | None,
+    ) -> None:
+        if topk_indices_buffer is None:
+            self.register_buffer(
+                "topk_indices_buffer",
+                torch.empty(
+                    max_tokens,
+                    self.indexer.output_width,
+                    dtype=torch.int32,
+                ),
+                persistent=False,
+            )
+            return
+
+        expected_width = self.indexer.output_width
+        if (
+            topk_indices_buffer.dtype != torch.int32
+            or topk_indices_buffer.ndim != 2
+            or topk_indices_buffer.shape[0] < max_tokens
+            or topk_indices_buffer.shape[1] != expected_width
+        ):
+            raise ValueError(
+                "QSA shared top-k buffer must have dtype int32 and shape "
+                f"[{max_tokens} or more, {expected_width}], got "
+                f"dtype={topk_indices_buffer.dtype}, "
+                f"shape={tuple(topk_indices_buffer.shape)}"
+            )
+        self.topk_indices_buffer = topk_indices_buffer
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend


### PR DESCRIPTION
## Summary

- Allocate one model-level int32 top-k workspace for all Qwen4Exp QSA layers.
- Inject the shared workspace into target-model QSA layers while retaining the existing private-buffer fallback for standalone and MTP construction paths.
- Validate injected dtype and shape before use, and add focused ownership/fallback tests.

## Why

QSA layers execute serially and fully consume their selected indices before the next layer overwrites them. Keeping one maximum-sized buffer per layer therefore duplicates memory without enabling overlap.

For the validated Qwen3.8 Flash Next contract (`max_num_batched_tokens=8192`, 12 QSA layers, width 2051), the previous layout retained 769.125 MiB per rank. Sharing one buffer retains 64.094 MiB and releases 705.031 MiB per rank without changing QSA math, selected indices, cache dtype, or CUDA Graph addresses.

## Validation

- Added unit coverage for model-level sharing, private fallback, and invalid injected buffers.
- 4x V100, TP4, MTP0, FP16 activation, QPN8 disabled, full-and-piecewise CUDA Graph:
  - model loading: 22.22 -> 21.54 GiB per rank
  - FP16 KV capacity: 310,480 -> 365,137 tokens (+17.60%)
  - calibrated E4M3 KV capacity: 569,579 -> 671,395 tokens (+17.88%)
- Both KV arms completed graph capture and deterministic forward checks; the E4M3 arm loaded 24/24 calibrated scales.
- A follow-up full C1/C4/C8, 1K-128K matrix with this change and the companion LM-head no-pack PR found no measurable same-dtype throughput regression over 16K+ cells (all prefill/decode/E2E deltas within 0.14%).

## Scope

This change is independent of QPN8 and KV dtype. MTP keeps the existing private-buffer fallback; this PR does not claim an MTP or PP performance acceptance.
