### PR TITLE
[Perf][SM70] Bound Qwen3.8 AWQ W2 output scratch

### DIFF
--- a/benchmarks/benchmark_sm70_awq_sorted_output.py
+++ b/benchmarks/benchmark_sm70_awq_sorted_output.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A/B the full and token-chunked AWQ W2 output paths on SM70.
+
+The benchmark loads one real Qwen3.8 AWQ MoE layer, applies the same TP shard
+and SM70 preprocessing as the service, and checks the final weighted output
+bitwise before reporting latency and scratch bytes.
+"""
+
+import argparse
+import json
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import torch
+
+from benchmarks.benchmark_sm70_turbomind_exactness import (
+    _expert_offsets,
+    _load_awq_moe_layer,
+    _make_input,
+    _make_logical_expert_ids,
+    _prepare_awq_moe_checkpoint_for_tp,
+    _prepare_awq_moe_weights,
+)
+from vllm import _sm70_ops as sm70_ops
+
+
+def _time_ms(fn: Callable[[], None], warmups: int, iterations: int) -> float:
+    for _ in range(warmups):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(iterations):
+        start = perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        samples.append((perf_counter() - start) * 1000.0)
+    return statistics.median(samples)
+
+
+def _tensor_bytes(*tensors: torch.Tensor) -> int:
+    return sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+
+
+def _make_expert_ids(
+    m: int,
+    top_k: int,
+    num_experts: int,
+    device: torch.device,
+    pattern: str,
+) -> torch.Tensor:
+    if not pattern.startswith("hot_route0:"):
+        return _make_logical_expert_ids(m * top_k, num_experts, device, pattern)
+
+    hot_expert = int(pattern.split(":", 1)[1])
+    if not 0 <= hot_expert < num_experts:
+        raise ValueError("hot expert is outside the configured expert range.")
+    tokens = torch.arange(m, dtype=torch.int64, device=device).view(-1, 1)
+    routes = torch.arange(top_k, dtype=torch.int64, device=device).view(1, -1)
+    expert_ids = (tokens * 17 + routes * 53 + 1) % (num_experts - 1)
+    expert_ids += expert_ids >= hot_expert
+    expert_ids[:, 0] = hot_expert
+    return expert_ids.flatten()
+
+
+def _run_shape(
+    m: int,
+    top_k: int,
+    num_experts: int,
+    group_size: int,
+    expert_pattern: str,
+    device: torch.device,
+    w2_ptrs_w: torch.Tensor,
+    w2_ptrs_s: torch.Tensor,
+    w2_k: int,
+    w2_n: int,
+    chunk_tokens: int,
+    warmups: int,
+    iterations: int,
+    check_cuda_graph: bool,
+) -> dict[str, Any]:
+    if chunk_tokens not in (4096, 6144):
+        raise ValueError("chunk_tokens must be 4096 or 6144.")
+    tail_tokens = m % chunk_tokens
+    if m < 8192 or chunk_tokens >= m or 0 < tail_tokens < 2048:
+        raise ValueError(
+            "chunked W2 requires m >= 8192, chunk_tokens in {4096, 6144}, "
+            "chunk_tokens < m, and an empty or >= 2048-token tail."
+        )
+    total_slots = m * top_k
+    logical_expert_ids = _make_expert_ids(m, top_k, num_experts, device, expert_pattern)
+    sorted_expert_ids, order = torch.sort(logical_expert_ids, stable=True)
+    expert_offsets, _ = _expert_offsets(sorted_expert_ids, num_experts)
+
+    route_input = _make_input(total_slots, w2_k, device)
+    sorted_input = route_input[order].contiguous()
+    inv_permuted_idx = torch.empty(total_slots, dtype=torch.int32, device=device)
+    inv_permuted_idx[order] = torch.arange(
+        total_slots, dtype=torch.int32, device=device
+    )
+    inv_permuted_idx = inv_permuted_idx.view(m, top_k)
+    permuted_idx = order.to(torch.int32).contiguous()
+    weights = torch.arange(1, top_k + 1, dtype=torch.float32, device=device)
+    topk_weights = (weights / weights.sum()).view(1, top_k).expand(m, -1)
+    topk_weights = topk_weights.contiguous()
+
+    sorted_output = torch.empty(total_slots, w2_n, dtype=torch.float16, device=device)
+    baseline_output = torch.empty(m, w2_n, dtype=torch.float16, device=device)
+
+    chunk_slots = chunk_tokens * top_k
+    chunk_output = torch.empty(chunk_slots, w2_n, dtype=torch.float16, device=device)
+    chunk_expert_offsets = torch.empty(
+        num_experts + 1, dtype=torch.int32, device=device
+    )
+    chunk_range_begin = torch.empty(num_experts, dtype=torch.int32, device=device)
+    chunk_range_end = torch.empty_like(chunk_range_begin)
+    chunk_a_indices = torch.empty(chunk_slots, dtype=torch.int32, device=device)
+    chunk_inv_permuted_idx = torch.empty_like(chunk_a_indices)
+    chunked_output = torch.empty_like(baseline_output)
+
+    def baseline() -> None:
+        sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+            sorted_output,
+            sorted_input,
+            expert_offsets,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            num_experts,
+            w2_k,
+            w2_n,
+            group_size,
+            False,
+        )
+        torch.ops._moe_C.moe_unpermute(
+            sorted_output,
+            topk_weights,
+            inv_permuted_idx,
+            None,
+            top_k,
+            baseline_output,
+        )
+
+    def chunked() -> None:
+        sm70_ops.awq_moe_chunked_w2_sm70_out(
+            chunked_output,
+            chunk_output,
+            sorted_input,
+            expert_offsets,
+            permuted_idx,
+            topk_weights,
+            chunk_expert_offsets,
+            chunk_range_begin,
+            chunk_range_end,
+            chunk_a_indices,
+            chunk_inv_permuted_idx,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            m,
+            top_k,
+            num_experts,
+            w2_k,
+            w2_n,
+            w2_n,
+            group_size,
+            chunk_tokens,
+        )
+
+    baseline()
+    chunked()
+    torch.cuda.synchronize()
+    first_chunked_output = chunked_output.clone()
+    chunked()
+    torch.cuda.synchronize()
+    mismatches = int((chunked_output != baseline_output).sum().item())
+    repeat_mismatches = int((chunked_output != first_chunked_output).sum().item())
+    bad_token_indices = torch.nonzero(
+        (chunked_output != baseline_output).any(dim=1), as_tuple=False
+    ).flatten()
+    max_abs_error = float(
+        (chunked_output.float() - baseline_output.float()).abs().max().item()
+    )
+    del first_chunked_output
+
+    graph_bitwise_equal = None
+    graph_repeat_bitwise_equal = None
+    if check_cuda_graph:
+        # Warm the dispatch cache before capture; graph replay must preserve the
+        # same route-order reduction result without any address changes.
+        chunked()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            chunked()
+        graph.replay()
+        torch.cuda.synchronize()
+        graph_first_output = chunked_output.clone()
+        graph_bitwise_equal = bool(torch.equal(chunked_output, baseline_output))
+        graph.replay()
+        torch.cuda.synchronize()
+        graph_repeat_bitwise_equal = bool(
+            torch.equal(chunked_output, graph_first_output)
+        )
+        del graph_first_output, graph
+
+    baseline_ms = _time_ms(baseline, warmups, iterations)
+    chunked_ms = _time_ms(chunked, warmups, iterations)
+    baseline_scratch_bytes = _tensor_bytes(sorted_output)
+    chunked_scratch_bytes = _tensor_bytes(
+        chunk_output,
+        chunk_expert_offsets,
+        chunk_range_begin,
+        chunk_range_end,
+        chunk_a_indices,
+        chunk_inv_permuted_idx,
+    )
+    return {
+        "m": m,
+        "top_k": top_k,
+        "total_slots": total_slots,
+        "expert_pattern": expert_pattern,
+        "bitwise_equal": mismatches == 0,
+        "mismatches": mismatches,
+        "bad_token_count": int(bad_token_indices.numel()),
+        "first_bad_token": (
+            int(bad_token_indices[0].item()) if bad_token_indices.numel() else None
+        ),
+        "last_bad_token": (
+            int(bad_token_indices[-1].item()) if bad_token_indices.numel() else None
+        ),
+        "nan_count": int(torch.isnan(chunked_output).sum().item()),
+        "repeat_bitwise_equal": repeat_mismatches == 0,
+        "repeat_mismatches": repeat_mismatches,
+        "cuda_graph_checked": check_cuda_graph,
+        "cuda_graph_bitwise_equal": graph_bitwise_equal,
+        "cuda_graph_repeat_bitwise_equal": graph_repeat_bitwise_equal,
+        "max_abs_error": max_abs_error,
+        "baseline_ms": baseline_ms,
+        "chunk_tokens": chunk_tokens,
+        "chunked_ms": chunked_ms,
+        "latency_ratio": chunked_ms / baseline_ms,
+        "baseline_scratch_bytes": baseline_scratch_bytes,
+        "chunked_scratch_bytes": chunked_scratch_bytes,
+        "scratch_bytes_saved": baseline_scratch_bytes - chunked_scratch_bytes,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--layer", default="model.language_model.layers.0.mlp.experts")
+    parser.add_argument("--m", type=int, nargs="+", default=[8192])
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--num-experts", type=int, default=512)
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument("--chunk-tokens", type=int, nargs="+", default=[4096])
+    parser.add_argument("--expert-pattern", default="random_unique:17")
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--check-cuda-graph", action="store_true")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This benchmark requires an SM70 GPU.")
+    if not hasattr(torch.ops._C, "awq_moe_chunked_w2_sm70_out"):
+        raise RuntimeError("The chunked W2 CUDA op is unavailable.")
+
+    loaded = _load_awq_moe_layer(args.model, args.layer, args.num_experts, device)
+    prepared = _prepare_awq_moe_checkpoint_for_tp(
+        loaded, args.tp_size, args.tp_rank, args.group_size
+    )
+    _, _, _, w2_qweight, w2_scales, w2_qzeros, group_size = prepared
+    w2_tm_weight, _, w2_ptrs_w, w2_ptrs_s, _, _ = _prepare_awq_moe_weights(
+        w2_qweight, w2_scales, w2_qzeros, group_size
+    )
+    w2_k = int(w2_tm_weight.shape[1])
+    w2_n = int(w2_qweight.shape[2]) * 8
+
+    results = [
+        _run_shape(
+            m,
+            args.top_k,
+            args.num_experts,
+            group_size,
+            args.expert_pattern,
+            device,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            w2_k,
+            w2_n,
+            chunk_tokens,
+            args.warmups,
+            args.iterations,
+            args.check_cuda_graph,
+        )
+        for m in args.m
+        for chunk_tokens in args.chunk_tokens
+    ]
+    report = {
+        "device": torch.cuda.get_device_name(device),
+        "device_capability": torch.cuda.get_device_capability(device),
+        "model": str(args.model),
+        "layer": args.layer,
+        "tp_size": args.tp_size,
+        "tp_rank": args.tp_rank,
+        "results": results,
+    }
+    encoded = json.dumps(report, indent=2, sort_keys=True)
+    print(encoded)
+    if args.json_out is not None:
+        args.json_out.write_text(encoded + "\n")
+    if not all(
+        result["bitwise_equal"]
+        and result["repeat_bitwise_equal"]
+        and (
+            not result["cuda_graph_checked"]
+            or (
+                result["cuda_graph_bitwise_equal"]
+                and result["cuda_graph_repeat_bitwise_equal"]
+            )
+        )
+        for result in results
+    ):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_sm70_turbomind_exactness.py
+++ b/benchmarks/benchmark_sm70_turbomind_exactness.py
@@ -36,6 +36,7 @@ Mode = Literal[
 ]
 MoEActual = Literal[
     "indexed_prefill",
+    "indexed_prefill_chunked_w2",
     "batched",
     "batched_per_expert_dispatch",
     "batched_w13_per_expert_dispatch",
@@ -722,7 +723,10 @@ def _classify_moe_results(
 
 
 def _stage_from_name(name: str) -> str:
-    match = re.search(r"_(w13_gate_up|silu_and_mul|w2_sorted_output)$", name)
+    match = re.search(
+        r"_(w13_gate_up|silu_and_mul|w2_sorted_output|final_weighted_output)$",
+        name,
+    )
     return match.group(1) if match else "unknown"
 
 
@@ -871,7 +875,14 @@ def _service_moe_permute_inputs(
     input: torch.Tensor,
     topk_ids: torch.Tensor,
     num_experts: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
     """Run both production MoE permute forms and prove their row mapping agrees."""
     for op_name in (
         "moe_permute_with_scratch",
@@ -976,6 +987,8 @@ def _service_moe_permute_inputs(
         input_row_indices,
         expert_offsets64.to(torch.int32),
         expert_offsets64,
+        metadata_scratch["inv_permuted_idx"],
+        metadata_scratch["permuted_idx"],
     )
 
 
@@ -1165,8 +1178,14 @@ def _check_awq_moe(
     _require_torch_op("awq_gemm_sm70")
     _require_torch_op("awq_moe_build_strided_ptrs")
     _require_torch_op("awq_moe_gemm_sm70_out")
-    if actual_impl == "indexed_prefill":
+    indexed_prefill_impl = actual_impl in (
+        "indexed_prefill",
+        "indexed_prefill_chunked_w2",
+    )
+    if indexed_prefill_impl:
         _require_torch_op("awq_moe_indexed_dense_w13_sm70_out")
+    if actual_impl == "indexed_prefill_chunked_w2":
+        _require_torch_op("awq_moe_chunked_w2_sm70_out")
     if actual_impl in (
         "batched",
         "batched_per_expert_dispatch",
@@ -1249,7 +1268,9 @@ def _check_awq_moe(
 
     hidden_size = int(w13_qweight.shape[1])
     input_row_indices = None
-    if actual_impl == "indexed_prefill":
+    inv_permuted_idx = None
+    permuted_idx = None
+    if indexed_prefill_impl:
         if (
             num_experts != 512
             or top_k != 10
@@ -1265,6 +1286,8 @@ def _check_awq_moe(
             input_row_indices,
             expert_offsets,
             expert_offsets64,
+            inv_permuted_idx,
+            permuted_idx,
         ) = _service_moe_permute_inputs(
             indexed_input,
             topk_ids,
@@ -1292,7 +1315,7 @@ def _check_awq_moe(
     single_token_offsets64 = None
     single_token_inv_permuted_idx = None
     single_token_sorted_expert_ids = None
-    if actual_impl == "indexed_prefill":
+    if indexed_prefill_impl:
         assert input_row_indices is not None
         sm70_ops.awq_moe_indexed_dense_w13_sm70_out(
             gate_up_actual,
@@ -1469,7 +1492,7 @@ def _check_awq_moe(
             w13_q_ld,
             w13_n,
         )
-    if actual_impl == "indexed_prefill":
+    if indexed_prefill_impl:
         gate_up_expected = torch.empty_like(gate_up_actual)
         sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
             gate_up_expected,
@@ -1509,11 +1532,63 @@ def _check_awq_moe(
         silu_and_mul(intermediate_actual, gate_up_actual)
     silu_and_mul(intermediate_expected, gate_up_expected)
 
-    if sorted_output_actual is None:
+    if sorted_output_actual is None and actual_impl != "indexed_prefill_chunked_w2":
         sorted_output_actual = torch.empty(
             (total_slots, hidden_out), dtype=torch.float16, device=device
         )
-    if actual_impl in ("batched", "batched_w13_per_expert_dispatch"):
+    if actual_impl == "indexed_prefill_chunked_w2":
+        assert inv_permuted_idx is not None
+        assert permuted_idx is not None
+        if m < 8192:
+            raise ValueError(
+                "indexed_prefill_chunked_w2 requires at least 8192 tokens."
+            )
+        topk_weights = _make_topk_weights(top_k, device).expand(m, -1).contiguous()
+        final_output_actual = torch.empty(
+            (m, hidden_size), dtype=torch.float16, device=device
+        )
+        chunk_tokens = 6144
+        tail_tokens = m % chunk_tokens
+        if 0 < tail_tokens < 2048:
+            raise ValueError(
+                "indexed_prefill_chunked_w2 requires an empty or at least "
+                "2048-token tail."
+            )
+        chunk_slots = chunk_tokens * top_k
+        chunk_output = torch.empty(
+            (chunk_slots, hidden_out), dtype=torch.float16, device=device
+        )
+        chunk_expert_offsets = torch.empty(
+            num_experts + 1, dtype=torch.int32, device=device
+        )
+        chunk_range_begin = torch.empty(num_experts, dtype=torch.int32, device=device)
+        chunk_range_end = torch.empty_like(chunk_range_begin)
+        chunk_a_indices = torch.empty(chunk_slots, dtype=torch.int32, device=device)
+        chunk_inv_permuted_idx = torch.empty_like(chunk_a_indices)
+        sm70_ops.awq_moe_chunked_w2_sm70_out(
+            final_output_actual,
+            chunk_output,
+            intermediate_actual,
+            expert_offsets,
+            permuted_idx,
+            topk_weights,
+            chunk_expert_offsets,
+            chunk_range_begin,
+            chunk_range_end,
+            chunk_a_indices,
+            chunk_inv_permuted_idx,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            m,
+            top_k,
+            num_experts,
+            int(w2_tm_weight.shape[1]),
+            hidden_out,
+            hidden_size,
+            group_size,
+            chunk_tokens,
+        )
+    elif actual_impl in ("batched", "batched_w13_per_expert_dispatch"):
         sm70_ops.awq_moe_gemm_sm70_out(
             sorted_output_actual,
             intermediate_actual,
@@ -1616,8 +1691,10 @@ def _check_awq_moe(
             w2_q_ld,
             hidden_out,
         )
-    if actual_impl == "indexed_prefill":
-        sorted_output_expected = torch.empty_like(sorted_output_actual)
+    if indexed_prefill_impl:
+        sorted_output_expected = torch.empty(
+            (total_slots, hidden_out), dtype=torch.float16, device=device
+        )
         sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
             sorted_output_expected,
             intermediate_expected,
@@ -1641,7 +1718,19 @@ def _check_awq_moe(
             w2_q_ld,
             hidden_out,
         )
-    if actual_impl == "legacy_single_token_compact":
+    if actual_impl == "indexed_prefill_chunked_w2":
+        assert inv_permuted_idx is not None
+        assert final_output_actual is not None
+        final_output_expected = torch.empty_like(final_output_actual)
+        torch.ops._moe_C.moe_unpermute(
+            sorted_output_expected,
+            topk_weights,
+            inv_permuted_idx,
+            None,
+            top_k,
+            final_output_expected,
+        )
+    elif actual_impl == "legacy_single_token_compact":
         assert final_output_actual is not None
         assert single_token_inv_permuted_idx is not None
         topk_weights = _make_topk_weights(top_k, device)
@@ -1693,7 +1782,10 @@ def _check_awq_moe(
             layer=awq_moe_layer,
         )
     )
-    if actual_impl != "legacy_single_token_compact":
+    if actual_impl not in (
+        "legacy_single_token_compact",
+        "indexed_prefill_chunked_w2",
+    ):
         results.append(
             _with_moe_metadata(
                 _stats(
@@ -1738,7 +1830,7 @@ def _check_awq_moe(
                 "weight_scale_dtype": str(w13_scales.dtype),
                 "reference_impl": (
                     "materialized_per_expert_dispatch"
-                    if actual_impl == "indexed_prefill"
+                    if indexed_prefill_impl
                     else "per_expert_dense"
                 ),
             }
@@ -2866,6 +2958,7 @@ def _parse_args() -> argparse.Namespace:
         "--awq-moe-actual",
         choices=[
             "indexed_prefill",
+            "indexed_prefill_chunked_w2",
             "batched",
             "batched_per_expert_dispatch",
             "batched_w13_per_expert_dispatch",

--- a/benchmarks/benchmark_sm70_turbomind_exactness.py
+++ b/benchmarks/benchmark_sm70_turbomind_exactness.py
@@ -19,6 +19,11 @@ import torch
 
 import vllm._custom_ops as ops
 from vllm import _sm70_ops as sm70_ops
+from vllm import envs
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _align_awq_input_dim,
+    _align_awq_output_dim,
+)
 
 Mode = Literal[
     "all",
@@ -30,6 +35,7 @@ Mode = Literal[
     "awq_moe_compile",
 ]
 MoEActual = Literal[
+    "indexed_prefill",
     "batched",
     "batched_per_expert_dispatch",
     "batched_w13_per_expert_dispatch",
@@ -137,7 +143,11 @@ def _load_awq_layer(
     with safe_open(model_path / filename, framework="pt", device="cpu") as f:
         qweight = f.get_tensor(f"{layer_prefix}.qweight").to(device).contiguous()
         qzeros = f.get_tensor(f"{layer_prefix}.qzeros").to(device).contiguous()
-        scales = f.get_tensor(f"{layer_prefix}.scales").to(device).contiguous()
+        scales = (
+            f.get_tensor(f"{layer_prefix}.scales")
+            .to(device=device, dtype=torch.float16)
+            .contiguous()
+        )
     return qweight, scales, qzeros
 
 
@@ -214,11 +224,113 @@ def _load_awq_moe_layer(
 
     return (
         torch.stack(w13_qweights),
-        torch.stack(w13_scales),
+        torch.stack(w13_scales).half(),
         torch.stack(w13_qzeros),
         torch.stack(w2_qweights),
-        torch.stack(w2_scales),
+        torch.stack(w2_scales).half(),
         torch.stack(w2_qzeros),
+    )
+
+
+def _prepare_awq_moe_checkpoint_for_tp(
+    tensors: tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    tp_size: int,
+    tp_rank: int,
+    checkpoint_group_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    int,
+]:
+    if tp_size <= 0 or not 0 <= tp_rank < tp_size:
+        raise ValueError("Invalid AWQ MoE TP size or rank.")
+    w13_qweight, w13_scales, w13_qzeros, w2_qweight, w2_scales, w2_qzeros = tensors
+    hidden_size = int(w13_qweight.shape[-2])
+    intermediate_size = int(w13_scales.shape[-1]) // 2
+    if intermediate_size % tp_size:
+        raise ValueError("AWQ intermediate size cannot be evenly sharded for TP.")
+    intermediate_size_per_partition = intermediate_size // tp_size
+    group_size = checkpoint_group_size
+    if hidden_size % group_size or intermediate_size_per_partition % group_size:
+        raise ValueError("AWQ dimensions must be divisible by the checkpoint group.")
+
+    w13_q_half = w13_qweight.shape[-1] // 2
+    w13_n_half = w13_scales.shape[-1] // 2
+    if w13_q_half % tp_size or w13_n_half % tp_size:
+        raise ValueError("AWQ W13 output cannot be evenly sharded for TP.")
+    q_start = tp_rank * (w13_q_half // tp_size)
+    q_end = (tp_rank + 1) * (w13_q_half // tp_size)
+    n_start = tp_rank * (w13_n_half // tp_size)
+    n_end = (tp_rank + 1) * (w13_n_half // tp_size)
+    w13_qweight = torch.cat(
+        (
+            w13_qweight[..., q_start:q_end],
+            w13_qweight[..., w13_q_half + q_start : w13_q_half + q_end],
+        ),
+        dim=-1,
+    ).contiguous()
+    w13_qzeros = torch.cat(
+        (
+            w13_qzeros[..., q_start:q_end],
+            w13_qzeros[..., w13_q_half + q_start : w13_q_half + q_end],
+        ),
+        dim=-1,
+    ).contiguous()
+    w13_scales = torch.cat(
+        (
+            w13_scales[..., n_start:n_end],
+            w13_scales[..., w13_n_half + n_start : w13_n_half + n_end],
+        ),
+        dim=-1,
+    ).contiguous()
+
+    w2_k = w2_qweight.shape[-2]
+    if w2_k % tp_size or (w2_k // tp_size) % group_size:
+        raise ValueError("AWQ W2 input cannot be evenly sharded by groups for TP.")
+    k_start = tp_rank * (w2_k // tp_size)
+    k_end = (tp_rank + 1) * (w2_k // tp_size)
+    group_start = k_start // group_size
+    group_end = k_end // group_size
+    w13_qweight, w13_scales, w13_qzeros, _ = _align_awq_output_dim(
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        8,
+        group_size * 2,
+    )
+    w2_qweight, w2_scales, w2_qzeros, _ = _align_awq_input_dim(
+        w2_qweight[..., k_start:k_end, :].contiguous(),
+        w2_scales[..., group_start:group_end, :].contiguous(),
+        w2_qzeros[..., group_start:group_end, :].contiguous(),
+        group_size,
+        group_size,
+    )
+    w2_qweight, w2_scales, w2_qzeros, _ = _align_awq_output_dim(
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+        8,
+        group_size,
+    )
+    return (
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+        group_size,
     )
 
 
@@ -755,6 +867,118 @@ def _expert_offsets(
     return offsets64.to(torch.int32), offsets64
 
 
+def _service_moe_permute_inputs(
+    input: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run both production MoE permute forms and prove their row mapping agrees."""
+    for op_name in (
+        "moe_permute_with_scratch",
+        "moe_permute_metadata_with_scratch",
+        "moe_permute_sort_workspace_size",
+    ):
+        if not hasattr(torch.ops._moe_C, op_name):
+            raise RuntimeError(f"Required torch op _moe_C.{op_name} is unavailable.")
+
+    num_tokens, hidden_size = input.shape
+    topk_ids_i32 = topk_ids.to(torch.int32).contiguous()
+    top_k = int(topk_ids_i32.shape[1])
+    total_slots = num_tokens * top_k
+    token_expert_indices = torch.arange(
+        total_slots, dtype=torch.int32, device=input.device
+    ).view(num_tokens, top_k)
+    workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+        total_slots, num_experts
+    )
+
+    def _scratch() -> dict[str, torch.Tensor]:
+        return {
+            "expert_offsets64": torch.empty(
+                num_experts + 1, dtype=torch.int64, device=input.device
+            ),
+            "inv_permuted_idx": torch.empty(
+                num_tokens, top_k, dtype=torch.int32, device=input.device
+            ),
+            "permuted_idx": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "sort_workspace": torch.empty(
+                workspace_size, dtype=torch.int8, device=input.device
+            ),
+            "permuted_experts_id": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "sorted_row_idx": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+            "topk_ids_for_sort": torch.empty(
+                total_slots, dtype=torch.int32, device=input.device
+            ),
+        }
+
+    materialized = torch.empty(
+        total_slots, hidden_size, dtype=input.dtype, device=input.device
+    )
+    materialized_scratch = _scratch()
+    torch.ops._moe_C.moe_permute_with_scratch(
+        input,
+        topk_ids_i32,
+        token_expert_indices,
+        None,
+        num_experts,
+        num_experts,
+        top_k,
+        materialized,
+        materialized_scratch["expert_offsets64"],
+        materialized_scratch["inv_permuted_idx"],
+        materialized_scratch["permuted_idx"],
+        materialized_scratch["sort_workspace"],
+        materialized_scratch["permuted_experts_id"],
+        materialized_scratch["sorted_row_idx"],
+        materialized_scratch["topk_ids_for_sort"],
+    )
+
+    metadata_scratch = _scratch()
+    input_row_indices = torch.empty(total_slots, dtype=torch.int32, device=input.device)
+    torch.ops._moe_C.moe_permute_metadata_with_scratch(
+        input,
+        topk_ids_i32,
+        token_expert_indices,
+        None,
+        num_experts,
+        num_experts,
+        top_k,
+        metadata_scratch["expert_offsets64"],
+        metadata_scratch["inv_permuted_idx"],
+        metadata_scratch["permuted_idx"],
+        input_row_indices,
+        metadata_scratch["sort_workspace"],
+        metadata_scratch["permuted_experts_id"],
+        metadata_scratch["sorted_row_idx"],
+        metadata_scratch["topk_ids_for_sort"],
+    )
+
+    if not torch.equal(
+        materialized_scratch["expert_offsets64"],
+        metadata_scratch["expert_offsets64"],
+    ):
+        raise AssertionError("Materialized and metadata MoE expert offsets differ.")
+    gathered = input[input_row_indices.to(torch.int64)]
+    if not torch.equal(materialized, gathered):
+        raise AssertionError(
+            "Metadata-only MoE row indices do not reproduce production permute."
+        )
+
+    expert_offsets64 = metadata_scratch["expert_offsets64"]
+    return (
+        materialized,
+        input_row_indices,
+        expert_offsets64.to(torch.int32),
+        expert_offsets64,
+    )
+
+
 def _make_logical_expert_ids(
     total_slots: int,
     num_experts: int,
@@ -934,11 +1158,15 @@ def _check_awq_moe(
     top_k: int,
     actual_impl: MoEActual,
     expert_pattern: str,
+    tp_size: int,
+    tp_rank: int,
 ) -> list[dict[str, Any]]:
     _require_torch_op("awq_sm70_prepare")
     _require_torch_op("awq_gemm_sm70")
     _require_torch_op("awq_moe_build_strided_ptrs")
     _require_torch_op("awq_moe_gemm_sm70_out")
+    if actual_impl == "indexed_prefill":
+        _require_torch_op("awq_moe_indexed_dense_w13_sm70_out")
     if actual_impl in (
         "batched",
         "batched_per_expert_dispatch",
@@ -965,6 +1193,8 @@ def _check_awq_moe(
         if m != 1:
             raise ValueError(f"{actual_impl} AWQ MoE check requires --m 1.")
 
+    checkpoint_group_size = group_size
+    loaded = _load_awq_moe_layer(awq_moe_model, awq_moe_layer, num_experts, device)
     (
         w13_qweight,
         w13_scales,
@@ -972,33 +1202,38 @@ def _check_awq_moe(
         w2_qweight,
         w2_scales,
         w2_qzeros,
-    ) = _load_awq_moe_layer(awq_moe_model, awq_moe_layer, num_experts, device)
+        group_size,
+    ) = _prepare_awq_moe_checkpoint_for_tp(
+        loaded,
+        tp_size,
+        tp_rank,
+        checkpoint_group_size,
+    )
+
+    w13_interleaved = bool(
+        actual_impl == "legacy_single_token_compact"
+        or (
+            envs.VLLM_SM70_AWQ_MOE_BATCHED_GEMM
+            and envs.VLLM_SM70_AWQ_MOE_LEGACY_SINGLE_TOKEN_COMPACT
+            and hasattr(torch.ops._C, "awq_moe_single_token_sm70_out")
+        )
+    )
 
     w13_tm_weight, w13_tm_scales, w13_ptrs_w, w13_ptrs_s, w13_k_ld, w13_q_ld = (
-        _prepare_awq_moe_weights(w13_qweight, w13_scales, w13_qzeros, group_size)
-    )
-    w2_tm_weight, w2_tm_scales, w2_ptrs_w, w2_ptrs_s, w2_k_ld, w2_q_ld = (
-        _prepare_awq_moe_weights(w2_qweight, w2_scales, w2_qzeros, group_size)
-    )
-    if actual_impl == "legacy_single_token_compact":
-        (
-            _w13_legacy_tm_weight,
-            _w13_legacy_tm_scales,
-            w13_legacy_ptrs_w,
-            w13_legacy_ptrs_s,
-            _w13_legacy_k_ld,
-            _w13_legacy_q_ld,
-        ) = _prepare_awq_moe_weights(
+        _prepare_awq_moe_weights(
             w13_qweight,
             w13_scales,
             w13_qzeros,
             group_size,
-            interleave_gated_silu=True,
+            interleave_gated_silu=w13_interleaved,
         )
-    else:
-        _w13_legacy_tm_weight = w13_tm_weight
-        w13_legacy_ptrs_w = w13_ptrs_w
-        w13_legacy_ptrs_s = w13_ptrs_s
+    )
+    w2_tm_weight, w2_tm_scales, w2_ptrs_w, w2_ptrs_s, w2_k_ld, w2_q_ld = (
+        _prepare_awq_moe_weights(w2_qweight, w2_scales, w2_qzeros, group_size)
+    )
+    _w13_legacy_tm_weight = w13_tm_weight
+    w13_legacy_ptrs_w = w13_ptrs_w
+    w13_legacy_ptrs_s = w13_ptrs_s
 
     total_slots = m * top_k
     logical_expert_ids = _make_logical_expert_ids(
@@ -1013,7 +1248,29 @@ def _check_awq_moe(
     dense_expert_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
 
     hidden_size = int(w13_qweight.shape[1])
-    if actual_impl in AWQ_SINGLE_TOKEN_ACTUALS:
+    input_row_indices = None
+    if actual_impl == "indexed_prefill":
+        if (
+            num_experts != 512
+            or top_k != 10
+            or checkpoint_group_size != 32
+            or group_size != 32
+        ):
+            raise ValueError(
+                "indexed_prefill requires the Qwen3.8 E512/K10 AWQ g32 contract."
+            )
+        indexed_input = _make_input(m, hidden_size, device)
+        (
+            sorted_input,
+            input_row_indices,
+            expert_offsets,
+            expert_offsets64,
+        ) = _service_moe_permute_inputs(
+            indexed_input,
+            topk_ids,
+            num_experts,
+        )
+    elif actual_impl in AWQ_SINGLE_TOKEN_ACTUALS:
         single_token_input = _make_input(1, hidden_size, device)
         sorted_input = single_token_input.expand(total_slots, hidden_size).contiguous()
         sorted_input = sorted_input[order]
@@ -1035,7 +1292,22 @@ def _check_awq_moe(
     single_token_offsets64 = None
     single_token_inv_permuted_idx = None
     single_token_sorted_expert_ids = None
-    if actual_impl in (
+    if actual_impl == "indexed_prefill":
+        assert input_row_indices is not None
+        sm70_ops.awq_moe_indexed_dense_w13_sm70_out(
+            gate_up_actual,
+            indexed_input,
+            input_row_indices,
+            expert_offsets,
+            dense_expert_ids,
+            w13_ptrs_w,
+            w13_ptrs_s,
+            num_experts,
+            int(w13_tm_weight.shape[1]),
+            w13_n,
+            group_size,
+        )
+    elif actual_impl in (
         "batched",
         "batched_per_expert_dispatch",
         "batched_w13_per_expert_dispatch",
@@ -1197,25 +1469,45 @@ def _check_awq_moe(
             w13_q_ld,
             w13_n,
         )
-    gate_up_expected = _dense_awq_moe_stage(
-        sorted_input,
-        expert_offsets64,
-        w13_tm_weight,
-        w13_tm_scales,
-        group_size,
-        w13_k_ld,
-        w13_q_ld,
-        w13_n,
-    )
+    if actual_impl == "indexed_prefill":
+        gate_up_expected = torch.empty_like(gate_up_actual)
+        sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+            gate_up_expected,
+            sorted_input,
+            expert_offsets,
+            w13_ptrs_w,
+            w13_ptrs_s,
+            num_experts,
+            int(w13_tm_weight.shape[1]),
+            w13_n,
+            group_size,
+            False,
+        )
+    else:
+        gate_up_expected = _dense_awq_moe_stage(
+            sorted_input,
+            expert_offsets64,
+            w13_tm_weight,
+            w13_tm_scales,
+            group_size,
+            w13_k_ld,
+            w13_q_ld,
+            w13_n,
+        )
 
     if intermediate_actual is None:
         intermediate_actual = torch.empty(
             (total_slots, intermediate_size), dtype=torch.float16, device=device
         )
     intermediate_expected = torch.empty_like(intermediate_actual)
+    silu_and_mul = (
+        sm70_ops.silu_and_mul_interleaved
+        if w13_interleaved
+        else torch.ops._C.silu_and_mul
+    )
     if actual_impl != "legacy_single_token_compact":
-        torch.ops._C.silu_and_mul(intermediate_actual, gate_up_actual)
-    torch.ops._C.silu_and_mul(intermediate_expected, gate_up_expected)
+        silu_and_mul(intermediate_actual, gate_up_actual)
+    silu_and_mul(intermediate_expected, gate_up_expected)
 
     if sorted_output_actual is None:
         sorted_output_actual = torch.empty(
@@ -1235,6 +1527,7 @@ def _check_awq_moe(
             False,
         )
     elif actual_impl in (
+        "indexed_prefill",
         "batched_per_expert_dispatch",
         "batched_w2_per_expert_dispatch",
     ):
@@ -1323,16 +1616,31 @@ def _check_awq_moe(
             w2_q_ld,
             hidden_out,
         )
-    sorted_output_expected = _dense_awq_moe_stage(
-        intermediate_expected,
-        expert_offsets64,
-        w2_tm_weight,
-        w2_tm_scales,
-        group_size,
-        w2_k_ld,
-        w2_q_ld,
-        hidden_out,
-    )
+    if actual_impl == "indexed_prefill":
+        sorted_output_expected = torch.empty_like(sorted_output_actual)
+        sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+            sorted_output_expected,
+            intermediate_expected,
+            expert_offsets,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            num_experts,
+            int(w2_tm_weight.shape[1]),
+            hidden_out,
+            group_size,
+            False,
+        )
+    else:
+        sorted_output_expected = _dense_awq_moe_stage(
+            intermediate_expected,
+            expert_offsets64,
+            w2_tm_weight,
+            w2_tm_scales,
+            group_size,
+            w2_k_ld,
+            w2_q_ld,
+            hidden_out,
+        )
     if actual_impl == "legacy_single_token_compact":
         assert final_output_actual is not None
         assert single_token_inv_permuted_idx is not None
@@ -1418,6 +1726,22 @@ def _check_awq_moe(
                 stage="final_weighted_output",
                 layer=awq_moe_layer,
             )
+        )
+    for result in results:
+        result.update(
+            {
+                "checkpoint_group_size": checkpoint_group_size,
+                "effective_group_size": group_size,
+                "tp_size": tp_size,
+                "tp_rank": tp_rank,
+                "w13_interleaved": w13_interleaved,
+                "weight_scale_dtype": str(w13_scales.dtype),
+                "reference_impl": (
+                    "materialized_per_expert_dispatch"
+                    if actual_impl == "indexed_prefill"
+                    else "per_expert_dense"
+                ),
+            }
         )
     return results
 
@@ -2536,9 +2860,12 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--awq-moe-num-experts", type=int, default=256)
     parser.add_argument("--awq-moe-top-k", type=int, default=8)
+    parser.add_argument("--awq-moe-tp-size", type=int, default=1)
+    parser.add_argument("--awq-moe-tp-rank", type=int, default=0)
     parser.add_argument(
         "--awq-moe-actual",
         choices=[
+            "indexed_prefill",
             "batched",
             "batched_per_expert_dispatch",
             "batched_w13_per_expert_dispatch",
@@ -2723,6 +3050,8 @@ def main() -> int:
                             args.awq_moe_top_k,
                             awq_moe_actual,
                             moe_expert_pattern,
+                            args.awq_moe_tp_size,
+                            args.awq_moe_tp_rank,
                         )
                     )
         if mode == "awq_moe_graph_replay":
@@ -2789,6 +3118,8 @@ def main() -> int:
         "awq_moe_layers": awq_moe_layers,
         "awq_moe_num_experts": args.awq_moe_num_experts,
         "awq_moe_top_k": args.awq_moe_top_k,
+        "awq_moe_tp_size": args.awq_moe_tp_size,
+        "awq_moe_tp_rank": args.awq_moe_tp_rank,
         "awq_moe_actual": awq_moe_actual,
         "awq_moe_dispatch_policy_env": os.getenv("VLLM_SM70_AWQ_MOE_DISPATCH_POLICY"),
         "fp8_model": str(args.fp8_model) if args.fp8_model else None,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -423,6 +423,12 @@ void awq_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
+void awq_moe_indexed_dense_w13_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size);
+
 void awq_moe_active_dense_stage_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor permuted_experts_id,
     torch::Tensor active_expert_offsets, torch::Tensor active_expert_ids,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -435,6 +435,16 @@ void awq_moe_active_dense_stage_sm70_out(
     torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t total_slots, int64_t k,
     int64_t n, int64_t group_size);
 
+void awq_moe_chunked_w2_sm70_out(
+    torch::Tensor out, torch::Tensor chunk_output, torch::Tensor input,
+    torch::Tensor expert_offsets, torch::Tensor permuted_idx,
+    torch::Tensor topk_weights, torch::Tensor chunk_expert_offsets,
+    torch::Tensor chunk_range_begin, torch::Tensor chunk_range_end,
+    torch::Tensor chunk_a_indices, torch::Tensor chunk_inv_permuted_idx,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_tokens,
+    int64_t top_k, int64_t num_experts, int64_t k, int64_t n,
+    int64_t hidden_logical_size, int64_t group_size, int64_t chunk_tokens);
+
 void awq_moe_single_token_dense_stage_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
     torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -7780,6 +7780,263 @@ void awq_moe_active_dense_stage_sm70_out(
   }
 }
 
+namespace {
+
+__device__ __forceinline__ int awq_moe_lower_bound_source_row(
+    const int* __restrict__ permuted_idx, int begin, int end, int target) {
+  while (begin < end) {
+    const int middle = begin + (end - begin) / 2;
+    if (permuted_idx[middle] < target) {
+      begin = middle + 1;
+    } else {
+      end = middle;
+    }
+  }
+  return begin;
+}
+
+__global__ void awq_moe_chunk_ranges_kernel(
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ permuted_idx,
+    int* __restrict__ chunk_expert_offsets, int* __restrict__ chunk_range_begin,
+    int* __restrict__ chunk_range_end, int num_experts, int source_begin,
+    int source_end) {
+  const int expert = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (expert >= num_experts) {
+    return;
+  }
+
+  const int expert_begin = expert_offsets[expert];
+  const int expert_end = expert_offsets[expert + 1];
+  const int range_begin = awq_moe_lower_bound_source_row(
+      permuted_idx, expert_begin, expert_end, source_begin);
+  const int range_end = awq_moe_lower_bound_source_row(
+      permuted_idx, range_begin, expert_end, source_end);
+  chunk_range_begin[expert] = range_begin;
+  chunk_range_end[expert] = range_end;
+  chunk_expert_offsets[expert + 1] = range_end - range_begin;
+}
+
+__global__ void awq_moe_prefix_chunk_offsets_kernel(
+    int* __restrict__ chunk_expert_offsets, int num_experts) {
+  int prefix = 0;
+  chunk_expert_offsets[0] = 0;
+  for (int expert = 0; expert < num_experts; ++expert) {
+    prefix += chunk_expert_offsets[expert + 1];
+    chunk_expert_offsets[expert + 1] = prefix;
+  }
+}
+
+__global__ void awq_moe_fill_chunk_indices_kernel(
+    const int* __restrict__ permuted_idx,
+    const int* __restrict__ chunk_expert_offsets,
+    const int* __restrict__ chunk_range_begin,
+    const int* __restrict__ chunk_range_end, int* __restrict__ chunk_a_indices,
+    int* __restrict__ chunk_inv_permuted_idx, int source_begin) {
+  const int expert = static_cast<int>(blockIdx.x);
+  const int range_begin = chunk_range_begin[expert];
+  const int range_end = chunk_range_end[expert];
+  const int chunk_begin = chunk_expert_offsets[expert];
+  for (int global_row = range_begin + threadIdx.x; global_row < range_end;
+       global_row += blockDim.x) {
+    const int chunk_row = chunk_begin + global_row - range_begin;
+    const int local_source_row = permuted_idx[global_row] - source_begin;
+    chunk_a_indices[chunk_row] = global_row;
+    chunk_inv_permuted_idx[local_source_row] = chunk_row;
+  }
+}
+
+__global__ void awq_moe_chunk_weighted_reduce_kernel(
+    __half* __restrict__ out, const __half* __restrict__ chunk_output,
+    const float* __restrict__ topk_weights,
+    const int* __restrict__ chunk_inv_permuted_idx, int output_token_begin,
+    int chunk_tokens, int top_k, int hidden_logical_size, int out_stride,
+    int chunk_output_stride) {
+  const int local_token = static_cast<int>(blockIdx.x);
+  if (local_token >= chunk_tokens) {
+    return;
+  }
+  const int output_token = output_token_begin + local_token;
+  for (int col = threadIdx.x; col < hidden_logical_size; col += blockDim.x) {
+    float reduced = 0.0f;
+    for (int route = 0; route < top_k; ++route) {
+      const int source_row = local_token * top_k + route;
+      const int chunk_row = chunk_inv_permuted_idx[source_row];
+      const float value = __half2float(
+          chunk_output[static_cast<int64_t>(chunk_row) * chunk_output_stride +
+                       col]);
+      const float weight = topk_weights[output_token * top_k + route];
+      reduced = fmaf(weight, value, reduced);
+    }
+    out[static_cast<int64_t>(output_token) * out_stride + col] =
+        __float2half_rn(reduced);
+  }
+}
+
+}  // namespace
+
+void awq_moe_chunked_w2_sm70_out(
+    torch::Tensor out, torch::Tensor chunk_output, torch::Tensor input,
+    torch::Tensor expert_offsets, torch::Tensor permuted_idx,
+    torch::Tensor topk_weights, torch::Tensor chunk_expert_offsets,
+    torch::Tensor chunk_range_begin, torch::Tensor chunk_range_end,
+    torch::Tensor chunk_a_indices, torch::Tensor chunk_inv_permuted_idx,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_tokens,
+    int64_t top_k, int64_t num_experts, int64_t k, int64_t n,
+    int64_t hidden_logical_size, int64_t group_size, int64_t chunk_tokens) {
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat16 &&
+                  out.is_contiguous(),
+              "awq_moe_chunked_w2_sm70_out: out must be contiguous CUDA "
+              "float16.");
+  TORCH_CHECK(chunk_output.is_cuda() &&
+                  chunk_output.scalar_type() == torch::kFloat16 &&
+                  chunk_output.is_contiguous(),
+              "awq_moe_chunked_w2_sm70_out: chunk output must be "
+              "contiguous CUDA float16.");
+  TORCH_CHECK(input.is_cuda() && input.scalar_type() == torch::kFloat16 &&
+                  input.is_contiguous(),
+              "awq_moe_chunked_w2_sm70_out: input must be contiguous "
+              "CUDA float16.");
+  TORCH_CHECK(expert_offsets.is_cuda() &&
+                  expert_offsets.scalar_type() == torch::kInt32 &&
+                  expert_offsets.is_contiguous() && permuted_idx.is_cuda() &&
+                  permuted_idx.scalar_type() == torch::kInt32 &&
+                  permuted_idx.is_contiguous() && topk_weights.is_cuda() &&
+                  topk_weights.scalar_type() == torch::kFloat32 &&
+                  topk_weights.is_contiguous(),
+              "awq_moe_chunked_w2_sm70_out: route metadata dtype/device "
+              "mismatch.");
+  TORCH_CHECK(
+      chunk_expert_offsets.is_cuda() &&
+          chunk_expert_offsets.scalar_type() == torch::kInt32 &&
+          chunk_expert_offsets.is_contiguous() && chunk_range_begin.is_cuda() &&
+          chunk_range_begin.scalar_type() == torch::kInt32 &&
+          chunk_range_begin.is_contiguous() && chunk_range_end.is_cuda() &&
+          chunk_range_end.scalar_type() == torch::kInt32 &&
+          chunk_range_end.is_contiguous() && chunk_a_indices.is_cuda() &&
+          chunk_a_indices.scalar_type() == torch::kInt32 &&
+          chunk_a_indices.is_contiguous() && chunk_inv_permuted_idx.is_cuda() &&
+          chunk_inv_permuted_idx.scalar_type() == torch::kInt32 &&
+          chunk_inv_permuted_idx.is_contiguous(),
+      "awq_moe_chunked_w2_sm70_out: chunk scratch must be "
+      "contiguous CUDA int32.");
+  TORCH_CHECK(ptrs_w.is_cuda() && ptrs_s.is_cuda(),
+              "awq_moe_chunked_w2_sm70_out: weight metadata must be CUDA.");
+  TORCH_CHECK(num_tokens >= 8192 && top_k > 0 && num_experts > 0 && k > 0 &&
+                  n > 0 && group_size > 0 &&
+                  (chunk_tokens == 4096 || chunk_tokens == 6144) &&
+                  chunk_tokens < num_tokens && hidden_logical_size > 0 &&
+                  hidden_logical_size <= n,
+              "awq_moe_chunked_w2_sm70_out: invalid dimensions.");
+  constexpr int64_t kIntMax = std::numeric_limits<int>::max();
+  TORCH_CHECK(num_tokens <= kIntMax / top_k && num_experts <= kIntMax &&
+                  k <= kIntMax && n <= kIntMax &&
+                  hidden_logical_size <= kIntMax && group_size <= kIntMax &&
+                  chunk_tokens <= kIntMax,
+              "awq_moe_chunked_w2_sm70_out: dimensions exceed int32.");
+  const int64_t total_slots = num_tokens * top_k;
+  const int64_t max_chunk_slots = std::min(num_tokens, chunk_tokens) * top_k;
+  constexpr int64_t kMinIndexedChunkTokens = 2048;
+  const int64_t tail_tokens = num_tokens % chunk_tokens;
+  TORCH_CHECK(
+      tail_tokens == 0 || tail_tokens >= kMinIndexedChunkTokens,
+      "awq_moe_chunked_w2_sm70_out: a non-empty tail chunk must contain at "
+      "least 2048 tokens.");
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(0) == num_tokens &&
+          out.size(1) == hidden_logical_size && input.dim() == 2 &&
+          input.size(0) == total_slots && input.size(1) == k &&
+          expert_offsets.dim() == 1 &&
+          expert_offsets.numel() == num_experts + 1 &&
+          permuted_idx.dim() == 1 && permuted_idx.numel() == total_slots &&
+          topk_weights.dim() == 2 && topk_weights.size(0) == num_tokens &&
+          topk_weights.size(1) == top_k,
+      "awq_moe_chunked_w2_sm70_out: input/metadata shape "
+      "mismatch.");
+  TORCH_CHECK(
+      chunk_output.dim() == 2 && chunk_output.size(0) >= max_chunk_slots &&
+          chunk_output.size(1) == n && chunk_expert_offsets.dim() == 1 &&
+          chunk_expert_offsets.numel() >= num_experts + 1 &&
+          chunk_range_begin.dim() == 1 &&
+          chunk_range_begin.numel() >= num_experts &&
+          chunk_range_end.dim() == 1 &&
+          chunk_range_end.numel() >= num_experts &&
+          chunk_a_indices.dim() == 1 &&
+          chunk_a_indices.numel() >= max_chunk_slots &&
+          chunk_inv_permuted_idx.dim() == 1 &&
+          chunk_inv_permuted_idx.numel() >= max_chunk_slots,
+      "awq_moe_chunked_w2_sm70_out: scratch/output too small.");
+
+  const int device = input.get_device();
+  TORCH_CHECK(
+      out.get_device() == device && chunk_output.get_device() == device &&
+          expert_offsets.get_device() == device &&
+          permuted_idx.get_device() == device &&
+          topk_weights.get_device() == device &&
+          chunk_expert_offsets.get_device() == device &&
+          chunk_range_begin.get_device() == device &&
+          chunk_range_end.get_device() == device &&
+          chunk_a_indices.get_device() == device &&
+          chunk_inv_permuted_idx.get_device() == device &&
+          ptrs_w.get_device() == device && ptrs_s.get_device() == device,
+      "awq_moe_chunked_w2_sm70_out: tensors must share a device.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  constexpr int kThreads = 256;
+  const int range_blocks =
+      static_cast<int>((num_experts + kThreads - 1) / kThreads);
+
+  // The production permutation is a stable expert-major sort, so source route
+  // indices remain ascending inside each expert segment. Intersecting every
+  // segment with a contiguous source-route interval therefore keeps the GEMM
+  // expert-major while allowing the final reduction to replay route 0..top_k-1
+  // in exactly the same FP32 order as moe_unpermute.
+  for (int64_t token_begin = 0; token_begin < num_tokens;
+       token_begin += chunk_tokens) {
+    const int64_t current_tokens =
+        std::min(chunk_tokens, num_tokens - token_begin);
+    const int64_t current_slots = current_tokens * top_k;
+    const int64_t source_begin = token_begin * top_k;
+    const int64_t source_end = source_begin + current_slots;
+
+    awq_moe_chunk_ranges_kernel<<<range_blocks, kThreads, 0, stream>>>(
+        expert_offsets.data_ptr<int>(), permuted_idx.data_ptr<int>(),
+        chunk_expert_offsets.data_ptr<int>(), chunk_range_begin.data_ptr<int>(),
+        chunk_range_end.data_ptr<int>(), static_cast<int>(num_experts),
+        static_cast<int>(source_begin), static_cast<int>(source_end));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    awq_moe_prefix_chunk_offsets_kernel<<<1, 1, 0, stream>>>(
+        chunk_expert_offsets.data_ptr<int>(), static_cast<int>(num_experts));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    awq_moe_fill_chunk_indices_kernel<<<num_experts, kThreads, 0, stream>>>(
+        permuted_idx.data_ptr<int>(), chunk_expert_offsets.data_ptr<int>(),
+        chunk_range_begin.data_ptr<int>(), chunk_range_end.data_ptr<int>(),
+        chunk_a_indices.data_ptr<int>(), chunk_inv_permuted_idx.data_ptr<int>(),
+        static_cast<int>(source_begin));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    awq_moe_gemm_sm70_out_impl(
+        chunk_output.narrow(0, 0, current_slots), input, chunk_expert_offsets,
+        ptrs_w, ptrs_s, num_experts, k, n, group_size, false, torch::Tensor(),
+        false, torch::Tensor(), torch::Tensor(), false, current_slots,
+        chunk_a_indices);
+
+    awq_moe_chunk_weighted_reduce_kernel<<<current_tokens, kThreads, 0,
+                                           stream>>>(
+        reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
+        reinterpret_cast<const __half*>(chunk_output.data_ptr<at::Half>()),
+        topk_weights.data_ptr<float>(), chunk_inv_permuted_idx.data_ptr<int>(),
+        static_cast<int>(token_begin), static_cast<int>(current_tokens),
+        static_cast<int>(top_k), static_cast<int>(hidden_logical_size),
+        static_cast<int>(out.stride(0)),
+        static_cast<int>(chunk_output.stride(0)));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+}
+
 void awq_moe_single_token_dense_stage_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
     torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -6512,7 +6512,8 @@ void awq_moe_gemm_sm70_out_impl(
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
     bool gated_silu, torch::Tensor b_group_indices, bool per_expert_dispatch,
     torch::Tensor reduce_out, torch::Tensor sorted_weights,
-    bool weighted_reduce);
+    bool weighted_reduce, int64_t logical_total_tokens,
+    torch::Tensor a_indices);
 
 template <typename index_t>
 __global__ void awq_moe_single_token_prepare_kernel(
@@ -7331,7 +7332,8 @@ void awq_moe_gemm_sm70_out_impl(
     bool per_expert_dispatch = false,
     torch::Tensor reduce_out = torch::Tensor(),
     torch::Tensor sorted_weights = torch::Tensor(),
-    bool weighted_reduce = false) {
+    bool weighted_reduce = false, int64_t logical_total_tokens = -1,
+    torch::Tensor a_indices = torch::Tensor()) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "awq_moe_gemm_sm70: input must be CUDA float16.");
@@ -7354,6 +7356,8 @@ void awq_moe_gemm_sm70_out_impl(
               "awq_moe_gemm_sm70: invalid dimensions.");
   TORCH_CHECK(k % group_size == 0,
               "awq_moe_gemm_sm70: input dim must be divisible by group size.");
+  TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
+              "awq_moe_gemm_sm70: input shape mismatch.");
   torch::Tensor b_group_indices_flat = b_group_indices;
   const bool use_b_group_indices =
       b_group_indices.defined() && b_group_indices.numel() > 0;
@@ -7370,7 +7374,25 @@ void awq_moe_gemm_sm70_out_impl(
   const int device = sorted_input.get_device();
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  const int64_t total_tokens = sorted_input.size(0);
+  const int64_t input_tokens = sorted_input.size(0);
+  const int64_t total_tokens =
+      logical_total_tokens > 0 ? logical_total_tokens : input_tokens;
+  const bool use_a_indices = a_indices.defined() && a_indices.numel() > 0;
+  torch::Tensor a_indices_flat = a_indices;
+  if (use_a_indices) {
+    TORCH_CHECK(a_indices.is_cuda() &&
+                    a_indices.scalar_type() == torch::kInt32 &&
+                    a_indices.is_contiguous(),
+                "awq_moe_gemm_sm70: A row indices must be contiguous CUDA "
+                "int32.");
+    a_indices_flat = a_indices.view({-1});
+    TORCH_CHECK(a_indices_flat.numel() >= total_tokens,
+                "awq_moe_gemm_sm70: A row indices size mismatch.");
+  } else {
+    TORCH_CHECK(input_tokens == total_tokens,
+                "awq_moe_gemm_sm70: non-indexed input rows must match "
+                "logical rows.");
+  }
   TORCH_CHECK(out.size(0) == total_tokens,
               "awq_moe_gemm_sm70: output rows must match input rows.");
   TORCH_CHECK(out.stride(1) == 1,
@@ -7412,10 +7434,11 @@ void awq_moe_gemm_sm70_out_impl(
       turbomind::gemm::kRowMajor,
       static_cast<int>(total_tokens),
       static_cast<int>(k),
-      static_cast<int>(k),
+      static_cast<int>(sorted_input.stride(0)),
   };
   desc_A.num = static_cast<int>(num_experts);
   desc_A.offsets = expert_offsets.data_ptr<int>();
+  desc_A.idxs = use_a_indices ? a_indices_flat.data_ptr<int>() : nullptr;
 
   turbomind::gemm::MatrixLayout desc_U{};
 
@@ -7545,6 +7568,53 @@ void awq_moe_gemm_sm70_per_expert_dispatch_out(
   awq_moe_gemm_sm70_out_impl(out, sorted_input, expert_offsets, strided_ptrs_w,
                              strided_ptrs_s, num_experts, k, n, group_size,
                              gated_silu, torch::Tensor(), true);
+}
+
+void awq_moe_indexed_dense_w13_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts, int64_t k,
+    int64_t n, int64_t group_size) {
+  constexpr int kQwen38TopK = 10;
+  TORCH_CHECK(input.dim() == 2 && input.size(0) > 0 && input.size(1) == 2560 &&
+                  input.scalar_type() == torch::kFloat16 && input.is_cuda() &&
+                  input.is_contiguous(),
+              "awq_moe_indexed_dense_w13_sm70_out: exact Qwen3.8 CUDA FP16 "
+              "[tokens, 2560] input is required.");
+  TORCH_CHECK(num_experts == 512 && k == 2560 && n == 320 && group_size == 32,
+              "awq_moe_indexed_dense_w13_sm70_out: exact Qwen3.8 TP4 W13 "
+              "g32 contract is required.");
+  TORCH_CHECK(input_row_indices.is_cuda() &&
+                  input_row_indices.scalar_type() == torch::kInt32 &&
+                  input_row_indices.is_contiguous() &&
+                  input_row_indices.numel() == input.size(0) * kQwen38TopK,
+              "awq_moe_indexed_dense_w13_sm70_out: input row indices must "
+              "contain exactly tokens*10 contiguous CUDA int32 entries.");
+  TORCH_CHECK(expert_offsets.is_cuda() &&
+                  expert_offsets.scalar_type() == torch::kInt32 &&
+                  expert_offsets.is_contiguous() &&
+                  expert_offsets.numel() >= num_experts + 1,
+              "awq_moe_indexed_dense_w13_sm70_out: expert offsets must be "
+              "contiguous CUDA int32 with num_experts+1 entries.");
+  TORCH_CHECK(dense_expert_ids.is_cuda() &&
+                  dense_expert_ids.scalar_type() == torch::kInt32 &&
+                  dense_expert_ids.is_contiguous() &&
+                  dense_expert_ids.numel() >= num_experts,
+              "awq_moe_indexed_dense_w13_sm70_out: dense expert IDs must be "
+              "contiguous CUDA int32.");
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == input_row_indices.numel() &&
+                  out.size(1) == n && out.stride(1) == 1,
+              "awq_moe_indexed_dense_w13_sm70_out: output shape mismatch.");
+
+  static std::atomic<unsigned> logged_awq_indexed_prefill{0u};
+  maybe_log_sm70_moe_route_once(
+      logged_awq_indexed_prefill,
+      "SM70 Qwen3.8 AWQ indexed-A W13 prefill path enabled C++ op reached",
+      input, input_row_indices.numel(), num_experts);
+  awq_moe_gemm_sm70_out_impl(
+      out, input, expert_offsets, ptrs_w, ptrs_s, num_experts, k, n, group_size,
+      false, dense_expert_ids, true, torch::Tensor(), torch::Tensor(), false,
+      input_row_indices.numel(), input_row_indices);
 }
 
 torch::Tensor awq_moe_gemm_sm70(torch::Tensor sorted_input,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -569,6 +569,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &awq_moe_dense_stage_sm70_out);
 
   ops.def(
+      "awq_moe_indexed_dense_w13_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
+      "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "
+      "Tensor ptrs_s, int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("awq_moe_indexed_dense_w13_sm70_out", torch::kCUDA,
+           &awq_moe_indexed_dense_w13_sm70_out);
+
+  ops.def(
       "awq_moe_active_dense_stage_sm70_out("
       "Tensor(a!) out, Tensor input, Tensor permuted_experts_id, "
       "Tensor active_expert_offsets, Tensor active_expert_ids, Tensor ptrs_w, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -585,6 +585,18 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &awq_moe_active_dense_stage_sm70_out);
 
   ops.def(
+      "awq_moe_chunked_w2_sm70_out("
+      "Tensor(a!) out, Tensor(b!) chunk_output, Tensor input, "
+      "Tensor expert_offsets, Tensor permuted_idx, Tensor topk_weights, "
+      "Tensor(c!) chunk_expert_offsets, Tensor(d!) chunk_range_begin, "
+      "Tensor(e!) chunk_range_end, Tensor(f!) chunk_a_indices, "
+      "Tensor(g!) chunk_inv_permuted_idx, Tensor ptrs_w, Tensor ptrs_s, "
+      "int num_tokens, int top_k, int num_experts, int k, int n, "
+      "int hidden_logical_size, int group_size, int chunk_tokens) -> ()");
+  ops.impl("awq_moe_chunked_w2_sm70_out", torch::kCUDA,
+           &awq_moe_chunked_w2_sm70_out);
+
+  ops.def(
       "awq_moe_single_token_dense_stage_sm70_out("
       "Tensor(a!) out, Tensor input, Tensor expert_offsets, "
       "Tensor sorted_expert_ids, Tensor ptrs_w, Tensor ptrs_s, int top_k, "

--- a/tests/quantization/test_awq_sm70_sorted_output_contract.py
+++ b/tests/quantization/test_awq_sm70_sorted_output_contract.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
+
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _use_qwen38_chunked_w2,
+)
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -32,6 +38,44 @@ def _route_order_direct_reduce(
     for route in range(top_k):
         output += topk_weights[:, route, None] * route_output[:, route].float()
     return output.to(route_output.dtype)
+
+
+def _chunked_reference_unpermute(
+    sorted_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    permuted_idx: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    chunk_tokens: int,
+) -> torch.Tensor:
+    num_tokens, top_k = topk_weights.shape
+    chunks = []
+    for token_begin in range(0, num_tokens, chunk_tokens):
+        current_tokens = min(chunk_tokens, num_tokens - token_begin)
+        source_begin = token_begin * top_k
+        source_end = source_begin + current_tokens * top_k
+        chunk_rows: list[int] = []
+        for expert in range(expert_offsets.numel() - 1):
+            expert_begin = int(expert_offsets[expert])
+            expert_end = int(expert_offsets[expert + 1])
+            expert_sources = permuted_idx[expert_begin:expert_end]
+            local_begin = int(torch.searchsorted(expert_sources, source_begin))
+            local_end = int(torch.searchsorted(expert_sources, source_end))
+            chunk_rows.extend(
+                range(expert_begin + local_begin, expert_begin + local_end)
+            )
+
+        chunk_rows_tensor = torch.tensor(chunk_rows, dtype=torch.int64)
+        chunk_sources = permuted_idx[chunk_rows_tensor] - source_begin
+        chunk_inverse = torch.empty(current_tokens * top_k, dtype=torch.int64)
+        chunk_inverse[chunk_sources] = torch.arange(current_tokens * top_k)
+        chunks.append(
+            _reference_unpermute(
+                sorted_output[chunk_rows_tensor],
+                topk_weights[token_begin : token_begin + current_tokens],
+                chunk_inverse.view(current_tokens, top_k),
+            )
+        )
+    return torch.cat(chunks)
 
 
 @pytest.mark.parametrize(
@@ -89,6 +133,52 @@ def test_fp16_atomic_style_accumulation_is_not_bitwise_reference() -> None:
     ) == pytest.approx(0.00390625)
 
 
+@pytest.mark.parametrize("chunk_tokens", [1, 3, 8])
+def test_token_chunks_preserve_stable_expert_order_and_final_output(
+    chunk_tokens: int,
+) -> None:
+    num_tokens = 17
+    top_k = 10
+    num_experts = 32
+    hidden = 64
+    generator = torch.Generator().manual_seed(20260903 + chunk_tokens)
+    route_output = torch.randn(
+        (num_tokens, top_k, hidden), generator=generator, dtype=torch.float16
+    )
+    topk_weights = torch.softmax(
+        torch.randn((num_tokens, top_k), generator=generator), dim=-1
+    )
+    expert_ids = torch.randint(
+        0,
+        num_experts,
+        (num_tokens, top_k),
+        generator=generator,
+        dtype=torch.int64,
+    )
+    flat_experts = expert_ids.flatten()
+    permuted_idx = torch.argsort(flat_experts, stable=True)
+    sorted_experts = flat_experts[permuted_idx]
+    counts = torch.bincount(sorted_experts, minlength=num_experts)
+    expert_offsets = torch.cat((torch.zeros(1, dtype=torch.int64), counts.cumsum(0)))
+    sorted_output = route_output.view(-1, hidden)[permuted_idx]
+
+    full_inverse = torch.empty_like(permuted_idx)
+    full_inverse[permuted_idx] = torch.arange(num_tokens * top_k)
+    expected = _reference_unpermute(
+        sorted_output,
+        topk_weights,
+        full_inverse.view(num_tokens, top_k),
+    )
+    actual = _chunked_reference_unpermute(
+        sorted_output,
+        topk_weights,
+        permuted_idx,
+        expert_offsets,
+        chunk_tokens,
+    )
+    assert torch.equal(actual, expected)
+
+
 def test_qwen38_sorted_output_memory_ledger() -> None:
     layers = 48
     hidden = 2560
@@ -99,6 +189,88 @@ def test_qwen38_sorted_output_memory_ledger() -> None:
     persistent_cap8_bytes = layers * 8 * top_k * hidden * element_bytes
     persistent_cap32_bytes = layers * 32 * top_k * hidden * element_bytes
 
+    def chunk_scratch_bytes(chunk_tokens: int) -> int:
+        chunk_slots = chunk_tokens * top_k
+        chunk_output = chunk_slots * hidden * element_bytes
+        chunk_metadata = (513 + 512 + 512 + chunk_slots + chunk_slots) * 4
+        return chunk_output + chunk_metadata
+
     assert max_batched_tokens_bytes == 400 * 1024**2
+    assert chunk_scratch_bytes(4096) == 200 * 1024**2 + 333_828
+    assert max_batched_tokens_bytes - chunk_scratch_bytes(4096) == 209_381_372
+    assert chunk_scratch_bytes(6144) == 300 * 1024**2 + 497_668
+    assert max_batched_tokens_bytes - chunk_scratch_bytes(6144) == 104_359_932
     assert persistent_cap8_bytes == pytest.approx(18.75 * 1024**2)
     assert persistent_cap32_bytes == 75 * 1024**2
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "indexed_w13", "expected"),
+    [
+        (6144, True, False),
+        (6537, True, False),
+        (6538, True, False),
+        (8192, True, True),
+        (8193, True, True),
+        (12288, True, True),
+        (12289, True, False),
+        (16384, True, True),
+        (8192, False, False),
+    ],
+)
+def test_chunked_w2_admission_is_profitable_and_tail_safe(
+    num_tokens: int,
+    indexed_w13: bool,
+    expected: bool,
+) -> None:
+    layer = SimpleNamespace(
+        sm70_awq_qwen38_w2_chunk_tokens=6144,
+        _awq_moe_buf_top_k=10,
+        sm70_w2_n_dim=2560,
+        sm70_num_experts=512,
+    )
+    assert _use_qwen38_chunked_w2(layer, num_tokens, indexed_w13) is expected
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not hasattr(torch.ops._C, "awq_moe_chunked_w2_sm70_out"),
+    reason="requires the CUDA chunked W2 extension",
+)
+def test_chunked_w2_cuda_op_rejects_small_tail() -> None:
+    device = torch.device("cuda")
+    out = torch.empty(1, dtype=torch.float16, device=device)
+    chunk_output = torch.empty_like(out)
+    input = torch.empty_like(out)
+    int_scratch = [torch.empty(1, dtype=torch.int32, device=device) for _ in range(7)]
+    topk_weights = torch.empty(1, dtype=torch.float32, device=device)
+    ptrs_w = torch.empty(1, dtype=torch.uint8, device=device)
+    ptrs_s = torch.empty_like(ptrs_w)
+
+    with pytest.raises(
+        RuntimeError,
+        match="tail chunk must contain at least 2048 tokens",
+    ):
+        torch.ops._C.awq_moe_chunked_w2_sm70_out(
+            out,
+            chunk_output,
+            input,
+            int_scratch[0],
+            int_scratch[1],
+            topk_weights,
+            int_scratch[2],
+            int_scratch[3],
+            int_scratch[4],
+            int_scratch[5],
+            int_scratch[6],
+            ptrs_w,
+            ptrs_s,
+            12289,
+            10,
+            512,
+            160,
+            2560,
+            2560,
+            32,
+            6144,
+        )

--- a/tests/quantization/test_awq_sm70_sorted_output_contract.py
+++ b/tests/quantization/test_awq_sm70_sorted_output_contract.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _reference_unpermute(
+    sorted_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    inv_permuted_idx: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens, top_k = topk_weights.shape
+    output = torch.zeros((num_tokens, sorted_output.shape[1]), dtype=torch.float32)
+    for token in range(num_tokens):
+        for route in range(top_k):
+            sorted_row = int(inv_permuted_idx[token, route])
+            output[token] += (
+                topk_weights[token, route] * sorted_output[sorted_row].float()
+            )
+    return output.to(sorted_output.dtype)
+
+
+def _route_order_direct_reduce(
+    route_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens, top_k, hidden = route_output.shape
+    output = torch.zeros((num_tokens, hidden), dtype=torch.float32)
+    for route in range(top_k):
+        output += topk_weights[:, route, None] * route_output[:, route].float()
+    return output.to(route_output.dtype)
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "hidden"), [(1, 10, 64), (8, 10, 256), (16, 10, 64)]
+)
+def test_route_order_direct_reduce_is_bitwise_reference(
+    num_tokens: int,
+    top_k: int,
+    hidden: int,
+) -> None:
+    generator = torch.Generator().manual_seed(num_tokens * 1000 + hidden)
+    route_output = torch.randn(
+        (num_tokens, top_k, hidden), generator=generator, dtype=torch.float16
+    )
+    topk_weights = torch.softmax(
+        torch.randn((num_tokens, top_k), generator=generator), dim=-1
+    )
+
+    # Model the stable expert sort: permuted_idx maps each sorted row back to
+    # the flattened source route, and inv_permuted_idx is its inverse.
+    expert_ids = torch.randint(
+        0, 512, (num_tokens, top_k), generator=generator, dtype=torch.int64
+    )
+    flat_experts = expert_ids.flatten()
+    permuted_idx = torch.argsort(flat_experts, stable=True)
+    inv_permuted_idx = torch.empty_like(permuted_idx)
+    inv_permuted_idx[permuted_idx] = torch.arange(num_tokens * top_k)
+    inv_permuted_idx = inv_permuted_idx.view(num_tokens, top_k)
+    sorted_output = route_output.view(-1, hidden)[permuted_idx]
+
+    reference = _reference_unpermute(sorted_output, topk_weights, inv_permuted_idx)
+    direct = _route_order_direct_reduce(route_output, topk_weights)
+    assert torch.equal(direct, reference)
+
+
+def test_fp16_atomic_style_accumulation_is_not_bitwise_reference() -> None:
+    generator = torch.Generator().manual_seed(0)
+    route_output = (
+        torch.randn((1, 10, 256), generator=generator, dtype=torch.float16) * 4
+    )
+    topk_weights = torch.softmax(torch.randn((1, 10), generator=generator), dim=-1)
+
+    reference = _route_order_direct_reduce(route_output, topk_weights)
+    atomic_style = torch.zeros_like(reference)
+    for route in range(10):
+        contribution = (
+            topk_weights[:, route, None] * route_output[:, route].float()
+        ).half()
+        atomic_style = (atomic_style + contribution).half()
+
+    assert not torch.equal(atomic_style, reference)
+    assert int((atomic_style != reference).sum()) == 168
+    assert float(
+        (atomic_style.float() - reference.float()).abs().max()
+    ) == pytest.approx(0.00390625)
+
+
+def test_qwen38_sorted_output_memory_ledger() -> None:
+    layers = 48
+    hidden = 2560
+    top_k = 10
+    element_bytes = 2
+
+    max_batched_tokens_bytes = 8192 * top_k * hidden * element_bytes
+    persistent_cap8_bytes = layers * 8 * top_k * hidden * element_bytes
+    persistent_cap32_bytes = layers * 32 * top_k * hidden * element_bytes
+
+    assert max_batched_tokens_bytes == 400 * 1024**2
+    assert persistent_cap8_bytes == pytest.approx(18.75 * 1024**2)
+    assert persistent_cap32_bytes == 75 * 1024**2

--- a/tests/quantization/test_sm70_awq_indexed_prefill.py
+++ b/tests/quantization/test_sm70_awq_indexed_prefill.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from benchmarks.benchmark_sm70_turbomind_exactness import (
+    _prepare_awq_moe_checkpoint_for_tp,
+)
+from vllm import envs
+from vllm.model_executor.layers.fused_moe.layer import (
+    FusedMoE,
+    FusedMoeWeightScaleSupported,
+)
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _QWEN38_INDEXED_PREFILL_MIN_TOKENS,
+    AWQSM70MoEMethod,
+    _use_qwen38_indexed_prefill,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _qwen38_layer() -> SimpleNamespace:
+    return SimpleNamespace(
+        moe_config=SimpleNamespace(tp_size=4),
+        sm70_awq_qwen38_indexed_prefill=True,
+        sm70_awq_moe_batched_gemm=True,
+        sm70_awq_checkpoint_group_size=32,
+        sm70_awq_group_size=32,
+        sm70_num_experts=512,
+        sm70_hidden_logical_size=2560,
+        sm70_intermediate_size=160,
+        sm70_w13_k_dim=2560,
+        sm70_w13_n_dim=320,
+    )
+
+
+def test_qwen38_awq_indexed_prefill_env_defaults_on(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", raising=False)
+    assert envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL
+
+    monkeypatch.setenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", "0")
+    assert not envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL
+
+
+def test_qwen38_awq_indexed_prefill_gate_is_exact():
+    layer = _qwen38_layer()
+    x = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 10, dtype=torch.int32)
+
+    assert _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    assert not _use_qwen38_indexed_prefill(layer, x[:127], topk_ids[:127])
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids[:, :9])
+
+    layer.moe_config.tp_size = 2
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.moe_config.tp_size = 4
+
+    layer.sm70_awq_checkpoint_group_size = 128
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.sm70_awq_checkpoint_group_size = 32
+
+    layer.sm70_awq_group_size = 128
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+    layer.sm70_awq_group_size = 32
+
+    layer.sm70_awq_qwen38_indexed_prefill = False
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+
+def test_qwen38_awq_indexed_prefill_rejects_noncontiguous_input():
+    layer = _qwen38_layer()
+    x = torch.empty(2560, _QWEN38_INDEXED_PREFILL_MIN_TOKENS).t()
+    topk_ids = torch.empty(_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 10, dtype=torch.int32)
+
+    assert x.shape == (_QWEN38_INDEXED_PREFILL_MIN_TOKENS, 2560)
+    assert not x.is_contiguous()
+    assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+
+def _synthetic_awq_checkpoint(group_size: int) -> tuple[torch.Tensor, ...]:
+    groups_w13 = 2560 // group_size
+    groups_w2 = 640 // group_size
+    w13_qweight = (
+        torch.arange(160, dtype=torch.int32).view(1, 1, 160).expand(1, 2560, 160)
+    )
+    w13_scales = (
+        torch.arange(1280, dtype=torch.float16)
+        .view(1, 1, 1280)
+        .expand(1, groups_w13, 1280)
+    )
+    w13_qzeros = (
+        torch.arange(groups_w13, dtype=torch.int32)
+        .view(1, groups_w13, 1)
+        .expand(1, groups_w13, 160)
+    )
+    w2_qweight = (
+        torch.arange(640, dtype=torch.int32).view(1, 640, 1).expand(1, 640, 320)
+    )
+    w2_scales = (
+        torch.arange(groups_w2, dtype=torch.float16)
+        .view(1, groups_w2, 1)
+        .expand(1, groups_w2, 2560)
+    )
+    w2_qzeros = (
+        torch.arange(groups_w2, dtype=torch.int32)
+        .view(1, groups_w2, 1)
+        .expand(1, groups_w2, 320)
+    )
+    return (
+        w13_qweight,
+        w13_scales,
+        w13_qzeros,
+        w2_qweight,
+        w2_scales,
+        w2_qzeros,
+    )
+
+
+def test_awq_checkpoint_tp4_layout_matches_loader_axes():
+    tensors = _prepare_awq_moe_checkpoint_for_tp(
+        _synthetic_awq_checkpoint(32), 4, 3, 32
+    )
+    w13_qweight, w13_scales, _, w2_qweight, w2_scales, _, group_size = tensors
+
+    assert group_size == 32
+    assert w13_qweight.shape == (1, 2560, 40)
+    assert w13_scales.shape == (1, 80, 320)
+    assert w2_qweight.shape == (1, 160, 320)
+    assert w2_scales.shape == (1, 5, 2560)
+    assert torch.equal(
+        w13_qweight[0, 0],
+        torch.cat((torch.arange(60, 80), torch.arange(140, 160))).to(torch.int32),
+    )
+    assert torch.equal(w2_qweight[0, :, 0], torch.arange(480, 640).to(torch.int32))
+    assert torch.equal(w2_scales[0, :, 0], torch.arange(15, 20).to(torch.float16))
+
+
+def test_g128_checkpoint_tp4_is_rejected_by_service_loader_geometry():
+    with pytest.raises(ValueError, match="divisible by the checkpoint group"):
+        _prepare_awq_moe_checkpoint_for_tp(_synthetic_awq_checkpoint(128), 4, 0, 128)
+
+
+class _FakeRoutedExpertsLoader:
+    weight_loader = FusedMoE.weight_loader
+    _map_global_expert_id_to_local_expert_id = (
+        FusedMoE._map_global_expert_id_to_local_expert_id
+    )
+    _get_hidden_dim = staticmethod(FusedMoE._get_hidden_dim)
+    _narrow_expert_data_for_padding = staticmethod(
+        FusedMoE._narrow_expert_data_for_padding
+    )
+    _load_w13 = FusedMoE._load_w13
+    _load_w2 = FusedMoE._load_w2
+    _load_model_weight_or_group_weight_scale = (
+        FusedMoE._load_model_weight_or_group_weight_scale
+    )
+
+    def __init__(self, tp_rank: int) -> None:
+        self.quant_config = None
+        self.quant_method = object.__new__(AWQSM70MoEMethod)
+        self.quant_method.group_size_div_factor = 1
+        self.expert_map_manager = SimpleNamespace(
+            map_global_to_local=lambda expert_id: expert_id
+        )
+        self.moe_config = SimpleNamespace(
+            is_act_and_mul=True, moe_parallel_config=SimpleNamespace(tp_size=4)
+        )
+        self.tp_rank = tp_rank
+
+
+def _service_loaded_awq_tensors(
+    checkpoint: tuple[torch.Tensor, ...], tp_rank: int
+) -> tuple[torch.Tensor, ...]:
+    w13_qweight, w13_scales, w13_qzeros, w2_qweight, w2_scales, w2_qzeros = checkpoint
+
+    def _parameter(tensor: torch.Tensor) -> torch.nn.Parameter:
+        return torch.nn.Parameter(tensor, requires_grad=False)
+
+    destinations = (
+        _parameter(torch.zeros(1, 2560, 40, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 80, 320, dtype=torch.float16)),
+        _parameter(torch.zeros(1, 80, 40, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 160, 320, dtype=torch.int32)),
+        _parameter(torch.zeros(1, 5, 2560, dtype=torch.float16)),
+        _parameter(torch.zeros(1, 5, 320, dtype=torch.int32)),
+    )
+    for param in destinations:
+        param.is_transposed = True
+        param.quant_method = FusedMoeWeightScaleSupported.GROUP.value
+
+    loader = _FakeRoutedExpertsLoader(tp_rank)
+    checkpoint_shards = (
+        (w13_qweight[..., :80], "qweight", "w1", destinations[0]),
+        (w13_qweight[..., 80:], "qweight", "w3", destinations[0]),
+        (w13_scales[..., :640], "scales", "w1", destinations[1]),
+        (w13_scales[..., 640:], "scales", "w3", destinations[1]),
+        (w13_qzeros[..., :80], "qzeros", "w1", destinations[2]),
+        (w13_qzeros[..., 80:], "qzeros", "w3", destinations[2]),
+        (w2_qweight, "qweight", "w2", destinations[3]),
+        (w2_scales, "scales", "w2", destinations[4]),
+        (w2_qzeros, "qzeros", "w2", destinations[5]),
+    )
+    for loaded, name, shard_id, param in checkpoint_shards:
+        loader.weight_loader(param, loaded[0], name, shard_id, 0)
+    return tuple(param.detach() for param in destinations)
+
+
+@pytest.mark.parametrize("tp_rank", [0, 3])
+def test_benchmark_tp4_preparation_matches_fused_moe_weight_loader(tp_rank: int):
+    checkpoint = _synthetic_awq_checkpoint(32)
+    checkpoint = (
+        checkpoint[0],
+        checkpoint[1].to(torch.bfloat16),
+        checkpoint[2],
+        checkpoint[3],
+        checkpoint[4].to(torch.bfloat16),
+        checkpoint[5],
+    )
+    benchmark_input = (
+        checkpoint[0],
+        checkpoint[1].half(),
+        checkpoint[2],
+        checkpoint[3],
+        checkpoint[4].half(),
+        checkpoint[5],
+    )
+    prepared = _prepare_awq_moe_checkpoint_for_tp(benchmark_input, 4, tp_rank, 32)
+    service_loaded = _service_loaded_awq_tensors(checkpoint, tp_rank)
+
+    assert prepared[-1] == 32
+    for benchmark_tensor, service_tensor in zip(prepared[:-1], service_loaded):
+        assert torch.equal(benchmark_tensor, service_tensor)

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -2670,6 +2670,53 @@ if hasattr(torch.ops._C, "awq_moe_dense_stage_sm70_out"):
         return None
 
 
+def awq_moe_indexed_dense_w13_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    input_row_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("awq_moe_indexed_dense_w13_sm70_out")(
+        out,
+        input,
+        input_row_indices,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "awq_moe_indexed_dense_w13_sm70_out"):
+
+    @register_fake("_C::awq_moe_indexed_dense_w13_sm70_out")
+    def _awq_moe_indexed_dense_w13_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        input_row_indices: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def awq_moe_active_dense_stage_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -2764,6 +2764,83 @@ if hasattr(torch.ops._C, "awq_moe_active_dense_stage_sm70_out"):
         return None
 
 
+def awq_moe_chunked_w2_sm70_out(
+    out: torch.Tensor,
+    chunk_output: torch.Tensor,
+    input: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    permuted_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    chunk_expert_offsets: torch.Tensor,
+    chunk_range_begin: torch.Tensor,
+    chunk_range_end: torch.Tensor,
+    chunk_a_indices: torch.Tensor,
+    chunk_inv_permuted_idx: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    k: int,
+    n: int,
+    hidden_logical_size: int,
+    group_size: int,
+    chunk_tokens: int,
+) -> None:
+    _op("awq_moe_chunked_w2_sm70_out")(
+        out,
+        chunk_output,
+        input,
+        expert_offsets,
+        permuted_idx,
+        topk_weights,
+        chunk_expert_offsets,
+        chunk_range_begin,
+        chunk_range_end,
+        chunk_a_indices,
+        chunk_inv_permuted_idx,
+        ptrs_w,
+        ptrs_s,
+        num_tokens,
+        top_k,
+        num_experts,
+        k,
+        n,
+        hidden_logical_size,
+        group_size,
+        chunk_tokens,
+    )
+
+
+if hasattr(torch.ops._C, "awq_moe_chunked_w2_sm70_out"):
+
+    @register_fake("_C::awq_moe_chunked_w2_sm70_out")
+    def _awq_moe_chunked_w2_sm70_out_fake(
+        out: torch.Tensor,
+        chunk_output: torch.Tensor,
+        input: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        permuted_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        chunk_expert_offsets: torch.Tensor,
+        chunk_range_begin: torch.Tensor,
+        chunk_range_end: torch.Tensor,
+        chunk_a_indices: torch.Tensor,
+        chunk_inv_permuted_idx: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_tokens: int,
+        top_k: int,
+        num_experts: int,
+        k: int,
+        n: int,
+        hidden_logical_size: int,
+        group_size: int,
+        chunk_tokens: int,
+    ) -> None:
+        return None
+
+
 def awq_moe_single_token_dense_stage_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
     VLLM_SM70_COMPRESSED_TENSORS_TURBOMIND: bool = False
     VLLM_SM70_AWQ_MOE_DISABLE: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_GEMM: bool = True
+    VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL: bool = True
     VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_ACTIVE_EXACT_W2: bool = False
@@ -1617,6 +1618,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # diagnostics and fallback comparison.
     "VLLM_SM70_AWQ_MOE_BATCHED_GEMM": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_GEMM", "1"))
+    ),
+    # Skip the materialized top-k input rows for the exact Qwen3.8
+    # Flash-Next TP4 AWQ W13 prefill contract. Unsupported shapes retain the
+    # existing materialized-input path.
+    "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", "1"))
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -119,6 +119,7 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_MOE_DISABLE: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_GEMM: bool = True
     VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL: bool = True
+    VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS: int = 0
     VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_ACTIVE_EXACT_W2: bool = False
@@ -1624,6 +1625,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # existing materialized-input path.
     "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL", "1"))
+    ),
+    # Zero disables chunking; 4096 and 6144 cap the indexed W2 scratch rows.
+    "VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS": lambda: int(
+        os.getenv("VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS", "0")
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_SINGLE_TOKEN_DENSE_W13", "0"))

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -30,6 +30,9 @@ logger = init_logger(__name__)
 
 _DEFAULT_PERSISTENT_MAX_TOKENS = 32
 _QWEN38_INDEXED_PREFILL_MIN_TOKENS: Final = 128
+_QWEN38_CHUNKED_W2_MIN_TOKENS: Final = 8192
+_QWEN38_CHUNKED_W2_MIN_INDEXED_TAIL_TOKENS: Final = 2048
+_QWEN38_CHUNKED_W2_SUPPORTED_TOKENS: Final = (4096, 6144)
 
 
 def _log_runtime_route_once(message: str, *args) -> None:
@@ -69,6 +72,34 @@ def _use_qwen38_indexed_prefill(
         and int(layer.sm70_awq_checkpoint_group_size) == 32
         and int(layer.sm70_awq_group_size) == 32
     )
+
+
+def _use_qwen38_chunked_w2(
+    layer: RoutedExperts,
+    num_tokens: int,
+    indexed_w13: bool,
+) -> bool:
+    chunk_tokens = int(layer.sm70_awq_qwen38_w2_chunk_tokens)
+    if (
+        not indexed_w13
+        or num_tokens < _QWEN38_CHUNKED_W2_MIN_TOKENS
+        or chunk_tokens not in _QWEN38_CHUNKED_W2_SUPPORTED_TOKENS
+        or chunk_tokens >= num_tokens
+    ):
+        return False
+
+    tail_tokens = num_tokens % chunk_tokens
+    if 0 < tail_tokens < _QWEN38_CHUNKED_W2_MIN_INDEXED_TAIL_TOKENS:
+        return False
+
+    top_k = int(layer._awq_moe_buf_top_k)
+    chunk_slots = chunk_tokens * top_k
+    full_scratch_bytes = num_tokens * top_k * int(layer.sm70_w2_n_dim) * 2
+    chunk_scratch_bytes = (
+        chunk_slots * (int(layer.sm70_w2_n_dim) * 2 + 2 * 4)
+        + (3 * int(layer.sm70_num_experts) + 1) * 4
+    )
+    return chunk_scratch_bytes < full_scratch_bytes
 
 
 def _single_token_weighted_reduce_enabled() -> bool:
@@ -732,6 +763,26 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             and indexed_prefill_requested
             and indexed_prefill_available
         )
+        w2_chunk_tokens = int(envs.VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS)
+        if w2_chunk_tokens not in (0, *_QWEN38_CHUNKED_W2_SUPPORTED_TOKENS):
+            raise ValueError(
+                "VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS must be one of "
+                "0, 4096, or 6144."
+            )
+        chunked_w2_available = hasattr(torch.ops._C, "awq_moe_chunked_w2_sm70_out")
+        if (
+            w2_chunk_tokens > 0
+            and layer.sm70_awq_qwen38_indexed_prefill
+            and not chunked_w2_available
+        ):
+            raise RuntimeError(
+                "The SM70 Qwen3.8 AWQ chunked W2 path requires its CUDA extension."
+            )
+        layer.sm70_awq_qwen38_w2_chunk_tokens = int(
+            w2_chunk_tokens
+            if layer.sm70_awq_qwen38_indexed_prefill and chunked_w2_available
+            else 0
+        )
 
         self._allocate_buffers(layer)
         del layer.w13_qweight, layer.w13_scales, layer.w13_qzeros
@@ -870,12 +921,19 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         num_tokens: int,
         indexed_w13: bool,
     ) -> dict[str, torch.Tensor]:
+        w2_chunk_tokens = int(layer.sm70_awq_qwen38_w2_chunk_tokens)
+        chunked_w2 = _use_qwen38_chunked_w2(layer, num_tokens, indexed_w13)
+        max_chunk_slots = min(num_tokens, w2_chunk_tokens) * layer._awq_moe_buf_top_k
         use_temporary_buffers = _use_temporary_buffers_for_dummy_or_capture()
         if (
             not use_temporary_buffers
             and total_slots <= layer._awq_moe_buf_max_slots
             and num_tokens <= layer._awq_moe_buf_max_tokens
         ):
+            assert not chunked_w2, (
+                "Qwen3.8 indexed prefill starts above the persistent AWQ MoE "
+                "buffer cap."
+            )
             return {
                 "output": layer._awq_moe_buf_output[:num_tokens],
                 "permuted_input": layer._awq_moe_buf_permuted_input[:total_slots],
@@ -989,9 +1047,34 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 device=device,
             ),
             "sorted_output": torch.empty(
-                total_slots,
+                max_chunk_slots if chunked_w2 else total_slots,
                 layer.sm70_w2_n_dim,
                 dtype=torch.float16,
+                device=device,
+            ),
+            "chunk_expert_offsets": torch.empty(
+                layer.sm70_num_experts + 1 if chunked_w2 else 0,
+                dtype=torch.int32,
+                device=device,
+            ),
+            "chunk_range_begin": torch.empty(
+                layer.sm70_num_experts if chunked_w2 else 0,
+                dtype=torch.int32,
+                device=device,
+            ),
+            "chunk_range_end": torch.empty(
+                layer.sm70_num_experts if chunked_w2 else 0,
+                dtype=torch.int32,
+                device=device,
+            ),
+            "chunk_a_indices": torch.empty(
+                max_chunk_slots if chunked_w2 else 0,
+                dtype=torch.int32,
+                device=device,
+            ),
+            "chunk_inv_permuted_idx": torch.empty(
+                max_chunk_slots if chunked_w2 else 0,
+                dtype=torch.int32,
                 device=device,
             ),
             "expert_offsets": torch.empty(
@@ -1507,6 +1590,39 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         buffers["intermediate"] = _dump_awq_moe_buffer(
             layer, buffers["intermediate"], "silu_out"
         )
+        w2_chunk_tokens = int(layer.sm70_awq_qwen38_w2_chunk_tokens)
+        if _use_qwen38_chunked_w2(layer, num_tokens, indexed_w13):
+            _log_runtime_route_once(
+                "SM70 Qwen3.8 AWQ chunked W2 enabled "
+                "(tokens=%d, routes=%d, chunk_tokens=%d).",
+                num_tokens,
+                total_slots,
+                w2_chunk_tokens,
+            )
+            sm70_ops.awq_moe_chunked_w2_sm70_out(
+                output,
+                buffers["sorted_output"],
+                buffers["intermediate"],
+                buffers["expert_offsets"],
+                buffers["permuted_idx"],
+                topk_weights,
+                buffers["chunk_expert_offsets"],
+                buffers["chunk_range_begin"],
+                buffers["chunk_range_end"],
+                buffers["chunk_a_indices"],
+                buffers["chunk_inv_permuted_idx"],
+                layer.w2_strided_ptrs_w,
+                layer.w2_strided_ptrs_s,
+                num_tokens,
+                top_k,
+                layer.sm70_num_experts,
+                layer.sm70_w2_k_dim,
+                layer.sm70_w2_n_dim,
+                layer.sm70_hidden_logical_size,
+                self.group_size,
+                w2_chunk_tokens,
+            )
+            return _dump_awq_moe_buffer(layer, output, "chunked_w2_output")
         if use_active_exact_small_batched_moe:
             sm70_ops.awq_moe_single_token_dense_stage_sm70_out(
                 buffers["sorted_output"],

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from typing import Final
 
 import torch
 from torch.nn import Parameter
@@ -28,6 +29,7 @@ from vllm.model_executor.utils import set_weight_attrs
 logger = init_logger(__name__)
 
 _DEFAULT_PERSISTENT_MAX_TOKENS = 32
+_QWEN38_INDEXED_PREFILL_MIN_TOKENS: Final = 128
 
 
 def _log_runtime_route_once(message: str, *args) -> None:
@@ -41,6 +43,32 @@ def _use_temporary_buffers_for_dummy_or_capture() -> bool:
     # during capture too, so the captured indexed MoE scratch/output lifetimes
     # do not depend on graph-pool temporary allocation analysis.
     return is_forward_context_available() and get_forward_context().is_dummy_run
+
+
+def _use_qwen38_indexed_prefill(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit only the exact Qwen3.8 TP4 g32 W13 prefill contract."""
+    return bool(
+        getattr(layer, "sm70_awq_qwen38_indexed_prefill", False)
+        and getattr(layer, "sm70_awq_moe_batched_gemm", False)
+        and x.ndim == 2
+        and x.shape[0] >= _QWEN38_INDEXED_PREFILL_MIN_TOKENS
+        and x.shape[1] == 2560
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (x.shape[0], 10)
+        and int(layer.moe_config.tp_size) == 4
+        and int(layer.sm70_num_experts) == 512
+        and int(layer.sm70_hidden_logical_size) == 2560
+        and int(layer.sm70_intermediate_size) == 160
+        and int(layer.sm70_w13_k_dim) == 2560
+        and int(layer.sm70_w13_n_dim) == 320
+        and int(layer.sm70_awq_checkpoint_group_size) == 32
+        and int(layer.sm70_awq_group_size) == 32
+    )
 
 
 def _single_token_weighted_reduce_enabled() -> bool:
@@ -646,9 +674,64 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         layer.sm70_w2_q_ld = w2_q_ld
         layer.sm70_intermediate_size = layer.sm70_w2_k_dim
         layer.sm70_awq_moe_batched_gemm = batched_gemm
+        checkpoint_group_size = int(
+            getattr(self, "checkpoint_group_size", self.group_size)
+        )
+        layer.sm70_awq_checkpoint_group_size = checkpoint_group_size
+        layer.sm70_awq_group_size = self.group_size
         layer.sm70_awq_moe_layer_id = _get_layer_id(layer)
         layer.sm70_awq_moe_w13_interleaved = w13_interleaved
         layer.sm70_awq_moe_legacy_single_token_compact = build_legacy_w13
+
+        indexed_prefill_contract = bool(
+            batched_gemm
+            and self.group_size == 32
+            and int(layer.moe_config.tp_size) == 4
+            and self.moe.experts_per_token == 10
+            and num_experts == 512
+            and hidden_logical_size == 2560
+            and intermediate_logical_size == 160
+            and layer.sm70_w13_k_dim == 2560
+            and layer.sm70_w13_n_dim == 320
+            and checkpoint_group_size == 32
+        )
+        indexed_prefill_requested = bool(envs.VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL)
+        indexed_prefill_ops = {
+            "awq_moe_indexed_dense_w13_sm70_out": hasattr(
+                torch.ops._C, "awq_moe_indexed_dense_w13_sm70_out"
+            ),
+            "moe_permute_metadata_with_scratch": hasattr(
+                torch.ops._moe_C, "moe_permute_metadata_with_scratch"
+            ),
+        }
+        indexed_prefill_available = all(indexed_prefill_ops.values())
+        indexed_prefill_explicit = (
+            "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL" in os.environ
+        )
+        if (
+            indexed_prefill_contract
+            and indexed_prefill_requested
+            and not indexed_prefill_available
+        ):
+            missing = [
+                name for name, available in indexed_prefill_ops.items() if not available
+            ]
+            if indexed_prefill_explicit:
+                raise RuntimeError(
+                    "The explicit SM70 Qwen3.8 AWQ indexed-A prefill route "
+                    "requires " + ", ".join(missing) + "."
+                )
+            logger.warning_once(
+                "The default SM70 Qwen3.8 AWQ indexed-A prefill route is not "
+                "present in the loaded extension; falling back to the "
+                "materialized-input route. Explicitly setting "
+                "VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL=1 fails closed."
+            )
+        layer.sm70_awq_qwen38_indexed_prefill = bool(
+            indexed_prefill_contract
+            and indexed_prefill_requested
+            and indexed_prefill_available
+        )
 
         self._allocate_buffers(layer)
         del layer.w13_qweight, layer.w13_scales, layer.w13_qzeros
@@ -687,6 +770,9 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             layer.sm70_hidden_logical_size,
             dtype=torch.float16,
             device=device,
+        )
+        layer._awq_moe_buf_input_row_indices = torch.empty(
+            max_slots, dtype=torch.int32, device=device
         )
         layer._awq_moe_buf_gate_up = torch.empty(
             max_slots, layer.sm70_w13_n_dim, dtype=torch.float16, device=device
@@ -782,6 +868,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         layer: RoutedExperts,
         total_slots: int,
         num_tokens: int,
+        indexed_w13: bool,
     ) -> dict[str, torch.Tensor]:
         use_temporary_buffers = _use_temporary_buffers_for_dummy_or_capture()
         if (
@@ -792,6 +879,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             return {
                 "output": layer._awq_moe_buf_output[:num_tokens],
                 "permuted_input": layer._awq_moe_buf_permuted_input[:total_slots],
+                "input_row_indices": layer._awq_moe_buf_input_row_indices[:total_slots],
                 "gate_up": layer._awq_moe_buf_gate_up[:total_slots],
                 "intermediate": layer._awq_moe_buf_intermediate[:total_slots],
                 "sorted_output": layer._awq_moe_buf_sorted_output[:total_slots],
@@ -868,11 +956,25 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 dtype=torch.float16,
                 device=device,
             ),
-            "permuted_input": torch.empty(
-                total_slots,
-                layer.sm70_hidden_logical_size,
-                dtype=torch.float16,
-                device=device,
+            "permuted_input": (
+                torch.empty(
+                    0,
+                    layer.sm70_hidden_logical_size,
+                    dtype=torch.float16,
+                    device=device,
+                )
+                if indexed_w13
+                else torch.empty(
+                    total_slots,
+                    layer.sm70_hidden_logical_size,
+                    dtype=torch.float16,
+                    device=device,
+                )
+            ),
+            "input_row_indices": (
+                torch.empty(total_slots, dtype=torch.int32, device=device)
+                if indexed_w13
+                else torch.empty(0, dtype=torch.int32, device=device)
             ),
             "gate_up": torch.empty(
                 total_slots,
@@ -1011,7 +1113,8 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         num_tokens = x.shape[0]
         top_k = topk_ids.shape[1]
         total_slots = num_tokens * top_k
-        buffers = self._get_buffers(layer, total_slots, num_tokens)
+        indexed_w13 = _use_qwen38_indexed_prefill(layer, x, topk_ids)
+        buffers = self._get_buffers(layer, total_slots, num_tokens, indexed_w13)
         output = buffers["output"]
         output.zero_()
         if total_slots == 0:
@@ -1217,23 +1320,42 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 )
             output = _dump_awq_moe_buffer(layer, output, "st_output")
             return output
-        torch.ops._moe_C.moe_permute_with_scratch(
-            x,
-            topk_ids_i32,
-            buffers["token_expert_indices"],
-            layer.expert_map,
-            layer.global_num_experts,
-            layer.local_num_experts,
-            top_k,
-            buffers["permuted_input"],
-            buffers["expert_offsets64"],
-            buffers["inv_permuted_idx"],
-            buffers["permuted_idx"],
-            buffers["sort_workspace"],
-            buffers["permuted_experts_id"],
-            buffers["sorted_row_idx"],
-            buffers["topk_ids_for_sort"],
-        )
+        if indexed_w13:
+            torch.ops._moe_C.moe_permute_metadata_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.expert_map,
+                layer.global_num_experts,
+                layer.local_num_experts,
+                top_k,
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["input_row_indices"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
+        else:
+            torch.ops._moe_C.moe_permute_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.expert_map,
+                layer.global_num_experts,
+                layer.local_num_experts,
+                top_k,
+                buffers["permuted_input"],
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
         buffers["expert_offsets"] = _dump_awq_moe_buffer(
             layer, buffers["expert_offsets"], "expert_offsets"
@@ -1280,7 +1402,27 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         if num_tokens <= 8 and use_batched_moe_gemm:
             compare_dense_step = _compare_dense_decode_step(layer)
 
-        if use_active_exact_small_batched_moe:
+        if indexed_w13:
+            _log_runtime_route_once(
+                "SM70 Qwen3.8 AWQ indexed-A W13 prefill route enabled "
+                "(tokens=%d, routes=%d).",
+                num_tokens,
+                total_slots,
+            )
+            sm70_ops.awq_moe_indexed_dense_w13_sm70_out(
+                buffers["gate_up"],
+                x,
+                buffers["input_row_indices"],
+                buffers["expert_offsets"],
+                layer._awq_moe_buf_dense_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                layer.sm70_num_experts,
+                layer.sm70_w13_k_dim,
+                layer.sm70_w13_n_dim,
+                self.group_size,
+            )
+        elif use_active_exact_small_batched_moe:
             _log_runtime_route_once(
                 "SM70 AWQ MoE batched path using active-route exact "
                 "dense-stage route (tokens=%d, routes=%d).",


### PR DESCRIPTION
## Summary

- chunk the expert-major AWQ W2 output for validated large Qwen3.8 prefills instead of materializing the full `num_tokens * top_k` output
- rebuild chunk-local indexed-A metadata from PR #464's stable permutation, then reduce route 0..9 in the original FP32 order for bitwise parity with `moe_unpermute`
- keep the path opt-in with `VLLM_SM70_AWQ_QWEN38_MOE_W2_CHUNK_TOKENS=4096|6144`
- fail closed to the existing full-output path below 8192 tokens and for non-empty tails smaller than 2048 tokens; the CUDA op enforces the same contract

Depends on #464. This branch is based directly on `d6caaf1bcf`; it does not contain #465. Until #464 lands, GitHub will show that dependency in this PR's main-base diff.

## Why this is not duplicate work

I searched the open 1Cat-vLLM and upstream vLLM PRs for SM70/AWQ sorted-output and chunked-W2 work and found no matching implementation. PR #464 removes the expanded W13 input; this PR separately bounds the remaining W2 output scratch.

## V100 results

Real Qwen3.8 native-g32 AWQ layer, TP4, 4x V100 PCIe 32 GB:

- M8192, chunk 6144: bitwise/repeat/CUDA Graph exact; scratch `419,430,400 -> 315,070,468` bytes (about 99.53 MiB saved); W2 latency +4.88%
- hot-route M8192: bitwise/repeat exact; W2 latency +3.83%
- M8193/M12288/M16384: bitwise/repeat exact, zero NaNs; savings about 99.58/299.53/499.53 MiB
- an unsafe M12289/chunk6144 one-token tail is rejected by the CUDA operator with the expected fail-closed error

Matched TP4 server A/B at GMU 0.89, max batched tokens 8192, E4M3 KV, FULL_AND_PIECEWISE graphs:

- KV capacity: `751,078 -> 765,834` tokens (+14,756, +1.96%)
- 8192-token prompt + one output, warm median: `1.66023 -> 1.69269 s` (+1.96%)
- deterministic output remained `" would"`; a 7168-token fallback request also passed

Because this is a real latency-for-memory tradeoff, the feature remains off by default.

## Risk envelope and ordering contract

- Under the validated `max_num_batched_tokens=8192` contract, chunk 6144 profiles about 300 MiB of W2 output scratch. Fallback shapes M=6145..8191 materialize about 300..400 MiB, at worst roughly 100 MiB above the profiled chunk buffer. The matched GMU 0.89 configuration had 11% unreserved headroom, but that is operational margin rather than a correctness guarantee. Larger max-batched-token settings can exceed this bound on a small-tail fallback; before default enablement, this needs either a bounded small-tail path or worst-supported-shape profiling.
- The binary expert-segment intersection relies on `_moe_C` producing a stable expert-major permutation whose flattened source-route indices remain ascending inside each expert segment. Four M shapes plus a hot-route skew were bitwise exact on V100. There is no runtime monotonicity assertion in the hot path.

## Tests

- `python -m pytest -q tests/quantization/test_awq_sm70_sorted_output_contract.py tests/quantization/test_sm70_awq_indexed_prefill.py` — 24 passed, 1 CUDA-only test skipped on the CPU host
- changed-file pre-commit suite — all hooks passed, including Ruff, clang-format, mypy, typos, SPDX, and environment validation
- CUDA `_C` target rebuilt successfully for SM70
- real-weight operator matrix, strict production-chain exactness at M8192/M8193, CUDA Graph replay, and matched full-server startup/request A/B passed

AI assistance was used for implementation, testing, and PR preparation. Human line-by-line review is required before merge.
