### PR TITLE
perf(sm70): right-size AWQ MoE persistent scratch

### DIFF
--- a/tests/quantization/test_awq_sm70_persistent_cap.py
+++ b/tests/quantization/test_awq_sm70_persistent_cap.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+import vllm.model_executor.layers.quantization.awq_sm70_moe as awq_sm70_moe
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "override", "expected"),
+    [
+        (1, 0, 1),
+        (8, 0, 8),
+        (16, 0, 16),
+        (32, 0, 32),
+        (48, 0, 32),
+        (64, 0, 32),
+        (64, 8, 8),
+        (64, 16, 16),
+        (64, 32, 32),
+        (8, 16, 8),
+        (0, 0, 1),
+        (-1, 0, 1),
+    ],
+)
+def test_resolve_persistent_max_tokens(
+    max_num_seqs: int,
+    override: int,
+    expected: int,
+) -> None:
+    assert (
+        awq_sm70_moe._resolve_persistent_max_tokens(max_num_seqs, override) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("config_max_num_seqs", "override", "expected"),
+    [
+        (8, 0, 8),
+        (16, 8, 8),
+        (64, 0, 32),
+        (64, 16, 16),
+        (None, 0, 32),
+    ],
+)
+def test_persistent_max_tokens_for_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    config_max_num_seqs: int | None,
+    override: int,
+    expected: int,
+) -> None:
+    if config_max_num_seqs is None:
+        config = None
+    else:
+        scheduler_config = type(
+            "SchedulerConfig",
+            (),
+            {"max_num_seqs": config_max_num_seqs},
+        )()
+        config = type(
+            "VllmConfig",
+            (),
+            {"scheduler_config": scheduler_config},
+        )()
+    monkeypatch.setattr(
+        awq_sm70_moe,
+        "get_current_vllm_config_or_none",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        awq_sm70_moe.envs,
+        "VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS",
+        override,
+    )
+
+    assert awq_sm70_moe._persistent_max_tokens_for_runtime() == expected

--- a/tests/quantization/test_awq_sm70_persistent_cap.py
+++ b/tests/quantization/test_awq_sm70_persistent_cap.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skip_global_cleanup
         (64, 8, 8),
         (64, 16, 16),
         (64, 32, 32),
-        (8, 16, 8),
+        (8, 16, 16),
         (0, 0, 1),
         (-1, 0, 1),
     ],
@@ -39,6 +39,7 @@ def test_resolve_persistent_max_tokens(
     ("config_max_num_seqs", "override", "expected"),
     [
         (8, 0, 8),
+        (8, 16, 16),
         (16, 8, 8),
         (64, 0, 32),
         (64, 16, 16),

--- a/tests/quantization/test_awq_sm70_persistent_cap.py
+++ b/tests/quantization/test_awq_sm70_persistent_cap.py
@@ -9,46 +9,60 @@ pytestmark = pytest.mark.skip_global_cleanup
 
 
 @pytest.mark.parametrize(
-    ("max_num_seqs", "override", "expected"),
+    ("max_num_seqs", "verifier_width", "override", "expected"),
     [
-        (1, 0, 1),
-        (8, 0, 8),
-        (16, 0, 16),
-        (32, 0, 32),
-        (48, 0, 32),
-        (64, 0, 32),
-        (64, 8, 8),
-        (64, 16, 16),
-        (64, 32, 32),
-        (8, 16, 16),
-        (0, 0, 1),
-        (-1, 0, 1),
+        (1, 1, 0, 1),
+        (8, 1, 0, 8),
+        (8, 2, 0, 16),
+        (8, 3, 0, 24),
+        (8, 4, 0, 32),
+        (16, 2, 0, 32),
+        (32, 1, 0, 32),
+        (48, 1, 0, 32),
+        (64, 1, 0, 32),
+        (64, 4, 8, 8),
+        (64, 4, 16, 16),
+        (64, 4, 32, 32),
+        (8, 1, 16, 16),
+        (0, 0, 0, 1),
+        (-1, -1, 0, 1),
     ],
 )
 def test_resolve_persistent_max_tokens(
     max_num_seqs: int,
+    verifier_width: int,
     override: int,
     expected: int,
 ) -> None:
     assert (
-        awq_sm70_moe._resolve_persistent_max_tokens(max_num_seqs, override) == expected
+        awq_sm70_moe._resolve_persistent_max_tokens(
+            max_num_seqs, verifier_width, override
+        )
+        == expected
     )
 
 
 @pytest.mark.parametrize(
-    ("config_max_num_seqs", "override", "expected"),
+    ("config_max_num_seqs", "spec_method", "spec_state_tokens", "override", "expected"),
     [
-        (8, 0, 8),
-        (8, 16, 16),
-        (16, 8, 8),
-        (64, 0, 32),
-        (64, 16, 16),
-        (None, 0, 32),
+        (8, None, 0, 0, 8),
+        (8, "mtp", 1, 0, 16),
+        (8, "mtp", 2, 0, 24),
+        (8, "mtp", 3, 0, 32),
+        (16, "mtp", 1, 0, 32),
+        (8, "eagle", 3, 0, 8),
+        (8, "mtp", 2, 16, 16),
+        (16, None, 0, 8, 8),
+        (64, None, 0, 0, 32),
+        (64, None, 0, 16, 16),
+        (None, None, 0, 0, 32),
     ],
 )
 def test_persistent_max_tokens_for_runtime(
     monkeypatch: pytest.MonkeyPatch,
     config_max_num_seqs: int | None,
+    spec_method: str | None,
+    spec_state_tokens: int,
     override: int,
     expected: int,
 ) -> None:
@@ -60,10 +74,23 @@ def test_persistent_max_tokens_for_runtime(
             (),
             {"max_num_seqs": config_max_num_seqs},
         )()
+        speculative_config = None
+        if spec_method is not None:
+            speculative_config = type(
+                "SpeculativeConfig",
+                (),
+                {
+                    "method": spec_method,
+                    "num_speculative_state_tokens": lambda self: spec_state_tokens,
+                },
+            )()
         config = type(
             "VllmConfig",
             (),
-            {"scheduler_config": scheduler_config},
+            {
+                "scheduler_config": scheduler_config,
+                "speculative_config": speculative_config,
+            },
         )()
     monkeypatch.setattr(
         awq_sm70_moe,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1631,9 +1631,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS", "0")
     ),
-    # Zero derives the resident MoE scratch cap from max_num_seqs, bounded by
-    # the historical 32-token ceiling. A positive value is an experimental
-    # cap for matched experiments and is still bounded by the legacy ceiling.
+    # Zero derives the resident MoE scratch cap from max_num_seqs and the MTP
+    # verifier width, bounded by the historical 32-token ceiling. A positive
+    # value is an experimental cap and is still bounded by that ceiling.
     "VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS", "0")
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -122,6 +122,7 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_MOE_BATCHED_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_ACTIVE_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS: int = 0
+    VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS: int = 0
     VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST: str | None = None
     VLLM_SM70_AWQ_MOE_BATCHED_LAYER_DENYLIST: str | None = None
     VLLM_SM70_AWQ_MOE_COMPARE_DENSE_DIR: str | None = None
@@ -1629,6 +1630,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS", "0")
+    ),
+    # Zero derives the resident MoE scratch cap from max_num_seqs, bounded by
+    # the historical 32-token ceiling. A positive value is an experimental
+    # lower cap and is still bounded by the scheduler contract.
+    "VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS": lambda: int(
+        os.getenv("VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS", "0")
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST": lambda: os.getenv(
         "VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST", None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1633,7 +1633,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Zero derives the resident MoE scratch cap from max_num_seqs, bounded by
     # the historical 32-token ceiling. A positive value is an experimental
-    # lower cap and is still bounded by the scheduler contract.
+    # cap for matched experiments and is still bounded by the legacy ceiling.
     "VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS", "0")
     ),

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -33,10 +33,11 @@ _DEFAULT_PERSISTENT_MAX_TOKENS = 32
 
 def _resolve_persistent_max_tokens(
     max_num_seqs: int,
+    verifier_width: int = 1,
     override: int = 0,
 ) -> int:
-    """Size resident decode scratch without growing past the legacy ceiling."""
-    scheduler_cap = max(1, int(max_num_seqs))
+    """Size resident decode/verifier scratch up to the legacy ceiling."""
+    scheduler_cap = max(1, int(max_num_seqs)) * max(1, int(verifier_width))
     requested_cap = int(override)
     if requested_cap <= 0:
         return min(scheduler_cap, _DEFAULT_PERSISTENT_MAX_TOKENS)
@@ -51,8 +52,15 @@ def _persistent_max_tokens_for_runtime() -> int:
         if scheduler_config is None
         else scheduler_config.max_num_seqs
     )
+    speculative_config = None if vllm_config is None else vllm_config.speculative_config
+    verifier_width = (
+        speculative_config.num_speculative_state_tokens() + 1
+        if speculative_config is not None and speculative_config.method == "mtp"
+        else 1
+    )
     return _resolve_persistent_max_tokens(
         max_num_seqs,
+        verifier_width,
         envs.VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS,
     )
 

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -10,6 +10,7 @@ from torch.nn import Parameter
 
 from vllm import _sm70_ops as sm70_ops
 from vllm import envs
+from vllm.config import get_current_vllm_config_or_none
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
@@ -30,6 +31,32 @@ logger = init_logger(__name__)
 _DEFAULT_PERSISTENT_MAX_TOKENS = 32
 
 
+def _resolve_persistent_max_tokens(
+    max_num_seqs: int,
+    override: int = 0,
+) -> int:
+    """Size resident decode scratch without growing past the legacy ceiling."""
+    scheduler_cap = max(1, int(max_num_seqs))
+    requested_cap = int(override)
+    if requested_cap <= 0:
+        requested_cap = scheduler_cap
+    return min(requested_cap, scheduler_cap, _DEFAULT_PERSISTENT_MAX_TOKENS)
+
+
+def _persistent_max_tokens_for_runtime() -> int:
+    vllm_config = get_current_vllm_config_or_none()
+    scheduler_config = None if vllm_config is None else vllm_config.scheduler_config
+    max_num_seqs = (
+        _DEFAULT_PERSISTENT_MAX_TOKENS
+        if scheduler_config is None
+        else scheduler_config.max_num_seqs
+    )
+    return _resolve_persistent_max_tokens(
+        max_num_seqs,
+        envs.VLLM_SM70_AWQ_MOE_PERSISTENT_MAX_TOKENS,
+    )
+
+
 def _log_runtime_route_once(message: str, *args) -> None:
     if torch.compiler.is_compiling():
         return
@@ -37,9 +64,9 @@ def _log_runtime_route_once(message: str, *args) -> None:
 
 
 def _use_temporary_buffers_for_dummy_or_capture() -> bool:
-    # CUDA graph replay is address-fixed. Use the per-layer persistent buffers
-    # during capture too, so the captured indexed MoE scratch/output lifetimes
-    # do not depend on graph-pool temporary allocation analysis.
+    # Dummy/profile and CUDA graph capture allocate temporary tensors. Captured
+    # addresses subsequently remain fixed in the graph pool; normal eager
+    # decode can reuse the smaller per-layer resident buffers below.
     return is_forward_context_available() and get_forward_context().is_dummy_run
 
 
@@ -671,11 +698,16 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
     def _allocate_buffers(self, layer: RoutedExperts) -> None:
         device = layer.w13_tm_weight.device
         top_k = self.moe.experts_per_token
-        persistent_tokens = _DEFAULT_PERSISTENT_MAX_TOKENS
+        persistent_tokens = _persistent_max_tokens_for_runtime()
         max_slots = persistent_tokens * top_k
         layer._awq_moe_buf_max_tokens = persistent_tokens
         layer._awq_moe_buf_max_slots = max_slots
         layer._awq_moe_buf_top_k = top_k
+        logger.info_once(
+            "SM70 AWQ MoE persistent scratch cap=%d tokens (legacy ceiling=%d).",
+            persistent_tokens,
+            _DEFAULT_PERSISTENT_MAX_TOKENS,
+        )
         layer._awq_moe_buf_output = torch.empty(
             persistent_tokens,
             layer.sm70_hidden_logical_size,

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -39,8 +39,8 @@ def _resolve_persistent_max_tokens(
     scheduler_cap = max(1, int(max_num_seqs))
     requested_cap = int(override)
     if requested_cap <= 0:
-        requested_cap = scheduler_cap
-    return min(requested_cap, scheduler_cap, _DEFAULT_PERSISTENT_MAX_TOKENS)
+        return min(scheduler_cap, _DEFAULT_PERSISTENT_MAX_TOKENS)
+    return min(requested_cap, _DEFAULT_PERSISTENT_MAX_TOKENS)
 
 
 def _persistent_max_tokens_for_runtime() -> int:


### PR DESCRIPTION
## Summary

- size SM70 AWQ MoE resident scratch from `max_num_seqs` instead of always reserving 32 tokens
- account for the resolved MTP verifier width, while retaining the historical 32-token ceiling
- keep an explicit env override for matched experiments and rollback
- continue using temporary buffers for dummy/profile, CUDA graph capture, and forwards larger than the resident cap

Auto sizing is `min(max_num_seqs * verifier_width, 32)` for MTP and `min(max_num_seqs, 32)` otherwise. Other speculative methods are deliberately not generalized.

## Validation

- `26 passed`: `tests/quantization/test_awq_sm70_persistent_cap.py`
- Ruff check and format check pass
- `git diff --check` passes
- matched TP4 V100, MTP0, max-num-seqs=8 A/B: model load 21.24 -> 21.11 GiB/card; calibrated E4M3 KV capacity 771,736 -> 789,443 tokens (+17,707, +2.29%)
- CUDA graph capture passed; C8 exact-output check passed
- explicit cap=8 boundary run with max-num-seqs=16 passed C16 exact-output check

## Scope

No CUDA kernel, quantization math, routing, or weight-format changes. TP8 and live MTP runtime validation remain follow-up acceptance gates.