### PR TITLE
[Model][Perf][SM70] Add pooled disk-backed Qwen3.8 PLE

### DIFF
--- a/docs/design/sm70_qwen38_ple_disk_offload.md
+++ b/docs/design/sm70_qwen38_ple_disk_offload.md
@@ -1,0 +1,207 @@
+# Qwen3.8 Flash Next PLE disk offload on SM70
+
+## Decision
+
+Qwen3.8 Flash Next's PLE is a learned trigram embedding, not prompt-lookup
+speculation. The NVFP4 checkpoint stores 47.684 GiB of PLE E4M3 rows in 128
+tensors across ten safetensor files. Keeping the table in an independent CPU
+process is fast, but consumes about 48 GiB of host memory.
+
+This change adds an experimental, default-off disk-backed mode. It retains the
+safetensors mappings and gathers rows directly from them without creating the
+complete anonymous host table. The mode is useful when host capacity matters.
+Its prefill path now deduplicates and sorts rows globally and drives independent
+checkpoint shards concurrently; decode still needs a bounded hot-row cache
+before this can become a performance default.
+
+Enable it only together with the existing CPU service:
+
+```bash
+VLLM_PLE_CPU_OFFLOAD=1 \
+VLLM_PLE_DISK_OFFLOAD=1 \
+VLLM_PLE_DISK_OFFLOAD_NUM_THREADS=32 \
+vllm serve RadixArk/Qwen3.8-Flash-Next-NVFP4 ...
+```
+
+Zero workers selects the bounded default of `min(32, os.cpu_count())`.
+
+`VLLM_PLE_DISK_OFFLOAD_PROFILE=1` additionally logs lookup wall time and Linux
+minor/major fault counts. It is intended for diagnosis rather than production.
+
+## Implementation and safety properties
+
+- The PLE worker constructs the logical embedding on `meta`; it does not
+  allocate the 47.684-GiB anonymous parameter.
+- The loader accepts only checkpoint-native FP8 CPU tensors whose addresses
+  belong to real file mappings. Eager copies and missing shards fail closed.
+- All 128 tensors are retained after loading. The small global scale is copied
+  so it does not depend on a transient loader mapping.
+- `MADV_RANDOM` prevents Linux mmap read-around from pulling almost the entire
+  table into page cache after a sparse lookup.
+- Lookup globally sorts and deduplicates logical row IDs, divides them by
+  checkpoint shard, gathers independent shard segments through a persistent
+  thread pool, then restores original token/head order into the pinned output.
+- Disk mode without `VLLM_PLE_CPU_OFFLOAD=1` is rejected before model loading.
+
+The feature changes no default. The normal CPU-resident PLE path is untouched.
+
+The shard discovery/reload coverage in upstream vLLM
+[#54129](https://github.com/vllm-project/vllm/pull/54129) is broader. This SM70
+variant adopts its useful `np.unique` and cross-shard worker-pool strategy, but
+keeps 1Cat's existing single PLE CPU process: one lookup is computed per DP
+rank and fanned out to all four TP ranks. Directly porting #54129 would instead
+run the host gather independently in every TP model process. `MADV_RANDOM` is
+also retained here because the V100 host's normal mmap advice pulled 378.5 MiB
+of a 400-MiB shard for a sparse 1,024-row lookup.
+
+## Validation contract
+
+The full-model measurements used:
+
+- `RadixArk/Qwen3.8-Flash-Next-NVFP4`;
+- four Tesla V100-SXM2-32GB GPUs, TP4, V2 model runner, no MTP;
+- FP16 activations and KV cache, 262,144 maximum length;
+- chunked prefill with 8,192 scheduled tokens and prefix caching disabled;
+- current Flash-V100 QSA page4, FlashQLA GDN, and grouped NVFP4 MoE prefill;
+- PyTorch 2.10.0+cu128 and the current 12-argument Flash-V100 extension.
+
+The storage volume is ext4 on a RAID0 pair of Samsung NVMe drives. Read-only
+`fio` screens measured about 47.7 MiB/s and 12.2K IOPS for 4-KiB QD1 random
+reads, 186 MiB/s and 47.7K IOPS at QD32, and 6,775 MiB/s for 1-MiB sequential
+reads at QD32.
+
+### Memory and loading
+
+A standalone real-checkpoint smoke retained all 47.684 GiB in ten file mappings
+with 4.546 GiB peak RSS. Loading took 53.77 seconds from the colder run; a
+subsequent cached full-model run discovered and retained the mappings in about
+7 seconds. The earlier anonymous-table service used about 45--50 GiB RSS and
+historically took about 126 seconds to copy and prefault the table.
+
+The virtual mapping size is still 47.684 GiB. It is not resident memory. During
+the cold random 256K run, clean file cache grew by only about 1.8 GiB because
+random pages remained reclaimable under host pressure.
+
+### Quality
+
+The normal-prompt TP4 gate completed through 256K. Its two deterministic quality
+outputs exactly matched the RAM baseline token hashes:
+
+- arithmetic: `42<|im_end|>`;
+- Chinese: `在标准大气压下，水的沸点是100摄氏度。<|im_end|>`.
+
+The mapped-shard unit gate also compares gathered E4M3 bytes exactly and rejects
+an incomplete 128-shard table. The pooled implementation additionally exercised
+duplicate IDs spanning two shards. The three full-model random-input cases
+produced the same output token IDs and hashes as the resident-RAM path.
+
+## Prefill results
+
+### Repeated prompt, warm page cache
+
+The established benchmark repeats one short English sentence to reach each
+length. Consequently it touches the same small n-gram working set after the
+first chunk. Disk mmap then behaves like a reclaimable RAM mapping:
+
+| Input | RAM PLE | Disk mmap | Throughput change |
+| ---: | ---: | ---: | ---: |
+| 8,192 | 7,056.26 tok/s | 7,026.03 tok/s | -0.43% |
+| 32,768 | 6,603.30 tok/s | 6,332.56 tok/s | -4.10% |
+| 65,536 | 6,327.43 tok/s | 6,192.32 tok/s | -2.14% |
+| 131,000 | 5,927.33 tok/s | 5,764.59 tok/s | -2.75% |
+| 262,143 | 5,248.63 tok/s | 5,102.62 tok/s | -2.78% |
+
+Per-8K PLE lookup was normally 13--26 ms with zero major faults. Average GPU
+utilization in the 256K request was 98.8%.
+
+### Unique random tokens, cache dropped before every request
+
+A second gate generated only valid non-control vocabulary IDs and had 262,141
+unique trigrams in the 256K request. It synchronously evicted all ten PLE files
+after engine initialization and immediately before each measured request.
+
+An additional resident-RAM run used exactly the same prompt hashes. This
+corrects the earlier, invalid comparison between random mmap input and the
+highly repetitive RAM benchmark.
+
+| Input | Resident RAM | Serial mmap | 32-worker mmap | Gain vs serial |
+| ---: | ---: | ---: | ---: | ---: |
+| 8,192 | 2,465.38 tok/s | 2,627.33 tok/s | 4,869.10 tok/s | +85.3% |
+| 32,768 | 2,412.51 tok/s | 2,171.23 tok/s | 4,771.18 tok/s | +119.8% |
+| 262,143 | 2,496.81 tok/s | 2,382.35 tok/s | 4,044.35 tok/s | +69.8% |
+
+The corresponding 256K prefill times were 104.991, 110.036, and 64.817
+seconds. The pooled mmap route beats the current RAM implementation because
+the latter performs an unsorted single `torch.index_select` over the resident
+47.684-GiB table; it is a same-prompt control, not an optimized DRAM ceiling.
+
+| Input | Serial mmap lookup | 32-worker lookup | Speedup | Major faults, pooled |
+| ---: | ---: | ---: | ---: | ---: |
+| 8,192 | 1.853 s | 0.427 s | 4.34x | 135,298 |
+| 32,768 | 9.346 s | 1.731 s | 5.40x | 527,484 |
+| 262,143 | 57.052 s | 11.645 s | 4.90x | 3,483,396 |
+
+At 256K, average GPU utilization rose from 48.8% to 82.3% and average board
+power from 157.8 W to 218.3 W. Pooled chunk lookup started at 0.427 seconds and
+settled around 0.31--0.40 seconds. The lower long-run fault count comes from
+deduplication and bounded page-cache reuse; the first 8K case has effectively
+the same 135K cold faults before and after, so its 4.34x lookup gain is genuine
+I/O concurrency rather than a warmer cache.
+
+## Hardware limit versus optimization headroom
+
+The old implementation reached the hardware random-IOPS wall through a poor
+submission pattern, not an unavoidable model limit. It sorted IDs, but then
+visited 128 shards serially; each shard received only about 1,024 rows in an 8K
+chunk, too little for PyTorch's intra-op pool to create useful queue depth.
+
+A one-shard cold screen with the same 28,775 major faults took 4.321 seconds at
+one worker and 0.173 seconds at 24 workers. The all-shard 8K screen fell from
+3.442 seconds with serial shard dispatch to 0.583 seconds with 32 workers. The
+full model then confirmed 1.853 to 0.427 seconds for the first cold 8K lookup
+while fault count stayed constant. This is direct evidence of software
+headroom above the original QD1-like path.
+
+The volume is still bounded by random I/O: 4-KiB QD32 `fio` measured 47.7K IOPS
+and 186 MiB/s, while sequential bandwidth is about 6.8 GiB/s. Larger sorted
+windows remain useful (a global 256K screen took 15.864 seconds instead of the
+old 57.052-second sum), but cross-shard queue depth captures most of that gain
+without changing vLLM's 8K scheduler chunk.
+
+## Next optimization sequence
+
+1. Add two bounded 8K or 32K output buffers. The model runner already retains
+   full prompt token IDs, but the current connector sends only the active 8K
+   batch. Prepare window N+1 while the GPUs execute N, validate request/range
+   keys before reuse, and fall back synchronously on a scheduling mismatch.
+2. Pin the PLE worker and its I/O pool deliberately by NUMA topology. GPUs 4--7
+   are local to NUMA node 1; compare 32 local workers with a bounded cross-node
+   pool without stealing CPU from the separate GPUs 0--3 service.
+3. Replace synchronous mmap faults with per-file batched asynchronous reads.
+   Sort and deduplicate page offsets, coalesce adjacent pages, use fixed output
+   buffers, and scatter rows only after I/O completion. Do not sequentially
+   populate the complete 47.684-GiB mapping.
+4. Apply global deduplication/sorting to the resident-RAM implementation too;
+   its 2.50K random-input result is not a useful DRAM performance ceiling.
+5. Add a bounded hot-page or hot-row cache for natural-language repetition.
+   Keep its memory budget explicit so disk mode still saves tens of GiB.
+6. Treat decode separately. A cold 16-row token lookup can take 2--20 ms, which
+   can consume or exceed a 100-tok/s latency budget. Decode needs a rolling cache
+   or lookahead before this mode can be recommended for low-latency serving.
+
+The 32-worker run spends 11.645 seconds in PLE gather during a 64.817-second
+256K prefill. Ideal lookahead would reduce the exposed total toward 53 seconds,
+or about 4.9K tok/s. Reaching 6K and 8K requires totals below 43.7 and 32.8
+seconds respectively, so after I/O overlap the remaining work belongs to the
+GPU prefill path rather than the disk table.
+
+## Promotion gate
+
+Keep disk offload opt-in until all of the following hold:
+
+- normal-prompt output tokens and hashes match the RAM path;
+- cold, diverse 256K prefill keeps average GPU utilization above 90%;
+- 256K disk-offload prefill is within 10% of the same-prompt RAM control;
+- PLE worker RSS plus its bounded cache stays within the documented budget;
+- cancellation, multiple requests, prefix reuse, and decode do not consume a
+  stale prefetched buffer.

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
@@ -162,6 +163,50 @@ def test_ngram_embedding_accepts_checkpoint_seed_none(
     assert layer.ngram_embedding.weight.is_meta
 
 
+def test_ngram_embedding_disk_offload_allocates_only_meta_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(embedding_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        embedding_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(ple_module.envs, "VLLM_PLE_DISK_OFFLOAD", True)
+    monkeypatch.setattr(ple_module.envs, "VLLM_PLE_DISK_OFFLOAD_NUM_THREADS", 0)
+    monkeypatch.setattr(ple_module, "is_offload_process", lambda: True)
+    config = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=8,
+        eos_token_id=2,
+        vocab_size=64,
+        split_ngram_parts=2,
+        seed=None,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=128,
+        ple_embedding_dtype="float8_e4m3fn",
+        ple_offload_embedding=False,
+    )
+
+    layer = Qwen4ExpNGramEmbedding(
+        config,
+        embedding_dim=256,
+        ple_dense_layer_id=0,
+        max_total_tokens=8,
+        max_num_reqs=2,
+        prefix="model.layers.2.ple.ple_embedding",
+        layer_name="model.layers.2.ple",
+        params_dtype=torch.float16,
+    )
+
+    assert layer._disk_offload
+    assert len(layer._disk_shards) == 2
+    assert layer.ngram_embedding.weight.is_meta
+    assert layer.positions_buffer.device.type == "cpu"
+
+
 def _make_ngram_embedding_for_load_test() -> Qwen4ExpNGramEmbedding:
     module = Qwen4ExpNGramEmbedding.__new__(Qwen4ExpNGramEmbedding)
     nn.Module.__init__(module)
@@ -202,6 +247,17 @@ def _make_fp8_ngram_embedding_for_load_test() -> Qwen4ExpNGramEmbedding:
         nn.Parameter(torch.zeros(1, dtype=torch.bfloat16), requires_grad=False),
     )
     module.ngram_embedding = embedding
+    return module
+
+
+def _make_disk_ngram_embedding_for_load_test() -> Qwen4ExpNGramEmbedding:
+    module = _make_fp8_ngram_embedding_for_load_test()
+    module._disk_offload = True
+    module._disk_shards = [None, None]
+    module._disk_mapped_paths = set()
+    module._disk_shard_size = 4
+    module._disk_shard_boundaries = torch.tensor([4], dtype=torch.int64)
+    module.head_dim = 2
     return module
 
 
@@ -294,6 +350,61 @@ def test_ngram_embedding_loads_fp8_shards_and_global_scale() -> None:
     )
     assert torch.equal(module.ngram_embedding.weight_scale, weight_scale)
     assert module.get_offload_output_dtype(torch.bfloat16) == torch.uint8
+
+
+def test_ngram_embedding_retains_and_gathers_disk_shards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _make_disk_ngram_embedding_for_load_test()
+    shard_0 = torch.arange(8, dtype=torch.float32).reshape(4, 2).to(torch.float8_e4m3fn)
+    shard_1 = (
+        torch.arange(8, 16, dtype=torch.float32).reshape(4, 2).to(torch.float8_e4m3fn)
+    )
+    monkeypatch.setattr(
+        ple_module,
+        "_advise_random_file_access",
+        lambda _: "/tmp/test-ple.safetensors",
+    )
+
+    loaded = module.load_weights(
+        [
+            ("ngram_embedding.shard_0.weight", shard_0),
+            ("ngram_embedding.shard_1.weight", shard_1),
+            ("ngram_embedding.weight_scale", torch.tensor([0.25])),
+        ]
+    )
+    output = torch.empty(4, 2, dtype=torch.uint8)
+    ngram_ids = torch.tensor([[7], [0], [7], [2]], dtype=torch.int64)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        module._disk_executor = executor
+        module._disk_embedding_lookup(ngram_ids, output)
+
+    assert loaded == {"ngram_embedding.weight", "ngram_embedding.weight_scale"}
+    assert module._disk_shards[0] is shard_0
+    assert module._disk_shards[1] is shard_1
+    expected = torch.cat((shard_0, shard_1))[ngram_ids.reshape(-1)]
+    assert torch.equal(output, expected.view(torch.uint8))
+
+
+def test_ngram_embedding_disk_offload_rejects_missing_shard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _make_disk_ngram_embedding_for_load_test()
+    monkeypatch.setattr(
+        ple_module,
+        "_advise_random_file_access",
+        lambda _: "/tmp/test-ple.safetensors",
+    )
+
+    with pytest.raises(RuntimeError, match=r"did not load shards: \[1\]"):
+        module.load_weights(
+            [
+                (
+                    "ngram_embedding.shard_0.weight",
+                    torch.zeros(4, 2).to(torch.float8_e4m3fn),
+                )
+            ]
+        )
 
 
 def test_ngram_gpu_offload_retains_only_fp8_global_scale(monkeypatch) -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -729,6 +729,9 @@ if TYPE_CHECKING:
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
     VLLM_PLE_CPU_OFFLOAD: bool = False
+    VLLM_PLE_DISK_OFFLOAD: bool = False
+    VLLM_PLE_DISK_OFFLOAD_NUM_THREADS: int = 0
+    VLLM_PLE_DISK_OFFLOAD_PROFILE: bool = False
     VLLM_PLE_OFFLOAD_READY_TIMEOUT: float = 600.0
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
@@ -4271,6 +4274,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # implementation supports ModelRunner V1/V2 and node-local MP DP/TP.
     "VLLM_PLE_CPU_OFFLOAD": lambda: (
         os.getenv("VLLM_PLE_CPU_OFFLOAD", "False").lower() in ("true", "1")
+    ),
+    # Retain Qwen4Exp PLE safetensor shards as file-backed mappings instead of
+    # copying the complete learned n-gram table into anonymous host memory.
+    "VLLM_PLE_DISK_OFFLOAD": lambda: (
+        os.getenv("VLLM_PLE_DISK_OFFLOAD", "False").lower() in ("true", "1")
+    ),
+    # Number of cross-shard mmap gather workers. Zero selects a bounded
+    # hardware-aware default.
+    "VLLM_PLE_DISK_OFFLOAD_NUM_THREADS": lambda: int(
+        os.getenv("VLLM_PLE_DISK_OFFLOAD_NUM_THREADS", "0")
+    ),
+    "VLLM_PLE_DISK_OFFLOAD_PROFILE": lambda: (
+        os.getenv("VLLM_PLE_DISK_OFFLOAD_PROFILE", "False").lower() in ("true", "1")
     ),
     # Timeout for PLE weight loading and TP worker registration.
     "VLLM_PLE_OFFLOAD_READY_TIMEOUT": lambda: float(

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -2,10 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Qwen4Exp position-learning enhancement layers."""
 
+import ctypes
 import math
+import os
+import resource
+import time
 from collections.abc import Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -71,8 +77,44 @@ _SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
 _SPLITMIX_M1 = 0xBF58476D1CE4E5B9
 _SPLITMIX_M2 = 0x94D049BB133111EB
 _PLE_LAYER_PRIME = 10007
+_MADV_RANDOM = 1
 
 logger = init_logger(__name__)
+
+
+def _advise_random_file_access(tensor: torch.Tensor) -> str:
+    """Require a lazy file mapping and disable destructive mmap read-around."""
+    if tensor.device.type != "cpu" or tensor.is_meta:
+        raise RuntimeError("PLE disk shards must be real CPU tensors")
+    address = tensor.data_ptr()
+    mapped_path = None
+    with open("/proc/self/maps") as mappings:
+        for line in mappings:
+            fields = line.rstrip().split(maxsplit=5)
+            start_text, end_text = fields[0].split("-", maxsplit=1)
+            if int(start_text, 16) <= address < int(end_text, 16):
+                if len(fields) == 6 and fields[5].startswith("/"):
+                    mapped_path = fields[5]
+                break
+    if mapped_path is None:
+        raise RuntimeError(
+            "VLLM_PLE_DISK_OFFLOAD requires lazy file-backed safetensor "
+            "weights; eager or copied tensors are unsupported"
+        )
+
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    byte_count = tensor.numel() * tensor.element_size()
+    aligned_address = address - address % page_size
+    aligned_end = (address + byte_count + page_size - 1) // page_size * page_size
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.madvise(
+        ctypes.c_void_p(aligned_address),
+        ctypes.c_size_t(aligned_end - aligned_address),
+        _MADV_RANDOM,
+    ):
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return mapped_path
 
 
 @triton.jit
@@ -528,7 +570,55 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             embedding_prefix,
             force_fp8_storage=ple_storage_dtype == "float8_e4m3fn",
         )
-        if _should_use_pinned_host_ple(config):
+        self._disk_offload = bool(envs.VLLM_PLE_DISK_OFFLOAD and is_offload_process())
+        self._disk_shards: list[torch.Tensor | None] = []
+        self._disk_mapped_paths: set[str] = set()
+        self._disk_executor: ThreadPoolExecutor | None = None
+        if self._disk_offload:
+            if quant_method is None:
+                raise NotImplementedError(
+                    "Qwen4Exp PLE disk offload requires FP8 checkpoint storage"
+                )
+            with torch.device("meta"):
+                self.ngram_embedding = VocabParallelEmbedding(
+                    padded_vocab_size,
+                    self.head_dim,
+                    params_dtype=params_dtype,
+                    padding_size=divisor,
+                    prefix=embedding_prefix,
+                    quant_method=quant_method,
+                )
+            self._disk_shards = [None] * self.split_ngram_parts
+            shard_size = (
+                self.ngram_embedding.org_vocab_size + self.split_ngram_parts - 1
+            ) // self.split_ngram_parts
+            self._disk_shard_size = shard_size
+            self._disk_shard_boundaries = (
+                torch.arange(
+                    1,
+                    self.split_ngram_parts,
+                    dtype=torch.int64,
+                )
+                * shard_size
+            )
+            num_threads = envs.VLLM_PLE_DISK_OFFLOAD_NUM_THREADS
+            if num_threads < 0:
+                raise ValueError(
+                    "VLLM_PLE_DISK_OFFLOAD_NUM_THREADS must be non-negative"
+                )
+            if num_threads == 0:
+                num_threads = min(32, os.cpu_count() or 1)
+            self._disk_executor = ThreadPoolExecutor(
+                max_workers=num_threads,
+                thread_name_prefix="ple-mmap",
+            )
+            logger.info(
+                "Qwen4Exp PLE disk mmap enabled "
+                "(shards=%d, mmap workers=%d, access=random).",
+                self.split_ngram_parts,
+                num_threads,
+            )
+        elif _should_use_pinned_host_ple(config):
             if quant_method is None:
                 raise NotImplementedError(
                     "Qwen4Exp pinned-host PLE requires FP8 checkpoint storage"
@@ -690,6 +780,72 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
             id_blocks.append(ids[request_indices, adjusted_columns])
         return torch.cat(id_blocks, dim=-1)
 
+    def _disk_embedding_lookup(
+        self,
+        ngram_ids: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        """Gather mapped FP8 shard rows in logical-ID order."""
+        if output.dtype not in (torch.uint8, torch.float8_e4m3fn):
+            raise RuntimeError("PLE disk lookup currently requires FP8 output")
+        if any(shard is None for shard in self._disk_shards):
+            raise RuntimeError("PLE disk lookup started before every shard was loaded")
+
+        profile = envs.VLLM_PLE_DISK_OFFLOAD_PROFILE
+        if profile:
+            faults_before = resource.getrusage(resource.RUSAGE_SELF)
+            started = time.perf_counter()
+        flat_ids = ngram_ids.reshape(-1).numpy()
+        if flat_ids.size == 0:
+            return
+        sorted_ids, inverse = np.unique(flat_ids, return_inverse=True)
+        if sorted_ids[0] < 0 or sorted_ids[-1] >= self.ngram_embedding.org_vocab_size:
+            raise IndexError(
+                "PLE disk row id out of range: "
+                f"[{sorted_ids[0]}, {sorted_ids[-1]}] for "
+                f"{self.ngram_embedding.org_vocab_size} rows"
+            )
+        boundaries = self._disk_shard_boundaries.numpy()
+        split_positions = np.searchsorted(sorted_ids, boundaries).tolist()
+        starts = [0, *split_positions]
+        ends = [*split_positions, sorted_ids.size]
+        sorted_output = np.empty((sorted_ids.size, self.head_dim), dtype=np.uint8)
+
+        tasks = [
+            (shard_index, start, end)
+            for shard_index, (start, end) in enumerate(zip(starts, ends, strict=True))
+            if start != end
+        ]
+
+        def gather_shard(task: tuple[int, int, int]) -> None:
+            shard_index, start, end = task
+            shard = self._disk_shards[shard_index]
+            assert shard is not None
+            local_ids = sorted_ids[start:end] - shard_index * self._disk_shard_size
+            sorted_output[start:end] = shard.view(torch.uint8).numpy()[local_ids]
+
+        executor = getattr(self, "_disk_executor", None)
+        if executor is None or len(tasks) == 1:
+            for task in tasks:
+                gather_shard(task)
+        else:
+            for _ in executor.map(gather_shard, tasks):
+                pass
+
+        output_bytes = output.view(torch.uint8).reshape(-1, self.head_dim).numpy()
+        np.take(sorted_output, inverse, axis=0, out=output_bytes)
+        if profile:
+            faults_after = resource.getrusage(resource.RUSAGE_SELF)
+            logger.info(
+                "PLE disk mmap gather: tokens=%d rows=%d wall=%.3f ms "
+                "major_faults=%d minor_faults=%d",
+                ngram_ids.shape[0],
+                flat_ids.size,
+                (time.perf_counter() - started) * 1000.0,
+                faults_after.ru_majflt - faults_before.ru_majflt,
+                faults_after.ru_minflt - faults_before.ru_minflt,
+            )
+
     def forward_impl(  # type: ignore[override]
         self,
         hidden_states: torch.Tensor,
@@ -729,12 +885,15 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                 if output.dtype == torch.uint8
                 else output
             )
-            torch.index_select(
-                self.ngram_embedding.weight,
-                0,
-                ngram_ids.reshape(-1),
-                out=embedding_output.reshape(-1, self.head_dim),
-            )
+            if getattr(self, "_disk_offload", False):
+                self._disk_embedding_lookup(ngram_ids, embedding_output)
+            else:
+                torch.index_select(
+                    self.ngram_embedding.weight,
+                    0,
+                    ngram_ids.reshape(-1),
+                    out=embedding_output.reshape(-1, self.head_dim),
+                )
             return output
         return self.ngram_embedding(ngram_ids).flatten(-2)
 
@@ -752,6 +911,8 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load hash buffers and checkpoint-split embedding rows."""
+
+        disk_offload = getattr(self, "_disk_offload", False)
 
         # GPU workers keep only the scale required to dequantize the FP8 rows
         # returned by the CPU process. The embedding weights live exclusively
@@ -827,6 +988,17 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                         f"expected {expected_shape}, got "
                         f"{tuple(loaded_weight.shape)}"
                     )
+                if disk_offload:
+                    if loaded_weight.dtype != embedding.weight.dtype:
+                        raise ValueError(
+                            "PLE disk shard dtype mismatch: expected "
+                            f"{embedding.weight.dtype}, got {loaded_weight.dtype}"
+                        )
+                    mapped_path = _advise_random_file_access(loaded_weight)
+                    self._disk_shards[shard_index] = loaded_weight
+                    self._disk_mapped_paths.add(mapped_path)
+                    loaded.add("ngram_embedding.weight")
+                    continue
                 copy_ple_embedding_shard_(
                     embedding.weight.data,
                     loaded_weight,
@@ -836,8 +1008,34 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                 )
                 loaded.add("ngram_embedding.weight")
                 continue
+            if disk_offload and name == "ngram_embedding.weight_scale":
+                self._disk_weight_scale = loaded_weight.clone()
+                loaded.add(name)
+                continue
             regular_weights.append((name, loaded_weight))
 
+        if disk_offload:
+            missing_shards = [
+                index for index, shard in enumerate(self._disk_shards) if shard is None
+            ]
+            if missing_shards:
+                raise RuntimeError(
+                    f"PLE disk offload did not load shards: {missing_shards}"
+                )
+            mapped_gib = (
+                sum(
+                    shard.numel() * shard.element_size()
+                    for shard in self._disk_shards
+                    if shard is not None
+                )
+                / 2**30
+            )
+            logger.info(
+                "Qwen4Exp PLE retained %.3f GiB across %d file-backed "
+                "safetensor mappings without an anonymous table copy.",
+                mapped_gib,
+                len(self._disk_mapped_paths),
+            )
         if regular_weights:
             loaded.update(AutoWeightsLoader(self).load_weights(regular_weights))
         return loaded

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -155,6 +155,8 @@ class Worker(WorkerBase):
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
         self._ple_offload_worker_handle: Any | None = None
+        if envs.VLLM_PLE_DISK_OFFLOAD and not envs.VLLM_PLE_CPU_OFFLOAD:
+            raise ValueError("VLLM_PLE_DISK_OFFLOAD requires VLLM_PLE_CPU_OFFLOAD=1")
         self._ple_offload_enabled = self._has_ple_layers()
         if envs.VLLM_PLE_CPU_OFFLOAD:
             if self._ple_offload_enabled:


### PR DESCRIPTION
## Summary

- add an opt-in disk-backed PLE mode for Qwen3.8 Flash Next on the existing shared CPU-offload worker
- retain all 47.684 GiB of checkpoint-native FP8 PLE shards as reclaimable safetensor mappings instead of allocating an anonymous table
- globally deduplicate/sort row IDs, gather independent shards through a bounded 32-worker pool, and restore exact token/head order before the existing TP fan-out
- require real file mappings, apply MADV_RANDOM, and fail closed on eager copies or missing shards

The gather strategy is informed by upstream vLLM PR https://github.com/vllm-project/vllm/pull/54129. This implementation deliberately retains the 1Cat topology: one PLE lookup per DP rank is fanned out to all TP ranks, rather than repeating host gather work in four TP model processes.

## TP4 V100 results

Contract: 4x V100 32 GiB, TP4, V2, no MTP, FP16 KV, q=8192, max_len=262144, prefix cache off, Flash-V100 QSA page4, FlashQLA GDN, grouped NVFP4 MoE. Random valid token IDs were identical across routes and all PLE checkpoint files were evicted immediately before each request.

| Input | Resident RAM | Serial mmap | Pooled mmap | Gain vs serial |
| ---: | ---: | ---: | ---: | ---: |
| 8,192 | 2,465 tok/s | 2,627 tok/s | 4,869 tok/s | +85.3% |
| 32,768 | 2,413 tok/s | 2,171 tok/s | 4,771 tok/s | +119.8% |
| 262,143 | 2,497 tok/s | 2,382 tok/s | 4,044 tok/s | +69.8% |

At 256K, PLE gather fell from 57.052 s to 11.645 s and GPU utilization rose from 48.8% to 82.3%. The first cold 8K lookup kept essentially the same major-fault count, 135,301 versus 135,298, while falling from 1.853 s to 0.427 s. This isolates queue-depth and cross-shard concurrency as the gain.

All three full-model random cases produced the same output token IDs and hashes as resident RAM. Earlier normal-language gates also matched arithmetic and Chinese reference outputs through 256K. The mmap worker retained ten file mappings with about 4.55 GiB peak RSS instead of a roughly 48 GiB anonymous PLE allocation.

## Validation

- ruff format/check on all changed Python files
- 48 targeted PLE and offload-worker tests passed after merging current main
- exact duplicate-ID gather across multiple shards
- full TP4 cold-random 8K, 32K, and 256K run
- git diff --check

## Scope and follow-up

The feature is default-off and requires VLLM_PLE_CPU_OFFLOAD=1. Cold single-token lookup can still violate the 100 tok/s decode latency budget, so disk PLE is not promoted as the serving default yet. The next useful optimization is bounded lookahead/double-buffering; the measured 11.645 s of 256K gather can then overlap GPU work and move prefill toward roughly 4.9K tok/s. Reaching 6K-8K also requires further GPU prefill work.

## AI assistance

This change was AI-assisted by OpenAI Codex. The human repository owner requested and reviewed the integration scope, explicitly authorized the merge, and all authored/integration commits include DCO sign-off.