### PR TITLE
[Bugfix][Perf][SM70/SM75] Widen QSA sparse launch profile to pre-Ampere

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_launch_profile.py
+++ b/tests/models/qwen4_exp/test_qsa_launch_profile.py
@@ -9,23 +9,24 @@ pytestmark = pytest.mark.skip_global_cleanup
 
 
 @pytest.mark.parametrize(
-    ("block_m", "base_programs", "is_sm70", "expected"),
+    ("block_m", "base_programs", "is_pre_ampere", "expected"),
     [
-        pytest.param(8, 8, True, (16, 64, 4), id="sm70_small_block_m8"),
-        pytest.param(16, 4, True, (16, 64, 4), id="sm70_small_block_m16"),
-        pytest.param(16, 5, True, (16, 32, 4), id="sm70_narrow"),
-        pytest.param(8, 256, True, (64, 8, 4), id="sm70_split8"),
-        pytest.param(8, 512, True, (32, 4, 4), id="sm70_split4"),
-        pytest.param(8, 513, False, (64, 1, 2), id="non_sm70_split1"),
-        pytest.param(8, 513, True, (32, 1, 4), id="sm70_split1"),
+        pytest.param(8, 8, True, (16, 64, 4), id="pre_ampere_small_block_m8"),
+        pytest.param(16, 4, True, (16, 64, 4), id="pre_ampere_small_block_m16"),
+        pytest.param(16, 5, True, (16, 32, 4), id="pre_ampere_narrow"),
+        pytest.param(8, 256, True, (16, 8, 4), id="pre_ampere_split8"),
+        pytest.param(8, 512, True, (16, 4, 4), id="pre_ampere_split4"),
+        pytest.param(8, 513, False, (64, 1, 2), id="ampere_split1"),
+        pytest.param(8, 513, True, (16, 1, 4), id="pre_ampere_split1"),
     ],
 )
 def test_qsa_sparse_launch_profile(
     block_m: int,
     base_programs: int,
-    is_sm70: bool,
+    is_pre_ampere: bool,
     expected: tuple[int, int, int],
 ) -> None:
     assert (
-        qsa_ops._qsa_sparse_launch_profile(base_programs, block_m, is_sm70) == expected
+        qsa_ops._qsa_sparse_launch_profile(base_programs, block_m, is_pre_ampere)
+        == expected
     )

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -19,13 +19,13 @@ from vllm.models.qwen4_exp.nvidia.ops.qsa import (
 pytestmark = pytest.mark.skip_global_cleanup
 
 
-def test_sm70_qsa_prefill_uses_narrow_tiles_and_four_warps():
-    assert _qsa_sparse_launch_profile(511, 8, True) == (64, 4, 4)
-    assert _qsa_sparse_launch_profile(512, 8, True) == (32, 4, 4)
-    assert _qsa_sparse_launch_profile(8192, 8, True) == (32, 1, 4)
+def test_pre_ampere_qsa_prefill_uses_narrow_tiles_and_four_warps():
+    assert _qsa_sparse_launch_profile(511, 8, True) == (16, 4, 4)
+    assert _qsa_sparse_launch_profile(512, 8, True) == (16, 4, 4)
+    assert _qsa_sparse_launch_profile(8192, 8, True) == (16, 1, 4)
 
 
-def test_non_sm70_qsa_prefill_keeps_gb300_profile():
+def test_ampere_qsa_prefill_keeps_gb300_profile():
     assert _qsa_sparse_launch_profile(512, 8, False) == (64, 4, 2)
     assert _qsa_sparse_launch_profile(8192, 8, False) == (64, 1, 2)
 

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -1900,7 +1900,7 @@ def qsa_sparse_paged_attention(
     block_n, target_splits, partial_warps = _qsa_sparse_launch_profile(
         base_programs,
         block_m,
-        current_platform.is_device_capability(70),
+        not current_platform.has_device_capability(80),
     )
 
     if (
@@ -2001,7 +2001,7 @@ def qsa_sparse_paged_attention(
 def _qsa_sparse_launch_profile(
     base_programs: int,
     block_m: int,
-    is_sm70: bool,
+    is_pre_ampere: bool,
 ) -> tuple[int, int, int]:
     """Return BLOCK_N, target splits, and warps for sparse QSA."""
     small_profile_limit = 8 if block_m <= 8 else 4
@@ -2018,14 +2018,16 @@ def _qsa_sparse_launch_profile(
         block_n, target_splits, partial_warps = 64, 4, 2
     else:
         block_n, target_splits, partial_warps = 64, 1, 2
-    if is_sm70 and block_n == 64:
-        # Two warps serialize the D=256 tensor-core work on V100. Four warps
-        # restore warp-level parallelism for split and non-split prefill.
+    if is_pre_ampere and block_n == 64:
+        # Pre-Ampere: the 64-column tile at D=256 does not fit Turing's
+        # 64 KiB shared-memory limit (Triton OutOfResources -- the kernel
+        # cannot launch on SM75 at all), and two warps serialize the D=256
+        # tensor-core work on V100. A 16-column tile with four warps
+        # launches on both and measured 1.16-2.6x faster than the best
+        # previously runnable profile across the 64..2048-row prefill
+        # regimes (V100-PCIE-32GB and Quadro RTX 8000, see #441).
         partial_warps = 4
-        if base_programs >= 512:
-            # A 32-column tile improves the exact 512-row and 8192-row Qwen4Exp
-            # prefill shapes without changing small-batch or non-SM70 routes.
-            block_n = 32
+        block_n = 16
     return block_n, target_splits, partial_warps
 
 


### PR DESCRIPTION
Follow-up to #441, as requested there. Unlike the closed #455 (our dispatch mistake — apologies again), every number below was measured against **this file** (`nvidia/ops/qsa.py` at ca73a34) on both of our pre-Ampere cards.

## What

Widen the existing SM70 branch in `_qsa_sparse_launch_profile` to all pre-Ampere devices and let it pick the narrow 16-column, four-warp tile:

- callsite gate: `current_platform.is_device_capability(70)` → `not current_platform.has_device_capability(80)` (SM80+ keeps the GB300 table bit-for-bit),
- the pre-Ampere branch sets `block_n = 16, partial_warps = 4` for every prefill regime (the branch only fires when the GB300 table chose `block_n == 64`, so the small-batch decode profiles are untouched),
- both test files updated accordingly.

## Why

1. **SM75 cannot launch the current profiles at all.** At D=256 the 64-column tile exceeds Turing's 64 KiB shared-memory limit: Triton raises `OutOfResources` for every prefill regime (rows ≥ 64 measured). The existing SM70 retune does not apply on SM75, and even force-applied it only helps ≥ 512 programs (N32) — the 33..256-program regimes keep N64 and still fail.
2. **N16/W4 is also faster where the current profiles do run.** 1.17–2.6× on V100 and 1.16–1.17× on SM75 against the best previously runnable profile, with identical outputs.

## Measurements

Production Qwen4Exp TP2 geometry (12 query heads, 1 KV head, D=256, TOPK=2048, PAGE_SIZE=16, bf16 caches, 16k-token KV), medians of 30 CUDA-event-timed calls after 3 warmups. `base_programs = rows` (1 KV head).

Tesla V100-PCIE-32GB (SM70):

| rows | GB300 profile (N64/W2) | current SM70 retune | this PR (N16/W4) |
|---:|---:|---:|---:|
| 64 | 13.38 ms | 2.40 ms (N64/S8/W4) | **1.11 ms** |
| 256 | 50.62 ms | 9.13 ms (N64/S8/W4) | **3.54 ms** |
| 512 | 100.69 ms | 8.63 ms (N32/S4/W4) | **6.96 ms** |
| 1024 | 262.67 ms | 17.18 ms (N32/S1/W4) | **14.71 ms** |
| 2048 | 525.24 ms | 32.98 ms (N32/S1/W4) | **27.39 ms** |

Quadro RTX 8000 (SM75):

| rows | current dispatch (GB300, no retune) | SM70 retune force-applied | this PR (N16/W4) |
|---:|---:|---:|---:|
| 64 | OutOfResources | OutOfResources (N64/S8/W4) | **2.08 ms** |
| 256 | OutOfResources | OutOfResources (N64/S8/W4) | **6.30 ms** |
| 512 | OutOfResources | 14.41 ms (N32/S4/W4) | **12.29 ms** |
| 1024 | OutOfResources | 29.27 ms (N32/S1/W4) | **25.23 ms** |
| 2048 | OutOfResources | 56.96 ms (N32/S1/W4) | **48.75 ms** |

Methodology: the file at ca73a34 is loaded as-is via importlib and only `_qsa_sparse_launch_profile` is overridden per data point, so launch, split merge and workspaces are exactly the shipped code paths. Every profile's output was cross-checked against the default profile's output — identical within bf16 split-reduction-order tolerance. With the patch applied, the default dispatch reproduces the N16 column on both cards.

Decode is deliberately untouched: at rows 1/6/8 the GB300 table already picks the narrow high-split profiles, and they win (forcing S8 at rows=1 measured 3× slower). Also untouched: `sm70_single_token` in `qsa_mqa_paged`, the TP4 `group_size == 6` warp special case, and everything SM80+.

## Open question

Your N32 choice at ≥ 512 programs was tuned on the exact 512/8192-row shapes; on our cards N16 measures ahead of N32 there too (SM70 1.20×, SM75 1.16–1.17×). If you prefer to keep N32 on SM70, the minimal alternative is widening only the gate — but that leaves the 33..256-program regimes unable to launch on SM75, which is why this PR proposes N16 across the pre-Ampere prefill branch. Happy to rerun any shape you care about on V100-PCIE or RTX 8000.

## Duplication check, tests, and AI assistance

Per the repository's agent guidelines:

- **Duplication:** `gh pr list --state open --search` for "qsa launch profile", "pre-ampere" and "441 in:body" each return only this PR. The related closed #455 was our own earlier attempt that measured the wrong file; this PR supersedes it as discussed in #441.
- **Tests:** both touched test files were run in full against the patched module (Python 3.12, torch 2.10.0, Tesla V100): `python -m pytest tests/models/qwen4_exp/test_qsa_launch_profile.py tests/models/qwen4_exp/test_qsa_ops.py -v` → **18 passed** (7 launch-profile cases + 11 ops tests, including every untouched one).
- **AI assistance:** this change was AI-assisted (Claude, see commit trailer). The submitter reviewed every changed line, ran all measurements on his own hardware, and can defend the change end-to-end.

Refs #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

