### PR TITLE
Fix SM70 full graph compile range endpoint

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -468,6 +468,28 @@ def test_cudagraph_sizes_post_init(
         )
 
 
+def test_sm70_full_and_piecewise_compile_range_includes_decode_token(monkeypatch):
+    monkeypatch.setenv("VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", "1")
+    monkeypatch.setenv("VLLM_SM70_FLASH_V100_0DOT3_DECODE_ONLY_CAPTURE", "0")
+
+    vllm_config = VllmConfig(
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1,
+            max_num_batched_tokens=512,
+            max_model_len=2048,
+            is_encoder_decoder=False,
+        ),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    )
+    vllm_config._set_compile_ranges()
+
+    assert vllm_config.scheduler_config.max_num_batched_tokens == 512
+    assert vllm_config.compilation_config.compile_ranges_endpoints == [513]
+
+
 @pytest.mark.skipif(
     not current_platform.support_static_graph_mode(),
     reason="Skip if not cudagraph mode supported",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2597,16 +2597,15 @@ class VllmConfig:
         if (
             compile_range_end is not None
             and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
-            and envs.VLLM_SM70_FLASH_V100_0DOT3_DECODE_ONLY_CAPTURE
             and compilation_config.mode == CompilationMode.VLLM_COMPILE
             and compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
         ):
-            # FULL decode capture can enter the compiled piecewise wrapper with
+            # FULL capture can enter the compiled piecewise wrapper with
             # max_num_batched_tokens + one decode token. Keep scheduler capacity
             # unchanged, but allow the wrapper to select a compiled range.
             compile_range_end += 1
             logger.info_once(
-                "Extending SM70 Flash-V100 0.0.3 decode-only compile range "
+                "Extending SM70 Flash-V100 0.0.3 compile range "
                 "endpoint to %d for CUDA graph capture.",
                 compile_range_end,
             )


### PR DESCRIPTION
## Purpose

Fix the SM70 Flash-V100 compile-range upper bound for FULL_AND_PIECEWISE CUDA Graph. The compiled wrapper can receive max_num_batched_tokens + 1 when it appends the decode token even when decode-only capture is disabled. Without the extra endpoint the boundary batch can miss the compiled range or fail during graph replay.

The change does not increase scheduler capacity or CUDA Graph capture sizes. It only extends the compile wrapper endpoint by one when the SM70 compile-graph path is active.

## Test Plan

- pytest -q tests/compile/test_config.py -k sm70_full_and_piecewise_compile_range_includes_decode_token
- git diff --check
- python -m compileall -q vllm/config/vllm.py tests/compile/test_config.py
- Run repository pre-commit CI with the ready label.

## Test Result

- Focused no-GPU regression: **1 passed, 39 deselected**.
- git diff --check: passed.
- Python compile check: passed.
- Virtual merge with current public main: conflict-free.
- A broader local file run was not accepted as evidence because its GPU-backed cases require an available accelerator; those failures were environment-only (device_count=0) and did not include the focused regression.

## Scope

SM70 Flash-V100 configuration only. No model arithmetic, sampling, KV-cache, or scheduler token-capacity behavior changes.