### PR TITLE
[Perf][SM70] Add indexed-A AWQ prefill for Qwen3.8

### DIFF
--- a/benchmarks/benchmark_sm70_turbomind_exactness.py
+++ b/benchmarks/benchmark_sm70_turbomind_exactness.py
@@ -19,6 +19,11 @@ import torch
 
 import vllm._custom_ops as ops
 from vllm import _sm70_ops as sm70_ops
+from vllm import envs
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _align_awq_input_dim,
+    _align_awq_output_dim,
+)
 
 Mode = Literal[
     "all",
@@ -30,6 +35,7 @@ Mode = Literal[
     "awq_moe_compile",
 ]
 MoEActual = Literal[
+    "indexed_prefill",
     "batched",
     "batched_per_expert_dispatch",
     "batched_w13_per_expert_dispatch",
@@ -137,7 +143,11 @@ def _load_awq_layer(
     with safe_open(model_path / filename, framework="pt", device="cpu") as f:
         qweight = f.get_tensor(f"{layer_prefix}.qweight").to(device).contiguous()
         qzeros = f.get_tensor(f"{layer_prefix}.qzeros").to(device).contiguous()
-        scales = f.get_tensor(f"{layer_prefix}.scales").to(device).contiguous()
+        scales = (
+            f.get_tensor(f"{layer_prefix}.scales")
+            .to(device=device, dtype=torch.float16)
+            .contiguous()
+        )
     return qweight, scales, qzeros
 
 
@@ -214,11 +224,113 @@ def _load_awq_moe_layer(
 
     return (
         torch.stack(w13_qweights),
-        torch.stack(w13_scales),
+        torch.stack(w13_scales).half(),
         torch.stack(w13_qzeros),
         torch.stack(w2_qweights),
-        torch.stack(w2_scales),
+        torch.stack(w2_scales).half(),
         torch.stack(w2_qzeros),
+    )
+
+
+def _prepare_awq_moe_checkpoint_for_tp(
+    tensors: tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    tp_size: int,
+    tp_rank: int,
+    checkpoint_group_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    int,
+]:
+    if tp_size <= 0 or not 0 <= tp_rank < tp_size:
+        raise ValueError("Invalid AWQ MoE TP size or rank.")
+    w13_qweight, w13_scales, w13_qzeros, w2_qweight, w2_scales, w2_qzeros = tensors
+    hidden_size = int(w13_qweight.shape[-2])
+    intermediate_size = int(w13_scales.shape[-1]) // 2
+    if intermediate_size % tp_size:
+        raise ValueError("AWQ intermediate size cannot be evenly sharded for TP.")
+    intermediate_size_per_partition = intermediate_size // tp_size
+    group_size = checkpoint_group_size
+    if hidden_size % group_size or intermediate_size_per_partition % group_size:
+        raise ValueError("AWQ dimensions must be divisible by the checkpoint group.")
+
+    w13_q_half = w13_qweight.shape[-1] // 2
+    w13_n_half = w13_scales.shape[-1] // 2
+    if w13_q_half % tp_size or w13_n_half % tp_size:
+        raise ValueError("AWQ W13 output cannot be evenly sharded for TP.")
+    q_start = tp_rank * (w13_q_half // tp_size)
+    q_end = (tp_rank + 1) * (w13_q_half // tp_size)
+    n_start = tp_rank * (w13_n_half // tp_size)
+    n_end = (tp_rank + 1) * (w13_n_half // tp_size)
+    w13_qweight = torch.cat(
+        (
+            w13_qweight[..., q_start:q_end],
+            w13_qweight[..., w13_q_half + q_start : w13_q_half + q_end],
+        ),
+        dim=-1,
+    ).contiguous()
+    w13_qzeros = torch.cat(
+        (
+            w13_qzeros[..., q_start:q_end],
+            w13_qzeros[..., w13_q_half + q_start : w13_q_half + q_end],
+        ),
+        dim=-1,
+    ).contiguous()
+    w13_scales = torch.cat(
+        (
+            w13_scales[..., n_start:n_end],
+            w13_scales[..., w13_n_half + n_start : w13_n_half + n_end],
+        ),
+        dim=-1,
+    ).contiguous()
+
+    w2_k = w2_qweight.shape[-2]
+    if w2_k % tp_size or (w2_k // tp_size) % group_size:
+        raise ValueError("AWQ W2 input cannot be evenly sharded by groups for TP.")
+    k_start = tp_rank * (w2_k // tp_size)
+    k_end = (tp_rank + 1) * (w2_k // tp_size)
+    group_start = k_start // group_size
+    group_end = k_end // group_size
+    w13_qweight, w13_scales, w13_qzeros, _ = _align_awq_output_dim(
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        8,
+        group_size * 2,
+    )
+    w2_qweight, w2_scales, w2_qzeros, _ = _align_awq_input_dim(
+        w2_qweight[..., k_start:k_end, :].contiguous(),
+        w2_scales[..., group_start:group_end, :].contiguous(),
+        w2_qzeros[..., group_start:group_end, :].contiguous(),
+        group_size,
+        group_size,
+    )
+    w2_qweight, w2_scales, w2_qzeros, _ = _align_awq_output_dim(
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+        8,
+        group_size,
+    )
+    return (
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+        group_size,
     )
 
 
@@ -755,6 +867,118 @@ def _expert_offsets(
     return offsets64.to(torch.int32), offsets64
 
 
+def _service_moe_permute_inputs(
+    input: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run both production MoE permute forms and prove their row mapping agrees."""
+    for op_name in (
+        "moe_permute_with_scratch",
+        "moe_permute_metadata_with_scratch",
+        "moe_permute_sort_workspace_size",
+    ):
+        if not hasattr(torch.ops._moe_C, op_name):
+            raise RuntimeError(f"Required torch op _moe_C.{op_name} is unavailable.")
+
+    num_tokens, hidden_size = input.shape
+    topk_ids_i32 = topk_ids.to(torch.int32).contiguous()
+    top_k = int(topk_ids_i32.shape[1])
+    total_slots = num_tokens * top_k
+    token_expert_indices = torch.arange(
+        total_slots, dtype=torch.int32, device=input.device
+    ).view(num_tokens, top_k)
+    workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+        total_slots, num_experts
+    )
+
+    def _scratch() -> dict[str, torch.Tensor]:
+        return {
+            "expert_offsets64": torch.empty(
+                num_experts + 1, dtype=torch.int64, device=input.device
+            ),
+            "inv_permuted_idx": torch.empty(
+                num_tokens, top_k, dtype=torch.int32, device=input.device
+            ),
+            "permuted_idx": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "sort_workspace": torch.empty(
+                workspace_size, dtype=torch.int8, device=input.device
+            ),
+            "permuted_experts_id": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "sorted_row_idx": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "topk_ids_for_sort": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+        }
+
+    materialized = torch.empty(
+        total_slots, hidden_size, dtype=input.dtype, device=input.device
+    )
+    materialized_scratch = _scratch()
+    torch.ops._moe_C.moe_permute_with_scratch(
+        input,
+        topk_ids_i32,
+        token_expert_indices,
+        None,
+        num_experts,
+        num_experts,
+        top_k,
+        materialized,
+        materialized_scratch["expert_offsets64"],
+        materialized_scratch["inv_permuted_idx"],
+        materialized_scratch["permuted_idx"],
+        materialized_scratch["sort_workspace"],
+        materialized_scratch["permuted_experts_id"],
+        materialized_scratch["sorted_row_idx"],
+        materialized_scratch["topk_ids_for_sort"],
+    )
+
+    metadata_scratch = _scratch()
+    input_row_indices = torch.empty(total_slots, dtype=torch.int32, device=input.device)
+    torch.ops._moe_C.moe_permute_metadata_with_scratch(
+        input,
+        topk_ids_i32,
+        token_expert_indices,
+        None,
+        num_experts,
+        num_experts,
+        top_k,
+        metadata_scratch["expert_offsets64"],
+        metadata_scratch["inv_permuted_idx"],
+        metadata_scratch["permuted_idx"],
+        input_row_indices,
+        metadata_scratch["sort_workspace"],
+        metadata_scratch["permuted_experts_id"],
+        metadata_scratch["sorted_row_idx"],
+        metadata_scratch["topk_ids_for_sort"],
+    )
+
+    if not torch.equal(
+        materialized_scratch["expert_offsets64"],
+        metadata_scratch["expert_offsets64"],
+    ):
+        raise AssertionError("Materialized and metadata MoE expert offsets differ.")
+    gathered = input[input_row_indices.to(torch.int64)]
+    if not torch.equal(materialized, gathered):
+        raise AssertionError(
+            "Metadata-only MoE row indices do not reproduce production permute."
+        )
+
+    expert_offsets64 = metadata_scratch["expert_offsets64"]
+    return (
+        materialized,
+        input_row_indices,
+        expert_offsets64.to(torch.int32),
+        expert_offsets64,
+    )
+
+
 def _make_logical_expert_ids(
     total_slots: int,
     num_experts: int,
@@ -934,11 +1158,15 @@ def _check_awq_moe(
     top_k: int,
     actual_impl: MoEActual,
     expert_pattern: str,
+    tp_size: int,
+    tp_rank: int,
 ) -> list[dict[str, Any]]:
     _require_torch_op("awq_sm70_prepare")
     _require_torch_op("awq_gemm_sm70")
     _require_torch_op("awq_moe_build_strided_ptrs")
     _require_torch_op("awq_moe_gemm_sm70_out")
+    if actual_impl == "indexed_prefill":
+        _require_torch_op("awq_moe_indexed_dense_w13_sm70_out")
     if actual_impl in (
         "batched",
         "batched_per_expert_dispatch",
@@ -965,6 +1193,8 @@ def _check_awq_moe(
         if m != 1:
             raise ValueError(f"{actual_impl} AWQ MoE check requires --m 1.")
 
+    checkpoint_group_size = group_size
+    loaded = _load_awq_moe_layer(awq_moe_model, awq_moe_layer, num_experts, device)
     (
         w13_qweight,
         w13_scales,
@@ -972,33 +1202,38 @@ def _check_awq_moe(
         w2_qweight,
         w2_scales,
         w2_qzeros,
-    ) = _load_awq_moe_layer(awq_moe_model, awq_moe_layer, num_experts, device)
+        group_size,
+    ) = _prepare_awq_moe_checkpoint_for_tp(
+        loaded,
+        tp_size,
+        tp_rank,
+        checkpoint_group_size,
+    )
+
+    w13_interleaved = bool(
+        actual_impl == "legacy_single_token_compact"
+        or (
+            envs.VLLM_SM70_AWQ_MOE_BATCHED_GEMM
+            and envs.VLLM_SM70_AWQ_MOE_LEGACY_SINGLE_TOKEN_COMPACT
+            and hasattr(torch.ops._C, "awq_moe_single_token_sm70_out")
+        )
+    )
 
     w13_tm_weight, w13_tm_scales, w13_ptrs_w, w13_ptrs_s, w13_k_ld, w13_q_ld = (
-        _prepare_awq_moe_weights(w13_qweight, w13_scales, w13_qzeros, group_size)
-    )
-    w2_tm_weight, w2_tm_scales, w2_ptrs_w, w2_ptrs_s, w2_k_ld, w2_q_ld = (
-        _prepare_awq_moe_weights(w2_qweight, w2_scales, w2_qzeros, group_size)
-    )
-    if actual_impl == "legacy_single_token_compact":
-        (
-            _w13_legacy_tm_weight,
-            _w13_legacy_tm_scales,
-            w13_legacy_ptrs_w,
-            w13_legacy_ptrs_s,
-            _w13_legacy_k_ld,
-            _w13_legacy_q_ld,
-        ) = _prepare_awq_moe_weights(
+        _prepare_awq_moe_weights(
             w13_qweight,
             w13_scales,
             w13_qzeros,
             group_size,
-            interleave_gated_silu=True,
+            interleave_gated_silu=w13_interleaved,
         )
-    else:
-        _w13_legacy_tm_weight = w13_tm_weight
-        w13_legacy_ptrs_w = w13_ptrs_w
-        w13_legacy_ptrs_s = w13_ptrs_s
+    )
+    w2_tm_weight, w2_tm_scales, w2_ptrs_w, w2_ptrs_s, w2_k_ld, w2_q_ld = (
+        _prepare_awq_moe_weights(w2_qweight, w2_scales, w2_qzeros, group_size)
+    )
+    _w13_legacy_tm_weight = w13_tm_weight
+    w13_legacy_ptrs_w = w13_ptrs_w
+    w13_legacy_ptrs_s = w13_ptrs_s
 
     total_slots = m * top_k
     logical_expert_ids = _make_logical_expert_ids(
@@ -1013,7 +1248,29 @@ def _check_awq_moe(
     dense_expert_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
 
     hidden_size = int(w13_qweight.shape[1])
-    if actual_impl in AWQ_SINGLE_TOKEN_ACTUALS:
+    input_row_indices = None
+    if actual_impl == "indexed_prefill":
+        if (
+            num_experts != 512
+            or top_k != 10
+            or checkpoint_group_size != 32
+            or group_size != 32
+        ):
+            raise ValueError(
+                "indexed_prefill requires the Qwen3.8 E512/K10 AWQ g32 contract."
+            )
+        indexed_input = _make_input(m, hidden_size, device)
+        (
+            sorted_input,
+            input_row_indices,
+            expert_offsets,
+            expert_offsets64,
+        ) = _service_moe_permute_inputs(
+            indexed_input,
+            topk_ids,
+            num_experts,
+        )
+    elif actual_impl in AWQ_SINGLE_TOKEN_ACTUALS:
         single_token_input = _make_input(1, hidden_size, device)
         sorted_input = single_token_input.expand(total_slots, hidden_size).contiguous()
         sorted_input = sorted_input[order]
@@ -1035,7 +1292,22 @@ def _check_awq_moe(
     single_token_offsets64 = None
     single_token_inv_permuted_idx = None
     single_token_sorted_expert_ids = None
-    if actual_impl in (
+    if actual_impl == "indexed_prefill":
+        assert input_row_indices is not None
+        sm70_ops.awq_moe_indexed_dense_w13_sm70_out(
+            gate_up_actual,
+            indexed_input,
+            input_row_indices,
+            expert_offsets,
+            dense_expert_ids,
+            w13_ptrs_w,
+            w13_ptrs_s,
+            num_experts,
+            int(w13_tm_weight.shape[1]),
+            w13_n,
+            group_size,
+        )
+    elif actual_impl in (
         "batched",
         "batched_per_expert_dispatch",
         "batched_w13_per_expert_dispatch",
@@ -1197,25 +1469,45 @@ def _check_awq_moe(
             w13_q_ld,
             w13_n,
         )
-    gate_up_expected = _dense_awq_moe_stage(
-        sorted_input,
-        expert_offsets64,
-        w13_tm_weight,
-        w13_tm_scales,
-        group_size,
-        w13_k_ld,
-        w13_q_ld,
-        w13_n,
-    )
+    if actual_impl == "indexed_prefill":
+        gate_up_expected = torch.empty_like(gate_up_actual)
+        sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+            gate_up_expected,
+            sorted_input,
+            expert_offsets,
+            w13_ptrs_w,
+            w13_ptrs_s,
+            num_experts,
+            int(w13_tm_weight.shape[1]),
+            w13_n,
+            group_size,
+            False,
+        )
+    else:
+        gate_up_expected = _dense_awq_moe_stage(
+            sorted_input,
+            expert_offsets64,
+            w13_tm_weight,
+            w13_tm_scales,
+            group_size,
+            w13_k_ld,
+            w13_q_ld,
+            w13_n,
+        )
 
     if intermediate_actual is None:
         intermediate_actual = torch.empty(
             (total_slots, intermediate_size), dtype=torch.float16, device=device
         )
     intermediate_expected = torch.empty_like(intermediate_actual)
+    silu_and_mul = (
+        sm70_ops.silu_and_mul_interleaved
+        if w13_interleaved
+        else torch.ops._C.silu_and_mul
+    )
     if actual_impl != "legacy_single_token_compact":
-        torch.ops._C.silu_and_mul(intermediate_actual, gate_up_actual)
-    torch.ops._C.silu_and_mul(intermediate_expected, gate_up_expected)
+        silu_and_mul(intermediate_actual, gate_up_actual)
+    silu_and_mul(intermediate_expected, gate_up_expected)
 
     if sorted_output_actual is None:
         sorted_output_actual = torch.empty(
@@ -1235,6 +1527,7 @@ def _check_awq_moe(
             False,
         )
     elif actual_impl in (
+        "indexed_prefill",
         "batched_per_expert_dispatch",
         "batched_w2_per_expert_dispatch",
     ):
@@ -1323,16 +1616,31 @@ def _check_awq_moe(
             w2_q_ld,
             hidden_out,
         )
-    sorted_output_expected = _dense_awq_moe_stage(
-        intermediate_expected,
-        expert_offsets64,
-        w2_tm_weight,
-        w2_tm_scales,
-        group_size,
-        w2_k_ld,
-        w2_q_ld,
-        hidden_out,
-    )
+    if actual_impl == "indexed_prefill":
+        sorted_output_expected = torch.empty_like(sorted_output_actual)
+        sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+            sorted_output_expected,
+            intermediate_expected,
+            expert_offsets,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            num_experts,
+            int(w2_tm_weight.shape[1]),
+            hidden_out,
+            group_size,
+            False,
+        )
+    else:
+        sorted_output_expected = _dense_awq_moe_stage(
+            intermediate_expected,
+            expert_offsets64,
+            w2_tm_weight,
+            w2_tm_scales,
+            group_size,
+            w2_k_ld,
+            w2_q_ld,
+            hidden_out,
+        )
     if actual_impl == "legacy_single_token_compact":
         assert final_output_actual is not None
         assert single_token_inv_permuted_idx is not None
@@ -1418,6 +1726,22 @@ def _check_awq_moe(
                 stage="final_weighted_output",
                 layer=awq_moe_layer,
             )
+        )
+    for result in results:
+        result.update(
+            {
+                "checkpoint_group_size": checkpoint_group_size,
+                "effective_group_size": group_size,
+                "tp_size": tp_size,
+                "tp_rank": tp_rank,
+                "w13_interleaved": w13_interleaved,
+                "weight_scale_dtype": str(w13_scales.dtype),
+                "reference_impl": (
+                    "materialized_per_expert_dispatch"
+                    if actual_impl == "indexed_prefill"
+                    else "per_expert_dense"
+                ),
+            }
         )
     return results
 
@@ -2536,9 +2860,12 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--awq-moe-num-experts", type=int, default=256)
     parser.add_argument("--awq-moe-top-k", type=int, default=8)
+    parser.add_argument("--awq-moe-tp-size", type=int, default=1)
+    parser.add_argument("--awq-moe-tp-rank", type=int, default=0)
     parser.add_argument(
         "--awq-moe-actual",
         choices=[
+            "indexed_prefill",
             "batched",
             "batched_per_expert_dispatch",
             "batched_w13_per_expert_dispatch",
@@ -2723,6 +3050,8 @@ def main() -> int:
                             args.awq_moe_top_k,
                             awq_moe_actual,
                             moe_expert_pattern,
+                            args.awq_moe_tp_size,
+                            args.awq_moe_tp_rank,
                         )
                     )
         if mode == "awq_moe_graph_replay":
@@ -2789,6 +3118,8 @@ def main() -> int:
         "awq_moe_layers": awq_moe_layers,
         "awq_moe_num_experts": args.awq_moe_num_experts,
         "awq_moe_top_k": args.awq_moe_top_k,
+        "awq_moe_tp_size": args.awq_moe_tp_size,
+        "awq_moe_tp_rank": args.awq_moe_tp_rank,
         "awq_moe_actual": awq_moe_actual,
         "awq_moe_dispatch_policy_env": os.getenv("VLLM_SM70_AWQ_MOE_DISPATCH_POLICY"),
         "fp8_model": str(args.fp8_model) if args.fp8_model else None,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -423,6 +423,12 @@ void awq_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
+void awq_moe_indexed_dense_w13_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size);
+
 void awq_moe_active_dense_stage_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor permuted_experts_id,
     torch::Tensor active_expert_offsets, torch::Tensor active_expert_ids,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -6512,7 +6512,8 @@ void awq_moe_gemm_sm70_out_impl(
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
     bool gated_silu, torch::Tensor b_group_indices, bool per_expert_dispatch,
     torch::Tensor reduce_out, torch::Tensor sorted_weights,
-    bool weighted_reduce);
+    bool weighted_reduce, int64_t logical_total_tokens,
+    torch::Tensor a_indices);
 
 template <typename index_t>
 __global__ void awq_moe_single_token_prepare_kernel(
@@ -7331,7 +7332,8 @@ void awq_moe_gemm_sm70_out_impl(
     bool per_expert_dispatch = false,
     torch::Tensor reduce_out = torch::Tensor(),
     torch::Tensor sorted_weights = torch::Tensor(),
-    bool weighted_reduce = false) {
+    bool weighted_reduce = false, int64_t logical_total_tokens = -1,
+    torch::Tensor a_indices = torch::Tensor()) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "awq_moe_gemm_sm70: input must be CUDA float16.");
@@ -7354,6 +7356,8 @@ void awq_moe_gemm_sm70_out_impl(
               "awq_moe_gemm_sm70: invalid dimensions.");
   TORCH_CHECK(k % group_size == 0,
               "awq_moe_gemm_sm70: input dim must be divisible by group size.");
+  TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
+              "awq_moe_gemm_sm70: input shape mismatch.");
   torch::Tensor b_group_indices_flat = b_group_indices;
   const bool use_b_group_indices =
       b_group_indices.defined() && b_group_indices.numel() > 0;
@@ -7370,7 +7374,25 @@ void awq_moe_gemm_sm70_out_impl(
   const int device = sorted_input.get_device();
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  const int64_t total_tokens = sorted_input.size(0);
+  const int64_t input_tokens = sorted_input.size(0);
+  const int64_t total_tokens =
+      logical_total_tokens > 0 ? logical_total_tokens : input_tokens;
+  const bool use_a_indices = a_indices.defined() && a_indices.numel() > 0;
+  torch::Tensor a_indices_flat = a_indices;
+  if (use_a_indices) {
+    TORCH_CHECK(a_indices.is_cuda() &&
+                    a_indices.scalar_type() == torch::kInt32 &&
+                    a_indices.is_contiguous(),
+                "awq_moe_gemm_sm70: A row indices must be contiguous CUDA "
+                "int32.");
+    a_indices_flat = a_indices.view({-1});
+    TORCH_CHECK(a_indices_flat.numel() >= total_tokens,
+                "awq_moe_gemm_sm70: A row indices size mismatch.");
+  } else {
+    TORCH_CHECK(input_tokens == total_tokens,
+                "awq_moe_gemm_sm70: non-indexed input rows must match "
+                "logical rows.");
+  }
   TORCH_CHECK(out.size(0) == total_tokens,
               "awq_moe_gemm_sm70: output rows must match input rows.");
   TORCH_CHECK(out.stride(1) == 1,
@@ -7412,10 +7434,11 @@ void awq_moe_gemm_sm70_out_impl(
       turbomind::gemm::kRowMajor,
       static_cast<int>(total_tokens),
       static_cast<int>(k),
-      static_cast<int>(k),
+      static_cast<int>(sorted_input.stride(0)),
   };
   desc_A.num = static_cast<int>(num_experts);
   desc_A.offsets = expert_offsets.data_ptr<int>();
+  desc_A.idxs = use_a_indices ? a_indices_flat.data_ptr<int>() : nullptr;
 
   turbomind::gemm::MatrixLayout desc_U{};
 
@@ -7545,6 +7568,53 @@ void awq_moe_gemm_sm70_per_expert_dispatch_out(
   awq_moe_gemm_sm70_out_impl(out, sorted_input, expert_offsets, strided_ptrs_w,
                              strided_ptrs_s, num_experts, k, n, group_size,
                              gated_silu, torch::Tensor(), true);
+}
+
+void awq_moe_indexed_dense_w13_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size) {
+  constexpr int kQwen38TopK = 10;
+  TORCH_CHECK(input.dim() == 2 && input.size(0) > 0 && input.size(1) == 2560 &&
+                  input.scalar_type() == torch::kFloat16 && input.is_cuda() &&
+                  input.is_contiguous(),
+              "awq_moe_indexed_dense_w13_sm70_out: exact Qwen3.8 CUDA FP16 "
+              "[tokens, 2560] input is required.");
+  TORCH_CHECK(num_experts == 512 && k == 2560 && n == 320 && group_size == 32,
+              "awq_moe_indexed_dense_w13_sm70_out: exact Qwen3.8 TP4 W13 "
+              "g32 contract is required.");
+  TORCH_CHECK(input_row_indices.is_cuda() &&
+                  input_row_indices.scalar_type() == torch::kInt32 &&
+                  input_row_indices.is_contiguous() &&
+                  input_row_indices.numel() == input.size(0) * kQwen38TopK,
+              "awq_moe_indexed_dense_w13_sm70_out: input row indices must "
+              "contain exactly tokens*10 contiguous CUDA int32 entries.");
+  TORCH_CHECK(expert_offsets.is_cuda() &&
+                  expert_offsets.scalar_type() == torch::kInt32 &&
+                  expert_offsets.is_contiguous() &&
+                  expert_offsets.numel() >= num_experts + 1,
+              "awq_moe_indexed_dense_w13_sm70_out: expert offsets must be "
+              "contiguous CUDA int32 with num_experts+1 entries.");
+  TORCH_CHECK(dense_expert_ids.is_cuda() &&
+                  dense_expert_ids.scalar_type() == torch::kInt32 &&
+                  dense_expert_ids.is_contiguous() &&
+                  dense_expert_ids.numel() >= num_experts,
+              "awq_moe_indexed_dense_w13_sm70_out: dense expert IDs must be "
+              "contiguous CUDA int32.");
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == input_row_indices.numel() &&
+                  out.size(1) == n && out.stride(1) == 1,
+              "awq_moe_indexed_dense_w13_sm70_out: output shape mismatch.");
+
+  static std::atomic<unsigned> logged_awq_indexed_prefill{0u};
+  maybe_log_sm70_moe_route_once(
+      logged_awq_indexed_prefill,
+      "SM70 Qwen3.8 AWQ indexed-A W13 prefill path enabled C++ op reached",
+      input, input_row_indices.numel(), num_experts);
+  awq_moe_gemm_sm70_out_impl(
+      out, input, expert_offsets, ptrs_w, ptrs_s, num_experts, k, n, group_size,
+      false, dense_expert_ids, true, torch::Tensor(), torch::Tensor(), false,
+      input_row_indices.numel(), input_row_indices);
 }
 
 torch::Tensor awq_moe_gemm_sm70(torch::Tensor sorted_input,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -569,6 +569,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &awq_moe_dense_stage_sm70_out);
 
   ops.def(
+      "awq_moe_indexed_dense_w13_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
+      "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "
+      "Tensor ptrs_s, int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("awq_moe_indexed_dense_w13_sm70_out", torch::kCUDA,
+           &awq_moe_indexed_dense_w13_sm70_out);
+
+  ops.def(
       "awq_moe_active_dense_stage_sm70_out("
       "Tensor(a!) out, Tensor input, Tensor permuted_experts_id, "
       "Tensor active_expert_offsets, Tensor active_expert_ids, Tensor ptrs_w, "

--- a/tests/quantization/test_sm70_awq_indexed_prefill.py
+++ b/tests/quantization/test_sm70_awq_indexed_prefill.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from benchmarks.benchmark_sm70_turbomind_exactness import (
+    _prepare_awq_moe_checkpoint_for_tp,
+)
+from vllm import envs
+from vllm.model_executor.layers.fused_moe.layer import (
+    FusedMoE,
+    FusedMoeWeightScaleSupported,
+)
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _QWEN38_INDEXED_PREFILL_MIN_TOKENS,
+    AWQSM70MoEMethod,
+    _use_qwen38_indexed_prefill,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _qwen38_layer() -> SimpleNamespace:
+    return SimpleNamespace(
+        moe_config=SimpleNamespace(tp_size=4),
+        sm70_awq_qwen38_indexed_prefill=True,
+        sm70_awq_moe_batched_gemm=True,
+        sm70_awq_checkpoint_group_size=32,
+        sm70_awq_group_size=32,
+        sm70_num_experts=512,
+        sm70_hidden_logical_size=2560,
+        sm70_intermediate_size=160,
+        sm70_w13_k_dim=2560,
+        sm70_w13_n_dim=320,
+    )
+
+
+def test_qwen38_awq_indexed_prefill_env_defaults_on(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", raising=False)
+    assert envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL
+
+    monkeypatch.setenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", "0")
+    assert not envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL
+
+
+def test_qwen38_awq_indexed_prefill_gate_is_exact():
+    layer = _qwen38_layer()
+    x = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 10, dtype=torch.int32)
+
+    assert _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    assert not _use_qwen38_indexed_prefill(layer, x[:127], topk_ids[:127])
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids[:, :9])
+
+    layer.moe_config.tp_size = 2
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.moe_config.tp_size = 4
+
+    layer.sm70_awq_checkpoint_group_size = 128
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.sm70_awq_checkpoint_group_size = 32
+
+    layer.sm70_awq_group_size = 128
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.sm70_awq_group_size = 32
+
+    layer.sm70_awq_qwen38_indexed_prefill = False
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+
+def test_qwen38_awq_indexed_prefill_rejects_noncontiguous_input():
+    layer = _qwen38_layer()
+    x = torch.empty(2560, _QWEN38_INDEXED_PREFILL_MIN_TOKENS).t()
+    topk_ids = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 10, dtype=torch.int32)
+
+    assert x.shape == (_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 2560)
+    assert not x.is_contiguous()
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+
+def _synthetic_awq_checkpoint(group_size: int) -> tuple[torch.Tensor, ...]:
+    groups_w13 = 2560 // group_size
+    groups_w2 = 640 // group_size
+    w13_qweight = (
+        torch.arange(160, dtype=torch.int32).view(1, 1, 160).expand(1, 2560, 160)
+    )
+    w13_scales = (
+        torch.arange(1280, dtype=torch.float16)
+        .view(1, 1, 1280)
+        .expand(1, groups_w13, 1280)
+    )
+    w13_qzeros = (
+        torch.arange(groups_w13, dtype=torch.int32)
+        .view(1, groups_w13, 1)
+        .expand(1, groups_w13, 160)
+    )
+    w2_qweight = (
+        torch.arange(640, dtype=torch.int32).view(1, 640, 1).expand(1, 640, 320)
+    )
+    w2_scales = (
+        torch.arange(groups_w2, dtype=torch.float16)
+        .view(1, groups_w2, 1)
+        .expand(1, groups_w2, 2560)
+    )
+    w2_qzeros = (
+        torch.arange(groups_w2, dtype=torch.int32)
+        .view(1, groups_w2, 1)
+        .expand(1, groups_w2, 320)
+    )
+    return (
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+    )
+
+
+def test_awq_checkpoint_tp4_layout_matches_loader_axes():
+    tensors = _prepare_awq_moe_checkpoint_for_tp(
+        _synthetic_awq_checkpoint(32), 4, 3, 32
+    )
+    w13_qweight, w13_scales, _, w2_qweight, w2_scales, _, group_size = tensors
+
+    assert group_size == 32
+    assert w13_qweight.shape == (1, 2560, 40)
+    assert w13_scales.shape == (1, 80, 320)
+    assert w2_qweight.shape == (1, 160, 320)
+    assert w2_scales.shape == (1, 5, 2560)
+    assert torch.equal(
+        w13_qweight[0, 0],
+        torch.cat((torch.arange(60, 80), torch.arange(140, 160))).to(torch.int32),
+    )
+    assert torch.equal(w2_qweight[0, :, 0], torch.arange(480, 640).to(torch.int32))
+    assert torch.equal(w2_scales[0, :, 0], torch.arange(15, 20).to(torch.float16))
+
+
+def test_g128_checkpoint_tp4_is_rejected_by_service_loader_geometry():
+    with pytest.raises(ValueError, match="divisible by the checkpoint group"):
+        _prepare_awq_moe_checkpoint_for_tp(_synthetic_awq_checkpoint(128), 4, 0, 128)
+
+
+class _FakeRoutedExpertsLoader:
+    weight_loader = FusedMoE.weight_loader
+    _map_global_expert_id_to_local_expert_id = (
+        FusedMoE._map_global_expert_id_to_local_expert_id
+    )
+    _get_hidden_dim = staticmethod(FusedMoE._get_hidden_dim)
+    _narrow_expert_data_for_padding = staticmethod(
+        FusedMoE._narrow_expert_data_for_padding
+    )
+    _load_w13 = FusedMoE._load_w13
+    _load_w2 = FusedMoE._load_w2
+    _load_model_weight_or_group_weight_scale = (
+        FusedMoE._load_model_weight_or_group_weight_scale
+    )
+
+    def __init__(self, tp_rank: int) -> None:
+        self.quant_config = None
+        self.quant_method = object.__new__(AWQSM70MoEMethod)
+        self.quant_method.group_size_div_factor = 1
+        self.expert_map_manager = SimpleNamespace(
+            map_global_to_local=lambda expert_id: expert_id
+        )
+        self.moe_config = SimpleNamespace(
+            is_act_and_mul=True, moe_parallel_config=SimpleNamespace(tp_size=4)
+        )
+        self.tp_rank = tp_rank
+
+
+def _service_loaded_awq_tensors(
+    checkpoint: tuple[torch.Tensor, ...], tp_rank: int
+) -> tuple[torch.Tensor, ...]:
+    w13_qweight, w13_scales, w13_qzeros, w2_qweight, w2_scales, w2_qzeros = checkpoint
+
+    def _parameter(tensor: torch.Tensor) -> torch.nn.Parameter:
+        return torch.nn.Parameter(tensor, requires_grad=False)
+
+    destinations = (
+        _parameter(torch.zeros(1, 2560, 40, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 80, 320, dtype=torch.float16)),
+        _parameter(torch.zeros(1, 80, 40, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 160, 320, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 5, 2560, dtype=torch.float16)),
+        _parameter(torch.zeros(1, 5, 320, dtype=torch.int32)),
+    )
+    for param in destinations:
+        param.is_transposed = True
+        param.quant_method = FusedMoeWeightScaleSupported.GROUP.value
+
+    loader = _FakeRoutedExpertsLoader(tp_rank)
+    checkpoint_shards = (
+        (w13_qweight[..., :80], "qweight", "w1", destinations[0]),
+        (w13_qweight[..., 80:], "qweight", "w3", destinations[0]),
+        (w13_scales[..., :640], "scales", "w1", destinations[1]),
+        (w13_scales[..., 640:], "scales", "w3", destinations[1]),
+        (w13_qzeros[..., :80], "qzeros", "w1", destinations[2]),
+        (w13_qzeros[..., 80:], "qzeros", "w3", destinations[2]),
+        (w2_qweight, "qweight", "w2", destinations[3]),
+        (w2_scales, "scales", "w2", destinations[4]),
+        (w2_qzeros, "qzeros", "w2", destinations[5]),
+    )
+    for loaded, name, shard_id, param in checkpoint_shards:
+        loader.weight_loader(param, loaded[0], name, shard_id, 0)
+    return tuple(param.detach() for param in destinations)
+
+
+@pytest.mark.parametrize("tp_rank", [0, 3])
+def test_benchmark_tp4_preparation_matches_fused_moe_weight_loader(tp_rank: int):
+    checkpoint = _synthetic_awq_checkpoint(32)
+    checkpoint = (
+        checkpoint[0],
+        checkpoint[1].to(torch.bfloat16),
+        checkpoint[2],
+        checkpoint[3],
+        checkpoint[4].to(torch.bfloat16),
+        checkpoint[5],
+    )
+    benchmark_input = (
+        checkpoint[0],
+        checkpoint[1].half(),
+        checkpoint[2],
+        checkpoint[3],
+        checkpoint[4].half(),
+        checkpoint[5],
+    )
+    prepared = _prepare_awq_moe_checkpoint_for_tp(benchmark_input, 4, tp_rank, 32)
+    service_loaded = _service_loaded_awq_tensors(checkpoint, tp_rank)
+
+    assert prepared[-1] == 32
+    for benchmark_tensor, service_tensor in zip(prepared[:-1], service_loaded):
+        assert torch.equal(benchmark_tensor, service_tensor)

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -2670,6 +2670,53 @@ if hasattr(torch.ops._C, "awq_moe_dense_stage_sm70_out"):
         return None
 
 
+def awq_moe_indexed_dense_w13_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    input_row_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("awq_moe_indexed_dense_w13_sm70_out")(
+        out,
+        input,
+        input_row_indices,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "awq_moe_indexed_dense_w13_sm70_out"):
+
+    @register_fake("_C::awq_moe_indexed_dense_w13_sm70_out")
+    def _awq_moe_indexed_dense_w13_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        input_row_indices: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def awq_moe_active_dense_stage_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
     VLLM_SM70_COMPRESSED_TENSORS_TURBOMIND: bool = False
     VLLM_SM70_AWQ_MOE_DISABLE: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_GEMM: bool = True
+    VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL: bool = True
     VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_ACTIVE_EXACT_W2: bool = False
@@ -1617,6 +1618,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # diagnostics and fallback comparison.
     "VLLM_SM70_AWQ_MOE_BATCHED_GEMM": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_GEMM", "1"))
+    ),
+    # Skip the materialized top-k input rows for the exact Qwen3.8
+    # Flash-Next TP4 AWQ W13 prefill contract. Unsupported shapes retain the
+    # existing materialized-input path.
+    "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", "1"))
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13", "0"))

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from typing import Final
 
 import torch
 from torch.nn import Parameter
@@ -28,6 +29,7 @@ from vllm.model_executor.utils import set_weight_attrs
 logger = init_logger(__name__)
 
 _DEFAULT_PERSISTENT_MAX_TOKENS = 32
+_QWEN38_INDEXED_PREFILL_MIN_TOKENS: Final = 128
 
 
 def _log_runtime_route_once(message: str, *args) -> None:
@@ -41,6 +43,32 @@ def _use_temporary_buffers_for_dummy_or_capture() -> bool:
     # during capture too, so the captured indexed MoE scratch/output lifetimes
     # do not depend on graph-pool temporary allocation analysis.
     return is_forward_context_available() and get_forward_context().is_dummy_run
+
+
+def _use_qwen38_indexed_prefill(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit only the exact Qwen3.8 TP4 g32 W13 prefill contract."""
+    return bool(
+        getattr(layer, "sm70_awq_qwen38_indexed_prefill", False)
+        and getattr(layer, "sm70_awq_moe_batched_gemm", False)
+        and x.ndim == 2
+        and x.shape[0] >= _QWEN38_INDEXED_PREFILL_MIN_TOKENS
+        and x.shape[1] == 2560
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (x.shape[0], 10)
+        and int(layer.moe_config.tp_size) == 4
+        and int(layer.sm70_num_experts) == 512
+        and int(layer.sm70_hidden_logical_size) == 2560
+        and int(layer.sm70_intermediate_size) == 160
+        and int(layer.sm70_w13_k_dim) == 2560
+        and int(layer.sm70_w13_n_dim) == 320
+        and int(layer.sm70_awq_checkpoint_group_size) == 32
+        and int(layer.sm70_awq_group_size) == 32
+    )
 
 
 def _single_token_weighted_reduce_enabled() -> bool:
@@ -646,9 +674,64 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         layer.sm70_w2_q_ld = w2_q_ld
         layer.sm70_intermediate_size = layer.sm70_w2_k_dim
         layer.sm70_awq_moe_batched_gemm = batched_gemm
+        checkpoint_group_size = int(
+            getattr(self, "checkpoint_group_size", self.group_size)
+        )
+        layer.sm70_awq_checkpoint_group_size = checkpoint_group_size
+        layer.sm70_awq_group_size = self.group_size
         layer.sm70_awq_moe_layer_id = _get_layer_id(layer)
         layer.sm70_awq_moe_w13_interleaved = w13_interleaved
         layer.sm70_awq_moe_legacy_single_token_compact = build_legacy_w13
+
+        indexed_prefill_contract = bool(
+            batched_gemm
+            and self.group_size == 32
+            and int(layer.moe_config.tp_size) == 4
+            and self.moe.experts_per_token == 10
+            and num_experts == 512
+            and hidden_logical_size == 2560
+            and intermediate_logical_size == 160
+            and layer.sm70_w13_k_dim == 2560
+            and layer.sm70_w13_n_dim == 320
+            and checkpoint_group_size == 32
+        )
+        indexed_prefill_requested = bool(envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL)
+        indexed_prefill_ops = {
+            "awq_moe_indexed_dense_w13_sm70_out": hasattr(
+                torch.ops._C, "awq_moe_indexed_dense_w13_sm70_out"
+            ),
+            "moe_permute_metadata_with_scratch": hasattr(
+                torch.ops._moe_C, "moe_permute_metadata_with_scratch"
+            ),
+        }
+        indexed_prefill_available = all(indexed_prefill_ops.values())
+        indexed_prefill_explicit = (
+            "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL" in os.environ
+        )
+        if (
+            indexed_prefill_contract
+            and indexed_prefill_requested
+            and not indexed_prefill_available
+        ):
+            missing = [
+                name for name, available in indexed_prefill_ops.items() if not available
+            ]
+            if indexed_prefill_explicit:
+                raise RuntimeError(
+                    "The explicit SM70 Qwen3.8 AWQ indexed-A prefill route "
+                    "requires " + ", ".join(missing) + "."
+                )
+            logger.warning_once(
+                "The default SM70 Qwen3.8 AWQ indexed-A prefill route is not "
+                "present in the loaded extension; falling back to the "
+                "materialized-input route. Explicitly setting "
+                "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL=1 fails closed."
+            )
+        layer.sm70_awq_qwen38_indexed_prefill = bool(
+            indexed_prefill_contract
+            and indexed_prefill_requested
+            and indexed_prefill_available
+        )
 
         self._allocate_buffers(layer)
         del layer.w13_qweight, layer.w13_scales, layer.w13_qzeros
@@ -687,6 +770,9 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             layer.sm70_hidden_logical_size,
             dtype=torch.float16,
             device=device,
+        )
+        layer._awq_moe_buf_input_row_indices = torch.empty(
+            max_slots, dtype=torch.int32, device=device
         )
         layer._awq_moe_buf_gate_up = torch.empty(
             max_slots, layer.sm70_w13_n_dim, dtype=torch.float16, device=device
@@ -782,6 +868,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         layer: RoutedExperts,
         total_slots: int,
         num_tokens: int,
+        indexed_w13: bool,
     ) -> dict[str, torch.Tensor]:
         use_temporary_buffers = _use_temporary_buffers_for_dummy_or_capture()
         if (
@@ -792,6 +879,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             return {
                 "output": layer._awq_moe_buf_output[:num_tokens],
                 "permuted_input": layer._awq_moe_buf_permuted_input[:total_slots],
+                "input_row_indices": layer._awq_moe_buf_input_row_indices[:total_slots],
                 "gate_up": layer._awq_moe_buf_gate_up[:total_slots],
                 "intermediate": layer._awq_moe_buf_intermediate[:total_slots],
                 "sorted_output": layer._awq_moe_buf_sorted_output[:total_slots],
@@ -868,11 +956,25 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 dtype=torch.float16,
                 device=device,
             ),
-            "permuted_input": torch.empty(
-                total_slots,
-                layer.sm70_hidden_logical_size,
-                dtype=torch.float16,
-                device=device,
+            "permuted_input": (
+                torch.empty(
+                    0,
+                    layer.sm70_hidden_logical_size,
+                    dtype=torch.float16,
+                    device=device,
+                )
+                if indexed_w13
+                else torch.empty(
+                    total_slots,
+                    layer.sm70_hidden_logical_size,
+                    dtype=torch.float16,
+                    device=device,
+                )
+            ),
+            "input_row_indices": (
+                torch.empty(total_slots, dtype=torch.int32, device=device)
+                if indexed_w13
+                else torch.empty(0, dtype=torch.int32, device=device)
             ),
             "gate_up": torch.empty(
                 total_slots,
@@ -1011,7 +1113,8 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         num_tokens = x.shape[0]
         top_k = topk_ids.shape[1]
         total_slots = num_tokens * top_k
-        buffers = self._get_buffers(layer, total_slots, num_tokens)
+        indexed_w13 = _use_qwen38_indexed_prefill(layer, x, topk_ids)
+        buffers = self._get_buffers(layer, total_slots, num_tokens, indexed_w13)
         output = buffers["output"]
         output.zero_()
         if total_slots == 0:
@@ -1217,23 +1320,42 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 )
             output = _dump_awq_moe_buffer(layer, output, "st_output")
             return output
-        torch.ops._moe_C.moe_permute_with_scratch(
-            x,
-            topk_ids_i32,
-            buffers["token_expert_indices"],
-            layer.expert_map,
-            layer.global_num_experts,
-            layer.local_num_experts,
-            top_k,
-            buffers["permuted_input"],
-            buffers["expert_offsets64"],
-            buffers["inv_permuted_idx"],
-            buffers["permuted_idx"],
-            buffers["sort_workspace"],
-            buffers["permuted_experts_id"],
-            buffers["sorted_row_idx"],
-            buffers["topk_ids_for_sort"],
-        )
+        if indexed_w13:
+            torch.ops._moe_C.moe_permute_metadata_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.expert_map,
+                layer.global_num_experts,
+                layer.local_num_experts,
+                top_k,
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["input_row_indices"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
+        else:
+            torch.ops._moe_C.moe_permute_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.expert_map,
+                layer.global_num_experts,
+                layer.local_num_experts,
+                top_k,
+                buffers["permuted_input"],
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
         buffers["expert_offsets"] = _dump_awq_moe_buffer(
             layer, buffers["expert_offsets"], "expert_offsets"
@@ -1280,7 +1402,27 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         if num_tokens <= 8 and use_batched_moe_gemm:
             compare_dense_step = _compare_dense_decode_step(layer)
 
-        if use_active_exact_small_batched_moe:
+        if indexed_w13:
+            _log_runtime_route_once(
+                "SM70 Qwen3.8 AWQ indexed-A W13 prefill route enabled "
+                "(tokens=%d, routes=%d).",
+                num_tokens,
+                total_slots,
+            )
+            sm70_ops.awq_moe_indexed_dense_w13_sm70_out(
+                buffers["gate_up"],
+                x,
+                buffers["input_row_indices"],
+                buffers["expert_offsets"],
+                layer._awq_moe_buf_dense_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                layer.sm70_num_experts,
+                layer.sm70_w13_k_dim,
+                layer.sm70_w13_n_dim,
+                self.group_size,
+            )
+        elif use_active_exact_small_batched_moe:
             _log_runtime_route_once(
                 "SM70 AWQ MoE batched path using active-route exact "
                 "dense-stage route (tokens=%d, routes=%d).",


### PR DESCRIPTION
## Purpose

Large Qwen3.8 Flash-Next AWQ prefills currently materialize the top-k-expanded
W13 input before the expert GEMM. At the validated 8192-token / top-k 10 /
hidden-size 2560 contract, that temporary FP16 tensor is 400 MiB.

This PR reuses the metadata-only MoE permutation and passes row indices into a
TurboMind indexed-A W13 entry point. W13 reads the original activation rows by
index; the existing SiLU, W2, and weighted-reduction stages remain unchanged.

This aligns AWQ large-prefill activation dispatch with the existing NVFP4
strategy: both retain the original activation matrix and use permutation row
metadata instead of allocating a `[tokens * top_k, hidden_size]` expanded
input. This is execution and peak-memory parity, not a claim that the AWQ and
NVFP4 weight formats or GEMM implementations are identical.

The production route is deliberately narrow:

- SM70 Qwen3.8 Flash-Next AWQ, TP4, top-k 10, 512 experts;
- native checkpoint g32 and effective runtime g32;
- FP16 activation with the exact TP4 W13 K/N layout;
- at least 128 input tokens.

Unsupported contracts retain the existing materialized-input path. Setting
`VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL=0` disables the route. If an operator
explicitly sets it to `1` while the required extensions are absent, startup
fails closed; the default setting warns and falls back when loading an older
extension.

The native-checkpoint g32 check is intentional. Expanding stored g128 metadata
to an effective g32 runtime layout is loader compatibility, not a native-g32
quantization result, and has not been admitted to this optimized path.

This does not duplicate an open change: searches for `AWQ indexed prefill` in
both 1Cat-vLLM and upstream vLLM returned no open PR. Existing code supplies the
metadata-only permutation primitive; this PR adds the AWQ indexed-A GEMM route,
its production dispatch, and loader-faithful validation.

## Test Plan

- Run the focused Python tests for route admission, fallback behavior, loader
  preprocessing, TP0/TP3 sharding, and runtime dispatch.
- Run pre-commit on all eight changed files.
- On V100, compare indexed-A against the previous materialized
  per-expert-dispatch implementation using the real native-g32 checkpoint,
  FP16 service scale loading, TP4 ranks 0 and 3, W13 interleaving, and production
  permutation metadata at M=128 and M=8192.
- Start the full TP4/MTP0 service and verify startup, graph capture, production
  route logs, KV capacity, and a targeted C1/C4 performance set.

## Test Result

- `python -m pytest tests/quantization/test_sm70_awq_indexed_prefill.py -q`:
  **7 passed**.
- `pre-commit run --files <changed files>`: all applicable hooks passed,
  including ruff, clang-format, mypy, SPDX, and configuration validation.
- V100 operator exactness, TP4 rank 0 and rank 3, M=128 and M=8192:
  W13, SiLU, and W2 were bitwise equal to the materialized reference
  (`max_diff=0`, `num_nonzero=0`).
- At M=8192, the route avoids the 400 MiB expanded W13 input. The measured
  W13-to-W2 chain improved from about 6.64 ms to 4.97 ms (about 1.34x) on both
  tested TP ranks.
- Full-service cold start kept model loading at 21.24 GiB/GPU and increased
  available KV memory from 4.89 to 5.28 GiB/GPU. KV capacity increased from
  714,188 to 771,736 tokens (`+57,548`, `+8.06%`).
- Against the same service baseline, the C1 16K-128K geometric mean was
  prefill `+5.83%`, decode `+0.24%`, and server E2E elapsed `-3.32%` (lower is
  better). The targeted service set covered C1 at 1K/4K/16K/32K/64K/128K and
  C4 at 1K/4K, with one warmup and three scored repeats per cell: 42/42 scored
  requests completed 256 output tokens, stderr was empty, and no OOM, runtime
  error, Xid, or ECC error was observed.

The service run used calibrated E4M3 QSA KV only as the fixed deployment
contract; this AWQ prefill optimization is independent of KV dtype. A complete
C1/C4/C8 tail matrix was intentionally not repeated, so this PR does not claim
full concurrency/tail acceptance.

AI assistance disclosure: OpenAI Codex assisted with implementation, test
harness changes, and result collation. The submitter reviewed the changed code
and ran the tests and V100 validation described above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and supported contract are documented.
- [x] Test commands and runtime validation are documented.
- [x] Before/after capacity and performance results are documented.
- [x] Duplicate-work checks and AI assistance are disclosed.

</details>
