### PR TITLE
[Bug]: Hybrid mamba "align" prefill can starve a request forever — _mamba_block_aligned_split returns 0 on every step

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -441,12 +441,18 @@ class Scheduler(SchedulerInterface):
 
         end = start + num_new_tokens
         if end < prefill_end:
-            max_prefill_tokens = self.max_num_scheduled_tokens
-            long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
-            if long_prefill_threshold > 0:
-                max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
             aligned_end = end // block_size * block_size
-            if aligned_end > start or block_size <= max_prefill_tokens:
+            # Only take the aligned end when it advances past `start`. Otherwise
+            # this returns 0, the caller treats that as "cannot schedule", and
+            # the request is skipped on every step while it holds its KV blocks
+            # and encoder-cache entries. The condition recurs whenever the chunk
+            # available this step is shorter than one state block -- e.g. when
+            # the encoder-cache gate caps it just before an image placeholder --
+            # so the request starves indefinitely. Scheduling the shorter,
+            # unaligned chunk only skips this block's Mamba state checkpoint, and
+            # it cannot straddle two state blocks because `aligned_end <= start`
+            # implies `end < next_block_boundary`.
+            if aligned_end > start:
                 end = aligned_end
 
         # The align allocator materializes one recurrent-state column per


### PR DESCRIPTION
### What happens

`Scheduler._mamba_block_aligned_split` can return `0` for a request that still has
prompt left to prefill. The caller treats `0` as "cannot schedule" and skips the
request:

```python
if num_new_tokens == 0:
    # ...
    # 4. Insufficient budget for a block-aligned chunk in hybrid
    #    models with mamba cache mode "align".
    req_index += 1
    continue
```

That is fine if the condition is transient. It is not: the thing that shortened the
chunk is a property of the request, so it recurs on every subsequent step. The
request is never scheduled again while it holds its KV blocks and encoder-cache
entries, and the engine stops making progress.

### Why the guard does not guard

```python
aligned_end = end // block_size * block_size
if aligned_end > start or block_size <= max_prefill_tokens:
    end = aligned_end
```

The second disjunct is reachable **only** when `aligned_end <= start` — had it been
greater, the first disjunct would already have fired. So whenever a full state block
fits in the step budget (`block_size <= max_prefill_tokens`, the common case) *and*
the chunk available this step is shorter than one state block, `end` is assigned at
or behind `start`, and the function's `return max(end - start, 0)` yields `0`.

A sub-block chunk arises whenever something other than the token budget caps it. The
reliable trigger is the encoder-cache gate stopping a chunk just before an image
placeholder, when a request's images cannot all fit the encoder cache at once.

### Reproduction

Qwen3.8-27B (hybrid GDN), TP8, FP16, `--enable-prefix-caching` (so
`mamba_cache_mode="align"`), `--max-model-len 262144`,
`--max-num-batched-tokens 8192`, `--limit-mm-per-prompt '{"image": 16}'`.
Resolved `block_size` 400; encoder cache budget 16,384 tokens.

One request carrying two max-size images that cannot share the encoder cache:

```
running            16 -> 0
waiting             0 -> 17
generation_tokens_total   flat at 298441 for > 4 minutes
num_preemptions_total     0
```

Every stream hangs with no error. It recovers within seconds of aborting the stuck
request. **It is intermittent** — a shorter run of the same probe against the same
build did not trigger it, so a single clean run does not clear the build.

With the patch, the same probe run three times: no flat `generation_tokens_total`,
and the probe completes normally (61.8 s, `cached_tokens` 32000 of 32331).

### The fix

Take the aligned end only when it actually advances past `start`. This changes
behaviour solely in the case that previously returned `0` — when alignment can
advance, `aligned_end > start` already selects it.

Scheduling the shorter, unaligned chunk only skips this block's Mamba state
checkpoint, which is a request-local prefix-cache miss and already the documented
behaviour for sub-block chunks. It cannot straddle two state blocks, because
`aligned_end <= start` implies `end < next_block_boundary`, so the boundary clamp
below it is a no-op for this chunk.

`max_prefill_tokens` and `long_prefill_threshold` become unused and are removed.

### Relationship to existing work

This is **not** fixed by #47782 (the `_mamba_block_aligned_split` rewrite that
shipped in v0.26.0). That rewrite fixed a real and different problem — it aligns the
absolute end position rather than the chunk size, so a sub-block chunk no longer
de-aligns a request permanently — but it introduced the guard quoted above. The code
shown here is current on `main`.

Older reports of the pre-rewrite floor-to-zero: #40707, #47738, #45414, with fix PRs
#40709, #40757, #47771. **Verify their current state before citing them** — that list
was compiled in July 2026 and has not been rechecked.
