### PR TITLE
[Kernel][SM70] Improve Qwen3.8 no-MTP concurrency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/tm_registry_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/fp8_qpn8_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/mxfp4_qpn_m1_sm70.cu"
+      "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_grouped_decode_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn4_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/qwen38_prefill_cutlass.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn2_sm70.cu"

--- a/benchmarks/benchmark_sm70_tp4_mtp5_push_allreduce.py
+++ b/benchmarks/benchmark_sm70_tp4_mtp5_push_allreduce.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Benchmark the opt-in SM70 TP4 push collective for Qwen3.8 MTP4.
+"""Benchmark the opt-in SM70 TP4 push collective for Qwen3.8.
 
 This captures both the existing pull path and the candidate push path in one
 ``torchrun`` lifetime.  Each graph mirrors one 48-layer verifier round: one
-regular all-reduce and one shared+routed sum2 all-reduce per layer, both with
-the exact FP16 [5, 2560] payload.
+regular all-reduce and one shared+routed sum2 all-reduce per layer. The default
+remains the FP16 [5, 2560] MTP4 payload; ``--tokens`` also screens no-MTP
+concurrency widths.
 
 Example:
   CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 \
@@ -24,16 +25,16 @@ import torch.distributed as dist
 
 from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
 
-_TOKENS = 5
 _HIDDEN_SIZE = 2560
 _LAYERS = 48
 _MTP5_ENV = "VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5"
+_BATCH_ENV = "VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH"
 
 
-def _make_inputs(rank: int) -> tuple[torch.Tensor, torch.Tensor]:
+def _make_inputs(rank: int, tokens: int) -> tuple[torch.Tensor, torch.Tensor]:
     generator = torch.Generator(device="cuda")
     generator.manual_seed(20260828 + rank)
-    shape = (_TOKENS, _HIDDEN_SIZE)
+    shape = (tokens, _HIDDEN_SIZE)
     input_a = (
         torch.randn(shape, device="cuda", generator=generator, dtype=torch.float32)
         * 0.03
@@ -51,8 +52,10 @@ def _capture_round(
     input_b: torch.Tensor,
     *,
     push: bool,
+    tokens: int,
 ) -> tuple[torch.cuda.CUDAGraph, list[torch.Tensor]]:
-    os.environ[_MTP5_ENV] = "1" if push else "0"
+    os.environ[_MTP5_ENV] = "1" if push and tokens == 5 else "0"
+    os.environ[_BATCH_ENV] = "1" if push and tokens in (4, 8, 16) else "0"
     torch.accelerator.synchronize()
     dist.barrier()
     regular_outputs = [torch.empty_like(input_a) for _ in range(_LAYERS)]
@@ -189,6 +192,7 @@ def main() -> None:
     parser.add_argument("--warmup", type=int, default=20)
     parser.add_argument("--iterations", type=int, default=100)
     parser.add_argument("--timing-repeats", type=int, default=4)
+    parser.add_argument("--tokens", type=int, choices=(4, 5, 8, 16), default=5)
     parser.add_argument("--json-out")
     args = parser.parse_args()
     if args.warmup < 0 or args.iterations <= 0 or args.timing_repeats <= 0:
@@ -198,9 +202,7 @@ def main() -> None:
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
     if world_size != 4:
-        raise ValueError(
-            f"Qwen3.8 MTP5 push benchmark requires TP4, got TP{world_size}"
-        )
+        raise ValueError(f"Qwen3.8 push benchmark requires TP4, got TP{world_size}")
 
     torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(backend="nccl")
@@ -218,16 +220,16 @@ def main() -> None:
         if communicator.sm70_tp4_push_buffer_ptrs is None:
             raise RuntimeError("SM70 TP4 push buffer was not registered")
 
-        input_a, input_b = _make_inputs(rank)
+        input_a, input_b = _make_inputs(rank, args.tokens)
         if rank == 0:
             print("[tp4-mtp5-ar] capture baseline pull graph", flush=True)
         baseline_graph, baseline_outputs = _capture_round(
-            communicator, input_a, input_b, push=False
+            communicator, input_a, input_b, push=False, tokens=args.tokens
         )
         if rank == 0:
             print("[tp4-mtp5-ar] capture candidate push graph", flush=True)
         candidate_graph, candidate_outputs = _capture_round(
-            communicator, input_a, input_b, push=True
+            communicator, input_a, input_b, push=True, tokens=args.tokens
         )
         if rank == 0:
             print("[tp4-mtp5-ar] compare dynamic graph outputs", flush=True)
@@ -263,7 +265,7 @@ def main() -> None:
         savings_ms = control_ms - candidate_ms
         result = {
             "world_size": world_size,
-            "shape": [_TOKENS, _HIDDEN_SIZE],
+            "shape": [args.tokens, _HIDDEN_SIZE],
             "dtype": "float16",
             "layers": _LAYERS,
             "collectives_per_round": collectives,
@@ -304,6 +306,7 @@ def main() -> None:
             raise SystemExit(1)
     finally:
         os.environ[_MTP5_ENV] = "0"
+        os.environ[_BATCH_ENV] = "0"
         communicator.close()
         dist.destroy_process_group(gloo_group)
         dist.destroy_process_group()

--- a/benchmarks/kernels/benchmark_qwen38_fp16_verifier_m5.py
+++ b/benchmarks/kernels/benchmark_qwen38_fp16_verifier_m5.py
@@ -242,6 +242,8 @@ def _benchmark_shape(
         candidates.append(row)
 
     for padded_m in (8, 16):
+        if padded_m < _M:
+            continue
         padded_x = torch.zeros((padded_m, k), dtype=x.dtype, device=x.device)
         padded_x[:_M].copy_(x)
         padded_output = torch.empty((padded_m, n), dtype=x.dtype, device=x.device)
@@ -538,7 +540,17 @@ def _benchmark_hc_pair(
 
 
 def main() -> None:
+    global _M
+
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tokens",
+        type=int,
+        choices=range(1, 17),
+        default=_M,
+        metavar="M",
+        help="Decode/verifier batch width (1..16; default: 5).",
+    )
     parser.add_argument("--warmups", type=int, default=20)
     parser.add_argument("--repeats", type=int, default=200)
     parser.add_argument("--seed", type=int, default=0)
@@ -565,6 +577,7 @@ def main() -> None:
     )
     parser.add_argument("--out", type=Path)
     args = parser.parse_args()
+    _M = args.tokens
 
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("This benchmark requires an NVIDIA SM70 GPU.")
@@ -621,7 +634,11 @@ def main() -> None:
         "weighted_cost_model": {
             "torch_us": baseline_weighted_us,
             "best_candidate_us": candidate_weighted_us,
-            "speedup": baseline_weighted_us / candidate_weighted_us,
+            "speedup": (
+                baseline_weighted_us / candidate_weighted_us
+                if candidate_weighted_us
+                else None
+            ),
             "saved_us": baseline_weighted_us - candidate_weighted_us,
             "note": (
                 "Serial service-sum model; accepted Nsight graph timing "

--- a/benchmarks/kernels/benchmark_qwen38_qsa_mtp5_flash_v100.py
+++ b/benchmarks/kernels/benchmark_qwen38_qsa_mtp5_flash_v100.py
@@ -42,7 +42,7 @@ def _measure_ms(call, *, warmups: int, repeats: int) -> float:
 
 
 def _logical_indices(
-    *, rows: int, seq_len: int, overlap: float, seed: int
+    *, rows: int, seq_len: int, overlap: float, seed: int, independent: bool
 ) -> torch.Tensor:
     """Build 2051-token selections with controlled adjacent-row Page4 overlap."""
     generator = torch.Generator().manual_seed(seed)
@@ -65,7 +65,7 @@ def _logical_indices(
         ]
         pages = torch.cat((shared, unique))
         tokens = (pages[:, None] * 4 + torch.arange(4)).flatten()
-        query_position = seq_len - rows + row
+        query_position = seq_len - 1 if independent else seq_len - rows + row
         tail = torch.arange(query_position - 2, query_position + 1)
         selections.append(torch.cat((tokens, tail)).to(torch.int32))
     return torch.stack(selections)
@@ -74,6 +74,8 @@ def _logical_indices(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--rows", type=int, choices=(5, 8, 16), default=5)
+    parser.add_argument("--independent-requests", action="store_true")
     parser.add_argument("--overlap", type=float, default=0.82)
     parser.add_argument("--warmups", type=int, default=20)
     parser.add_argument("--repeats", type=int, default=200)
@@ -90,12 +92,14 @@ def main() -> int:
     if not all(hasattr(flash_attn_v100_cuda, name) for name in required):
         raise RuntimeError("Flash-V100 was not built with grouped Page4 operators")
 
-    rows = 5
-    padded_rows = 8
+    rows = args.rows
+    padded_rows = ((rows + 7) // 8) * 8
     heads = 6
     head_dim = 256
     page_size = 784
-    num_cache_blocks = (args.seq_len + page_size - 1) // page_size
+    blocks_per_request = (args.seq_len + page_size - 1) // page_size
+    num_requests = rows if args.independent_requests else 1
+    num_cache_blocks = blocks_per_request * num_requests
     torch.manual_seed(args.seed)
     query = torch.randn((rows, heads, head_dim), device="cuda", dtype=torch.float16)
     key_cache = torch.randn(
@@ -109,18 +113,29 @@ def main() -> int:
         seq_len=args.seq_len,
         overlap=args.overlap,
         seed=args.seed,
+        independent=args.independent_requests,
     ).to("cuda")
-    block_table = torch.arange(num_cache_blocks, dtype=torch.int32, device="cuda")[
-        None, :
-    ]
-    token_to_req = torch.zeros(rows, dtype=torch.int32, device="cuda")
-    query_positions = torch.arange(
-        args.seq_len - rows,
-        args.seq_len,
-        dtype=torch.int64,
-        device="cuda",
+    block_table = torch.arange(num_cache_blocks, dtype=torch.int32, device="cuda").view(
+        num_requests, blocks_per_request
     )
-    sequence_lengths = torch.tensor([args.seq_len], dtype=torch.int32, device="cuda")
+    token_to_req = (
+        torch.arange(rows, dtype=torch.int32, device="cuda")
+        if args.independent_requests
+        else torch.zeros(rows, dtype=torch.int32, device="cuda")
+    )
+    query_positions = (
+        torch.full((rows,), args.seq_len - 1, dtype=torch.int64, device="cuda")
+        if args.independent_requests
+        else torch.arange(
+            args.seq_len - rows,
+            args.seq_len,
+            dtype=torch.int64,
+            device="cuda",
+        )
+    )
+    sequence_lengths = torch.full(
+        (num_requests,), args.seq_len, dtype=torch.int32, device="cuda"
+    )
     reference = torch.empty_like(query)
     xqa_candidate = torch.empty_like(query)
 
@@ -166,6 +181,9 @@ def main() -> int:
             padded_query_positions,
             sequence_lengths,
             candidate,
+            "auto",
+            1.0,
+            1.0,
             flash_attn_v100_cuda,
         )
 
@@ -180,6 +198,9 @@ def main() -> int:
             query_positions,
             sequence_lengths,
             xqa_candidate,
+            "auto",
+            1.0,
+            1.0,
         )
         if result is None:
             raise RuntimeError("Flash-V100 XQA Page4 route is unavailable")
@@ -209,6 +230,7 @@ def main() -> int:
         "sm": list(torch.cuda.get_device_capability()),
         "rows": rows,
         "padded_rows": padded_rows,
+        "independent_requests": args.independent_requests,
         "seq_len": args.seq_len,
         "selection_width": indices.shape[1],
         "requested_page_overlap": args.overlap,

--- a/benchmarks/kernels/benchmark_qwen38_router_mtp5.py
+++ b/benchmarks/kernels/benchmark_qwen38_router_mtp5.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Benchmark the exact SM70 Qwen3.8 E512/K10 router at verifier M=5."""
+"""Benchmark the exact SM70 Qwen3.8 E512/K10 small-batch router."""
 
 from __future__ import annotations
 
@@ -17,7 +17,6 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
     _sm70_qwen38_router_topk,
 )
 
-TOKENS = 5
 EXPERTS = 512
 TOP_K = 10
 LAYERS = 48
@@ -56,14 +55,16 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--warmup", type=int, default=20)
     parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--tokens", type=int, choices=range(1, 17), default=5)
     args = parser.parse_args()
     if torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("benchmark requires exact SM70")
 
     torch.manual_seed(args.seed)
-    logits = torch.randn(TOKENS, EXPERTS, device="cuda", dtype=torch.float16)
-    baseline_weights = torch.empty(TOKENS, TOP_K, device="cuda", dtype=torch.float32)
-    baseline_ids = torch.empty(TOKENS, TOP_K, device="cuda", dtype=torch.int32)
+    tokens = args.tokens
+    logits = torch.randn(tokens, EXPERTS, device="cuda", dtype=torch.float16)
+    baseline_weights = torch.empty(tokens, TOP_K, device="cuda", dtype=torch.float32)
+    baseline_ids = torch.empty(tokens, TOP_K, device="cuda", dtype=torch.int32)
     baseline_rows = torch.empty_like(baseline_ids)
     candidate_weights = torch.empty_like(baseline_weights)
     candidate_ids = torch.empty_like(baseline_ids)
@@ -119,7 +120,7 @@ def main() -> None:
     )
     result = {
         "device": torch.cuda.get_device_name(),
-        "shape": [TOKENS, EXPERTS],
+        "shape": [tokens, EXPERTS],
         "top_k": TOP_K,
         "layers_per_round": LAYERS,
         "dynamic_graph_comparison": comparison,

--- a/benchmarks/kernels/benchmark_sm70_hc_batch.py
+++ b/benchmarks/kernels/benchmark_sm70_hc_batch.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: B023
+"""Benchmark-only packed FP16 HC fusion; no activation quantization.
+
+Real checkpoint weights, synthetic activations. Timings include the complete
+down/inject -> FP16 -> SiLU -> FP16 -> up -> FP16 -> gate/mix chain.
+No model-quality or endpoint-throughput claim. Loop closures are synchronous.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from torch.utils.cpp_extension import load
+
+from vllm.models.qwen4_exp.nvidia.ops.hc import hc_gate_mix, hc_silu
+
+
+def capture(fn, unroll=32):
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for _ in range(unroll):
+            output = fn()
+    return graph, output
+
+
+def timed(graph, repeats, unroll=32):
+    begin, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    begin.record()
+    for _ in range(repeats):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return begin.elapsed_time(end) * 1000 / (repeats * unroll)
+
+
+def error(actual, expected):
+    a, b = actual.float(), expected.float()
+    return dict(
+        exact=torch.equal(actual, expected),
+        finite=torch.isfinite(a).all().item(),
+        max_abs=(a - b).abs().max().item(),
+        relative_l2=((a - b).norm() / b.norm().clamp_min(1e-12)).item(),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--layers", default="0")
+    parser.add_argument("--pairs", default="attn,mlp")
+    parser.add_argument("--tokens", default="4,8,16")
+    parser.add_argument("--splits", default="4,8,16,20")
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("This benchmark requires SM70")
+    if not os.environ.get("TORCH_EXTENSIONS_DIR"):
+        raise RuntimeError("Set a task-owned TORCH_EXTENSIONS_DIR")
+    source = Path(__file__).with_name("sm70_hc_batch_screen.cu")
+    source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+    library = load(
+        name="sm70_hc_batch_screen",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "-lineinfo", "-Xptxas=-v"],
+        is_python_module=False,
+    )
+    library_sha = hashlib.sha256(Path(library).read_bytes()).hexdigest()
+    index = json.loads((args.model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+
+    def weight(name):
+        with safe_open(args.model / index[name], framework="pt", device="cpu") as f:
+            return f.get_tensor(name).half().cuda().contiguous()
+
+    rows = []
+    torch.manual_seed(20260905)
+    for layer in map(int, args.layers.split(",")):
+        for pair in args.pairs.split(","):
+            stem = f"model.language_model.layers.{layer}.{pair}_hyper_connection"
+            down = weight(stem + ".input_mix_weight_down.weight")
+            inject = weight(stem + ".block_inject_weight.weight")
+            down = torch.cat((down, inject, down.new_zeros(12, 10240)))
+            up = weight(stem + ".input_mix_weight_up.weight")
+            # Lossless permutation/padding, done before capture. It costs one
+            # extra persistent copy in this prototype and is explicitly reported.
+            down_p = torch.cat((down, down.new_zeros(16, 10240)))
+            down_p = down_p.view(11, 32, 640, 2, 8).permute(0, 2, 3, 1, 4).contiguous()
+            up_p = up.view(4, 80, 32, 20, 2, 8).permute(0, 1, 3, 4, 2, 5).contiguous()
+            for m in map(int, args.tokens.split(",")):
+                x = torch.randn(m, 10240, dtype=torch.float16, device="cuda")
+                lora = x.new_empty(m, 320)
+                injection = x.new_empty(m, 4)
+                out = x.new_empty(m, 2560)
+                scratch = torch.empty(20, m, 352, dtype=torch.float32, device="cuda")
+
+                def baseline():
+                    d = torch.nn.functional.linear(x, down)
+                    h = hc_silu(d[:, :320], 4)
+                    return hc_gate_mix(x, torch.nn.functional.linear(h, up), 4), d[
+                        :, 320:324
+                    ]
+
+                def up_only():
+                    d = torch.nn.functional.linear(x, down)
+                    h = hc_silu(d[:, :320], 4)
+                    torch.ops.sm70_hc_screen.up(out, h, up_p, x)
+                    return out, d[:, 320:324]
+
+                base_graph, base_outputs = capture(baseline)
+                for split in [0, *map(int, args.splits.split(","))]:
+
+                    def full():
+                        torch.ops.sm70_hc_screen.down(
+                            lora, injection, x, down_p, scratch, split
+                        )
+                        torch.ops.sm70_hc_screen.up(out, lora, up_p, x)
+                        return out, injection
+
+                    fn = full if split else up_only
+                    candidate_graph, candidate_outputs = capture(fn)
+                    checks = []
+                    for scale in (0.25, 1.0, 3.0):
+                        x.normal_().mul_(scale)
+                        expected = tuple(t.clone() for t in baseline())
+                        actual = tuple(t.clone() for t in fn())
+                        out.fill_(float("nan"))
+                        scratch.fill_(float("nan"))
+                        lora.fill_(float("nan"))
+                        injection.fill_(float("nan"))
+                        candidate_graph.replay()
+                        torch.cuda.synchronize()
+                        graph_errors = [
+                            error(a, b) for a, b in zip(candidate_outputs, actual)
+                        ]
+                        assert all(e["exact"] and e["finite"] for e in graph_errors)
+                        checks.append(
+                            dict(
+                                scale=scale,
+                                block=error(actual[0], expected[0]),
+                                injection=error(actual[1], expected[1]),
+                            )
+                        )
+                    assert all(
+                        c[k]["finite"] for c in checks for k in ("block", "injection")
+                    )
+                    # Alternate A/B order with fixed pointers and amortized replay
+                    # submission; do not promote a single noisy minimum.
+                    a, b = [], []
+                    for sample in range(args.samples):
+                        for graph, dest in (
+                            ((base_graph, a), (candidate_graph, b))
+                            if sample % 2 == 0
+                            else ((candidate_graph, b), (base_graph, a))
+                        ):
+                            dest.append(timed(graph, args.repeats))
+                    row = dict(
+                        layer=layer,
+                        pair=pair,
+                        tokens=m,
+                        split=split,
+                        baseline_us=statistics.median(a),
+                        candidate_us=statistics.median(b),
+                        paired_saving_us=statistics.median(
+                            [aa - bb for aa, bb in zip(a, b)]
+                        ),
+                        baseline_samples=a,
+                        candidate_samples=b,
+                        checks=checks,
+                    )
+                    rows.append(row)
+                    print(json.dumps(row), flush=True)
+                    del candidate_graph, candidate_outputs
+                del base_graph, base_outputs
+    payload = dict(
+        gpu=torch.cuda.get_device_name(),
+        torch=torch.__version__,
+        cuda=torch.version.cuda,
+        model=str(args.model),
+        args=vars(args),
+        source_sha256=source_sha,
+        library_sha256=library_sha,
+        extra_weight_mib_per_hc=(352 * 10240 + 10240 * 320) * 2 / 2**20,
+        rows=rows,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, default=str) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
+++ b/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
@@ -59,10 +59,19 @@ def main():
     p.add_argument("--pair", choices=("attn", "mlp"), default="attn")
     p.add_argument("--mode", choices=("full", "down"), default="full")
     p.add_argument(
+        "--weight-copies",
+        type=int,
+        default=1,
+        help="Distinct allocations of the same real weights: cache-footprint screen",
+    )
+    p.add_argument(
         "--profile", action="store_true", help="Capture graph nodes, skip timing sweep"
     )
     p.add_argument("--out", type=Path, required=True)
     args = p.parse_args()
+    if args.weight_copies <= 0:
+        p.error("--weight-copies must be positive")
+    calls_per_graph = max(16, args.weight_copies)
     rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(rank)
     dist.init_process_group("nccl")
@@ -125,6 +134,9 @@ def main():
         .reshape(2560, 320)
         .contiguous()
     )
+    weights = [(down, up, local_down_w, local_up_w)]
+    for _ in range(args.weight_copies - 1):
+        weights.append(tuple(w.clone() for w in weights[0]))
     results = []
     try:
         for m in map(int, args.tokens.split(",")):
@@ -135,23 +147,25 @@ def main():
             sparse_output = x.new_empty(m, 2560)
             output = torch.empty_like(sparse_output)
 
-            def baseline():
-                d = torch.nn.functional.linear(x, down)
+            def baseline(index=0):
+                wd, wu, _, _ = weights[index]
+                d = torch.nn.functional.linear(x, wd)
                 lora = hc_silu(d[:, :320], 4)
-                return hc_gate_mix(x, torch.nn.functional.linear(lora, up), 4), d[
+                return hc_gate_mix(x, torch.nn.functional.linear(lora, wu), 4), d[
                     :, 320:324
                 ]
 
-            def candidate(registered):
-                d = torch.nn.functional.linear(x, local_down_w)
+            def candidate(registered, index=0):
+                _, wu, local_wd, local_wu = weights[index]
+                d = torch.nn.functional.linear(x, local_wd)
                 scatter_down[(m,)](d, sparse_down, RANK=rank)
                 ca.all_reduce(sparse_down, out=full_down, registered=registered)
                 lora = hc_silu(full_down[:, :320], 4)
                 if args.mode == "down":
                     return hc_gate_mix(
-                        x, torch.nn.functional.linear(lora, up), 4
+                        x, torch.nn.functional.linear(lora, wu), 4
                     ), full_down[:, 320:324]
-                gate = torch.nn.functional.linear(lora, local_up_w)
+                gate = torch.nn.functional.linear(lora, local_wu)
                 mix_scatter[(m, 10)](gate, x, sparse_output, RANK=rank)
                 ca.all_reduce(sparse_output, out=output, registered=registered)
                 return output, full_down[:, 320:324]
@@ -165,8 +179,9 @@ def main():
             for which in (0, 1):
                 graph = torch.cuda.CUDAGraph()
                 with ca.capture(), torch.cuda.graph(graph):
-                    for _ in range(16):
-                        values = candidate(True) if which else baseline()
+                    for call in range(calls_per_graph):
+                        index = call % args.weight_copies
+                        values = candidate(True, index) if which else baseline(index)
                 graphs.append(graph)
                 outputs.append(values)
             checks = []
@@ -236,7 +251,7 @@ def main():
                         graphs[which].replay()
                     end.record()
                     end.synchronize()
-                    us = begin.elapsed_time(end) * 1000 / (40 * 16)
+                    us = begin.elapsed_time(end) * 1000 / (40 * calls_per_graph)
                     all_us = [None] * 4
                     dist.all_gather_object(all_us, us, group=group)
                     check_exclusive()
@@ -261,6 +276,13 @@ def main():
                 "custom_ar_library": library,
                 "small_message_push": os.environ.get(
                     "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "0"
+                ),
+                "calls_per_graph": calls_per_graph,
+                "replicated_weight_bytes": sum(
+                    w.numel() * w.element_size() for ws in weights for w in ws[:2]
+                ),
+                "sharded_weight_bytes": sum(
+                    w.numel() * w.element_size() for ws in weights for w in ws[2:]
                 ),
             }
             if library:

--- a/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
+++ b/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: B023
+"""HC output sharding screen using existing SM70 collectives, no new runtime.
+
+Unlike the M1 path in PR #481, this uses batched cuBLAS on local output columns
+and disjoint-output all-reduces. Includes both communications and scatter/mix.
+Real weights, synthetic activations; this is not a model-quality test.
+"""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from safetensors import safe_open
+
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+from vllm.models.qwen4_exp.nvidia.ops.hc import hc_gate_mix, hc_silu
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def scatter_down(local, full, RANK: tl.constexpr):
+    row = tl.program_id(0)
+    col = tl.arange(0, 512)
+    idx = col - RANK * 80
+    belongs = (idx >= 0) & (idx < 80)
+    if RANK == 3:
+        belongs |= (idx >= 80) & (idx < 84)
+    val = tl.load(local + row * 88 + idx, belongs, 0)
+    tl.store(full + row * 336 + col, val, col < 336)
+
+
+@triton.jit
+def mix_scatter(gate, x, out, RANK: tl.constexpr):
+    row = tl.program_id(0)
+    col = tl.program_id(1) * 256 + tl.arange(0, 256)
+    local = col - RANK * 640
+    valid = (local >= 0) & (local < 640)
+    acc = tl.full((256,), 0, tl.float32)
+    for branch in tl.static_range(4):
+        g = tl.load(gate + row * 2560 + branch * 640 + local, valid, 0).to(tl.float32)
+        val = tl.load(x + row * 10240 + branch * 2560 + col, valid, 0).to(tl.float32)
+        acc = tl.fma(tl.sigmoid(g), val, acc)
+    tl.store(out + row * 2560 + col, acc / 4)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", type=Path, required=True)
+    p.add_argument("--tokens", default="4,8,16")
+    p.add_argument("--layer", type=int, default=0)
+    p.add_argument("--pair", choices=("attn", "mlp"), default="attn")
+    p.add_argument("--mode", choices=("full", "down"), default="full")
+    p.add_argument("--out", type=Path, required=True)
+    args = p.parse_args()
+    rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl")
+    assert dist.get_world_size() == 4
+    group = dist.new_group(backend="gloo")
+    owned_pids = [None] * 4
+    dist.all_gather_object(owned_pids, os.getpid(), group=group)
+
+    def check_exclusive():
+        other = []
+        if rank == 0:
+            devices = os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3")
+            report = subprocess.check_output(
+                [
+                    "nvidia-smi",
+                    "-i",
+                    devices,
+                    "--query-compute-apps=pid,process_name",
+                    "--format=csv,noheader,nounits",
+                ],
+                text=True,
+            )
+            for line in report.splitlines():
+                pid, _, name = line.partition(",")
+                if (
+                    pid.strip().isdigit()
+                    and int(pid) not in owned_pids
+                    and "snapd-desktop-integration" not in name
+                ):
+                    other.append(line)
+        result = [other]
+        dist.broadcast_object_list(result, src=0, group=group)
+        if result[0]:
+            raise RuntimeError(
+                f"Foreign GPU processes appeared; discard this timing: {result[0]}"
+            )
+
+    ca = CustomAllreduce(group, rank, max_size=128 * 1024)
+    assert not ca.disabled
+    index = json.loads((args.model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    stem = f"model.language_model.layers.{args.layer}.{args.pair}_hyper_connection"
+
+    def weight(suffix):
+        key = stem + suffix
+        with safe_open(args.model / index[key], framework="pt", device="cpu") as f:
+            return f.get_tensor(key).half().cuda().contiguous()
+
+    down = weight(".input_mix_weight_down.weight")
+    injection = weight(".block_inject_weight.weight")
+    down = torch.cat((down, injection, down.new_zeros(12, 10240)))
+    up = weight(".input_mix_weight_up.weight")
+    local_down_w = down.new_zeros(88, 10240)
+    local_down_w[:80].copy_(down[rank * 80 : (rank + 1) * 80])
+    if rank == 3:
+        local_down_w[80:84].copy_(down[320:324])
+    local_up_w = (
+        up.view(4, 2560, 320)[:, rank * 640 : (rank + 1) * 640]
+        .reshape(2560, 320)
+        .contiguous()
+    )
+    results = []
+    try:
+        for m in map(int, args.tokens.split(",")):
+            torch.manual_seed(20260905)
+            x = torch.randn(m, 10240, device="cuda", dtype=torch.float16)
+            sparse_down = x.new_empty(m, 336)
+            full_down = torch.empty_like(sparse_down)
+            sparse_output = x.new_empty(m, 2560)
+            output = torch.empty_like(sparse_output)
+
+            def baseline():
+                d = torch.nn.functional.linear(x, down)
+                lora = hc_silu(d[:, :320], 4)
+                return hc_gate_mix(x, torch.nn.functional.linear(lora, up), 4), d[
+                    :, 320:324
+                ]
+
+            def candidate(registered):
+                d = torch.nn.functional.linear(x, local_down_w)
+                scatter_down[(m,)](d, sparse_down, RANK=rank)
+                ca.all_reduce(sparse_down, out=full_down, registered=registered)
+                lora = hc_silu(full_down[:, :320], 4)
+                if args.mode == "down":
+                    return hc_gate_mix(
+                        x, torch.nn.functional.linear(lora, up), 4
+                    ), full_down[:, 320:324]
+                gate = torch.nn.functional.linear(lora, local_up_w)
+                mix_scatter[(m, 10)](gate, x, sparse_output, RANK=rank)
+                ca.all_reduce(sparse_output, out=output, registered=registered)
+                return output, full_down[:, 320:324]
+
+            for _ in range(3):
+                baseline()
+                candidate(False)
+            torch.cuda.synchronize()
+            dist.barrier()
+            graphs, outputs = [], []
+            for which in (0, 1):
+                graph = torch.cuda.CUDAGraph()
+                with ca.capture(), torch.cuda.graph(graph):
+                    for _ in range(16):
+                        values = candidate(True) if which else baseline()
+                graphs.append(graph)
+                outputs.append(values)
+            checks = []
+            for scale in (0.25, 1.0, 3.0):
+                x.normal_().mul_(scale)
+                # Identical generators on all ranks; enforce common inputs.
+                dist.broadcast(x, 0)
+                expected = tuple(t.clone() for t in baseline())
+                actual = tuple(t.clone() for t in candidate(False))
+                sparse_down.fill_(float("nan"))
+                output.fill_(float("nan"))
+                graphs[1].replay()
+                torch.cuda.synchronize()
+                row = []
+                for i, (a, b) in enumerate(zip(outputs[1], expected)):
+                    torch.testing.assert_close(a, actual[i], rtol=0, atol=0)
+                    delta = a.float() - b.float()
+                    row.append(
+                        dict(
+                            exact=torch.equal(a, b),
+                            max_abs=delta.abs().max().item(),
+                            relative_l2=(
+                                delta.norm() / b.float().norm().clamp_min(1e-12)
+                            ).item(),
+                            finite=torch.isfinite(a).all().item(),
+                        )
+                    )
+                checks.append(row)
+            assert all(c["finite"] for row in checks for c in row)
+            times = [[], []]
+            for sample in range(5):
+                for which in (0, 1) if sample % 2 == 0 else (1, 0):
+                    for _ in range(20):
+                        graphs[which].replay()
+                    torch.cuda.synchronize()
+                    dist.barrier()
+                    check_exclusive()
+                    begin, end = (
+                        torch.cuda.Event(enable_timing=True) for _ in range(2)
+                    )
+                    begin.record()
+                    for _ in range(40):
+                        graphs[which].replay()
+                    end.record()
+                    end.synchronize()
+                    us = begin.elapsed_time(end) * 1000 / (40 * 16)
+                    all_us = [None] * 4
+                    dist.all_gather_object(all_us, us, group=group)
+                    check_exclusive()
+                    times[which].append(max(all_us))
+            local_result = dict(
+                rank=rank,
+                tokens=m,
+                baseline_us=statistics.median(times[0]),
+                candidate_us=statistics.median(times[1]),
+                times=times,
+                checks=checks,
+            )
+            gathered = [None] * 4
+            dist.all_gather_object(gathered, local_result, group=group)
+            if rank == 0:
+                results.append(gathered)
+                print(json.dumps(gathered), flush=True)
+            del graphs, outputs
+        if rank == 0:
+            args.out.parent.mkdir(exist_ok=True, parents=True)
+            args.out.write_text(
+                json.dumps(
+                    dict(args=vars(args), results=results), default=str, indent=2
+                )
+                + "\n"
+            )
+    finally:
+        ca.close()
+        dist.destroy_process_group(group)
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
+++ b/benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py
@@ -9,6 +9,7 @@ Real weights, synthetic activations; this is not a model-quality test.
 """
 
 import argparse
+import hashlib
 import json
 import os
 import statistics
@@ -57,6 +58,9 @@ def main():
     p.add_argument("--layer", type=int, default=0)
     p.add_argument("--pair", choices=("attn", "mlp"), default="attn")
     p.add_argument("--mode", choices=("full", "down"), default="full")
+    p.add_argument(
+        "--profile", action="store_true", help="Capture graph nodes, skip timing sweep"
+    )
     p.add_argument("--out", type=Path, required=True)
     args = p.parse_args()
     rank = int(os.environ["LOCAL_RANK"])
@@ -192,6 +196,30 @@ def main():
                     )
                 checks.append(row)
             assert all(c["finite"] for row in checks for c in row)
+            if args.profile:
+                for _ in range(30):
+                    graphs[0].replay()
+                    graphs[1].replay()
+                torch.cuda.synchronize()
+                check_exclusive()
+                dist.barrier()
+                torch.cuda.profiler.start()
+                for _ in range(3):
+                    for which, name in ((0, "hc.baseline"), (1, "hc.candidate")):
+                        with torch.cuda.nvtx.range(name):
+                            graphs[which].replay()
+                            torch.cuda.synchronize()
+                        dist.barrier()
+                torch.cuda.profiler.stop()
+                check_exclusive()
+                if rank == 0:
+                    print(
+                        "HC profile completed; trace is composition evidence, "
+                        "not a speed gate.",
+                        flush=True,
+                    )
+                del graphs, outputs
+                continue
             times = [[], []]
             for sample in range(5):
                 for which in (0, 1) if sample % 2 == 0 else (1, 0):
@@ -228,10 +256,23 @@ def main():
                 print(json.dumps(gathered), flush=True)
             del graphs, outputs
         if rank == 0:
+            library = os.environ.get("VLLM_SM70_CUSTOM_AR_LIBRARY")
+            runtime = {
+                "custom_ar_library": library,
+                "small_message_push": os.environ.get(
+                    "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "0"
+                ),
+            }
+            if library:
+                runtime["custom_ar_sha256"] = hashlib.sha256(
+                    Path(library).read_bytes()
+                ).hexdigest()
             args.out.parent.mkdir(exist_ok=True, parents=True)
             args.out.write_text(
                 json.dumps(
-                    dict(args=vars(args), results=results), default=str, indent=2
+                    dict(args=vars(args), results=results, runtime=runtime),
+                    default=str,
+                    indent=2,
                 )
                 + "\n"
             )

--- a/benchmarks/kernels/benchmark_sm70_moe_packed_w13.py
+++ b/benchmarks/kernels/benchmark_sm70_moe_packed_w13.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: B023
+"""Paired graph screen, including grouping, W13/SiLU and unchanged fused W2.
+
+This builds a benchmark-only CUDA extension, not a production override. Use
+--model for actual checkpoint weights; otherwise only synthetic screening is
+performed. Activations are synthetic in both modes. No model quality claim.
+Loop-local closures are consumed synchronously before advancing the loop.
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import statistics
+from contextlib import ExitStack
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from torch.utils.cpp_extension import load
+
+from vllm import _sm70_ops as ops
+from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    unpack_mxfp4_weight,
+)
+
+
+def checkpoint_weights(model, layer, rank, interleaved):
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    prepared = [[], [], [], []]
+    with ExitStack() as stack:
+        handles = {}
+
+        def tensor(expert, projection, suffix):
+            key = (
+                f"model.language_model.layers.{layer}.mlp.experts."
+                f"{expert}.{projection}.{suffix}"
+            )
+            shard = index[key]
+            if shard not in handles:
+                handles[shard] = stack.enter_context(
+                    safe_open(model / shard, framework="pt", device="cpu")
+                )
+            return handles[shard].get_tensor(key)
+
+        for e in range(512):
+            weights, scales = [], []
+            for p in ("gate_proj", "up_proj"):
+                weights.append(tensor(e, p, "weight")[rank * 160 : (rank + 1) * 160])
+                scales.append(
+                    tensor(e, p, "weight_scale")[rank * 160 : (rank + 1) * 160].float()
+                    * tensor(e, p, "weight_scale_2").float()
+                )
+            w13, s13, _ = ops.nvfp4_sm70_prepare(
+                unpack_mxfp4_weight(torch.cat(weights).cuda()),
+                torch.cat(scales).half().t().contiguous().cuda(),
+                16,
+                interleave_gated_silu=interleaved,
+            )
+            w2, s2, _ = ops.nvfp4_sm70_prepare(
+                unpack_mxfp4_weight(
+                    tensor(e, "down_proj", "weight")[:, rank * 80 : (rank + 1) * 80]
+                    .contiguous()
+                    .cuda()
+                ),
+                (
+                    tensor(e, "down_proj", "weight_scale")[
+                        :, rank * 10 : (rank + 1) * 10
+                    ].float()
+                    * tensor(e, "down_proj", "weight_scale_2").float()
+                )
+                .half()
+                .t()
+                .contiguous()
+                .cuda(),
+                16,
+            )
+            for dest, value in zip(prepared, (w13, s13, w2, s2)):
+                dest.append(value)
+    return tuple(torch.stack(values) for values in prepared)
+
+
+def graph(fn, unroll=16):
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    result = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(result):
+        for _ in range(unroll):
+            fn()
+    return result
+
+
+def latency(g, repeats, unroll=16):
+    for _ in range(3):
+        g.replay()
+    begin, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    begin.record()
+    for _ in range(repeats):
+        g.replay()
+    end.record()
+    end.synchronize()
+    return begin.elapsed_time(end) * 1000 / (repeats * unroll)
+
+
+def error(a, b):
+    delta = a.float() - b.float()
+    return dict(
+        exact=torch.equal(a, b),
+        max_abs=delta.abs().max().item(),
+        relative_l2=(delta.norm() / b.float().norm().clamp_min(1e-12)).item(),
+        finite=torch.isfinite(a).all().item(),
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--model", type=Path)
+    p.add_argument("--layer", type=int, default=0)
+    p.add_argument("--rank", type=int, choices=range(4), default=0)
+    p.add_argument("--routes", type=Path, help="Saved topk_ids tensor or {tensor: ...}")
+    p.add_argument("--route-glob", help="Sweep saved routes instead of synthetic cases")
+    p.add_argument("--tokens", default="4,8,16")
+    p.add_argument("--splits", default="1,2,4,5,8")
+    p.add_argument("--interleaved", action="store_true")
+    p.add_argument("--packed-w2", action="store_true", help="Reuse grouping in W2")
+    p.add_argument("--repeats", type=int, default=20)
+    p.add_argument("--samples", type=int, default=7)
+    args = p.parse_args()
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("SM70 only")
+    if "TORCH_EXTENSIONS_DIR" not in os.environ:
+        raise RuntimeError("Set a task-owned TORCH_EXTENSIONS_DIR")
+    source = Path(__file__).with_name("sm70_moe_packed_w13.cu")
+    load(
+        name="sm70_moe_packed_w13_screen",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
+        is_python_module=False,
+        verbose=True,
+    )
+    torch.manual_seed(20260905)
+    if args.model:
+        w13, s13, w2, s2 = checkpoint_weights(
+            args.model, args.layer, args.rank, args.interleaved
+        )
+    else:
+        w13 = torch.randint(
+            -(2**31), 2**31 - 1, (512, 2560, 40), device="cuda", dtype=torch.int32
+        )
+        w2 = torch.randint(
+            -(2**31), 2**31 - 1, (512, 160, 320), device="cuda", dtype=torch.int32
+        )
+        s13 = torch.rand(512, 160, 320, device="cuda", dtype=torch.float16) * 2**-14
+        s2 = torch.rand(512, 10, 2560, device="cuda", dtype=torch.float16) * 2**-14
+    captured = {}
+    route_paths = (
+        sorted(map(Path, glob.glob(args.route_glob))) if args.route_glob else []
+    )
+    if args.route_glob and not route_paths:
+        p.error("--route-glob did not match any files")
+    if args.routes:
+        route_paths.append(args.routes)
+    for path in route_paths:
+        value = torch.load(path, weights_only=True, map_location="cpu")
+        if isinstance(value, dict):
+            value = value["tensor"]
+        if value.ndim != 2 or value.shape[1] != 10:
+            p.error(f"Expected [M,10] routes: {path}")
+        captured[path.name] = value.to(torch.int32)
+    results = []
+    for m in map(int, args.tokens.split(",")):
+        if m not in (4, 8, 16):
+            p.error("paired native W13 baseline supports M4/8/16")
+        x = torch.randn(m, 2560, device="cuda", dtype=torch.float16) * 0.1
+        ids = torch.empty(m, 10, device="cuda", dtype=torch.int32)
+        topk = torch.softmax(torch.randn(m, 10, device="cuda"), -1)
+        direct_mid = torch.empty(m * 10, 160, device="cuda", dtype=torch.float16)
+        packed_mid = torch.empty_like(direct_mid)
+        direct_out = torch.empty_like(x)
+        packed_out = torch.empty_like(x)
+        routed_out = torch.empty(m * 10, 2560, device="cuda", dtype=torch.float16)
+        rows = torch.empty(m * 10, 8, device="cuda", dtype=torch.int32)
+        experts = torch.empty(m * 10, device="cuda", dtype=torch.int32)
+        sizes = torch.empty_like(experts)
+        total = torch.empty(1, device="cuda", dtype=torch.int32)
+
+        def direct():
+            ops.nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+                direct_mid, x, w13, s13, ids.view(-1), args.interleaved
+            )
+            ops.nvfp4_moe_qpn_w2_reduce_sm70_out(
+                direct_out, direct_mid, w2, s2, ids.view(-1), topk
+            )
+
+        def candidate(split):
+            torch.ops.sm70_packed_screen.run(
+                packed_mid,
+                x,
+                w13,
+                s13,
+                ids.view(-1),
+                rows,
+                experts,
+                sizes,
+                total,
+                split,
+                args.interleaved,
+            )
+            if args.packed_w2:
+                torch.ops.sm70_packed_screen.w2(
+                    packed_out,
+                    routed_out,
+                    packed_mid,
+                    w2,
+                    s2,
+                    topk,
+                    rows,
+                    experts,
+                    sizes,
+                    total,
+                )
+            else:
+                ops.nvfp4_moe_qpn_w2_reduce_sm70_out(
+                    packed_out, packed_mid, w2, s2, ids.view(-1), topk
+                )
+
+        cases = {
+            "distinct": torch.arange(m * 10).view(m, 10),
+            "shared10": torch.arange(10).repeat(m, 1),
+        }
+        if args.route_glob:
+            cases = {}
+        if captured:
+            cases.update({name: value[:m] for name, value in captured.items()})
+        else:
+            cases["random"] = torch.stack([torch.randperm(512)[:10] for _ in range(m)])
+        for name, case in cases.items():
+            if case.shape != ids.shape:
+                p.error(f"Insufficient captured rows in {name} for M{m}")
+            ids.copy_(case)
+            control = graph(direct)
+            for split in map(int, args.splits.split(",")):
+                packed = graph(lambda: candidate(split))
+                # Replay uses new values and poisoned scratch, not capture-time
+                # values. All source/output pointers remain fixed.
+                checks = []
+                replay_ids = (
+                    case,
+                    case.flip(0),
+                    torch.arange(10).repeat(m, 1),
+                    torch.arange(m * 10).view(m, 10),
+                    torch.full((m, 10), -1),
+                )
+                for changed_ids in replay_ids:
+                    x.normal_(0, 0.1)
+                    ids.copy_(changed_ids)
+                    for buf in (rows, experts, sizes, total):
+                        buf.fill_(-12345)
+                    packed_mid.fill_(float("nan"))
+                    packed_out.fill_(float("nan"))
+                    routed_out.fill_(float("nan"))
+                    control.replay()
+                    packed.replay()
+                    torch.cuda.synchronize()
+                    checks.append(
+                        dict(
+                            mid=error(packed_mid, direct_mid),
+                            out=error(packed_out, direct_out),
+                        )
+                    )
+                ids.copy_(case)
+                control.replay()
+                packed.replay()
+                times = [[], []]
+                for sample in range(args.samples):
+                    for idx in (0, 1) if sample % 2 == 0 else (1, 0):
+                        times[idx].append(latency((control, packed)[idx], args.repeats))
+                a, b = map(statistics.median, times)
+                result = dict(
+                    tokens=m,
+                    case=name,
+                    split=split,
+                    unique=case.unique().numel(),
+                    control_us=a,
+                    candidate_us=b,
+                    saving_us=a - b,
+                    paired_samples_us=times,
+                    checks=checks,
+                )
+                if not all(
+                    c[stage]["finite"] for c in checks for stage in ("mid", "out")
+                ):
+                    raise AssertionError(f"Non-finite output: M{m}/{name}/split{split}")
+                if split == {4: 5, 8: 4, 16: 1}[m] and not all(
+                    c[stage]["exact"] for c in checks for stage in ("mid", "out")
+                ):
+                    raise AssertionError("Packing changed same-split arithmetic")
+                results.append(result)
+                print(
+                    json.dumps(
+                        {
+                            k: v
+                            for k, v in result.items()
+                            if k not in ("paired_samples_us", "checks")
+                        }
+                    ),
+                    flush=True,
+                )
+    report = dict(
+        model=str(args.model),
+        layer=args.layer,
+        tp4_rank=args.rank,
+        synthetic_activations=True,
+        graph_unroll=16,
+        interleaved=args.interleaved,
+        packed_w2=args.packed_w2,
+        source_sha256=hashlib.sha256(source.read_bytes()).hexdigest(),
+        route_sha256={
+            str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in route_paths
+        },
+        torch=torch.__version__,
+        cuda=torch.version.cuda,
+        device=torch.cuda.get_device_name(),
+        results=results,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_moe_packed_w13.py
+++ b/benchmarks/kernels/benchmark_sm70_moe_packed_w13.py
@@ -3,7 +3,7 @@
 # ruff: noqa: B023
 """Paired graph screen, including grouping, W13/SiLU and unchanged fused W2.
 
-This builds a benchmark-only CUDA extension, not a production override. Use
+Uses production native ops, or builds the same source for standalone screening. Use
 --model for actual checkpoint weights; otherwise only synthetic screening is
 performed. Activations are synthetic in both modes. No model quality claim.
 Loop-local closures are consumed synchronously before advancing the loop.
@@ -137,14 +137,18 @@ def main():
         raise RuntimeError("SM70 only")
     if "TORCH_EXTENSIONS_DIR" not in os.environ:
         raise RuntimeError("Set a task-owned TORCH_EXTENSIONS_DIR")
-    source = Path(__file__).with_name("sm70_moe_packed_w13.cu")
-    load(
-        name="sm70_moe_packed_w13_screen",
-        sources=[str(source)],
-        extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
-        is_python_module=False,
-        verbose=True,
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu"
     )
+    if not ops.has_nvfp4_grouped_decode_dispatch():
+        load(
+            name="sm70_moe_packed_w13_screen",
+            sources=[str(source)],
+            extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
+            is_python_module=False,
+            verbose=True,
+        )
     torch.manual_seed(20260905)
     if args.model:
         w13, s13, w2, s2 = checkpoint_weights(
@@ -200,7 +204,7 @@ def main():
             )
 
         def candidate(split):
-            torch.ops.sm70_packed_screen.run(
+            torch.ops._C.nvfp4_grouped_w13_sm70_out(
                 packed_mid,
                 x,
                 w13,
@@ -214,7 +218,7 @@ def main():
                 args.interleaved,
             )
             if args.packed_w2:
-                torch.ops.sm70_packed_screen.w2(
+                torch.ops._C.nvfp4_grouped_w2_sm70_out(
                     packed_out,
                     routed_out,
                     packed_mid,

--- a/benchmarks/kernels/benchmark_sm70_tp4_small_message_push.py
+++ b/benchmarks/kernels/benchmark_sm70_tp4_small_message_push.py
@@ -59,7 +59,12 @@ def main():
             torch.zeros(n // 2, device="cuda", dtype=torch.float16) for n in SIZES
         ]
         graphs, storage = [], []
-        for enabled, reverse in ((False, False), (True, False), (True, True)):
+        for enabled, reverse, sum2 in (
+            (False, False, False),
+            (True, False, False),
+            (True, True, False),
+            (True, False, True),
+        ):
             os.environ[FLAG] = str(int(enabled))
             envs.disable_envs_cache()
             buffers = [x.new_full((x.numel() + 16,), -37) for x in inputs]
@@ -75,6 +80,10 @@ def main():
                 # per-block epochs must stay valid across all these transitions.
                 for i in order:
                     ca.all_reduce(inputs[i], out=outputs[i], registered=True)
+                    if sum2:
+                        # Same push storage, but sum2 retains its old launch
+                        # policy. Exercise transitions between both protocols.
+                        ca.all_reduce_sum2(inputs[i], inputs[i], out=outputs[i])
             graphs.append(graph)
             storage.append(buffers)
 
@@ -116,7 +125,7 @@ def main():
                     for b in buffers:
                         b[8:-8].fill_(float("nan"))
                 dist.barrier()
-                for which in (0, 1, 2) if cycle % 2 else (2, 0, 1):
+                for which in (0, 1, 2, 3) if cycle % 2 else (3, 2, 0, 1):
                     if rank == cycle % 4:
                         torch.cuda._sleep(10000)
                     graphs[which].replay()
@@ -128,15 +137,20 @@ def main():
                     for peer in peers[1:]:
                         expected.add_(peer.float())
                     expected = expected.half()
-                    finite = torch.isfinite(expected)
-                    for buffers in storage:
+                    expected_sum2 = (peers[0] + peers[0]).float()
+                    for peer in peers[1:]:
+                        expected_sum2.add_((peer + peer).float())
+                    expected_sum2 = expected_sum2.half()
+                    for graph_id, buffers in enumerate(storage):
                         actual = buffers[i][8:-8]
+                        reference = expected_sum2 if graph_id == 3 else expected
+                        finite = torch.isfinite(reference)
                         torch.testing.assert_close(
-                            actual, expected, rtol=0, atol=0, equal_nan=True
+                            actual, reference, rtol=0, atol=0, equal_nan=True
                         )
                         assert torch.equal(
                             actual.view(torch.int16)[finite],
-                            expected.view(torch.int16)[finite],
+                            reference.view(torch.int16)[finite],
                         )
                         assert (buffers[i][:8] == -37).all()
                         assert (buffers[i][-8:] == -37).all()
@@ -144,7 +158,7 @@ def main():
                 dict(
                     pattern=pattern,
                     cycles=args.cycles,
-                    graph_orders=3,
+                    graph_orders=len(graphs),
                     sizes=len(SIZES),
                 )
             )
@@ -158,6 +172,7 @@ def main():
                 torch=torch.__version__,
                 library=library,
                 finite_bits_exact=True,
+                sum2_interleaved=True,
                 nan_payload_identity_required=False,
                 model_quality_test=False,
             )

--- a/benchmarks/kernels/benchmark_sm70_tp4_small_message_push.py
+++ b/benchmarks/kernels/benchmark_sm70_tp4_small_message_push.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mixed-size graph correctness gate for the experimental TP4 push admission.
+
+Launch with torchrun on four idle fully-connected V100 GPUs. This is a native
+collective gate, not a model-quality test or an endpoint speed measurement.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from vllm import envs
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+
+FLAG = "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES"
+# Include partial CTAs, HC payloads, established sizes and the pull fallback.
+SIZES = (
+    16,
+    2048,
+    2064,
+    2688,
+    5120,
+    5376,
+    8192,
+    10752,
+    20480,
+    25600,
+    40960,
+    81920,
+    81936,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--cycles", default=64, type=int)
+    args = parser.parse_args()
+    if args.cycles <= 0:
+        raise ValueError("cycles must be positive")
+    rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl")
+    group = dist.new_group(backend="gloo")
+    assert dist.get_world_size() == 4
+    assert torch.cuda.get_device_capability() == (7, 0)
+    ca = CustomAllreduce(group, rank, max_size=128 * 1024)
+    old = os.environ.get(FLAG)
+    try:
+        assert not ca.disabled and ca.fully_connected
+        assert ca.sm70_tp4_push_buffer_ptrs is not None
+        inputs = [
+            torch.zeros(n // 2, device="cuda", dtype=torch.float16) for n in SIZES
+        ]
+        graphs, storage = [], []
+        for enabled, reverse in ((False, False), (True, False), (True, True)):
+            os.environ[FLAG] = str(int(enabled))
+            envs.disable_envs_cache()
+            buffers = [x.new_full((x.numel() + 16,), -37) for x in inputs]
+            outputs = [x[8:-8] for x in buffers]
+            graph = torch.cuda.CUDAGraph()
+            order = list(range(len(inputs)))
+            if reverse:
+                order.reverse()
+            torch.cuda.synchronize()
+            dist.barrier()
+            with ca.capture(), torch.cuda.graph(graph):
+                # Odd count, changing CTA counts, followed by another graph:
+                # per-block epochs must stay valid across all these transitions.
+                for i in order:
+                    ca.all_reduce(inputs[i], out=outputs[i], registered=True)
+            graphs.append(graph)
+            storage.append(buffers)
+
+        checks = []
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(20260905 + rank)
+        specials = torch.tensor(
+            [
+                0,
+                -32768,
+                1,
+                -32767,
+                15360,
+                -17408,
+                31743,
+                -1025,
+                31744,
+                -1024,
+                32639,
+                32256,
+                -512,
+            ],
+            device="cuda",
+            dtype=torch.int16,
+        ).view(torch.float16)
+        for pattern in ("random", "signed_zero", "special"):
+            for cycle in range(args.cycles):
+                for x in inputs:
+                    if pattern == "random":
+                        x.normal_(generator=generator).mul_(0.03)
+                    elif pattern == "signed_zero":
+                        x.zero_()
+                        x[::2] = -0.0
+                    else:
+                        idx = torch.arange(x.numel(), device="cuda") + cycle + rank
+                        x.copy_(specials[idx % specials.numel()])
+                # Distinct outputs and poison on every replay catch stale writes.
+                for buffers in storage:
+                    for b in buffers:
+                        b[8:-8].fill_(float("nan"))
+                dist.barrier()
+                for which in (0, 1, 2) if cycle % 2 else (2, 0, 1):
+                    if rank == cycle % 4:
+                        torch.cuda._sleep(10000)
+                    graphs[which].replay()
+                torch.cuda.synchronize()
+                for i, x in enumerate(inputs):
+                    peers = [torch.empty_like(x) for _ in range(4)]
+                    dist.all_gather(peers, x)
+                    expected = peers[0].float()
+                    for peer in peers[1:]:
+                        expected.add_(peer.float())
+                    expected = expected.half()
+                    finite = torch.isfinite(expected)
+                    for buffers in storage:
+                        actual = buffers[i][8:-8]
+                        torch.testing.assert_close(
+                            actual, expected, rtol=0, atol=0, equal_nan=True
+                        )
+                        assert torch.equal(
+                            actual.view(torch.int16)[finite],
+                            expected.view(torch.int16)[finite],
+                        )
+                        assert (buffers[i][:8] == -37).all()
+                        assert (buffers[i][-8:] == -37).all()
+            checks.append(
+                dict(
+                    pattern=pattern,
+                    cycles=args.cycles,
+                    graph_orders=3,
+                    sizes=len(SIZES),
+                )
+            )
+            if rank == 0:
+                print(f"passed {pattern}: {args.cycles} cycles", flush=True)
+        if rank == 0:
+            library = os.environ.get("VLLM_SM70_CUSTOM_AR_LIBRARY")
+            result = dict(
+                checks=checks,
+                bytes=SIZES,
+                torch=torch.__version__,
+                library=library,
+                finite_bits_exact=True,
+                nan_payload_identity_required=False,
+                model_quality_test=False,
+            )
+            if library:
+                result["library_sha256"] = hashlib.sha256(
+                    Path(library).read_bytes()
+                ).hexdigest()
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(json.dumps(result, indent=2) + "\n")
+    finally:
+        if old is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = old
+        envs.disable_envs_cache()
+        ca.close()
+        dist.destroy_process_group(group)
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/sm70_hc_batch_screen.cu
+++ b/benchmarks/kernels/sm70_hc_batch_screen.cu
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+// Benchmark-only FP16 multi-row HC. No production registration or dispatch.
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+#include <torch/library.h>
+#include <torch/types.h>
+
+namespace {
+#define HC_MMA(C, A0, A1, B0, B1)                                   \
+  asm volatile(                                                     \
+      "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "            \
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, "             \
+      "{%0,%1,%2,%3,%4,%5,%6,%7};\n"                                \
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]), "+f"(C[4]), \
+        "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
+      : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
+
+// Four warps produce the four HC branch gates for the same Rows x 32 tile.
+// Packed weights [4, H/32, K/16, 2, 32, 8] permit coalesced 128-bit reads.
+template <int Rows>
+__global__ void up_mix(const half* x, const half* weight, const half* residual,
+                       half* out, int m) {
+  __shared__ half gates[4][Rows][32];
+  const int lane = threadIdx.x % 32, branch = threadIdx.x / 32;
+  const int r = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int quad = (lane >> 2) & 3, col = quad * 8 + r;
+  float acc[Rows / 8][8] = {};
+#pragma unroll
+  for (int g = 0; g < 20; ++g) {
+    const int idx = ((branch * 80 + blockIdx.x) * 20 + g) * 512 + col * 8;
+    const uint4 wlo = *reinterpret_cast<const uint4*>(weight + idx);
+    const uint4 whi = *reinterpret_cast<const uint4*>(weight + idx + 256);
+#pragma unroll
+    for (int pack = 0; pack < Rows / 8; ++pack) {
+      const int token = blockIdx.y * Rows + pack * 8 + r;
+      uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+      if (token < m) {
+        lo = *reinterpret_cast<const uint4*>(x + token * 320 + g * 16);
+        hi = *reinterpret_cast<const uint4*>(x + token * 320 + g * 16 + 8);
+      }
+      HC_MMA(acc[pack], lo.x, lo.y, wlo.x, wlo.y);
+      HC_MMA(acc[pack], lo.z, lo.w, wlo.z, wlo.w);
+      HC_MMA(acc[pack], hi.x, hi.y, whi.x, whi.y);
+      HC_MMA(acc[pack], hi.z, hi.w, whi.z, whi.w);
+    }
+  }
+#pragma unroll
+  for (int pack = 0; pack < Rows / 8; ++pack) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int rr = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int cc = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+      gates[branch][pack * 8 + rr][quad * 8 + cc] =
+          __float2half_rn(acc[pack][i]);
+    }
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < Rows * 32; idx += blockDim.x) {
+    const int rr = idx / 32, cc = idx % 32, t = blockIdx.y * Rows + rr;
+    if (t < m) {
+      float value = 0;
+#pragma unroll
+      for (int hc = 0; hc < 4; ++hc) {
+        const float gate = __half2float(gates[hc][rr][cc]);
+        const float scale = 1.0f / (1.0f + expf(-gate));
+        value =
+            fmaf(scale,
+                 __half2float(
+                     residual[t * 10240 + hc * 2560 + blockIdx.x * 32 + cc]),
+                 value);
+      }
+      out[t * 2560 + blockIdx.x * 32 + cc] = __float2half_rn(value * 0.25f);
+    }
+  }
+}
+
+// Global Split-K keeps short output-N from starving the 80 SMs. Four warps
+// also split K inside each CTA; the second kernel performs an ordered FP32
+// reduction and retains the original FP16 rounding before SiLU/injection.
+template <int Split>
+__global__ void down_partial(const half* x, const half* w, float* partial,
+                             int m) {
+  __shared__ float sums[4][8][32];
+  const int lane = threadIdx.x % 32, warp = threadIdx.x / 32;
+  const int r = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int quad = (lane >> 2) & 3, col = quad * 8 + r;
+  const int token = blockIdx.y * 8 + r;
+  float acc[8] = {};
+  const int begin = (blockIdx.z * 4 + warp) * (640 / (Split * 4));
+  const int end = begin + 640 / (Split * 4);
+#pragma unroll 2
+  for (int g = begin; g < end; ++g) {
+    const int idx = (blockIdx.x * 640 + g) * 512 + col * 8;
+    const uint4 wlo = *reinterpret_cast<const uint4*>(w + idx);
+    const uint4 whi = *reinterpret_cast<const uint4*>(w + idx + 256);
+    uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+    if (token < m) {
+      lo = *reinterpret_cast<const uint4*>(x + token * 10240 + g * 16);
+      hi = *reinterpret_cast<const uint4*>(x + token * 10240 + g * 16 + 8);
+    }
+    HC_MMA(acc, lo.x, lo.y, wlo.x, wlo.y);
+    HC_MMA(acc, lo.z, lo.w, wlo.z, wlo.w);
+    HC_MMA(acc, hi.x, hi.y, whi.x, whi.y);
+    HC_MMA(acc, hi.z, hi.w, whi.z, whi.w);
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int rr = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+    const int cc = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+    sums[warp][rr][quad * 8 + cc] = acc[i];
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < 256; idx += blockDim.x) {
+    const int rr = idx / 32, cc = idx % 32, t = blockIdx.y * 8 + rr;
+    float value = 0;
+#pragma unroll
+    for (int s = 0; s < 4; ++s) value += sums[s][rr][cc];
+    if (t < m)
+      partial[(blockIdx.z * m + t) * 352 + blockIdx.x * 32 + cc] = value;
+  }
+}
+
+template <int Split>
+__global__ void down_tail(const float* partial, half* lora, half* inject,
+                          int m) {
+  const int t = blockIdx.x, col = threadIdx.x;
+  if (col >= 324) return;
+  float value = 0;
+#pragma unroll
+  for (int s = 0; s < Split; ++s) value += partial[(s * m + t) * 352 + col];
+  const half rounded = __float2half_rn(value);
+  if (col < 320) {
+    const float v = __half2float(rounded) * 0.25f;
+    lora[t * 320 + col] = __float2half_rn(v / (1.0f + expf(-v)));
+  } else {
+    inject[t * 4 + col - 320] = rounded;
+  }
+}
+
+void check_half(const torch::Tensor& t, const torch::Tensor& ref) {
+  TORCH_CHECK(t.is_cuda() && t.device() == ref.device() && t.is_contiguous() &&
+              t.scalar_type() == at::kHalf);
+}
+void run_up(torch::Tensor out, torch::Tensor x, torch::Tensor w,
+            torch::Tensor residual) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  for (const auto& t : {out, x, w, residual}) check_half(t, x);
+  TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 16 &&
+              x.size(1) == 320);
+  const int m = x.size(0);
+  TORCH_CHECK(out.numel() == m * 2560 && residual.numel() == m * 10240 &&
+              w.numel() == 10240 * 320);
+#define UP(R)                                             \
+  up_mix<R><<<dim3(80, (m + R - 1) / R), 128, 0,          \
+              at::cuda::getCurrentCUDAStream()>>>(        \
+      reinterpret_cast<const half*>(x.data_ptr()),        \
+      reinterpret_cast<const half*>(w.data_ptr()),        \
+      reinterpret_cast<const half*>(residual.data_ptr()), \
+      reinterpret_cast<half*>(out.data_ptr()), m)
+  if (m > 8) {
+    UP(16);
+  } else {
+    UP(8);
+  }
+#undef UP
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+void run_down(torch::Tensor lora, torch::Tensor inject, torch::Tensor x,
+              torch::Tensor w, torch::Tensor tmp, int64_t split) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  for (const auto& t : {lora, inject, x, w}) check_half(t, x);
+  TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 16 &&
+              x.size(1) == 10240);
+  const int m = x.size(0);
+  TORCH_CHECK(lora.numel() == m * 320 && inject.numel() == m * 4 &&
+              w.numel() == 352 * 10240);
+  TORCH_CHECK(tmp.is_cuda() && tmp.device() == x.device() &&
+              tmp.is_contiguous() && tmp.scalar_type() == at::kFloat &&
+              tmp.numel() >= split * m * 352);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+#define CASE(S)                                                             \
+  case S:                                                                   \
+    down_partial<S><<<dim3(11, (m + 7) / 8, S), 128, 0, stream>>>(          \
+        reinterpret_cast<const half*>(x.data_ptr()),                        \
+        reinterpret_cast<const half*>(w.data_ptr()), tmp.data_ptr<float>(), \
+        m);                                                                 \
+    down_tail<S><<<m, 352, 0, stream>>>(                                    \
+        tmp.data_ptr<float>(), reinterpret_cast<half*>(lora.data_ptr()),    \
+        reinterpret_cast<half*>(inject.data_ptr()), m);                     \
+    break
+  switch (split) {
+    CASE(4);
+    CASE(8);
+    CASE(16);
+    CASE(20);
+    default:
+      TORCH_CHECK(false, "Unsupported split");
+  }
+#undef CASE
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+}  // namespace
+TORCH_LIBRARY(sm70_hc_screen, m) {
+  m.def("up(Tensor(a!) out, Tensor x, Tensor w, Tensor residual) -> ()");
+  m.def(
+      "down(Tensor(a!) lora, Tensor(b!) inject, Tensor x, Tensor w, Tensor(c!) "
+      "tmp, int split) -> ()");
+}
+TORCH_LIBRARY_IMPL(sm70_hc_screen, CUDA, m) {
+  m.impl("up", &run_up);
+  m.impl("down", &run_down);
+}

--- a/benchmarks/kernels/sm70_moe_packed_w13.cu
+++ b/benchmarks/kernels/sm70_moe_packed_w13.cu
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+// Benchmark-only multi-row W13 candidate. No production dispatcher uses this.
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+#include <torch/library.h>
+#include <torch/types.h>
+
+namespace {
+constexpr int kMaxRoutes = 160;
+constexpr int kPack = 8;
+constexpr int kExperts = 512;
+constexpr int kChunks = kMaxRoutes / kPack;
+
+// Integer atomics only: route order within a pack is immaterial because both
+// projections scatter back to the original route before the unchanged W2.
+__global__ void plan_kernel(const int32_t* ids, int32_t* rows, int32_t* experts,
+                            int32_t* sizes, int32_t* total, int routes) {
+  __shared__ int counts[kExperts + 1];
+  __shared__ int groups[kExperts + 1][kChunks];
+  const int t = threadIdx.x;
+  for (int e = t; e <= kExperts; e += blockDim.x) counts[e] = 0;
+  if (t == 0) *total = 0;
+  __syncthreads();
+  int expert = 0, ordinal = 0;
+  if (t < routes) {
+    expert = ids[t];
+    if (expert < 0 || expert >= kExperts) expert = kExperts;
+    ordinal = atomicAdd(counts + expert, 1);
+  }
+  __syncthreads();
+  if (t < routes && ordinal % kPack == 0) {
+    const int group = atomicAdd(total, 1);
+    groups[expert][ordinal / kPack] = group;
+    experts[group] = expert;
+    sizes[group] = min(kPack, counts[expert] - ordinal);
+  }
+  __syncthreads();
+  if (t < routes) {
+    const int group = groups[expert][ordinal / kPack];
+    rows[group * kPack + ordinal % kPack] = t;
+  }
+}
+
+__device__ __forceinline__ void decode(unsigned packed, half2 scale,
+                                       half2* out) {
+  constexpr unsigned sign = 0x80008000u, em = 0x0e000e00u;
+  unsigned v[4] = {((packed << 12) & sign) | ((packed << 9) & em),
+                   ((packed << 8) & sign) | ((packed << 5) & em),
+                   ((packed << 4) & sign) | ((packed << 1) & em),
+                   (packed & sign) | ((packed >> 3) & em)};
+#pragma unroll
+  for (int i = 0; i < 4; ++i)
+    out[i] = __hmul2(*reinterpret_cast<half2*>(v + i), scale);
+}
+
+#define PACKED_MMA(C, A0, A1, B0, B1)                               \
+  asm volatile(                                                     \
+      "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "            \
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, "             \
+      "{%0,%1,%2,%3,%4,%5,%6,%7};\n"                                \
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]), "+f"(C[4]), \
+        "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
+      : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
+
+template <int Split, bool Interleaved>
+__global__ void w13_kernel(const half* x, const uint32_t* weights,
+                           const half* scales, const int32_t* rows,
+                           const int32_t* experts, const int32_t* sizes,
+                           const int32_t* total, half* out) {
+  // Split within the CTA: no floating-point atomics or global partial tensor.
+  __shared__ float partial[2][Split][kPack][32];
+  __shared__ half projected[2][kPack][32];
+  const int group_id = blockIdx.y;
+  if (group_id >= *total) return;
+  const int count = sizes[group_id], expert = experts[group_id];
+  const int lane = threadIdx.x % 32, warp = threadIdx.x / 32;
+  const int projection = warp / Split, split = warp % Split;
+  const int tile =
+      Interleaved ? blockIdx.x * 2 + projection : blockIdx.x + projection * 5;
+  const int mma_row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int quad = (lane >> 2) & 3;
+  const int col = quad * 8 + mma_row;
+  const int route = mma_row < count ? rows[group_id * kPack + mma_row] : 0;
+  float accum[8] = {};
+  if (expert < kExperts) {
+    const uint32_t* w = weights + static_cast<size_t>(expert) * 2560 * 40;
+    const half* s = scales + static_cast<size_t>(expert) * 160 * 320;
+    const half* input = x + static_cast<size_t>(route / 10) * 2560;
+#pragma unroll 4
+    for (int g = split * (160 / Split); g < (split + 1) * (160 / Split); ++g) {
+      const size_t offset =
+          (static_cast<size_t>(tile) * 320 + g * 2) * 32 + col;
+      const half scalar = __hmul(__ldg(s + (g * 10 + tile) * 32 + col),
+                                 __float2half_rn(16384.0f));
+      const half2 scale = __halves2half2(scalar, scalar);
+      half2 decoded[8];
+      decode(__ldcs(w + offset), scale, decoded);
+      decode(__ldcs(w + offset + 32), scale, decoded + 4);
+      const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+      uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+      if (mma_row < count) {
+        lo = *reinterpret_cast<const uint4*>(input + g * 16);
+        hi = *reinterpret_cast<const uint4*>(input + g * 16 + 8);
+      }
+      PACKED_MMA(accum, lo.x, lo.y, b[0], b[1]);
+      PACKED_MMA(accum, lo.z, lo.w, b[2], b[3]);
+      PACKED_MMA(accum, hi.x, hi.y, b[4], b[5]);
+      PACKED_MMA(accum, hi.z, hi.w, b[6], b[7]);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int r = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+    const int c = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+    partial[projection][split][r][quad * 8 + c] = accum[i];
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < 2 * kPack * 32; idx += blockDim.x) {
+    const int p = idx / (kPack * 32), r = idx / 32 % kPack, c = idx % 32;
+    // FP16 materialization is retained before SiLU, then again before the
+    // multiplication. Split>1 changes FP32 association, not quantization.
+    float value = 0;
+#pragma unroll
+    for (int s = 0; s < Split; ++s) value += partial[p][s][r][c];
+    projected[p][r][c] = __float2half_rn(value);
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < count * 32; idx += blockDim.x) {
+    const int r = idx / 32, c = idx % 32;
+    const int p = Interleaved ? c / 16 : 0;
+    const int pc = Interleaved ? c % 16 * 2 : c;
+    const half gate = projected[p][r][pc];
+    const half up = Interleaved ? projected[p][r][pc + 1] : projected[1][r][c];
+    const float gf = __half2float(gate);
+    const half activated = __float2half_rn(gf / (1.0f + expf(-gf)));
+    out[static_cast<size_t>(rows[group_id * kPack + r]) * 160 +
+        blockIdx.x * 32 + c] = __hmul(activated, up);
+  }
+}
+
+void run(torch::Tensor out, torch::Tensor x, torch::Tensor w, torch::Tensor s,
+         torch::Tensor ids, torch::Tensor rows, torch::Tensor experts,
+         torch::Tensor sizes, torch::Tensor total, int64_t split,
+         bool interleaved) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  const int routes = x.size(0) * 10;
+  TORCH_CHECK(x.dim() == 2 && x.size(1) == 2560 && routes > 0 && routes <= 160);
+  for (const auto& t : {out, x, w, s, ids, rows, experts, sizes, total}) {
+    TORCH_CHECK(t.is_cuda() && t.device() == x.device() && t.is_contiguous());
+  }
+  TORCH_CHECK(x.scalar_type() == at::kHalf && s.scalar_type() == at::kHalf &&
+              out.scalar_type() == at::kHalf && w.scalar_type() == at::kInt);
+  for (const auto& t : {ids, rows, experts, sizes, total})
+    TORCH_CHECK(t.scalar_type() == at::kInt);
+  TORCH_CHECK(ids.numel() == routes && rows.numel() >= routes * kPack &&
+              experts.numel() >= routes && sizes.numel() >= routes &&
+              total.numel() == 1 && out.numel() == routes * 160 &&
+              w.numel() == 512 * 2560 * 40 && s.numel() == 512 * 160 * 320);
+  const auto stream = at::cuda::getCurrentCUDAStream(x.get_device());
+  plan_kernel<<<1, 256, 0, stream>>>(
+      ids.data_ptr<int32_t>(), rows.data_ptr<int32_t>(),
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),
+      total.data_ptr<int32_t>(), routes);
+#define LAUNCH(S, I)                                                         \
+  w13_kernel<S, I><<<dim3(5, routes), 64 * S, 0, stream>>>(                  \
+      reinterpret_cast<const half*>(x.data_ptr()),                           \
+      reinterpret_cast<const uint32_t*>(w.data_ptr()),                       \
+      reinterpret_cast<const half*>(s.data_ptr()), rows.data_ptr<int32_t>(), \
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),                \
+      total.data_ptr<int32_t>(), reinterpret_cast<half*>(out.data_ptr()))
+#define CASE(S)         \
+  case S:               \
+    if (interleaved) {  \
+      LAUNCH(S, true);  \
+    } else {            \
+      LAUNCH(S, false); \
+    }                   \
+    break
+  switch (split) {
+    CASE(1);
+    CASE(2);
+    CASE(4);
+    CASE(5);
+    CASE(8);
+    default:
+      TORCH_CHECK(false, "Unsupported split");
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+#undef CASE
+#undef LAUNCH
+}
+
+// All groups, including singletons, use one kernel. The earlier prototype
+// launched separate repeated/singleton kernels; their overhead erased reuse.
+__global__ void w2_kernel(const half* x, const uint32_t* weights,
+                          const half* scales, const int32_t* rows,
+                          const int32_t* experts, const int32_t* sizes,
+                          const int32_t* total, half* out) {
+  const int group = blockIdx.y * 4 + threadIdx.x / 32;
+  if (group >= *total) return;
+  const int count = sizes[group], expert = experts[group];
+  const int lane = threadIdx.x % 32, quad = (lane >> 2) & 3;
+  const int r = (lane & 3) + ((lane & 16) ? 4 : 0), col = quad * 8 + r;
+  const int route = r < count ? rows[group * kPack + r] : 0;
+  float accum[8] = {};
+  if (expert < kExperts) {
+    const uint32_t* w = weights + static_cast<size_t>(expert) * 160 * 320;
+    const half* s = scales + static_cast<size_t>(expert) * 10 * 2560;
+    const half* input = x + static_cast<size_t>(route) * 160;
+#pragma unroll
+    for (int g = 0; g < 10; ++g) {
+      const int offset = (blockIdx.x * 20 + g * 2) * 32 + col;
+      const half scalar = __hmul(__ldg(s + (g * 80 + blockIdx.x) * 32 + col),
+                                 __float2half_rn(16384.0f));
+      const half2 scale = __halves2half2(scalar, scalar);
+      half2 decoded[8];
+      decode(__ldcs(w + offset), scale, decoded);
+      decode(__ldcs(w + offset + 32), scale, decoded + 4);
+      const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+      uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+      if (r < count) {
+        lo = *reinterpret_cast<const uint4*>(input + g * 16);
+        hi = *reinterpret_cast<const uint4*>(input + g * 16 + 8);
+      }
+      PACKED_MMA(accum, lo.x, lo.y, b[0], b[1]);
+      PACKED_MMA(accum, lo.z, lo.w, b[2], b[3]);
+      PACKED_MMA(accum, hi.x, hi.y, b[4], b[5]);
+      PACKED_MMA(accum, hi.z, hi.w, b[6], b[7]);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+    const int c = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+    if (row < count) {
+      const int dst = rows[group * kPack + row];
+      out[static_cast<size_t>(dst) * 2560 + blockIdx.x * 32 + quad * 8 + c] =
+          __float2half_rn(accum[i]);
+    }
+  }
+}
+
+__global__ void reduce_kernel(const half* routed, const float* weights,
+                              half* out) {
+  const int token = blockIdx.y, col = blockIdx.x * 256 + threadIdx.x;
+  float result = 0;
+#pragma unroll
+  for (int slot = 0; slot < 10; ++slot)
+    result = fmaf(__half2float(routed[(token * 10 + slot) * 2560 + col]),
+                  weights[token * 10 + slot], result);
+  out[token * 2560 + col] = __float2half_rn(result);
+}
+
+void w2(torch::Tensor out, torch::Tensor routed, torch::Tensor x,
+        torch::Tensor w, torch::Tensor s, torch::Tensor topk,
+        torch::Tensor rows, torch::Tensor experts, torch::Tensor sizes,
+        torch::Tensor total) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  TORCH_CHECK(x.dim() == 2 && x.size(1) == 160 && x.size(0) % 10 == 0);
+  const int routes = x.size(0), tokens = routes / 10;
+  TORCH_CHECK(tokens >= 1 && tokens <= 16);
+  for (const auto& t :
+       {out, routed, x, w, s, topk, rows, experts, sizes, total})
+    TORCH_CHECK(t.is_cuda() && t.device() == x.device() && t.is_contiguous());
+  for (const auto& t : {out, routed, x, s})
+    TORCH_CHECK(t.scalar_type() == at::kHalf);
+  for (const auto& t : {w, rows, experts, sizes, total})
+    TORCH_CHECK(t.scalar_type() == at::kInt);
+  TORCH_CHECK(topk.scalar_type() == at::kFloat && topk.numel() == routes &&
+              out.numel() == tokens * 2560 && routed.numel() == routes * 2560 &&
+              rows.numel() >= routes * 8 && experts.numel() >= routes &&
+              sizes.numel() >= routes && total.numel() == 1 &&
+              w.numel() == 512 * 160 * 320 && s.numel() == 512 * 10 * 2560);
+  const auto stream = at::cuda::getCurrentCUDAStream(x.get_device());
+  w2_kernel<<<dim3(80, (routes + 3) / 4), 128, 0, stream>>>(
+      reinterpret_cast<const half*>(x.data_ptr()),
+      reinterpret_cast<const uint32_t*>(w.data_ptr()),
+      reinterpret_cast<const half*>(s.data_ptr()), rows.data_ptr<int32_t>(),
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),
+      total.data_ptr<int32_t>(), reinterpret_cast<half*>(routed.data_ptr()));
+  reduce_kernel<<<dim3(10, tokens), 256, 0, stream>>>(
+      reinterpret_cast<const half*>(routed.data_ptr()), topk.data_ptr<float>(),
+      reinterpret_cast<half*>(out.data_ptr()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+}  // namespace
+
+TORCH_LIBRARY(sm70_packed_screen, m) {
+  m.def(
+      "run(Tensor(a!) out, Tensor x, Tensor w, Tensor s, Tensor ids, "
+      "Tensor(b!) rows, Tensor(c!) experts, Tensor(d!) sizes, Tensor(e!) "
+      "total, "
+      "int split, bool interleaved) -> ()");
+  m.def(
+      "w2(Tensor(a!) out, Tensor(b!) routed, Tensor x, Tensor w, Tensor s, "
+      "Tensor topk, Tensor rows, Tensor experts, Tensor sizes, Tensor total) "
+      "-> ()");
+}
+TORCH_LIBRARY_IMPL(sm70_packed_screen, CUDA, m) {
+  m.impl("run", &run);
+  m.impl("w2", &w2);
+}

--- a/benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py
+++ b/benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare real TP4 checkpoint shards through the production MoE loader/apply.
+
+This single-GPU diagnostic uses synthetic activations and all 512 experts in
+each selected layer. It is not an end-to-end quality benchmark. Example:
+
+  CUDA_VISIBLE_DEVICES=0 .venv/bin/python \
+    benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py \
+    --model /path/to/checkpoint --layers 0,23,47 --ranks 0,3 \
+    --tokens 1,4,8,16,784 --out raw-storage.json
+"""
+
+import argparse
+import gc
+import json
+import os
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors import safe_open
+
+from vllm import _sm70_ops as ops
+from vllm import envs
+from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    ModelOptNvFp4SM70MoEMethod,
+    MoEActivation,
+)
+
+
+def error(a, b):
+    d = a.float() - b.float()
+    return dict(
+        exact=torch.equal(a, b),
+        max_abs=d.abs().max().item(),
+        relative_l2=(d.norm() / b.float().norm().clamp_min(1e-12)).item(),
+        mismatches=(a != b).sum().item(),
+        finite=torch.isfinite(a).all().item(),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--layers", default="0")
+    parser.add_argument("--ranks", default="0")
+    parser.add_argument("--tokens", default="1,3,4,7,8,16,32,128,784")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--dynamic", action="store_true")
+    args = parser.parse_args()
+    layers = tuple(map(int, args.layers.split(",")))
+    ranks = tuple(map(int, args.ranks.split(",")))
+    token_counts = tuple(map(int, args.tokens.split(",")))
+    if any(rank not in range(4) for rank in ranks):
+        parser.error("--ranks must select TP4 shards 0..3")
+    if any(layer < 0 for layer in layers) or any(m <= 0 for m in token_counts):
+        parser.error("layer indices must be nonnegative; token counts positive")
+    os.environ["VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE"] = str(int(args.dynamic))
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("This kernel audit requires SM70")
+    if not ops.has_nvfp4_qpn_raw_scale_dispatch():
+        raise RuntimeError("Build the raw-scale native operators first")
+    model = args.model
+    index = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    rows = []
+    cfg = SimpleNamespace(
+        num_experts=512,
+        experts_per_token=10,
+        hidden_dim=2560,
+        intermediate_size_per_partition=160,
+        tp_size=4,
+        has_bias=False,
+        moe_parallel_config=SimpleNamespace(use_all2all_kernels=False),
+    )
+    method = object.__new__(ModelOptNvFp4SM70MoEMethod)
+    method.moe = cfg
+    for layer_no in layers:
+        for rank in ranks:
+            prefix = f"model.language_model.layers.{layer_no}.mlp.experts"
+            with ExitStack() as stack:
+                handles = {}
+
+                def load(
+                    expert, suffix, *, prefix=prefix, handles=handles, stack=stack
+                ):
+                    key = f"{prefix}.{expert}.{suffix}"
+                    shard = index[key]
+                    if shard not in handles:
+                        handles[shard] = stack.enter_context(
+                            safe_open(model / shard, framework="pt", device="cpu")
+                        )
+                    return handles[shard].get_tensor(key)
+
+                tensors = {
+                    k: []
+                    for k in (
+                        "w13_weight",
+                        "w13_weight_scale",
+                        "w13_weight_scale_2",
+                        "w2_weight",
+                        "w2_weight_scale",
+                        "w2_weight_scale_2",
+                    )
+                }
+                for e in range(512):
+                    for suffix, dst in (
+                        ("weight", "w13_weight"),
+                        ("weight_scale", "w13_weight_scale"),
+                    ):
+                        tensors[dst].append(
+                            torch.cat(
+                                [
+                                    load(e, f"{p}.{suffix}")[
+                                        rank * 160 : (rank + 1) * 160
+                                    ]
+                                    for p in ("gate_proj", "up_proj")
+                                ]
+                            )
+                        )
+                    tensors["w13_weight_scale_2"].append(
+                        torch.stack(
+                            [
+                                load(e, f"{p}.weight_scale_2").reshape(())
+                                for p in ("gate_proj", "up_proj")
+                            ]
+                        )
+                    )
+                    tensors["w2_weight"].append(
+                        load(e, "down_proj.weight")[:, rank * 80 : (rank + 1) * 80]
+                    )
+                    tensors["w2_weight_scale"].append(
+                        load(e, "down_proj.weight_scale")[
+                            :, rank * 10 : (rank + 1) * 10
+                        ]
+                    )
+                    tensors["w2_weight_scale_2"].append(
+                        load(e, "down_proj.weight_scale_2").reshape(())
+                    )
+                tensors = {
+                    k: torch.stack(v).cuda().contiguous() for k, v in tensors.items()
+                }
+
+            def make(raw, tensors=tensors):
+                os.environ["VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE"] = str(int(raw))
+                envs.disable_envs_cache()
+                layer = SimpleNamespace(
+                    moe_config=cfg,
+                    local_num_experts=512,
+                    global_num_experts=512,
+                    activation=MoEActivation.SILU,
+                    apply_router_weight_on_input=False,
+                    expert_map=None,
+                    swiglu_limit=None,
+                    w13_input_scale=None,
+                    w2_input_scale=None,
+                    **tensors,
+                )
+                method.process_weights_after_loading(layer)
+                return layer
+
+            prepared, raw = make(False), make(True)
+            del make, tensors
+            scales = {}
+            interleaved_w13 = raw.sm70_nvfp4_qwen38_fused_swiglu_prefill
+            for stage, interleaved in (("w13", interleaved_w13), ("w2", False)):
+                expected = getattr(prepared, f"{stage}_tm_scales")
+                dest = torch.empty_like(expected)
+                codes = getattr(raw, f"{stage}_raw_scale_codes")
+                glob = getattr(raw, f"{stage}_raw_global_scales")
+                for fast in (False, True):
+                    ops.nvfp4_expand_raw_scales_sm70_out(
+                        dest, codes, glob, interleaved, fast
+                    )
+                    scales[f"{stage}_{fast}"] = error(
+                        dest, expected * (16384.0 if fast else 1.0)
+                    )
+            print(
+                json.dumps(dict(layer=layer_no, rank=rank, scales=scales)), flush=True
+            )
+            for tokens in token_counts:
+                torch.manual_seed(20260905 + tokens)
+                x = torch.randn(tokens, 2560, device="cuda", dtype=torch.float16) * 0.1
+                scores = torch.randn(tokens, 512, device="cuda")
+                vals, ids = torch.topk(scores, 10, dim=-1)
+                ids = ids.int().contiguous()
+                weights = torch.softmax(vals, dim=-1)
+                # Run same allocation/shape twice to distinguish nondeterminism.
+                a = method.apply(prepared, x, weights, ids, None, None).clone()
+                aa = method.apply(prepared, x, weights, ids, None, None).clone()
+                b = method.apply(raw, x, weights, ids, None, None).clone()
+                bb = method.apply(raw, x, weights, ids, None, None).clone()
+                row = dict(
+                    layer=layer_no,
+                    rank=rank,
+                    tokens=tokens,
+                    dynamic_decode=args.dynamic,
+                    scales=scales,
+                    raw_vs_prepared=error(b, a),
+                    prepared_repeat=error(aa, a),
+                    raw_repeat=error(bb, b),
+                )
+                if tokens <= 16:
+                    graph = torch.cuda.CUDAGraph()
+                    torch.accelerator.synchronize()
+                    with torch.cuda.graph(graph):
+                        bgraph = method.apply(raw, x, weights, ids, None, None)
+                    for _ in range(3):
+                        graph.replay()
+                    row["graph_vs_eager"] = error(bgraph, b)
+                    del graph
+                rows.append(row)
+                print(json.dumps(row), flush=True)
+            del prepared, raw
+            gc.collect()
+            torch.accelerator.empty_cache()
+    Path(args.out).write_text(json.dumps(rows, indent=2) + "\n")
+    for row in rows:
+        checks = [row[k] for k in ("raw_vs_prepared", "prepared_repeat", "raw_repeat")]
+        checks.extend(row["scales"].values())
+        if "graph_vs_eager" in row:
+            checks.append(row["graph_vs_eager"])
+        if any(not check["exact"] or not check["finite"] for check in checks):
+            raise SystemExit(f"Numerical mismatch; inspect {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py
+++ b/benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py
@@ -24,6 +24,7 @@ from safetensors import safe_open
 
 from vllm import _sm70_ops as ops
 from vllm import envs
+from vllm.forward_context import ForwardContext, override_forward_context
 from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
     ModelOptNvFp4SM70MoEMethod,
     MoEActivation,
@@ -49,6 +50,11 @@ def main():
     parser.add_argument("--tokens", default="1,3,4,7,8,16,32,128,784")
     parser.add_argument("--out", required=True)
     parser.add_argument("--dynamic", action="store_true")
+    parser.add_argument(
+        "--grouped",
+        action="store_true",
+        help="Audit grouped decode instead of raw-scale storage",
+    )
     args = parser.parse_args()
     layers = tuple(map(int, args.layers.split(",")))
     ranks = tuple(map(int, args.ranks.split(",")))
@@ -60,7 +66,9 @@ def main():
     os.environ["VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE"] = str(int(args.dynamic))
     if torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("This kernel audit requires SM70")
-    if not ops.has_nvfp4_qpn_raw_scale_dispatch():
+    if args.grouped and not ops.has_nvfp4_grouped_decode_dispatch():
+        raise RuntimeError("Build the grouped-decode native operators first")
+    if not args.grouped and not ops.has_nvfp4_qpn_raw_scale_dispatch():
         raise RuntimeError("Build the raw-scale native operators first")
     model = args.model
     index = json.loads((model / "model.safetensors.index.json").read_text())[
@@ -145,7 +153,12 @@ def main():
                 }
 
             def make(raw, tensors=tensors):
-                os.environ["VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE"] = str(int(raw))
+                os.environ["VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE"] = str(
+                    int(raw and not args.grouped)
+                )
+                os.environ["VLLM_SM70_NVFP4_MOE_GROUPED_DECODE"] = str(
+                    int(raw and args.grouped)
+                )
                 envs.disable_envs_cache()
                 layer = SimpleNamespace(
                     moe_config=cfg,
@@ -166,7 +179,9 @@ def main():
             del make, tensors
             scales = {}
             interleaved_w13 = raw.sm70_nvfp4_qwen38_fused_swiglu_prefill
-            for stage, interleaved in (("w13", interleaved_w13), ("w2", False)):
+            for stage, interleaved in (
+                () if args.grouped else (("w13", interleaved_w13), ("w2", False))
+            ):
                 expected = getattr(prepared, f"{stage}_tm_scales")
                 dest = torch.empty_like(expected)
                 codes = getattr(raw, f"{stage}_raw_scale_codes")
@@ -188,18 +203,39 @@ def main():
                 vals, ids = torch.topk(scores, 10, dim=-1)
                 ids = ids.int().contiguous()
                 weights = torch.softmax(vals, dim=-1)
+
+                def apply(layer, tokens=tokens, x=x, weights=weights, ids=ids):
+                    context = ForwardContext(
+                        no_compile_layers={},
+                        slot_mapping={},
+                        attn_metadata={
+                            "attn": SimpleNamespace(
+                                max_query_len=1 if tokens <= 16 else tokens
+                            )
+                        },
+                    )
+                    with override_forward_context(context):
+                        return method.apply(layer, x, weights, ids, None, None)
+
                 # Run same allocation/shape twice to distinguish nondeterminism.
-                a = method.apply(prepared, x, weights, ids, None, None).clone()
-                aa = method.apply(prepared, x, weights, ids, None, None).clone()
-                b = method.apply(raw, x, weights, ids, None, None).clone()
-                bb = method.apply(raw, x, weights, ids, None, None).clone()
+                a = apply(prepared).clone()
+                aa = apply(prepared).clone()
+                b = apply(raw).clone()
+                bb = apply(raw).clone()
+                if args.grouped:
+                    torch.testing.assert_close(b, a, rtol=1e-3, atol=1e-5)
                 row = dict(
                     layer=layer_no,
                     rank=rank,
                     tokens=tokens,
                     dynamic_decode=args.dynamic,
+                    grouped_decode=args.grouped,
                     scales=scales,
-                    raw_vs_prepared=error(b, a),
+                    **{
+                        (
+                            "grouped_vs_prepared" if args.grouped else "raw_vs_prepared"
+                        ): error(b, a)
+                    },
                     prepared_repeat=error(aa, a),
                     raw_repeat=error(bb, b),
                 )
@@ -207,7 +243,7 @@ def main():
                     graph = torch.cuda.CUDAGraph()
                     torch.accelerator.synchronize()
                     with torch.cuda.graph(graph):
-                        bgraph = method.apply(raw, x, weights, ids, None, None)
+                        bgraph = apply(raw)
                     for _ in range(3):
                         graph.replay()
                     row["graph_vs_eager"] = error(bgraph, b)
@@ -219,7 +255,11 @@ def main():
             torch.accelerator.empty_cache()
     Path(args.out).write_text(json.dumps(rows, indent=2) + "\n")
     for row in rows:
-        checks = [row[k] for k in ("raw_vs_prepared", "prepared_repeat", "raw_repeat")]
+        checks = [row[k] for k in ("prepared_repeat", "raw_repeat")]
+        if not args.grouped:
+            checks.append(row["raw_vs_prepared"])
+        elif row["tokens"] != 16:
+            checks.append(row["grouped_vs_prepared"])
         checks.extend(row["scales"].values())
         if "graph_vs_eager" in row:
             checks.append(row["graph_vs_eager"])

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -100,9 +100,25 @@ inline int sm70_tp4_push_allreduce_blocks(size_t bytes) {
         std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH_BLOCKS");
     if (blocks != nullptr) {
       const int parsed = std::atoi(blocks);
-      if (parsed > 0 && parsed <= kSm70Tp4PushAllreduceBlocks) return parsed;
+      const int min_blocks = (bytes + kSm70Tp4PushAllreduceThreads * 16 - 1) /
+                             (kSm70Tp4PushAllreduceThreads * 16);
+      // This push kernel handles one pack per thread, without a grid-stride
+      // loop. An undersized launch silently leaves the output tail unwritten.
+      if (parsed >= min_blocks && parsed <= kSm70Tp4PushAllreduceBlocks) {
+        return parsed;
+      }
     }
     return bytes == kSm70Tp4PushAllreduceQwen38M4Bytes ? 10 : 20;
+  }
+  // Experimental message-size admission, independent of model or batch shape.
+  // Preserve the established launch choices above. Each thread handles one
+  // 16-byte pack, and the persistent buffer remains bounded by its old size.
+  const char* small =
+      std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES");
+  if (small != nullptr && std::strcmp(small, "1") == 0 && bytes > 0 &&
+      bytes <= kSm70Tp4PushAllreduceBytes && bytes % 16 == 0) {
+    return static_cast<int>((bytes + kSm70Tp4PushAllreduceThreads * 16 - 1) /
+                            (kSm70Tp4PushAllreduceThreads * 16));
   }
   const char* mtp5 = std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5");
   return bytes == kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes && mtp5 != nullptr &&

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -82,7 +82,18 @@ constexpr size_t kSm70Tp4PushAllreduceBufferBytes =
                                            kSm70Tp4PushAllreduceWorldSize *
                                            kSm70Tp4PushAllreduceBytes;
 
-inline int sm70_tp4_push_allreduce_blocks(size_t bytes) {
+inline int sm70_tp4_push_allreduce_blocks(size_t bytes,
+                                          bool allow_generic = false) {
+  // Experimental message-size admission, independent of model or batch shape.
+  // Each thread handles one 16-byte pack. Use the smallest covering grid,
+  // bounded by the existing persistent buffer, including for known payloads.
+  const char* small =
+      std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES");
+  if (allow_generic && small != nullptr && std::strcmp(small, "1") == 0 &&
+      bytes > 0 && bytes <= kSm70Tp4PushAllreduceBytes && bytes % 16 == 0) {
+    return static_cast<int>((bytes + kSm70Tp4PushAllreduceThreads * 16 - 1) /
+                            (kSm70Tp4PushAllreduceThreads * 16));
+  }
   if (bytes == kSm70Tp4PushAllreduceBytes) {
     return kSm70Tp4PushAllreduceBlocks;
   }
@@ -109,16 +120,6 @@ inline int sm70_tp4_push_allreduce_blocks(size_t bytes) {
       }
     }
     return bytes == kSm70Tp4PushAllreduceQwen38M4Bytes ? 10 : 20;
-  }
-  // Experimental message-size admission, independent of model or batch shape.
-  // Preserve the established launch choices above. Each thread handles one
-  // 16-byte pack, and the persistent buffer remains bounded by its old size.
-  const char* small =
-      std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES");
-  if (small != nullptr && std::strcmp(small, "1") == 0 && bytes > 0 &&
-      bytes <= kSm70Tp4PushAllreduceBytes && bytes % 16 == 0) {
-    return static_cast<int>((bytes + kSm70Tp4PushAllreduceThreads * 16 - 1) /
-                            (kSm70Tp4PushAllreduceThreads * 16));
   }
   const char* mtp5 = std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5");
   return bytes == kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes && mtp5 != nullptr &&
@@ -1656,7 +1657,7 @@ class CustomAllreduce {
           status == cudaStreamCaptureStatusActive &&
           world_size_ == kSm70Tp4PushAllreduceWorldSize && fully_connected_ &&
           custom_allreduce_current_device_is_sm70()) {
-        const int push_blocks = sm70_tp4_push_allreduce_blocks(bytes);
+        const int push_blocks = sm70_tp4_push_allreduce_blocks(bytes, true);
         if (push_blocks > 0) {
           sm70_cross_device_reduce_1stage_push<kSm70Tp4PushAllreduceWorldSize>
               <<<push_blocks, kSm70Tp4PushAllreduceThreads, 0, stream>>>(

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -73,6 +73,8 @@ constexpr size_t kSm70Tp4PushAllreduce8KiBBytes = 4096 * sizeof(half);
 constexpr size_t kSm70Tp4PushAllreduceQwen4ExpBytes = 2560 * sizeof(half);
 constexpr size_t kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes =
     5 * 2560 * sizeof(half);
+constexpr size_t kSm70Tp4PushAllreduceQwen38M4Bytes = 4 * 2560 * sizeof(half);
+constexpr size_t kSm70Tp4PushAllreduceQwen38M8Bytes = 8 * 2560 * sizeof(half);
 constexpr size_t kSm70Tp4PushAllreduceSignalBytes =
     ((kSm70Tp4PushAllreduceBlocks * sizeof(uint32_t) + 127) / 128) * 128;
 constexpr size_t kSm70Tp4PushAllreduceBufferBytes =
@@ -89,6 +91,18 @@ inline int sm70_tp4_push_allreduce_blocks(size_t bytes) {
   }
   if (bytes == kSm70Tp4PushAllreduceQwen4ExpBytes) {
     return 3;
+  }
+  const char* batch = std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH");
+  const bool batch_enabled = batch == nullptr || std::strcmp(batch, "1") == 0;
+  if (batch_enabled && (bytes == kSm70Tp4PushAllreduceQwen38M4Bytes ||
+                        bytes == kSm70Tp4PushAllreduceQwen38M8Bytes)) {
+    const char* blocks =
+        std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH_BLOCKS");
+    if (blocks != nullptr) {
+      const int parsed = std::atoi(blocks);
+      if (parsed > 0 && parsed <= kSm70Tp4PushAllreduceBlocks) return parsed;
+    }
+    return bytes == kSm70Tp4PushAllreduceQwen38M4Bytes ? 10 : 20;
   }
   const char* mtp5 = std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5");
   return bytes == kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes && mtp5 != nullptr &&
@@ -1862,10 +1876,20 @@ class CustomAllreduce {
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
     if constexpr (std::is_same_v<T, half>) {
+      const char* batch =
+          std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH");
+      const bool qwen38_batch =
+          (batch == nullptr || std::strcmp(batch, "1") == 0) &&
+          (bytes == kSm70Tp4PushAllreduceQwen38M4Bytes ||
+           bytes == kSm70Tp4PushAllreduceQwen38M8Bytes ||
+           bytes == kSm70Tp4PushAllreduceBytes);
+      const char* mtp5 = std::getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5");
+      const bool qwen38_mtp5 = mtp5 != nullptr && std::strcmp(mtp5, "1") == 0 &&
+                               bytes == kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes;
       if (sm70_tp4_push_buffers_registered_ &&
           status == cudaStreamCaptureStatusActive &&
           world_size_ == kSm70Tp4PushAllreduceWorldSize && fully_connected_ &&
-          bytes == kSm70Tp4PushAllreduceQwen4ExpMtp5Bytes &&
+          (qwen38_batch || qwen38_mtp5) &&
           custom_allreduce_current_device_is_sm70()) {
         const int push_blocks = sm70_tp4_push_allreduce_blocks(bytes);
         if (push_blocks > 0) {

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -523,6 +523,40 @@ void nvfp4_moe_qpn_m1_sm70_out(torch::Tensor out, torch::Tensor input,
                                torch::Tensor expert_ids, bool broadcast_input,
                                int64_t split_k);
 
+void nvfp4_expand_raw_scales_sm70_out(torch::Tensor out,
+                                      torch::Tensor scale_codes,
+                                      torch::Tensor global_scales,
+                                      bool interleaved_w13,
+                                      bool fast_decode_rounding);
+
+void nvfp4_moe_qpn_raw_scale_sm70_out(torch::Tensor out, torch::Tensor input,
+                                      torch::Tensor weights,
+                                      torch::Tensor scale_codes,
+                                      torch::Tensor global_scales,
+                                      torch::Tensor expert_ids,
+                                      bool broadcast_input,
+                                      bool interleaved_w13, int64_t split_k);
+
+void nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scales, torch::Tensor expert_ids, bool interleaved);
+
+void nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scale_codes, torch::Tensor global_scales,
+    torch::Tensor expert_ids, bool interleaved);
+
+void nvfp4_moe_qpn_w2_reduce_sm70_out(torch::Tensor out, torch::Tensor input,
+                                      torch::Tensor weights,
+                                      torch::Tensor scales,
+                                      torch::Tensor expert_ids,
+                                      torch::Tensor topk_weights);
+
+void nvfp4_moe_qpn_raw_w2_reduce_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scale_codes, torch::Tensor global_scales,
+    torch::Tensor expert_ids, torch::Tensor topk_weights);
+
 void nvfp4_moe_qpn_mtp5_sm70_out(torch::Tensor out, torch::Tensor input,
                                  torch::Tensor weights, torch::Tensor scales,
                                  torch::Tensor expert_ids, bool broadcast_input,

--- a/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
+++ b/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
@@ -243,6 +243,414 @@ __global__ void nvfp4_qpn_m1_sm70_kernel(const half* __restrict__ input,
   }
 }
 
+__device__ __forceinline__ half nvfp4_raw_scale_to_half(uint8_t scale_code,
+                                                        half scale_hi,
+                                                        half scale_lo) {
+  // This fast reconstruction is selected only after a load-time exhaustive
+  // comparison with the checkpoint's prepared FP16 scales. The high/low split
+  // avoids an FP32 multiply in every QPN inner-loop iteration.
+  const unsigned half_bits =
+      (static_cast<unsigned>(scale_code) << 7U) + 0x2000U;
+  const half raw_scale = *reinterpret_cast<const half*>(&half_bits);
+  const half correction = __hmul(raw_scale, scale_lo);
+  return __hfma(raw_scale, scale_hi, correction);
+}
+
+__global__ void nvfp4_expand_raw_scales_sm70_kernel(
+    half* __restrict__ output, const uint8_t* __restrict__ scale_codes,
+    const float* __restrict__ global_scales, size_t elements,
+    size_t scales_per_expert, int n, int global_stride, bool interleaved_w13,
+    bool fast_decode_rounding) {
+  const size_t index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= elements) {
+    return;
+  }
+  const int expert = static_cast<int>(index / scales_per_expert);
+  const int col = static_cast<int>(index % n);
+  int global_slot = 0;
+  if (global_stride == 2) {
+    global_slot = interleaved_w13 ? ((col >> 5) & 1) : (col >= n / 2);
+  }
+  const float global_scale =
+      global_scales[static_cast<size_t>(expert) * global_stride + global_slot];
+  if (fast_decode_rounding) {
+    const float scaled_global = global_scale * 16384.0f;
+    const half scale_hi = __float2half_rn(scaled_global);
+    const half scale_lo =
+        __float2half_rn(scaled_global - __half2float(scale_hi));
+    // Validate the effective scale consumed by HMMA directly. Dividing back
+    // to the stored scale could hide a mismatch through FP16 underflow.
+    output[index] =
+        nvfp4_raw_scale_to_half(scale_codes[index], scale_hi, scale_lo);
+  } else {
+    const unsigned code = scale_codes[index];
+    const unsigned magnitude = code & 0x7fU;
+    unsigned half_bits =
+        magnitude == 0x7fU ? 0x7e00U : (magnitude << 7U) + 0x2000U;
+    if (magnitude < 8U) {
+      const half subnormal = __float2half_rn(magnitude * 0x1p-9f);
+      half_bits = __half_as_ushort(subnormal);
+    }
+    half_bits |= (code & 0x80U) << 8U;
+    const half raw_scale = *reinterpret_cast<const half*>(&half_bits);
+    output[index] = __float2half_rn(__half2float(raw_scale) * global_scale);
+  }
+}
+
+template <int kSplitK>
+__global__ void nvfp4_qpn_raw_scale_sm70_kernel(
+    const half* __restrict__ input, const uint32_t* __restrict__ weights,
+    const uint8_t* __restrict__ scale_codes,
+    const float* __restrict__ global_scales,
+    const int32_t* __restrict__ expert_ids, half* __restrict__ output, int n,
+    int k, bool broadcast_input, bool interleaved_w13) {
+  __shared__ float partials[kSplitK][32];
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int tile = blockIdx.x;
+  const int route = blockIdx.y;
+  const int expert = __ldg(expert_ids + route);
+  if (expert < 0 || expert >= 512) {
+    if (threadIdx.x < 32) {
+      output[static_cast<size_t>(route) * n + tile * 32 + threadIdx.x] =
+          __float2half(0.0f);
+    }
+    return;
+  }
+
+  const int quadpair = (lane >> 2) & 3;
+  const int a_row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int packed_col =
+      ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int groups_k16 = k >> 4;
+  const int groups_per_warp = groups_k16 / kSplitK;
+  const int group_begin = warp * groups_per_warp;
+  const int groups_k8 = k >> 3;
+  const int tiles_n32 = n >> 5;
+  const bool is_w13 = k == 2560 && n == 320;
+
+  const size_t words_per_expert = static_cast<size_t>(k) * n / 8;
+  const uint32_t* expert_weights =
+      weights + static_cast<size_t>(expert) * words_per_expert;
+  const size_t scales_per_expert = static_cast<size_t>(k >> 4) * n;
+  const uint8_t* expert_scale_codes =
+      scale_codes + static_cast<size_t>(expert) * scales_per_expert;
+  const int input_route = broadcast_input ? route / 10 : route;
+  const half* input_row = input + static_cast<size_t>(input_route) * k;
+
+  int global_slot = 0;
+  if (is_w13) {
+    global_slot = interleaved_w13 ? (tile & 1) : (tile >= tiles_n32 / 2);
+  }
+  const float global_scale =
+      __ldg(global_scales + static_cast<size_t>(expert) * (is_w13 ? 2 : 1) +
+            global_slot) *
+      16384.0f;
+  const half scale_hi = __float2half_rn(global_scale);
+  const half scale_lo = __float2half_rn(global_scale - __half2float(scale_hi));
+
+  float accum[8] = {};
+#pragma unroll 4
+  for (int group = group_begin; group < group_begin + groups_per_warp;
+       ++group) {
+    const size_t tile_group_base =
+        (static_cast<size_t>(tile) * groups_k8 + group * 2) * 32 + packed_col;
+    const unsigned packed0 = __ldcs(expert_weights + tile_group_base);
+    const unsigned packed1 = __ldcs(expert_weights + tile_group_base + 32);
+    const size_t scale_index =
+        (static_cast<size_t>(group) * tiles_n32 + tile) * 32 + packed_col;
+    const uint8_t scale_code = __ldg(expert_scale_codes + scale_index);
+    const half scalar = nvfp4_raw_scale_to_half(scale_code, scale_hi, scale_lo);
+    const half2 scale = __halves2half2(scalar, scalar);
+    half2 decoded[8];
+    dequant_e2m1x8(packed0, scale, decoded);
+    dequant_e2m1x8(packed1, scale, decoded + 4);
+    const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+
+    uint4 input01 = make_uint4(0, 0, 0, 0);
+    uint4 input23 = make_uint4(0, 0, 0, 0);
+    if (a_row == 0) {
+      input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+      input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+    }
+    const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+    const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+    VLLM_SM70_MMA_8N8K4(accum, a0[0], a0[1], b[0], b[1]);
+    VLLM_SM70_MMA_8N8K4(accum, a0[2], a0[3], b[2], b[3]);
+    VLLM_SM70_MMA_8N8K4(accum, a1[0], a1[1], b[4], b[5]);
+    VLLM_SM70_MMA_8N8K4(accum, a1[2], a1[3], b[6], b[7]);
+  }
+
+  if ((lane & 17) == 0) {
+#pragma unroll
+    for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+      for (int offset = 0; offset < 2; ++offset) {
+        const int index = pair * 4 + offset;
+        const int local_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        partials[warp][quadpair * 8 + local_col] = accum[index];
+      }
+    }
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+    float value = 0.0f;
+#pragma unroll
+    for (int k_warp = 0; k_warp < kSplitK; ++k_warp) {
+      value += partials[k_warp][lane];
+    }
+    output[static_cast<size_t>(route) * n + tile * 32 + lane] =
+        __float2half(value);
+  }
+}
+
+template <int kSplitK, bool kInterleaved, bool kRawScale = false>
+__global__ void nvfp4_qpn_w13_swiglu_batch_sm70_kernel(
+    const half* __restrict__ input, const uint32_t* __restrict__ weights,
+    const void* __restrict__ scales, const float* __restrict__ global_scales,
+    const int32_t* __restrict__ expert_ids, half* __restrict__ output) {
+  constexpr int kInput = 2560;
+  constexpr int kOutput = 320;
+  constexpr int kIntermediate = 160;
+  constexpr int kTilesN32 = kOutput / 32;
+  constexpr int kGroupsK16 = kInput / 16;
+  __shared__ float partials[2][kSplitK][32];
+  __shared__ half projected[2][32];
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int projection = warp / kSplitK;
+  const int split = warp % kSplitK;
+  const int route = blockIdx.y;
+  const int tile = kInterleaved
+                       ? blockIdx.x * 2 + projection
+                       : blockIdx.x + projection * (kIntermediate / 32);
+  const int expert = __ldg(expert_ids + route);
+  const int quadpair = (lane >> 2) & 3;
+  const int mma_row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int packed_col =
+      ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+  constexpr int kGroupsPerWarp = kGroupsK16 / kSplitK;
+  const int group_begin = split * kGroupsPerWarp;
+
+  float accum[8] = {};
+  if (expert >= 0 && expert < 512) {
+    const size_t words_per_expert = static_cast<size_t>(kInput) * kOutput / 8;
+    const uint32_t* expert_weights =
+        weights + static_cast<size_t>(expert) * words_per_expert;
+    const size_t scales_per_expert = static_cast<size_t>(kInput / 16) * kOutput;
+    const half* expert_scales = reinterpret_cast<const half*>(scales) +
+                                static_cast<size_t>(expert) * scales_per_expert;
+    const uint8_t* expert_scale_codes =
+        reinterpret_cast<const uint8_t*>(scales) +
+        static_cast<size_t>(expert) * scales_per_expert;
+    const half* input_row = input + static_cast<size_t>(route / 10) * kInput;
+    half scale_hi = __float2half(0.0f);
+    half scale_lo = __float2half(0.0f);
+    if constexpr (kRawScale) {
+      const float global_scale =
+          __ldg(global_scales + static_cast<size_t>(expert) * 2 + projection) *
+          16384.0f;
+      scale_hi = __float2half_rn(global_scale);
+      scale_lo = __float2half_rn(global_scale - __half2float(scale_hi));
+    }
+
+#pragma unroll 4
+    for (int group = group_begin; group < group_begin + kGroupsPerWarp;
+         ++group) {
+      const size_t tile_group_base =
+          (static_cast<size_t>(tile) * (kInput / 8) + group * 2) * 32 +
+          packed_col;
+      const unsigned packed0 = __ldcs(expert_weights + tile_group_base);
+      const unsigned packed1 = __ldcs(expert_weights + tile_group_base + 32);
+      const size_t scale_index =
+          (static_cast<size_t>(group) * kTilesN32 + tile) * 32 + packed_col;
+      half scalar;
+      if constexpr (kRawScale) {
+        scalar = nvfp4_raw_scale_to_half(
+            __ldg(expert_scale_codes + scale_index), scale_hi, scale_lo);
+      } else {
+        const half prepared_scale = __ldg(expert_scales + scale_index);
+        scalar = __hmul(prepared_scale, __float2half_rn(16384.0f));
+      }
+      const half2 scale = __halves2half2(scalar, scalar);
+      half2 decoded[8];
+      dequant_e2m1x8(packed0, scale, decoded);
+      dequant_e2m1x8(packed1, scale, decoded + 4);
+      const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+
+      uint4 input01 = make_uint4(0, 0, 0, 0);
+      uint4 input23 = make_uint4(0, 0, 0, 0);
+      if (mma_row == 0) {
+        input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+        input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+      }
+      const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+      const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+      VLLM_SM70_MMA_8N8K4(accum, a0[0], a0[1], b[0], b[1]);
+      VLLM_SM70_MMA_8N8K4(accum, a0[2], a0[3], b[2], b[3]);
+      VLLM_SM70_MMA_8N8K4(accum, a1[0], a1[1], b[4], b[5]);
+      VLLM_SM70_MMA_8N8K4(accum, a1[2], a1[3], b[6], b[7]);
+    }
+  }
+
+  if ((lane & 17) == 0) {
+#pragma unroll
+    for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+      for (int offset = 0; offset < 2; ++offset) {
+        const int index = pair * 4 + offset;
+        const int output_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        if constexpr (kSplitK == 1) {
+          projected[projection][quadpair * 8 + output_col] =
+              __float2half(accum[index]);
+        } else {
+          partials[projection][split][quadpair * 8 + output_col] = accum[index];
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  if constexpr (kSplitK > 1) {
+    if (warp < 2) {
+      float value = 0.0f;
+#pragma unroll
+      for (int k_warp = 0; k_warp < kSplitK; ++k_warp) {
+        value += partials[warp][k_warp][lane];
+      }
+      projected[warp][lane] = __float2half(value);
+    }
+    __syncthreads();
+  }
+
+  if (warp == 0) {
+    const int projection_index = kInterleaved ? lane / 16 : 0;
+    const int projection_col = kInterleaved ? (lane % 16) * 2 : lane;
+    const half gate = projected[projection_index][projection_col];
+    const half up = kInterleaved
+                        ? projected[projection_index][projection_col + 1]
+                        : projected[1][lane];
+    const float gate_f = __half2float(gate);
+    const half activated = __float2half(gate_f / (1.0f + expf(-gate_f)));
+    output[static_cast<size_t>(route) * kIntermediate + blockIdx.x * 32 +
+           lane] = __hmul(activated, up);
+  }
+}
+
+template <bool kRawScale = false>
+__global__ void nvfp4_qpn_w2_reduce_sm70_kernel(
+    const half* __restrict__ input, const uint32_t* __restrict__ weights,
+    const void* __restrict__ scales, const float* __restrict__ global_scales,
+    const int32_t* __restrict__ expert_ids,
+    const float* __restrict__ topk_weights, half* __restrict__ output,
+    int tokens) {
+  constexpr int kTopK = 10;
+  constexpr int kInput = 160;
+  constexpr int kOutput = 2560;
+  constexpr int kTilesN32 = kOutput / 32;
+  constexpr int kGroupsK16 = kInput / 16;
+  __shared__ half routed_output[kTopK][32];
+
+  const int lane = threadIdx.x & 31;
+  const int slot = threadIdx.x >> 5;
+  const int token = blockIdx.y;
+  const int tile = blockIdx.x;
+  const int route = token * kTopK + slot;
+  const int expert = __ldg(expert_ids + route);
+  const int quadpair = (lane >> 2) & 3;
+  const int mma_row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int packed_col =
+      ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+
+  float accum[8] = {};
+  if (token < tokens && expert >= 0 && expert < 512) {
+    const size_t words_per_expert = static_cast<size_t>(kInput) * kOutput / 8;
+    const uint32_t* expert_weights =
+        weights + static_cast<size_t>(expert) * words_per_expert;
+    const size_t scales_per_expert = static_cast<size_t>(kInput / 16) * kOutput;
+    const half* expert_scales = reinterpret_cast<const half*>(scales) +
+                                static_cast<size_t>(expert) * scales_per_expert;
+    const uint8_t* expert_scale_codes =
+        reinterpret_cast<const uint8_t*>(scales) +
+        static_cast<size_t>(expert) * scales_per_expert;
+    const half* input_row = input + static_cast<size_t>(route) * kInput;
+    half scale_hi = __float2half(0.0f);
+    half scale_lo = __float2half(0.0f);
+    if constexpr (kRawScale) {
+      const float global_scale = __ldg(global_scales + expert) * 16384.0f;
+      scale_hi = __float2half_rn(global_scale);
+      scale_lo = __float2half_rn(global_scale - __half2float(scale_hi));
+    }
+
+#pragma unroll
+    for (int group = 0; group < kGroupsK16; ++group) {
+      const size_t tile_group_base =
+          (static_cast<size_t>(tile) * (kInput / 8) + group * 2) * 32 +
+          packed_col;
+      const unsigned packed0 = __ldcs(expert_weights + tile_group_base);
+      const unsigned packed1 = __ldcs(expert_weights + tile_group_base + 32);
+      const size_t scale_index =
+          (static_cast<size_t>(group) * kTilesN32 + tile) * 32 + packed_col;
+      half scalar;
+      if constexpr (kRawScale) {
+        scalar = nvfp4_raw_scale_to_half(
+            __ldg(expert_scale_codes + scale_index), scale_hi, scale_lo);
+      } else {
+        const half prepared_scale = __ldg(expert_scales + scale_index);
+        scalar = __hmul(prepared_scale, __float2half_rn(16384.0f));
+      }
+      const half2 scale = __halves2half2(scalar, scalar);
+      half2 decoded[8];
+      dequant_e2m1x8(packed0, scale, decoded);
+      dequant_e2m1x8(packed1, scale, decoded + 4);
+      const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+
+      uint4 input01 = make_uint4(0, 0, 0, 0);
+      uint4 input23 = make_uint4(0, 0, 0, 0);
+      if (mma_row == 0) {
+        input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+        input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+      }
+      const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+      const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+      VLLM_SM70_MMA_8N8K4(accum, a0[0], a0[1], b[0], b[1]);
+      VLLM_SM70_MMA_8N8K4(accum, a0[2], a0[3], b[2], b[3]);
+      VLLM_SM70_MMA_8N8K4(accum, a1[0], a1[1], b[4], b[5]);
+      VLLM_SM70_MMA_8N8K4(accum, a1[2], a1[3], b[6], b[7]);
+    }
+  }
+
+  if ((lane & 17) == 0) {
+#pragma unroll
+    for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+      for (int offset = 0; offset < 2; ++offset) {
+        const int index = pair * 4 + offset;
+        const int output_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        routed_output[slot][quadpair * 8 + output_col] =
+            __float2half(accum[index]);
+      }
+    }
+  }
+  __syncthreads();
+
+  if (slot == 0 && token < tokens) {
+    float weighted = 0.0f;
+#pragma unroll
+    for (int routed_slot = 0; routed_slot < kTopK; ++routed_slot) {
+      weighted =
+          fmaf(__half2float(routed_output[routed_slot][lane]),
+               __ldg(topk_weights + token * kTopK + routed_slot), weighted);
+    }
+    output[static_cast<size_t>(token) * kOutput + tile * 32 + lane] =
+        __float2half(weighted);
+  }
+}
+
 template <int kSplitK>
 void launch_mxfp4_qpn_m1(torch::Tensor out, torch::Tensor input,
                          torch::Tensor weights, torch::Tensor scales,
@@ -274,6 +682,27 @@ void launch_nvfp4_qpn_m1(torch::Tensor out, torch::Tensor input,
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), n, k, broadcast_input);
 }
 
+template <int kSplitK>
+void launch_nvfp4_qpn_raw_scale(torch::Tensor out, torch::Tensor input,
+                                torch::Tensor weights,
+                                torch::Tensor scale_codes,
+                                torch::Tensor global_scales,
+                                torch::Tensor expert_ids, bool broadcast_input,
+                                bool interleaved_w13) {
+  const int n = static_cast<int>(out.size(1));
+  const int k = static_cast<int>(input.size(1));
+  const int routes = static_cast<int>(expert_ids.numel());
+  nvfp4_qpn_raw_scale_sm70_kernel<kSplitK>
+      <<<dim3(n / 32, routes), 32 * kSplitK, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+          reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>()),
+          scale_codes.data_ptr<uint8_t>(), global_scales.data_ptr<float>(),
+          expert_ids.data_ptr<int32_t>(),
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()), n, k,
+          broadcast_input, interleaved_w13);
+}
+
 void dispatch_nvfp4_qpn_m1(torch::Tensor out, torch::Tensor input,
                            torch::Tensor weights, torch::Tensor scales,
                            torch::Tensor expert_ids, bool broadcast_input,
@@ -300,7 +729,80 @@ void dispatch_nvfp4_qpn_m1(torch::Tensor out, torch::Tensor input,
 #undef VLLM_NVFP4_QPN_M1_CASE
 }
 
+void dispatch_nvfp4_qpn_raw_scale(torch::Tensor out, torch::Tensor input,
+                                  torch::Tensor weights,
+                                  torch::Tensor scale_codes,
+                                  torch::Tensor global_scales,
+                                  torch::Tensor expert_ids,
+                                  bool broadcast_input, bool interleaved_w13,
+                                  int64_t split_k) {
+#define VLLM_NVFP4_QPN_RAW_CASE(SPLIT)                                   \
+  case SPLIT:                                                            \
+    launch_nvfp4_qpn_raw_scale<SPLIT>(out, input, weights, scale_codes,  \
+                                      global_scales, expert_ids,         \
+                                      broadcast_input, interleaved_w13); \
+    break
+  switch (split_k) {
+    VLLM_NVFP4_QPN_RAW_CASE(1);
+    VLLM_NVFP4_QPN_RAW_CASE(2);
+    VLLM_NVFP4_QPN_RAW_CASE(4);
+    VLLM_NVFP4_QPN_RAW_CASE(5);
+    VLLM_NVFP4_QPN_RAW_CASE(8);
+    VLLM_NVFP4_QPN_RAW_CASE(10);
+    VLLM_NVFP4_QPN_RAW_CASE(16);
+    VLLM_NVFP4_QPN_RAW_CASE(20);
+    VLLM_NVFP4_QPN_RAW_CASE(32);
+    default:
+      TORCH_CHECK(false,
+                  "nvfp4_moe_qpn_raw_scale_sm70_out: unsupported split_k ",
+                  split_k);
+  }
+#undef VLLM_NVFP4_QPN_RAW_CASE
+}
+
 }  // namespace
+
+void nvfp4_expand_raw_scales_sm70_out(torch::Tensor out,
+                                      torch::Tensor scale_codes,
+                                      torch::Tensor global_scales,
+                                      bool interleaved_w13,
+                                      bool fast_decode_rounding) {
+  TORCH_CHECK(out.is_cuda() && scale_codes.is_cuda() && global_scales.is_cuda(),
+              "nvfp4_expand_raw_scales_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  scale_codes.scalar_type() == torch::kUInt8 &&
+                  global_scales.scalar_type() == torch::kFloat32,
+              "nvfp4_expand_raw_scales_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && scale_codes.is_contiguous() &&
+                  global_scales.is_contiguous(),
+              "nvfp4_expand_raw_scales_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(out.sizes() == scale_codes.sizes() && out.dim() == 3 &&
+                  out.size(0) == 512,
+              "nvfp4_expand_raw_scales_sm70_out: scale shape mismatch");
+  const bool is_w13 = out.sizes() == torch::IntArrayRef({512, 160, 320});
+  const bool is_w2 = out.sizes() == torch::IntArrayRef({512, 10, 2560});
+  TORCH_CHECK(is_w13 || is_w2,
+              "nvfp4_expand_raw_scales_sm70_out: unsupported Qwen3.8 shape");
+  TORCH_CHECK(global_scales.sizes() == (is_w13 ? torch::IntArrayRef({512, 2})
+                                               : torch::IntArrayRef({512, 1})),
+              "nvfp4_expand_raw_scales_sm70_out: global-scale shape mismatch");
+  TORCH_CHECK(out.get_device() == scale_codes.get_device() &&
+                  out.get_device() == global_scales.get_device(),
+              "nvfp4_expand_raw_scales_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
+  constexpr int threads = 256;
+  const size_t elements = static_cast<size_t>(out.numel());
+  const int blocks = static_cast<int>((elements + threads - 1) / threads);
+  nvfp4_expand_raw_scales_sm70_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+      scale_codes.data_ptr<uint8_t>(), global_scales.data_ptr<float>(),
+      elements, static_cast<size_t>(out.numel() / out.size(0)),
+      static_cast<int>(out.size(2)), is_w13 ? 2 : 1, interleaved_w13,
+      fast_decode_rounding);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
 
 void mxfp4_moe_qpn_m1_sm70_out(torch::Tensor out, torch::Tensor input,
                                torch::Tensor weights, torch::Tensor scales,
@@ -370,10 +872,11 @@ void nvfp4_moe_qpn_m1_sm70_out(torch::Tensor out, torch::Tensor input,
                   scales.dim() == 3 && expert_ids.dim() == 1,
               "nvfp4_moe_qpn_m1_sm70_out: rank mismatch");
   const int64_t routes = expert_ids.numel();
-  TORCH_CHECK((routes == 10 || routes == 50) && out.size(0) == routes &&
-                  weights.size(0) == 512 && scales.size(0) == 512,
-              "nvfp4_moe_qpn_m1_sm70_out: expected 10 or 50 routes and 512 "
-              "experts");
+  TORCH_CHECK(routes >= 10 && routes <= 160 && routes % 10 == 0 &&
+                  out.size(0) == routes && weights.size(0) == 512 &&
+                  scales.size(0) == 512,
+              "nvfp4_moe_qpn_m1_sm70_out: expected 10..160 routes in "
+              "10-route token groups and 512 experts");
   TORCH_CHECK(input.get_device() == out.get_device() &&
                   input.get_device() == weights.get_device() &&
                   input.get_device() == scales.get_device() &&
@@ -406,6 +909,70 @@ void nvfp4_moe_qpn_m1_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+void nvfp4_moe_qpn_raw_scale_sm70_out(torch::Tensor out, torch::Tensor input,
+                                      torch::Tensor weights,
+                                      torch::Tensor scale_codes,
+                                      torch::Tensor global_scales,
+                                      torch::Tensor expert_ids,
+                                      bool broadcast_input,
+                                      bool interleaved_w13, int64_t split_k) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+                  scale_codes.is_cuda() && global_scales.is_cuda() &&
+                  expert_ids.is_cuda(),
+              "nvfp4_moe_qpn_raw_scale_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weights.scalar_type() == torch::kInt32 &&
+                  scale_codes.scalar_type() == torch::kUInt8 &&
+                  global_scales.scalar_type() == torch::kFloat32 &&
+                  expert_ids.scalar_type() == torch::kInt32,
+              "nvfp4_moe_qpn_raw_scale_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  weights.is_contiguous() && scale_codes.is_contiguous() &&
+                  global_scales.is_contiguous() && expert_ids.is_contiguous(),
+              "nvfp4_moe_qpn_raw_scale_sm70_out: tensors must be contiguous");
+  const int64_t routes = expert_ids.numel();
+  TORCH_CHECK(routes >= 10 && routes <= 160 && routes % 10 == 0 &&
+                  out.size(0) == routes && weights.size(0) == 512 &&
+                  scale_codes.size(0) == 512,
+              "nvfp4_moe_qpn_raw_scale_sm70_out: expected 10..160 routes ");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == weights.get_device() &&
+                  input.get_device() == scale_codes.get_device() &&
+                  input.get_device() == global_scales.get_device() &&
+                  input.get_device() == expert_ids.get_device(),
+              "nvfp4_moe_qpn_raw_scale_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const int64_t groups_k16 = input.size(1) / 16;
+  TORCH_CHECK(split_k > 0 && split_k <= 32 && groups_k16 % split_k == 0,
+              "nvfp4_moe_qpn_raw_scale_sm70_out: split_k must divide K/16");
+  const bool is_w13 = input.size(1) == 2560 && out.size(1) == 320;
+  if (is_w13) {
+    const int64_t expected_input_rows = broadcast_input ? routes / 10 : routes;
+    TORCH_CHECK(
+        input.sizes() == torch::IntArrayRef({expected_input_rows, 2560}) &&
+            out.sizes() == torch::IntArrayRef({routes, 320}) &&
+            weights.sizes() == torch::IntArrayRef({512, 2560, 40}) &&
+            scale_codes.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+            global_scales.sizes() == torch::IntArrayRef({512, 2}),
+        "nvfp4_moe_qpn_raw_scale_sm70_out: W13 tensor contract mismatch");
+  } else {
+    TORCH_CHECK(
+        !broadcast_input && !interleaved_w13 &&
+            input.sizes() == torch::IntArrayRef({routes, 160}) &&
+            out.sizes() == torch::IntArrayRef({routes, 2560}) &&
+            weights.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+            scale_codes.sizes() == torch::IntArrayRef({512, 10, 2560}) &&
+            global_scales.sizes() == torch::IntArrayRef({512, 1}),
+        "nvfp4_moe_qpn_raw_scale_sm70_out: W2 tensor contract mismatch");
+  }
+  dispatch_nvfp4_qpn_raw_scale(out, input, weights, scale_codes, global_scales,
+                               expert_ids, broadcast_input, interleaved_w13,
+                               split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 void nvfp4_moe_qpn_mtp5_sm70_out(torch::Tensor out, torch::Tensor input,
                                  torch::Tensor weights, torch::Tensor scales,
                                  torch::Tensor expert_ids, bool broadcast_input,
@@ -414,4 +981,258 @@ void nvfp4_moe_qpn_mtp5_sm70_out(torch::Tensor out, torch::Tensor input,
               "nvfp4_moe_qpn_mtp5_sm70_out: expected fifty routes");
   nvfp4_moe_qpn_m1_sm70_out(out, input, weights, scales, expert_ids,
                             broadcast_input, split_k);
+}
+
+template <int kSplitK, bool kInterleaved>
+void launch_nvfp4_qpn_w13_swiglu_batch(torch::Tensor out, torch::Tensor input,
+                                       torch::Tensor weights,
+                                       torch::Tensor scales,
+                                       torch::Tensor expert_ids) {
+  const int routes = static_cast<int>(expert_ids.numel());
+  nvfp4_qpn_w13_swiglu_batch_sm70_kernel<kSplitK, kInterleaved>
+      <<<dim3(5, static_cast<unsigned>(routes)), 64 * kSplitK, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+          reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>()),
+          scales.data_ptr<at::Half>(), nullptr, expert_ids.data_ptr<int32_t>(),
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()));
+}
+
+template <int kSplitK, bool kInterleaved>
+void launch_nvfp4_qpn_raw_w13_swiglu_batch(torch::Tensor out,
+                                           torch::Tensor input,
+                                           torch::Tensor weights,
+                                           torch::Tensor scale_codes,
+                                           torch::Tensor global_scales,
+                                           torch::Tensor expert_ids) {
+  const int routes = static_cast<int>(expert_ids.numel());
+  nvfp4_qpn_w13_swiglu_batch_sm70_kernel<kSplitK, kInterleaved, true>
+      <<<dim3(5, static_cast<unsigned>(routes)), 64 * kSplitK, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+          reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>()),
+          scale_codes.data_ptr<uint8_t>(), global_scales.data_ptr<float>(),
+          expert_ids.data_ptr<int32_t>(),
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()));
+}
+
+void nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scales, torch::Tensor expert_ids, bool interleaved) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+                  scales.is_cuda() && expert_ids.is_cuda(),
+              "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weights.scalar_type() == torch::kInt32 &&
+                  scales.scalar_type() == torch::kFloat16 &&
+                  expert_ids.scalar_type() == torch::kInt32,
+              "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  weights.is_contiguous() && scales.is_contiguous() &&
+                  expert_ids.is_contiguous(),
+              "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out: tensors must be "
+              "contiguous");
+  const int64_t tokens = input.size(0);
+  const int64_t routes = tokens * 10;
+  TORCH_CHECK((tokens == 4 || tokens == 8 || tokens == 16) &&
+                  out.sizes() == torch::IntArrayRef({routes, 160}) &&
+                  input.sizes() == torch::IntArrayRef({tokens, 2560}) &&
+                  weights.sizes() == torch::IntArrayRef({512, 2560, 40}) &&
+                  scales.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+                  expert_ids.sizes() == torch::IntArrayRef({routes}),
+              "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out: expected exact "
+              "M4/M8/M16 "
+              "Qwen3.8 W13 tensors");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == weights.get_device() &&
+                  input.get_device() == scales.get_device() &&
+                  input.get_device() == expert_ids.get_device(),
+              "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+#define VLLM_LAUNCH_QWEN38_W13_SWIGLU(SPLIT)                               \
+  do {                                                                     \
+    if (interleaved) {                                                     \
+      launch_nvfp4_qpn_w13_swiglu_batch<SPLIT, true>(out, input, weights,  \
+                                                     scales, expert_ids);  \
+    } else {                                                               \
+      launch_nvfp4_qpn_w13_swiglu_batch<SPLIT, false>(out, input, weights, \
+                                                      scales, expert_ids); \
+    }                                                                      \
+  } while (false)
+  if (tokens == 4) {
+    VLLM_LAUNCH_QWEN38_W13_SWIGLU(5);
+  } else if (tokens == 8) {
+    VLLM_LAUNCH_QWEN38_W13_SWIGLU(4);
+  } else {
+    VLLM_LAUNCH_QWEN38_W13_SWIGLU(1);
+  }
+#undef VLLM_LAUNCH_QWEN38_W13_SWIGLU
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scale_codes, torch::Tensor global_scales,
+    torch::Tensor expert_ids, bool interleaved) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+                  scale_codes.is_cuda() && global_scales.is_cuda() &&
+                  expert_ids.is_cuda(),
+              "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out: tensors must be "
+              "CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weights.scalar_type() == torch::kInt32 &&
+                  scale_codes.scalar_type() == torch::kUInt8 &&
+                  global_scales.scalar_type() == torch::kFloat32 &&
+                  expert_ids.scalar_type() == torch::kInt32,
+              "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  weights.is_contiguous() && scale_codes.is_contiguous() &&
+                  global_scales.is_contiguous() && expert_ids.is_contiguous(),
+              "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out: tensors must be "
+              "contiguous");
+  const int64_t tokens = input.size(0);
+  const int64_t routes = tokens * 10;
+  TORCH_CHECK((tokens == 4 || tokens == 8 || tokens == 16) &&
+                  out.sizes() == torch::IntArrayRef({routes, 160}) &&
+                  input.sizes() == torch::IntArrayRef({tokens, 2560}) &&
+                  weights.sizes() == torch::IntArrayRef({512, 2560, 40}) &&
+                  scale_codes.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+                  global_scales.sizes() == torch::IntArrayRef({512, 2}) &&
+                  expert_ids.sizes() == torch::IntArrayRef({routes}),
+              "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out: expected exact "
+              "M4/M8/M16 Qwen3.8 tensors");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == weights.get_device() &&
+                  input.get_device() == scale_codes.get_device() &&
+                  input.get_device() == global_scales.get_device() &&
+                  input.get_device() == expert_ids.get_device(),
+              "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+#define VLLM_LAUNCH_QWEN38_RAW_W13_SWIGLU(SPLIT)                        \
+  do {                                                                  \
+    if (interleaved) {                                                  \
+      launch_nvfp4_qpn_raw_w13_swiglu_batch<SPLIT, true>(               \
+          out, input, weights, scale_codes, global_scales, expert_ids); \
+    } else {                                                            \
+      launch_nvfp4_qpn_raw_w13_swiglu_batch<SPLIT, false>(              \
+          out, input, weights, scale_codes, global_scales, expert_ids); \
+    }                                                                   \
+  } while (false)
+  if (tokens == 4) {
+    VLLM_LAUNCH_QWEN38_RAW_W13_SWIGLU(5);
+  } else if (tokens == 8) {
+    VLLM_LAUNCH_QWEN38_RAW_W13_SWIGLU(4);
+  } else {
+    VLLM_LAUNCH_QWEN38_RAW_W13_SWIGLU(1);
+  }
+#undef VLLM_LAUNCH_QWEN38_RAW_W13_SWIGLU
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_moe_qpn_w2_reduce_sm70_out(torch::Tensor out, torch::Tensor input,
+                                      torch::Tensor weights,
+                                      torch::Tensor scales,
+                                      torch::Tensor expert_ids,
+                                      torch::Tensor topk_weights) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+                  scales.is_cuda() && expert_ids.is_cuda() &&
+                  topk_weights.is_cuda(),
+              "nvfp4_moe_qpn_w2_reduce_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weights.scalar_type() == torch::kInt32 &&
+                  scales.scalar_type() == torch::kFloat16 &&
+                  expert_ids.scalar_type() == torch::kInt32 &&
+                  topk_weights.scalar_type() == torch::kFloat32,
+              "nvfp4_moe_qpn_w2_reduce_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  weights.is_contiguous() && scales.is_contiguous() &&
+                  expert_ids.is_contiguous() && topk_weights.is_contiguous(),
+              "nvfp4_moe_qpn_w2_reduce_sm70_out: tensors must be contiguous");
+  const int64_t tokens = out.size(0);
+  TORCH_CHECK(tokens >= 1 && tokens <= 16 &&
+                  out.sizes() == torch::IntArrayRef({tokens, 2560}) &&
+                  input.sizes() == torch::IntArrayRef({tokens * 10, 160}) &&
+                  weights.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+                  scales.sizes() == torch::IntArrayRef({512, 10, 2560}) &&
+                  expert_ids.sizes() == torch::IntArrayRef({tokens * 10}) &&
+                  topk_weights.sizes() == torch::IntArrayRef({tokens, 10}),
+              "nvfp4_moe_qpn_w2_reduce_sm70_out: expected Qwen3.8 E512/K10 "
+              "W2 tensors for 1..16 tokens");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == weights.get_device() &&
+                  input.get_device() == scales.get_device() &&
+                  input.get_device() == expert_ids.get_device() &&
+                  input.get_device() == topk_weights.get_device(),
+              "nvfp4_moe_qpn_w2_reduce_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  nvfp4_qpn_w2_reduce_sm70_kernel<false>
+      <<<dim3(80, static_cast<unsigned>(tokens)), 320, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+          reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>()),
+          scales.data_ptr<at::Half>(), nullptr, expert_ids.data_ptr<int32_t>(),
+          topk_weights.data_ptr<float>(),
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+          static_cast<int>(tokens));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_moe_qpn_raw_w2_reduce_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+    torch::Tensor scale_codes, torch::Tensor global_scales,
+    torch::Tensor expert_ids, torch::Tensor topk_weights) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+                  scale_codes.is_cuda() && global_scales.is_cuda() &&
+                  expert_ids.is_cuda() && topk_weights.is_cuda(),
+              "nvfp4_moe_qpn_raw_w2_reduce_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weights.scalar_type() == torch::kInt32 &&
+                  scale_codes.scalar_type() == torch::kUInt8 &&
+                  global_scales.scalar_type() == torch::kFloat32 &&
+                  expert_ids.scalar_type() == torch::kInt32 &&
+                  topk_weights.scalar_type() == torch::kFloat32,
+              "nvfp4_moe_qpn_raw_w2_reduce_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  weights.is_contiguous() && scale_codes.is_contiguous() &&
+                  global_scales.is_contiguous() && expert_ids.is_contiguous() &&
+                  topk_weights.is_contiguous(),
+              "nvfp4_moe_qpn_raw_w2_reduce_sm70_out: tensors must be "
+              "contiguous");
+  const int64_t tokens = out.size(0);
+  TORCH_CHECK(tokens >= 1 && tokens <= 16 &&
+                  out.sizes() == torch::IntArrayRef({tokens, 2560}) &&
+                  input.sizes() == torch::IntArrayRef({tokens * 10, 160}) &&
+                  weights.sizes() == torch::IntArrayRef({512, 160, 320}) &&
+                  scale_codes.sizes() == torch::IntArrayRef({512, 10, 2560}) &&
+                  global_scales.sizes() == torch::IntArrayRef({512, 1}) &&
+                  expert_ids.sizes() == torch::IntArrayRef({tokens * 10}) &&
+                  topk_weights.sizes() == torch::IntArrayRef({tokens, 10}),
+              "nvfp4_moe_qpn_raw_w2_reduce_sm70_out: expected Qwen3.8 "
+              "E512/K10 tensors for 1..16 tokens");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == weights.get_device() &&
+                  input.get_device() == scale_codes.get_device() &&
+                  input.get_device() == global_scales.get_device() &&
+                  input.get_device() == expert_ids.get_device() &&
+                  input.get_device() == topk_weights.get_device(),
+              "nvfp4_moe_qpn_raw_w2_reduce_sm70_out: device mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  nvfp4_qpn_w2_reduce_sm70_kernel<true>
+      <<<dim3(80, static_cast<unsigned>(tokens)), 320, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+          reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>()),
+          scale_codes.data_ptr<uint8_t>(), global_scales.data_ptr<float>(),
+          expert_ids.data_ptr<int32_t>(), topk_weights.data_ptr<float>(),
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+          static_cast<int>(tokens));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-// Benchmark-only multi-row W13 candidate. No production dispatcher uses this.
+// Experimental multi-row native-NVFP4 decode. Python dispatch defaults off.
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -288,18 +288,20 @@ void w2(torch::Tensor out, torch::Tensor routed, torch::Tensor x,
 }
 }  // namespace
 
-TORCH_LIBRARY(sm70_packed_screen, m) {
+TORCH_LIBRARY_FRAGMENT(_C, m) {
   m.def(
-      "run(Tensor(a!) out, Tensor x, Tensor w, Tensor s, Tensor ids, "
+      "nvfp4_grouped_w13_sm70_out(Tensor(a!) out, Tensor x, Tensor w, Tensor "
+      "s, Tensor ids, "
       "Tensor(b!) rows, Tensor(c!) experts, Tensor(d!) sizes, Tensor(e!) "
       "total, "
       "int split, bool interleaved) -> ()");
   m.def(
-      "w2(Tensor(a!) out, Tensor(b!) routed, Tensor x, Tensor w, Tensor s, "
+      "nvfp4_grouped_w2_sm70_out(Tensor(a!) out, Tensor(b!) routed, Tensor x, "
+      "Tensor w, Tensor s, "
       "Tensor topk, Tensor rows, Tensor experts, Tensor sizes, Tensor total) "
       "-> ()");
 }
-TORCH_LIBRARY_IMPL(sm70_packed_screen, CUDA, m) {
-  m.impl("run", &run);
-  m.impl("w2", &w2);
+TORCH_LIBRARY_IMPL(_C, CUDA, m) {
+  m.impl("nvfp4_grouped_w13_sm70_out", &run);
+  m.impl("nvfp4_grouped_w2_sm70_out", &w2);
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -697,6 +697,49 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("nvfp4_moe_qpn_m1_sm70_out", torch::kCUDA,
            &nvfp4_moe_qpn_m1_sm70_out);
 
+  ops.def(
+      "nvfp4_expand_raw_scales_sm70_out("
+      "Tensor(a!) out, Tensor scale_codes, Tensor global_scales, "
+      "bool interleaved_w13, bool fast_decode_rounding) -> ()");
+  ops.impl("nvfp4_expand_raw_scales_sm70_out", torch::kCUDA,
+           &nvfp4_expand_raw_scales_sm70_out);
+
+  ops.def(
+      "nvfp4_moe_qpn_raw_scale_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor weights, Tensor scale_codes, "
+      "Tensor global_scales, Tensor expert_ids, bool broadcast_input, "
+      "bool interleaved_w13, int split_k) -> ()");
+  ops.impl("nvfp4_moe_qpn_raw_scale_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_raw_scale_sm70_out);
+
+  ops.def(
+      "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor weights, Tensor scales, "
+      "Tensor expert_ids, bool interleaved) -> ()");
+  ops.impl("nvfp4_moe_qpn_w13_swiglu_batch_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_w13_swiglu_batch_sm70_out);
+
+  ops.def(
+      "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor weights, Tensor scale_codes, "
+      "Tensor global_scales, Tensor expert_ids, bool interleaved) -> ()");
+  ops.impl("nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out);
+
+  ops.def(
+      "nvfp4_moe_qpn_w2_reduce_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor weights, Tensor scales, "
+      "Tensor expert_ids, Tensor topk_weights) -> ()");
+  ops.impl("nvfp4_moe_qpn_w2_reduce_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_w2_reduce_sm70_out);
+
+  ops.def(
+      "nvfp4_moe_qpn_raw_w2_reduce_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor weights, Tensor scale_codes, "
+      "Tensor global_scales, Tensor expert_ids, Tensor topk_weights) -> ()");
+  ops.impl("nvfp4_moe_qpn_raw_w2_reduce_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_raw_w2_reduce_sm70_out);
+
   // Keep the five-row verifier on a distinct schema so an old extension that
   // only supports the ten-route M=1 contract cannot be selected accidentally.
   ops.def(

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -21,6 +21,14 @@ throughput from the same `max_num_seqs=16` engine is:
 Raw baseline:
 `.artifacts/qwen38_flash_next_no_mtp_concurrency/result.json`.
 
+Measurement correction (2026-09-05): the initial fixed-width tables below
+used client `get_output()` blocking wait, not complete inter-token intervals.
+They remain historical diagnostics and must not be described as end-to-end
+throughput. The reaccounted engine-timestamp results below supersede that
+accounting, without rerunning or changing any prompt, seed, output, or frozen
+70 tokens/s reference. The original request-level baseline and fixed-width
+steady-state measurements also remain distinct contracts.
+
 ## Evidence-first sequence
 
 1. Generalize the native NVFP4 QPN expert route from token counts 1 and 5 to
@@ -35,6 +43,457 @@ Raw baseline:
 5. Run one C1/C4/C8/C16 end-to-end acceptance test after admitted candidates
    have enough projected savings; do not repeatedly relaunch the full model.
 
+## Baseline trace and contract separation
+
+The historical E4M3-KV SPEED-Bench result (`C8=465.24`, `C16=772.44`) is not
+the baseline above. It used 1K input, E4M3 KV, the official low-entropy prompt
+set, stochastic generation, and natural EOS. The frozen baseline here uses 8K
+independent prompts, checkpoint-native FP16 KV, greedy generation, and 512
+forced output tokens. The historical result proves that the requested scaling
+is possible on these GPUs, but it is not interchangeable evidence.
+
+A fixed-live-width C16 graph-node trace was captured after the microbenchmarks
+justified profiling. Ubuntu installed the Nsight target and importer in
+different roots, so the raw QDSTRM was recovered directly with
+`/usr/lib/nsight-systems/host-linux-x64/QdstrmImporter`; the model was not run a
+second time. The accepted trace contains 12 graph replays on four TP ranks.
+After removing two head and tail samples, eight steady steps average 28.847 ms
+maximum-rank replay interval and 28.304 ms maximum-rank summed GPU service.
+Wall minus GPU service is only 0.543 ms, so the remaining C16 gap is on the GPU
+critical path rather than in request timing or scheduler bookkeeping.
+
+The principal service terms are direct NVFP4 W13 (5.583 ms), direct NVFP4 W2
+(2.573 ms), sparse QSA attention (1.840 ms), GDN recurrent update (1.351 ms),
+and TP communication (1.625 ms). Dense FP16 CUTLASS/cuBLAS kernels account for
+roughly another 8.9 ms when the broad 16x16 signature and the split-K
+main/reduction signatures are combined. The parser's `LM-head/sample` label
+includes that broad CUTLASS signature and must not be read as 5.736 ms of LM
+head alone. The accepted artifacts are under
+`.artifacts/qwen38_nomtp_concurrency/profiles/`
+`c16_graph_node_batch_qpn_v6_static_fallback*`.
+
+## Microbenchmark decisions
+
+### Native NVFP4 direct batch route: admitted
+
+The existing checkpoint NVFP4 packing is unchanged. Direct dispatch reads the
+same packed weights with FP16 inputs and FP32 HMMA accumulation while avoiding
+expert sort and replicated-input materialization. Production grouped-GEMM
+accumulation was screened independently at each graph width. The retained
+performance splits are:
+
+| Tokens | W13 split-K | Warm saving over 48 layers | Cold diagnostic saving |
+| ---: | ---: | ---: | ---: |
+| 4 | 5 | 1.59--2.13 ms | 5.41--8.06 ms |
+| 8 | 4 | 1.53--2.80 ms | 4.62--7.08 ms |
+| 16 | 1 | 0.05--4.09 ms | 17.01--17.60 ms |
+
+The ranges cover the two endpoint patterns: all rows reuse ten experts versus
+every routed row selecting a distinct expert. The cold numbers are planning
+diagnostics, not an additive endpoint claim. Direct-kernel output is replay
+deterministic. A same-process grouped comparison was bitwise equal for the
+reported runs, but that is not a portable quality proof: TurboMind can choose
+a different CTA/split reduction order when autotuning in another process.
+Final admission therefore requires an independent FP32 reference plus endpoint
+dataset scores. The M16 overlap case is effectively neutral while distinct
+routes improve strongly. The exact shape/capability fallback remains available
+through `VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE=0`.
+
+### Router top-k: admitted pending endpoint quality battery
+
+The SM70 E512/K10 router is now selected for every live width from M1 through
+M16 instead of only M1/M5 and the three target widths. At M4/M8/M16 it reduces
+a 48-layer micro-round by 0.335/0.342/0.343 ms (2.33--2.35x). A separate sweep
+of M2/M3/M6/M7/M9--M15 saves 0.330--0.433 ms per 48 layers. Expert IDs and
+source-row maps are exact. Normalized FP32 route weights differ by at most
+`2.24e-8`, inside the existing M1/M5 `1e-7` contract. This closes the generic
+router fallback while requests enter or leave a batch without binding the
+optimization to a configured concurrency. The endpoint quality battery remains
+mandatory before this extension is called release-ready.
+
+### TP4 push collective: admitted
+
+For one regular and one shared+routed sum2 reduction per layer, 48 layers:
+
+| Tokens | Pull | Push | Saving | Speedup |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 1.169 ms | 0.355 ms | 0.814 ms | 3.30x |
+| 8 | 1.289 ms | 0.441 ms | 0.848 ms | 2.92x |
+| 16 | 1.183 ms | 0.651 ms | 0.532 ms | 1.82x |
+
+All four ranks are bitwise equal for exact-integer, signed-zero, and
+model-scale dynamic graph inputs. Dispatch is restricted to fully connected
+SM70 TP4, CUDA Graph capture, FP16 payloads of exactly 20/40/80 KiB, and has an
+explicit `VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH=0` rollback.
+
+### Sparse QSA partial launch: admitted; split cap rejected
+
+Keeping the production split count and changing only the partial kernel from
+four to two warps is bitwise equal at M2/M4/M8/M16. The projected 12-layer
+savings are approximately 0.19/0.24/0.34/0.84 ms against the old four-warp
+launch. A broader BLOCK_N sweep confirms that 16 remains the SM70 winner;
+BLOCK_N=8 does not satisfy Triton's tensor-core K requirement and BLOCK_N=32
+is slower. An M8/M16 split-count cap to 32/16 projected another 0.14/0.16 ms
+per 12-layer round, but changed the FP32 merge association and produced a
+maximum FP16 output difference of `6.11e-5`. In the fixed C16 endpoint run,
+the cap plus the exact expert-pack candidate measured 28.861 ms versus the
+28.815 ms baseline and retained only 4 of 16 greedy completion hashes. The cap
+was therefore removed; only the bitwise two-warp partial launch remains.
+
+### M4/M8/M16 W13/SwiGLU fusion: admitted pending endpoint battery
+
+For the production interleaved gate/up layout, one CTA now computes a gate/up
+tile pair and applies the existing FP16 SwiGLU epilogue without writing the
+320-column intermediate. M4 retains the admitted five-way K reduction, M8 the
+four-way reduction, and M16 the single-way reduction; each split partial is
+summed and rounded in the same order as the direct QPN route before SwiGLU.
+Static and changed-expert CUDA Graph replay are bitwise equal to that direct
+route at all three widths. The fused route inherits any tiny direct-vs-grouped
+reduction difference; it introduces no additional numerical difference.
+
+Against direct W13 plus the already fused W2 path, the incremental 48-layer
+saving is about 0--0.12 ms at M4, 0.46--0.54 ms at M8, and 0.25--0.28 ms at
+M16. The route is limited to exact M4/M8/M16, TP4, E512/K10, H2560/I160 and
+has a default-on rollback switch. The kernel explicitly supports both the
+ordinary and interleaved W13 layouts; selection therefore depends on its own
+operator capability, not on whether the separate large-prefill fused-SwiGLU
+operator is present in an overlay build.
+
+### Parallel W2 plus weighted reduction: admitted pending endpoint battery
+
+The first W2-fusion prototype serialized ten experts in one warp and was
+removed. The retained design assigns one warp to each of the ten routed slots
+inside a token/output-tile CTA, rounds each HMMA result to the same FP16 route
+value, then lets warp zero accumulate those values in fixed slot order with
+FP32 FMA. It removes the routed W2 global write/read and standalone reduction
+without changing weights or activation precision.
+
+At M1/M4/M8/M16 it saves another 1.56/4.10--6.39/5.69--6.79/6.70--9.32 us
+per layer over the direct QPN path. All eight static endpoint comparisons are
+bitwise equal to that direct path. Dynamic CUDA Graph replay with changed
+expert IDs and route weights is exact at M4/M8/M16; M1 differs from the
+grouped baseline by at most `4.77e-7`, but remains bitwise equal to the direct
+path and is therefore not selected by the new batch gate. The M2/M4/M8/M16 route
+is default-on only when the exact SM70 TP4 E512/K10/H2560/I160 contract and
+operator capability are present; setting
+`VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2=0` restores the two-stage path.
+
+Earlier trace interpretation incorrectly attributed M1/M2/M4 observations to
+TP sequence splitting. The fixed-width trace and four-rank tensor dump prove
+that a global C16 step executes M16 expert tensors on every TP rank. The lower
+widths came from requests leaving the batch in the earlier request-level
+trace. M2 remains useful for those live-width transitions: a checkpoint-backed
+screen selected split-K 10 for direct M2 W13. Direct W13/W2 saves
+1.69--1.72 ms per 48-layer M2 round; adding the fixed-order fused W2 raises
+that to 1.80--1.83 ms. Dynamic expert-ID and route-weight replay remains
+bitwise equal to the direct path; the maximum difference from grouped dispatch
+is `2.38e-7`. Fusing W13+SwiGLU at M2 regresses about 0.13 ms per round, so M2
+uses direct W13 plus fused W2 while the W13 epilogue fusion remains M4/M8/M16.
+
+### Cross-token expert packing: rejected after endpoint validation
+
+A four-rank C16 tensor capture records identical E512/K10 routes on every TP
+replica. Across all 48 layers, 160 routes select a mean 87.3 unique experts;
+66.6% of routes belong to an expert selected more than once. Packing up to
+eight rows for the same expert therefore has a real reuse opportunity.
+
+The first compact implementation lost that opportunity to an O(routes squared)
+planner. Replacing it with one shared-memory expert counter per expert reduces
+planning from 15.15 to roughly 4--6 us per layer. A fixed-grid packed W13 plus
+four-warps-per-CTA W2 implementation is bitwise equal to the current direct
+route on all 48 captured layers. A repeated same-environment run measured
+165.74 us direct versus 156.57 us packed, or 0.440 ms projected saving across
+48 layers. A 128-group grid severely regresses synthetic routes above 128
+groups, so it is not a production choice.
+
+The route distribution is request-dependent and the speed crossover is around
+96 groups. More importantly, the combined fixed C16 endpoint run did not turn
+the micro saving into wall-time benefit: 28.861 ms / 554.38 tok/s versus the
+28.815 ms / 555.26 tok/s baseline. The production dispatch and build wiring
+were removed rather than retaining a speculative opt-in. The task-local
+evidence is in
+`.artifacts/qwen38_nomtp_concurrency/c16_topk_ids_analysis.json` and
+`.artifacts/qwen38_nomtp_concurrency/expert_pack_m16_route_sweep_production.json`.
+
+### Shared-expert gate fusion at M1--M16: admitted pending endpoint battery
+
+The existing native shared-expert gate kernel was artificially restricted to
+one row even though its implementation is row-independent. Selecting it by the
+measured live shape (`1 <= M <= 16`) fuses the FP16 gate dot, sigmoid, and
+in-place output multiply for all small CUDA-graph widths. On checkpoint gate
+weights it saves 0.250--0.320 ms per 48-layer round at M4/M8/M16. The first
+model-scale comparison was bitwise equal; a broader dynamic replay sweep found
+one non-bitwise case out of 32 at M16, bounded to `1.22e-4` maximum absolute
+error and `1.45e-4` relative L2. Extreme synthetic activation scaling is not
+bitwise invariant, so this is a score-gated scheduling/numerical candidate, not
+an exact-arithmetic claim. The existing
+`VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION=0` rollback remains available.
+
+The first fixed-width endpoint log exposed an integration miss: construction
+compared the global shared-expert intermediate width (`640`) with the local
+TP4 width (`160`), so the measured kernel existed but the model never selected
+it. Eligibility now checks the actual local projection contract instead:
+gate/up partitions `(160, 160)`, down input `160`, and hidden input/output
+`2560`. This is a capability/shape check rather than a model-name or
+configured-batch check. A subsequent endpoint must print the shared-gate route
+log before its projected saving is credited.
+
+### Raw E4M3 scale bandwidth: experimental, default off
+
+The checkpoint stores one-byte E4M3 block scales plus one FP32 global scale per
+expert, while the previous loader permanently expanded every block scale to
+FP16. Keeping only the checkpoint representation removes about 1.875 GiB of
+persistent scale tensors per TP rank. A reusable per-device FP16 workspace of
+about 50 MiB materializes scales for prefill and other generic shapes. Decode
+widths 2--16 instead reconstruct the effective scale in-register and never pay
+the workspace expansion on the hot path.
+
+The fast SM70 decode reconstruction uses a high/low half split of the global
+scale. This is not a universal identity for every legal E4M3 code and global
+scale. Production therefore does not infer safety from the model name or
+quantization label. During loading, each layer temporarily constructs the old
+prepared-FP16 tensors, reconstructs every W13 and W2 scale with both the strict
+prefill arithmetic and the proposed decode arithmetic, and requires
+`torch.equal` over the complete tensors. Decode comparison is against the
+effective `prepared_half * 2**14` consumed by HMMA; dividing a candidate back
+before comparison can hide mismatches through FP16 subnormal rounding. A
+mismatch warns and retains the established prepared-FP16 route in automatic
+mode; an explicitly forced raw route fails startup. Generic/prefill expansion
+uses the strict FP32 multiply and FP16 rounding order independently of this
+fast-path capability result.
+
+The checkpoint audit sampled 3,072,000 physical block codes across layer 0 and
+ten experts: all codes were in the normal positive interval 73--126, with no
+zero, subnormal, sign, infinity, or NaN encodings. Inverse recovery from the
+prepared scales had zero mismatches. All 73,728 gate/up/down global-scale
+tensors across 48 layers were audited, yielding 470 distinct global scales.
+Simulation over those globals and every observed-range code had zero mismatch;
+smaller legal codes do produce counterexamples and are the reason the runtime
+full-tensor capability check is mandatory.
+
+On actual routed checkpoint weights, strict expansion and fast validation were
+bitwise equal. The fixed fused route changed one 48-layer round by
+0.121/0.584/0.340 ms at M4/M8/M16 respectively. The generic raw-kernel screen for
+otherwise uncovered M3/M5/M7/M10/M15 remained bitwise equal and changed the
+round by +0.008/+0.302/+0.456/+0.431/+0.241 ms versus already prepared scales;
+its benefit is avoiding a much larger per-entry scale expansion, not beating a
+resident prepared tensor. These are microbenchmark results only. The raw route
+remains pending full-model quality admission before it can be credited to the
+production baseline. That micro comparison used direct kernels on both sides;
+it did not prove that enabling raw storage preserved the production dispatcher.
+
+The production-loader/apply audit found that M3 and M7 were changing from
+grouped TurboMind to QPN when raw storage was enabled. On actual layer-0/rank-0
+weights this produced up to `2.38e-7` absolute output differences, despite
+exact scales. Storage and dispatch are now independent:
+
+- `VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE=1` changes only scale storage.
+- `VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE=1` independently extends QPN
+  to every live width 2--16, for both prepared and raw storage. Default off;
+  the existing 2/4/8/16 split choices remain unchanged.
+- Both switches remain experimental pending quality scores. Dynamic extension
+  must not silently accompany a memory-format optimization.
+
+After separation, real layer-0/rank-0 loader/apply comparisons are bitwise
+equal at all M1--M16 plus M784 prefill with dynamic extension off, and at
+all M1--M16 with it on. Small-width eager and CUDA Graph results agree.
+Earlier boundary coverage also passed all 30 combinations of layers 0/23/47,
+TP ranks 0/3, and M1/4/8/16/784 using all 512 experts per sampled layer.
+These are real checkpoint weights with synthetic activations, not a full
+model quality score. All 256 E4M3 encodings, signed zero, subnormal/NaN
+rejection, W13 global-slot layout, effective-scale admission, and changed-input
+Graph replay have focused native tests.
+
+Task evidence:
+`.artifacts/raw-audit/{decoupled_storage_v2,decoupled_dynamic_v2,`
+`layers_boundary_ranks_v1}.json` and `pytest-admission-v2.log` (52 passed).
+The updated native `_C` SHA256 is
+`6db72e5d72ed051423ce5dc62f5a935e716c02e85c3c423c92edc96fcce51fa3`.
+
+The portable reproduction is now in
+`benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py`, taking an explicit
+`--model` directory instead of a developer-specific model path. It fails on
+numerical mismatch and uses one GPU to inspect the selected TP4 shards:
+
+```bash
+CUDA_VISIBLE_DEVICES=<idle-gpu> .venv/bin/python \
+  benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py \
+  --model <checkpoint-directory> --layers 0,23,47 --ranks 0,3 \
+  --tokens 1,4,8,16,784 --out raw-storage.json
+```
+
+Add `--dynamic` for the independently controlled M2--M16 QPN extension.
+CPU regression coverage across MoE admission, shared-gate/QSA shape policies,
+and shutdown cleanup passes 108 tests; six GPU-only cases were skipped in
+that CPU run. This is separate from the 52 focused tests above, which included
+the new native raw-scale tests on an idle V100.
+
+### Endpoint run: directional only
+
+One post-candidate 8K/512 run measured C1/C4/C8/C16 at
+79.906/196.021/318.883/475.165 aggregate tokens/s. This is a directional
+improvement of 12.9/19.7/13.5/7.7% over the frozen run, but tokenizer and kernel
+caches were not identical between launches. It therefore does not replace the
+frozen baseline or satisfy the final paired acceptance gate. A subsequent
+call-chain audit found that this run also predated effective production-namespace
+registration of the parallel W2 operator, and an intermediate edit had disabled
+the shared-gate fusion at model construction. Both integration defects are now
+covered by focused tests; the directional result must not be credited with
+either projected saving.
+
+The next endpoint result uses `EngineCoreOutputs` rather than request-level
+first/last timestamps. A sample is admitted only when scheduler running width
+equals C, no requests are waiting, exactly C outputs are returned, every
+request emits one token, and neither a prefill marker nor a finished request is
+present. Eight head and tail samples are discarded. This avoids charging the
+large staggered admission spans (up to about two seconds at C16) to steady
+decode and makes the 16.81/19.05/21.98 ms C4/C8/C16 target thresholds directly
+testable.
+
+The first fixed-live-width candidate completed with all intended graph routes
+visible in the production call chain. M4/M8/M16 selected the widened router,
+direct NVFP4 QPN expert path, fixed-order W2/weighted-reduce fusion, sparse-QSA
+partial specialization, and TP4 push collective; M16 additionally selected the
+W13/SwiGLU fusion. After discarding eight head and tail samples, the medians
+were:
+
+| Live width | Legacy receive wait | Reciprocal-wait estimate | Fixed-70 estimate | Gate |
+| ---: | ---: | ---: | ---: | --- |
+| 1 | 12.181 ms | 82.096 tok/s | 117.3% | reference |
+| 4 | 18.522 ms | 215.963 tok/s | 77.1% | fail 85% |
+| 8 | 22.469 ms | 356.054 tok/s | 63.6% | fail 75% |
+| 16 | 28.815 ms | 555.259 tok/s | 49.6% | fail 65% |
+
+This is substantially better than the request-level frozen result, but it does
+not meet the 238/420/728 tok/s acceptance targets. The residual grows with the
+number of live routed rows, so subsequent work stays focused on cold expert
+weight service and batch dense projections rather than scheduler constants.
+Raw evidence is in
+`.artifacts/qwen38_nomtp_concurrency/fixed_width_candidate_v1.json`.
+
+### Paired production build and corrected timing (2026-09-05)
+
+The raw/prepared pair uses the same production-built MoE operators and
+Python code, TP4 V100, Torch 2.10/CUDA 12.8, 8K prompts, 256 forced output
+tokens, no MTP, FP16 KV, Prefix Cache/Mamba align, 256K maximum length, 2048
+prefill chunk and max-num-seqs 16. Its compiled `_C` SHA256 is
+`04818aa069b7098927fdb4a47d516d2b316f081afd68f3612634fd2e7af5fdb3`.
+The later admission fix above was rebuilt separately; these endpoint numbers
+must not be presented as measurements of that newer binary.
+Both arms still use the same pinned custom-allreduce and FlashQLA sidecars;
+this is not a clean-wheel deployment gate. Their respective SHA256 values are
+`4fdf9148b4d21951b7f40edd54a43be0ce387bbf4eb86ce010845f702531e55d` and
+`c8bd7650444ec56cfe2576c044d8f5f438b0a352877064bbb51ac0510dc2ea2c`.
+
+Client receive wait excludes processing between receives. The corrected
+accounting includes only consecutive eligible engine output timestamps, trims
+eight head/tail samples, and computes aggregate tokens divided by summed
+interval time. No GPU rerun was needed. Four accounting regression tests cover
+client wait, prefill gaps, insufficient data, and mean-vs-median throughput.
+
+| C | Prepared mean step | Raw mean step | Prepared tok/s | Raw tok/s | Raw fixed-70 efficiency | Target |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 12.398 ms | 12.361 ms | 80.66 | 80.90 | reference | 70 |
+| 4 | 18.826 ms | 18.769 ms | 212.48 | 213.11 | 76.1% | 85% |
+| 8 | 22.386 ms | 22.022 ms | 357.37 | 363.28 | 64.9% | 75% |
+| 16 | 29.829 ms | 29.593 ms | 536.38 | 540.67 | 48.3% | 65% |
+
+These are paired-run diagnostics, not passed performance/quality gates. Raw
+storage frees about 1.73 GiB per worker (reported model memory 21.27 ->
+19.54 GiB), but its incremental C8/C16 aggregate gain is only 1.66%/0.80%.
+Full-model greedy completion hashes differ in some requests, including C1.
+The dynamic-width dispatcher explains an identified difference, not the C1
+case. Autotuned prefill reduction order is a hypothesis, not an established
+root cause. Full-model quality and the remaining mismatch audit are still
+required; keep raw storage off by default and do not promote this Draft PR.
+
+Original paired artifacts are
+`.artifacts/qwen38_nomtp_concurrency/fixed_width_{prepared,raw}_production_v1.json`.
+The unchanged records are reaccounted in
+`.artifacts/raw-audit/engine_intervals_reaccounted_v2.json`. The benchmark now
+records raw-storage and dynamic-dispatch switches separately and uses complete
+engine intervals for acceptance. The 238/420/728 tok/s targets are unchanged
+and remain unmet.
+
+### Related work and next bounded screen
+
+PR #481 (`codex/v100-qwen38-nomtp-token-trace-20260903-173451`) is a related
+single-request no-MTP campaign, not another source of accepted batch numbers.
+Its latest inspected commit is `30f81105621e9f39e6b3bf9d816f77d63acd8307`.
+It adds exact PLE primitives, a different shared-gate kernel, and a QSA
+output-gate epilogue. Reuse and widen those implementations only after a
+paired M4/M8/M16 operator screen, rather than writing competing kernels.
+Its shared-gate and W13 edits overlap this branch and need explicit
+consolidation before integration; do not merge both blindly or count their
+savings twice. Single-row acceptance does not prove multi-row graph safety.
+In particular, the inspected #481 shared-gate construction still checks the
+global `intermediate_size == 160`, while this checkpoint supplies 640 and TP4
+local projection partitions are 160. Preserve this branch's local-shape
+admission fix when consolidating; an operator-only win is not a route-hit.
+
+No additional endpoint run is justified by the small raw-scale gain alone.
+Keep the existing C16 trace as the optimization guide (about 8 ms direct MoE
+and 8.9 ms dense FP16 service), finish the C1 mismatch localization, then
+screen reusable batch epilogues before another full-model measurement.
+
+### Rejected screens
+
+- GDN CTA-group-block sweeps change a 36-layer round by only about 0.01 ms;
+  the current setting remains unchanged.
+- The apparent M8 FP16-padding gain was allocator/order noise. A fixed-pointer,
+  alternating A/B test reduces the real weighted saving to 0.338 ms; M4 is
+  only 0.128 ms and two shapes are not bitwise equal. No production padding
+  route is added.
+- The prior MTP campaign already measured the SM70 port of SGLang's persistent
+  HC-mix kernel at 40.5x slower and found only 0.190 ms from unquantized FP16
+  projection substitution. Those dead ends are not rerun here.
+- A second HC experiment fused the FP16 HC up projection with the following
+  gate-mix operation. It regressed one call from 12.29/13.00/15.10 us to
+  163.94/164.81/166.40 us at M4/M8/M16, or about 14.5 ms across the 96 calls
+  in one round. It also changed some FP32 results, so it was rejected before
+  production integration.
+- A follow-up exact launch-geometry screen covered the existing HC gate-mix
+  and combine-norm Triton kernels at M4/M8/M16. The best bitwise gate-mix
+  schedules save only about 0.04--0.09 ms per complete round. The faster M16
+  combine-norm schedule changes the normalized tensor, while the fastest
+  bitwise schedule is effectively the current one. No production policy was
+  added for this sub-millisecond noise-floor result. Raw evidence is in
+  `.artifacts/qwen38_nomtp_concurrency/hc_postops_batch_v1.json`.
+- Real-checkpoint generic TurboMind FP16 projection substitutions were either
+  slower in the hot-cache regime or changed outputs by about `1e-3`; none are
+  admitted.
+- A cuBLASLt heuristic sweep covered all algorithms returned for the eight
+  dominant M16 FP16 projection shapes. The exact algorithms are already at or
+  within measurement noise of the PyTorch choice. Permitting alternate FP32
+  association order projects only about 0.08 ms total saving while producing
+  relative-L2 differences around `3.6e-4`; this does not justify a new 64 MiB
+  workspace or a numerical risk. The apparent 0.93 ms of split-K reduction in
+  the trace is part of the fastest complete algorithm, not removable overhead
+  in isolation.
+- FP16 GDN recurrent state saves only about 0.04/0.12/0.77 ms at M4/M8/M16,
+  while state and output relative-L2 errors are roughly 26--29%. It remains a
+  capacity experiment and is rejected under the quality gate.
+- A per-expert 256-entry FP16 scale LUT is bitwise exact but adds a dependent
+  random load; it regresses the M16 direct path and is rejected.
+- Concatenating the FP16 GDN qkvz and b/a projections saves only
+  0.41--0.44 ms in the serial 36-layer cost model. It also changes b/a at M8
+  and M16 (maximum absolute difference up to `2.44e-4`) because cuBLAS chooses
+  a different reduction for the wider output. The small saving cannot justify
+  the extra packed weights and numerical change, so this route is rejected.
+- Running the existing FP16 GDN qkvz and b/a projections concurrently is
+  bitwise exact before and after changed-input CUDA Graph replay. The actual
+  production custom-op boundary, however, saves only 0.071/0.072/0.067 ms per
+  36-layer M4/M8/M16 round, far below the 0.2 ms integration threshold. The
+  initial bare-`torch.mm` screen overestimated the realizable overlap, so the
+  multi-stream production edit was removed. Evidence is in
+  `.artifacts/qwen38_nomtp_concurrency/gdn_parallel_input_production_v1.json`.
+- Sorting QSA selector indices before sparse attention does not provide useful
+  locality at these widths. Excluding the sort itself, the projected saving is
+  only 0.020/0.002/0.006 ms per 12-layer M4/M8/M16 round, and restoring the
+  original order still changes the FP16 result by up to `1.22e-4`. The runtime
+  route remains unsorted. Evidence is in
+  `.artifacts/qwen38_nomtp_concurrency/qsa_index_order_v1.json`.
+
 ## Acceptance gates
 
 - A microbenchmark candidate must improve median CUDA Graph replay time at its
@@ -48,4 +507,3 @@ Raw baseline:
 - Runtime selection must be capability- and shape-based. It must not bind the
   model to one concurrency, KV dtype, maximum sequence count, or scheduler
   setting.
-

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -674,6 +674,111 @@ unfinished optimization track.
 Keep Draft; neither default enablement nor a release claim is authorized by
 these microbenchmarks.
 
+## Guarded production integration (2026-09-05)
+
+Starting source is `992a9375153d307c119c7b2dc6311a938bae3791`, owned PR #474,
+same original integration base and performance contract as above. The former
+benchmark CUDA source is moved to
+`csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu` and included in the SM70
+native build. Both operations register in `_C`, with Python wrappers and fake
+implementations; tests and the standalone screen reuse this source rather
+than maintaining a second kernel copy.
+
+`VLLM_SM70_NVFP4_MOE_GROUPED_DECODE=1` enables the experimental route at load
+time; **the default remains 0**. Admission uses the actual local
+E512/H2560/I160/top10 shape, native packed weights and prepared FP16 scales,
+without a model-name, TP-degree, KV-dtype, maximum-sequence-count or prefill
+chunk-size restriction. Raw-scale storage, clamped SwiGLU and unsupported
+shapes retain the old route. An eligible explicit opt-in with missing native
+operations fails at startup. Runtime initially admits the screened M8/split4
+and M16/split8 specializations; all other widths retain their prior paths.
+
+Crucially, an M16 input is not necessarily 16 single-token decode requests.
+The opaque MoE call checks existing CPU attention metadata to reject prefill,
+mixed batches and multi-token verification. Missing/list/unknown metadata
+fails closed. The decision is cached only within that `ForwardContext`, not
+across requests or graph captures. There is no `.item()` or device-to-host
+transfer in this route selection. Per-layer integer metadata is allocated
+before capture (6,404 bytes/layer); W2 reuses the existing routed-output
+workspace. There is no new process-global tensor cache.
+
+Native rebuild succeeded. Tested `_C` SHA256:
+`76f106f86f7e7bdf5f8a51b64378fee7ee09ba8a6d3cb51e699a944985711858`.
+Validation so far:
+
+- Existing mixed-NVFP4 and initial dispatch suites: 91 passed / 5 GPU-only
+  skipped in the CPU run. Final dispatch suite including fake-op execution
+  and CPU-integer metadata guards: 33 passed. These suites overlap; do not
+  sum them.
+- The 22 grouped-operator GPU tests pass against the production `_C`, not the
+  former benchmark namespace.
+- All applicable staged pre-commit hooks pass, including mypy, Python/CUDA
+  formatting, Markdown lint and source-header checks.
+- Real checkpoint layer-0/rank-0 **loader + `ModelOptNvFp4SM70MoEMethod.apply`**
+  audit selects M8/M16 in logs. M1/M4/M8 and fallback M17/M32/M784 are exact
+  against disabled control. M16 max-abs `2.38419e-7`, relative L2 `1.38547e-4`;
+  repeated calls and CUDA Graph versus eager are exact. These are operator
+  checks with synthetic activations, not model-quality acceptance.
+- Artifact: `.artifacts/raw-audit/grouped-production-apply-v1.json`; command:
+  `benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py --grouped --model
+  <model-dir> --layers 0 --ranks 0 --tokens 1,4,8,16,17,32,784 --out <result>`.
+
+The control/candidate/control engine experiment completed under
+`.artifacts/grouped-runtime/{control_before,candidate,control_after}.{log,json}`.
+All arms use the same new `_C`, source, uv Python, custom-AR/FlashQLA sidecars,
+TP4, no MTP, FP16 KV, FP32 GDN state, max length 262144, prefix/Mamba align,
+2048 prefill chunk, max-seqs16, 8192 input / 256 forced output, and widths
+1/4/8/16. Only the grouped-decode opt-in differs; raw storage and dynamic QPN
+dispatch stay off. This source-build experiment is not a clean-wheel gate.
+The launcher waits for cooperative locks **and actual idle GPUs** and never
+terminates another task to make room. Report engine intervals, not receive
+wait or the microbenchmark projection.
+
+### Actual engine results
+
+Baseline below is tokens divided by the mean complete step time of the two
+disabled runs, not a historical speed figure. All four workers in the enabled
+arm used full CUDA graphs; M8/M16 grouped dispatch is confirmed in capture
+logs. The QSA page4-XQA import fallback warning also occurs in the retained old
+baseline logs: all these arms use the same Triton sparse QSA path. Do not claim
+that the standalone page4-XQA implementation was exercised.
+
+| C | Control-before step | Candidate step | Control-after step | Baseline tok/s | Candidate tok/s | Throughput change | Fixed-70 efficiency / goal |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 12.275 ms | 12.280 ms | 12.267 ms | 81.493 | 81.435 | -0.07% | reference |
+| 4 | 18.671 ms | 18.645 ms | 18.694 ms | 214.108 | 214.535 | +0.20% | 76.62% / 85% |
+| 8 | 22.212 ms | 22.040 ms | 22.239 ms | 359.942 | 362.981 | +0.84% | 64.82% / 75% |
+| 16 | 29.566 ms | 27.371 ms | 29.589 ms | 540.951 | 584.568 | +8.06% | 52.19% / 65% |
+
+C16 saves **2.207 ms per complete step**, confirming most of the 2.470 ms
+microbenchmark projection in this fixed workload. C1 satisfies the <=1%
+regression screen. C4 does not select the new route, so its small difference
+is not credited as an optimization. C8 is only a small gain; none of the
+238/420/728 tok/s goals is met. This one bracketed experiment is not a
+confidence interval across independent repeated campaigns or other contexts.
+
+All C1 completions are identical. C4/C8/C16 completions differ even between
+the two disabled controls; enabled C4 matches the second disabled control.
+That establishes baseline run-to-run token variability, **not its cause or
+quality impact**. Do not label all differences as new-kernel damage, harmless
+rounding, or proof of quality. Preserve the token IDs for subsequent score
+tests/first-divergence diagnosis. Greedy identity is not the release criterion.
+
+All three engines and their workers shut down; no task API remains resident.
+The longstanding Python resource-tracker shared-memory cleanup warning occurs
+at shutdown, as in prior baseline logs; it is not evidence of a new GPU leak.
+GPU0--3 were rechecked after completion and only the desktop process remained.
+Final source adds a CPU-integer metadata type guard (non-integer metadata
+fails closed without tensor comparisons); this guard does not change the
+screened host-integer decisions. No second full-model run is claimed for that
+defensive type check or whitespace-only CUDA formatting.
+
+Quality admission remains pending. In particular, prefill perplexity alone
+does not exercise a decode-only optimization. Any PPL claim must include
+teacher-forced decode through the new route; coding/tool/schema score tests
+must actually contain active M8/M16 batches. Keep default dispatch unchanged
+until end-to-end, quality and C1-regression gates pass.
+
 ## Acceptance gates
 
 - A microbenchmark candidate must improve median CUDA Graph replay time at its

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -984,7 +984,13 @@ cu128 / CUDA 12.8, native SM70 only. Candidate v2 binary SHA256:
 The earlier flag-off timing attempt was rejected before any accepted timing
 because an external GPU process appeared during the run. Do not count it or
 compare different CUDA-built binaries as if only the new flag changed.
-Use the same v2 sidecar with flag 0/1 for the pending matched HC screen.
+The same v2 sidecar was subsequently used for flag 0/1 screening. At M16,
+flag-off baseline/candidate were 31.872/37.363 us; a later flag-on process
+measured 33.790/33.552 us. The replicated baseline itself moved between
+processes, so do not attribute the raw 37.363-to-33.552 difference entirely
+to the flag. Within-process flag-on paired savings were 3.536/2.338/0.238 us
+at M4/M8/M16. The first flag-on attempt also detected foreign workers and
+was discarded; only the `on-retry` artifact supplies those results.
 
 Artifacts relative to this worktree:
 
@@ -992,6 +998,7 @@ Artifacts relative to this worktree:
 - `.artifacts/raw-audit/hc-tp4-smallmsg-off.log` (discarded timing)
 - `.artifacts/raw-audit/smallmsg-mixed-v2.{json,log}` (8-cycle native gate)
 - `.artifacts/raw-audit/hc-tp4-smallmsg-v2-off.{json,log}` (timing job)
+- `.artifacts/raw-audit/hc-tp4-smallmsg-v2-on-retry.{json,log}`
 
 Primary upstream references rechecked for the next design decision:
 [vLLM fusion design](https://github.com/vllm-project/vllm/blob/main/docs/design/fusions.md)
@@ -1000,6 +1007,74 @@ describes sequence parallel and compute/collective fusion, while
 explicitly reports that extra AG/RS work can erase overlap gains for small
 tensors. These motivate measuring the complete local chain; neither is V100
 performance evidence or justification for a blanket distributed rewrite.
+
+### Follow-up: remove empty push CTAs and reject the HC cache-footprint bias
+
+The 80-KiB legacy push launch uses 80 CTAs, but only 40 CTAs have active
+16-byte packs. The current experimental admission therefore uses
+`ceil(bytes / 2048)` for **all ordinary** covered messages, including known
+sizes. This happens only when `SMALL_MESSAGES=1`; ordinary flag-off launches
+remain unchanged. The helper's explicit `allow_generic` argument keeps
+`sum2` admission and launch geometry unchanged even while the experiment is
+active. No new scratch space or communicator ABI is introduced.
+
+Candidate **v4** sidecar SHA256:
+`348b782113785d374d397362b37cc93dc06f445d595b7cd4a0d5e5f3fdaf3888`.
+The intermediate v3 DSO is not used for accepted GPU evidence: source review
+separated `sum2` from generic grid selection before launching v4.
+The expanded native gate passes **64 cycles per pattern / 13 sizes / four
+graph sequences / four ranks**. The fourth graph interleaves ordinary and
+`sum2` calls sharing the same push storage. Rank-skew, poisoned output,
+canaries, finite-bit equality and NaN classification all pass, still with
+the intentionally undersized legacy block override. This does not establish
+model scores. Artifact: `.artifacts/raw-audit/smallmsg-mixed-v4.{json,log}`.
+
+The HC screen now offers `--weight-copies`: rotate distinct allocations of
+the **same checkpoint HC pair**, not an actual multi-layer model. This
+separates hot single-pair behavior from a working set too large for cache.
+With one copy, the candidate uses 3,440,640 bytes of local weights versus
+13,434,880 bytes in the replicated path. With 16 copies those working sets
+are 55,050,240 and 214,958,080 bytes. Both paths still execute the same
+16-call graph and include GEMMs, SiLU, scatter, mix and both communications.
+This allocation test is not a claim about production model memory savings.
+
+Five alternating unprofiled samples, per-sample maximum rank duration:
+
+| M | One-copy baseline | One-copy candidate | 16-copy baseline | 16-copy candidate |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 31.235 us | 27.187 us | 31.370 us | 31.198 us |
+| 8 | 31.872 us | 28.843 us | 32.018 us | 33.462 us |
+| 16 | 33.781 us | 32.486 us | 33.947 us | 36.520 us |
+
+One M4 candidate timing outlier is retained in each report rather than
+trimmed; the table uses medians. M8/M16 rotating-weight regressions occur in
+all five samples. Foreign-process checks pass in these completed runs.
+Changed-input/poisoned graph results equal candidate eager outputs, but the
+earlier small non-exact differences versus the replicated model remain.
+
+**Decision: reject this HC sharding implementation for production.** The
+single-pair cache benefit is not robust to a layer-like working set; removing
+the 10.5-KiB pull fallback and inactive CTAs does not overcome the complete
+chain's communication/data-movement cost. Do not integrate it, launch a full
+model for it, or count its hot-cache micro gain toward 238/420/728 tok/s.
+The generic push experiment stays off by default in the WIP branch.
+The next bounded implementation would need to fuse local pointwise work and
+disjoint publication/gather, eliminating zero-filled scatter and redundant
+traffic/launches, rather than merely split more GEMMs. Screen it with the
+rotating-weight case first. Reuse existing push storage/protocol, keep all
+communicator lifecycle calls within one DSO, and retain the native/model
+quality gates. No such fused operator has been implemented or measured yet.
+
+Artifacts: `.artifacts/raw-audit/hc-tp4-smallmsg-v4-copies{1,16}.{json,log}`.
+The first old-binary undercoverage reproducer never reached the GPU because
+an edit to its waiting shell launcher invalidated the shell's read position;
+that log is a tooling failure, not a kernel result. The retry is a separate
+job/artifact. Do not modify launch scripts while their waiting processes
+are live. The launcher now also honors the paper campaign's full-job GPU
+reservation, in addition to per-GPU locks and actual process checks.
+All completed GPU workers exit. Current endpoint evidence remains the
+grouped-MoE candidate's 27.371-ms C16 result, pending model-quality admission;
+the overall concurrency and C1/quality goals remain **unmet**.
 
 ## Acceptance gates
 

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -779,6 +779,145 @@ teacher-forced decode through the new route; coding/tool/schema score tests
 must actually contain active M8/M16 batches. Keep default dispatch unchanged
 until end-to-end, quality and C1-regression gates pass.
 
+## HC batch follow-up and attribution correction (2026-09-05)
+
+Source anchor remains `94dd55c899be8c4725eab55374393b10315ca718`; there is
+no new production route or new endpoint result in this follow-up. Reaching
+C16 728 tok/s from the retained 27.371 ms step requires a further 5.393 ms
+step reduction, not another sub-millisecond dispatch tweak.
+
+Offline reanalysis uses complete `(globalPid, correlationId)` graph groups:
+four ranks each have nine complete 1,976-node graphs in the retained
+pre-grouped trace. Dropping the first/last complete graph leaves seven steps
+on all four ranks. Exact launch geometry, same-stream reduction adjacency and
+source order identify 97 HC down/up calls (48*2 plus final mixer), 36 GDN
+inputs, 12 QSA inputs/index projections and 48 shared-expert/router calls.
+This is inferred role attribution, not module NVTX measurement.
+
+Dense model-graph service, excluding outside-graph LM-head/sampling:
+
+| Role, including its split-K reduction | Rank/graph mean ms |
+| --- | ---: |
+| HC down/inject + up | 3.558 |
+| GDN qkvz + b/a | 2.023 |
+| Attention/PLE output | 1.192 |
+| Shared expert gate/up + down | 0.992 |
+| Router projection | 0.816 |
+| QSA qkvg + index projection | 0.661 |
+| PLE input projection | 0.091 |
+| Total | 9.334 |
+
+HC postops add 1.074 ms of service. These terms overlap other streams and
+are not independently removable wall time. They describe the old graph,
+not the grouped candidate's current per-kernel costs.
+
+**Correction to the early trace interpretation:** wall minus summed GPU
+service (about 0.543 ms in the old interval parser) is not total device idle
+time or a closed host residual. Complete-graph kernel interval union gives
+27.449 ms activity envelope, 26.854 ms service sum and 25.520 ms union busy:
+1.334 ms of overlapped service and 1.929 ms of no-kernel gaps. The latter
+contains 1.434 ms across about 1,533 gaps shorter than 2 us, 0.362 ms of
+2--10 us gaps and 0.133 ms of longer gaps. Copies/dependencies may occupy
+those gaps; they are not proof of CPU overhead or guaranteed fusion savings.
+Reproducer/report: `.artifacts/raw-audit/attribute_c16_complete_graphs.py`
+and `c16-bottleneck-audit-20260905.md` in the same directory.
+
+### FP16 tensor-core HC fusion screen: rejected
+
+A materially different candidate from the prior slow SIMT/Triton pointwise
+projection uses Volta `mma.m8n8k4`, packed FP16 weights, 8-row tiles, shared
+FP16 gates and fused ordered sigmoid/mix. Down uses global/intra-CTA Split-K
+and a tail that retains FP16 rounding before SiLU/injection. No activation
+or weight quantization is introduced. The later vector-load variant shares
+weights across all 16 rows and replaces scalar half loads with 128-bit loads.
+
+Actual layer-0 attention-HC weights, synthetic activations at scales
+0.25/1/3, alternating A/B, 32 complete HC chains per graph, five samples:
+
+| Initial screen | Baseline complete chain | Candidate | Decision |
+| --- | ---: | ---: | --- |
+| M8, fuse up/mix only | 33.658 us | 42.706 us | Slower |
+| M16, fuse up/mix only | 33.726 us | 40.970 us | Slower |
+| M8, full chain, best screened split20 | 32.698 us | 39.966 us | Slower |
+| M16, full chain, best screened split20 | 34.571 us | 42.443 us | Slower |
+
+Repeated changed-input graph replay after poisoning workspaces matches eager
+candidate outputs. Up-only injection is exact; full-chain injection differs
+because FP32 reduction association changes. These numerical checks are not
+model-quality scores. No candidate is admitted. The prototype also requires
+13.125 MiB of extra packed weights per HC pair (1.23 GiB across 96 pairs),
+so packing must not be described as a free runtime improvement.
+
+Artifacts: `.artifacts/raw-audit/hc-batch-v1.json` (native SHA256
+`ac87b87aad8116332c02b83ea3a614ca24d63a461ab1bab90cd8f1de4ba9ea97`).
+Vector-load screen: `hc-batch-v2-vector.{json,log}`. Another workload entered
+GPU0--3 during the vector test despite cooperative locks; its unstable timing
+samples are contaminated and cannot support a performance claim. It did not
+establish a gain; do not promote it or repeat a full model run for this path.
+Subsequent distributed tests check foreign GPU processes before and after
+each timed group and fail closed if exclusivity is lost.
+
+### Batched TP4 HC output sharding: also rejected
+
+The next bounded screen borrows the output-sharding idea of PR #481, but
+uses batched local linears and existing disjoint-output SM70 reductions,
+including communication and data movement. It does not copy the M1 kernel
+or communicator ABI, and does not widen its production guard.
+Each rank computes 80 low-rank coordinates (rank3 also publishes injection),
+then optionally computes/mixes 640 hidden coordinates across all HC branches.
+Zero-filled disjoint publication uses the existing communicator's reductions.
+All four ranks use the same inputs and retain the original weight precision.
+
+Actual layer-0 attention-HC pair, M16, five alternating timing samples, 16
+complete chains per graph, 40 replays/sample, maximum rank duration:
+
+| Distributed screen | Matched replicated baseline | Candidate | Decision |
+| --- | ---: | ---: | --- |
+| Shard down and up; two reductions | 33.992 us | 41.787 us | Slower |
+| Shard down only; one reduction | 33.285 us | 43.504 us | Slower |
+
+Baseline sample ranges are 33.960--34.003 and 33.261--33.314 us; candidate
+ranges are 41.414--41.950 and 42.846--43.552 us respectively. Runtime logs
+confirm the existing SM70 communicator and push-buffer registration. Foreign
+process checks before/after each timed group pass in both distributed runs.
+This is not an NCCL-only surrogate or a sum of independently timed pieces.
+
+Changed-input, poisoned-workspace Graph replay equals candidate eager output
+on all four ranks at all three activation scales. Against the replicated
+baseline, block relative-L2 reaches `2.981e-4` and injection `4.385e-4`; max
+absolute differences are `0.00390625` and `0.0078125`. There is no model-score
+pass. Both variants fail the performance screen before endpoint admission.
+
+The combination of smaller local GEMMs, scatter and collectives is slower;
+the complete-chain test alone does not separate their individual causality.
+Do not claim that dividing weight bytes by four yields a fourfold compute
+speedup, or that all the regression is communication. No more context or
+batch sweeps are warranted for these unmodified implementations. The next
+useful diagnostic is a short **single-HC** stage timeline of the local GEMMs,
+publication and reductions before designing a fused compute/publication op.
+
+Portable commands (task uv Python/torchrun, real checkpoint supplied locally):
+
+```bash
+.venv/bin/python benchmarks/kernels/benchmark_sm70_hc_batch.py \
+  --model "$MODEL" --pairs attn --tokens 8,16 --out hc-packed.json
+.venv/bin/python -m torch.distributed.run --standalone --nproc-per-node=4 \
+  benchmarks/kernels/benchmark_sm70_hc_batch_tp4.py \
+  --model "$MODEL" --tokens 16 --mode full --out hc-tp4.json
+```
+
+Use `--mode down` for the one-reduction ablation. Actual launcher/cache and
+results live in `.artifacts/raw-audit/run_hc{,_tp4}_screen.sh`,
+`hc-batch-tp4-v1.{json,log}` and `hc-batch-tp4-down-v1.{json,log}`.
+The task-created uv Python is `.artifacts/raw-audit/.venv/bin/python`,
+Torch `2.10.0+cu128`, CUDA toolkit 12.8, V100-SXM2-32GB. The communicator is
+the same frozen sidecar as the earlier engine tests, not a new ABI/build.
+All applicable staged pre-commit hooks pass. Only benchmark/diagnostic files
+are added: no production defaults, model weights, sampling or kernel routes
+change. All microbenchmark workers/lock holders exit and GPU0--3 are released;
+unrelated services are untouched. Current accepted endpoint evidence remains
+the prior grouped candidate's 27.371 ms, still pending model-quality admission.
+
 ## Acceptance gates
 
 - A microbenchmark candidate must improve median CUDA Graph replay time at its

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -918,6 +918,89 @@ change. All microbenchmark workers/lock holders exit and GPU0--3 are released;
 unrelated services are untouched. Current accepted endpoint evidence remains
 the prior grouped candidate's 27.371 ms, still pending model-quality admission.
 
+### HC sharding trace and generic small-message admission (2026-09-05)
+
+The next diagnostic is a **single HC pair**, not another full-model launch.
+`benchmark_sm70_hc_batch_tp4.py --tokens 16 --profile` captures three paired
+graph replays on all four ranks, each containing 16 complete HC calls.
+Nsight Systems 2022.4.2 uses `--cuda-graph-trace=node` on this host; its
+standalone `QdstrmImporter` recovered the report without rerunning GPUs.
+Each NVTX range is joined to `cudaGraphLaunch` and then to kernels by
+`(globalPid, correlationId)`, not clipped to host launch duration. There are
+192 occurrences of each stage across all ranks and repeats.
+
+Mean **profiled kernel service per HC call**, not accepted absolute speed:
+
+| Stage | Replicated baseline | Sharded candidate |
+| --- | ---: | ---: |
+| Down GEMM | 16.363 us | 8.631 us |
+| Down split-K reduction | 4.370 us | 4.200 us |
+| Scatter down result | absent | 2.103 us |
+| Down-result all-reduce | absent | 16.365 us |
+| SiLU | 2.581 us | 2.374 us |
+| Up GEMM | 13.892 us | 6.830 us |
+| Gate mix / disjoint scatter | 4.563 us | 2.946 us |
+| Output all-reduce | absent | 8.775 us |
+
+This establishes that the local GEMMs are faster, while publication and
+collectives erase the saving. In particular, the `16 * 336 * 2 = 10752` byte
+down result misses the existing push size whitelist and selects ordinary
+`cross_device_reduce_1stage<half,4>` with grid `(2,1,1)`. The 80-KiB output
+already selects the push kernel. Do not subtract these profiled service
+numbers from the 27.371-ms full-model candidate result.
+
+The bounded next screen adds default-**off**
+`VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES`. It admits ordinary FP16
+all-reduces of positive, 16-byte-aligned messages up to the existing 80-KiB
+storage capacity. SM70, fully connected TP4, registered push storage and
+active graph capture are still required by the native caller. Established
+payload launch choices and the `sum2` admission remain unchanged. This is a
+message-size capability gate, not a model/max-sequence/chunk/KV condition.
+The explicit experiment can also admit the existing 25-KiB MTP payload;
+without it, the separate legacy MTP flag retains its old semantics.
+
+Source review also found a correctness bug in the old batch block-count
+override: an override below `ceil(bytes / 2048)` leaves a tail unwritten,
+because the push kernel processes one 16-byte pack per thread and has no
+grid-stride loop. Such overrides now fall back to the established safe
+launch count. Unset/default overrides are unaffected.
+
+`benchmark_sm70_tp4_small_message_push.py` exercises 13 sizes from 16 bytes
+through 80 KiB + 16 bytes (ordinary pull fallback), partial CTAs, 10.5-KiB HC
+payloads, forward/reverse mixed-size graphs and interleaved graph replay.
+Changed random inputs, signed zero, subnormals, finite extremes, infinities
+and NaNs (including the reserved sentinel payload) are checked against a
+rank-ordered FP32 sum with FP16 output. Outputs are poisoned before replay;
+prefix/suffix canaries and rank-skew delays cover stale buffers and tails.
+Finite values require bitwise equality; NaN payload identity is not required.
+An initial **8 cycles per pattern**, three graphs, all four ranks passes,
+including an intentionally undersized `QWEN38_BATCH_BLOCKS=1` override.
+This is a native numerical/graph gate, **not a model-quality score pass**.
+The existing CPU allocator/dispatch suite also passes: **21 tests**.
+
+Task-owned sidecar, same communicator lifecycle in one DSO, Torch 2.10.0
+cu128 / CUDA 12.8, native SM70 only. Candidate v2 binary SHA256:
+`68a14e492cc20e9fd5f8801051eabdd91a8d048537e4de32d4d564495a3491fd`.
+The earlier flag-off timing attempt was rejected before any accepted timing
+because an external GPU process appeared during the run. Do not count it or
+compare different CUDA-built binaries as if only the new flag changed.
+Use the same v2 sidecar with flag 0/1 for the pending matched HC screen.
+
+Artifacts relative to this worktree:
+
+- `.artifacts/raw-audit/hc-tp4-profile-v1.{qdstrm,nsys-rep,sqlite,log}`
+- `.artifacts/raw-audit/hc-tp4-smallmsg-off.log` (discarded timing)
+- `.artifacts/raw-audit/smallmsg-mixed-v2.{json,log}` (8-cycle native gate)
+- `.artifacts/raw-audit/hc-tp4-smallmsg-v2-off.{json,log}` (timing job)
+
+Primary upstream references rechecked for the next design decision:
+[vLLM fusion design](https://github.com/vllm-project/vllm/blob/main/docs/design/fusions.md)
+describes sequence parallel and compute/collective fusion, while
+[Triton-distributed's end-to-end guide](https://github.com/ByteDance-Seed/Triton-distributed/blob/main/docs/getting-started/e2e/e2e_dense.md)
+explicitly reports that extra AG/RS work can erase overlap gains for small
+tensors. These motivate measuring the complete local chain; neither is V100
+performance evidence or justification for a blanket distributed rewrite.
+
 ## Acceptance gates
 
 - A microbenchmark candidate must improve median CUDA Graph replay time at its

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -494,6 +494,186 @@ screen reusable batch epilogues before another full-model measurement.
   route remains unsorted. Evidence is in
   `.artifacts/qwen38_nomtp_concurrency/qsa_index_order_v1.json`.
 
+## Batch fusion implementation screen (2026-09-05)
+
+Control remains `d20a077bf4cc22da15850c03527ac323f30ff0cc`, prepared
+scales, raw-storage/dynamic-dispatch experiments off. The integration line is
+still `onecat/main`, original base
+`45a58ab6749096248dc15b1263bdf5faf51f5c70`, owned Draft PR #474.
+Protect the **measured 80.657 tok/s C1** within 1%; 70 tok/s is only the fixed
+denominator for the user's concurrency targets. Targets are 238/420/728 tok/s
+at C4/C8/C16, requiring complete steps <=16.807/19.048/21.978 ms. They are not
+met by the existing endpoint measurements.
+
+Source audit of the frozen control:
+
+| Component | M1 | M4/M8/M16 | Remaining batch limitation |
+| --- | --- | --- | --- |
+| FP16 dense projection | custom row GEMV | cuBLAS linear fallback | M1 kernel cannot be enabled merely by deleting its row guard |
+| HC input/up/gate mix | fused M1 operators | two GEMMs plus SiLU and gate mix | true multi-row projection/epilogue still pending |
+| GDN input qkvz + b/a | fused M1 projection | two GEMMs plus contiguous copies | prior overlap and concatenate experiments did not earn integration |
+| Routed W13 + SiLU | direct QPN | fused direct route, split5/4/1 | each route feeds only one logical HMMA row; repeated experts reload weights |
+| Routed W2 + ordered reduce | direct QPN | fused multi-route CTA | no cross-request weight reuse; preserve original top-k reduction order |
+| Router/shared gate/QSA | existing paths | batch candidates already on this branch | their gains must not be counted a second time |
+
+Trace correction: C16 dense matrix kernels account for **8.864 ms** of GPU
+service, plus **0.929 ms** split-K reduction = **9.792 ms**. The broad 5.736 ms
+cuBLAS signature is not exclusively LM-head work. These are service sums, not
+independent wall-clock savings or a valid subtraction from a differently
+configured C1 trace.
+
+### Implemented: grouped W13 plus intra-CTA Split-K prototype
+
+New portable benchmark and source:
+
+- `benchmarks/kernels/benchmark_sm70_moe_packed_w13.py`
+- `benchmarks/kernels/sm70_moe_packed_w13.cu`
+- `tests/kernels/quantization/test_sm70_moe_packed_w13.py`
+
+This is **benchmark-only**, with no production dispatch, CLI, model loader,
+prefill, or M1 change. It is materially different from the rejected packed
+W13+packed W2 path: gather up to eight original input rows per expert directly
+inside W13, divide K across CTA warps, retain the FP16 projection and SiLU
+materialization boundaries, scatter to original route slots, then use the
+unchanged fused W2/reduce. There is no duplicated top-k input tensor, floating
+atomic reduction, CPU routing readback, or persistent FP16 expert copy.
+The integer grouping plan and all writeback costs are inside the timed graph.
+An optional benchmark-only `--packed-w2` variant now reuses that metadata for
+W2 as described below; the default screen still uses the existing fused W2.
+
+Algorithm reference: [PyTorch's locality-aware vLLM MoE study](https://pytorch.org/blog/accelerating-moe-model/)
+supports investigating expert locality and Split-K, but its A100/H100 numbers
+and floating atomic implementation are not imported as V100 evidence. It also
+reports unresolved end-to-end expert mapping inconsistencies. This prototype
+therefore explicitly tests changing route groups and original-slot restoration.
+
+One idle V100 (physical GPU1), Torch 2.10/CUDA 12.8, SM70-only task-owned
+extension; all 512 experts from actual checkpoint **layer 0 / TP4 shard 0**,
+interleaved native NVFP4 weights/prepared FP16 scales, synthetic activations.
+Replay the 48 captured C16 routing patterns from the existing fixed baseline:
+
+| Screen | Control mean per-layer call | Candidate mean | Sum of paired savings across 48 route patterns |
+| --- | ---: | ---: | ---: |
+| grouped W13 split8 + unchanged W2 | 164.596 us | 124.579 us | 1.921 ms |
+| additionally mask inactive shared-memory rows | 164.408 us | 124.456 us | 1.918 ms |
+
+All 48 route patterns improved in the first screen (28.38--49.20 us).
+The second change is neutral and has been removed for simplicity. **This is
+not an actual 48-layer execution**: it reuses layer-0 weights with each layer's
+captured routing, and is only a phase-admission estimate. No endpoint speed
+or capacity improvement is claimed. This W13-only candidate is below the
+>=2 ms C16 screen gate; the subsequent grouped-W2 combination is assessed
+separately below.
+
+At the layer-0 captured routing, split8 saves only 3.63 us at M4. M8's
+same-split4 variant saves 3.28 us; forcing split1 on M4/M8 loses 36.12/25.80 us.
+Thus widening a guard is not a batch implementation or a universal speedup.
+
+Quality status: grouping with the **same split as the control** is exact in
+the exercised real-weight M4/M8/M16 cases, including interleaved W13. Split8
+at C16 changes FP32 association; the 48-pattern screen's maximum final-output
+absolute difference is `1.90735e-6`, maximum relative L2 `1.97128e-4`.
+These small operator errors are **not** a model-quality pass. Full HumanEval,
+MBPP, GSM8K, perplexity, tool-call and structured-output score gates remain
+pending; greedy hashes remain diagnostics rather than the score criterion.
+
+Graph checks poison scratch/output buffers and replay changed inputs with
+distinct, repeated, reversed and invalid routes. Dedicated tests also cover
+every width M1--M16, one expert filling multiple packs, and both physical W13
+layouts. Unsupported production widths still use the unchanged production
+fallback because this extension is not registered into the model dispatcher.
+W13-only focused GPU pytest: **22 passed** in 33.23 seconds (two unrelated Swig
+deprecation warnings). Run:
+`.venv/bin/python -m pytest -q tests/kernels/quantization/test_sm70_moe_packed_w13.py`.
+
+#### Follow-up: reuse the grouping in W2
+
+The new `--packed-w2` screen processes **both singleton and repeated groups in
+one kernel**, followed by one fixed original-slot weighted reduction. This
+removes the old repeated/singleton split and its redundant launches. It uses
+a bounded FP16 routed-output buffer (0.78125 MiB at M16), not a second grouping
+pass. The initial layer-0 / rank-0 real-weight C16 screen gives:
+
+| Route pattern | Direct production MoE | Grouped W13 split8 + grouped W2 | Saving |
+| --- | ---: | ---: | ---: |
+| all 160 experts different | 191.478 us | 178.256 us | 13.222 us |
+| all requests share 10 experts | 106.326 us | 33.245 us | 73.082 us |
+| captured layer-0 route, 99 experts | 170.886 us | 125.130 us | 45.757 us |
+
+Same-split1 W13 plus grouped W2 remains exact against the native control in
+all five changed-input/group-count checks. Split8 retains the previously
+described FP32 association difference. These are not endpoint or model-score
+results. The 48-route sweep and the expanded M1--M16 W2 pytest were initially
+deferred because another task occupied GPUs 0--3; the preflight correctly
+returned 75 before launching. No foreign processes were terminated. The
+W13-only 22-pass result above is not attributed to those expanded tests.
+
+After the other task exited, the expanded **22 GPU tests passed in 33.59 s**.
+Grouped W2 is bitwise equal to native W2 at every width M1--M16, including
+changing route counts and invalid slots after graph capture. The full
+48-route-pattern screen then measured **164.404 -> 112.939 us** per MoE call,
+**31.30% lower**, and **2.470 ms** summed paired saving. All 48 improved
+(30.22--68.55 us); final-output max-abs/relative-L2 error remained
+`1.90735e-6`/`1.97128e-4`. This crosses the >=2 ms *microbenchmark admission*
+gate, not an endpoint or quality-score gate. Layer-0 weights are still reused
+with all captured routes, so no actual full-model latency reduction is claimed.
+The combination is now eligible for production-wrapper integration followed
+by the planned paired endpoint/score tests; keep it out of default dispatch
+until those are completed.
+
+### Measurement hygiene and retained evidence
+
+Initial short-call timing used one operator sequence per graph and showed
+large C4/C8 fluctuations. The accepted screen captures 16 complete calls
+inside each graph, uses fixed pointers and alternating A/B order, and divides
+CUDA-event time by both unroll count and replay count. Initial v1 artifacts
+are retained but are not speed gates. A targeted recheck of the prior dense
+cuBLASLt sweep using 32 calls per graph still projects only 0.237 ms across
+all shapes, with several non-exact winners. It does not justify a new 64 MiB
+workspace or replacement of the production dense path.
+
+Artifacts relative to this owned worktree:
+
+- `.artifacts/raw-audit/packed-w13-real-layer0-unrolled-v2.json`
+- `.artifacts/raw-audit/packed-w13-real-48routes-v3.json`
+- `.artifacts/raw-audit/packed-w13-real-48routes-masked-v4.json`
+- `.artifacts/raw-audit/packed-w13-w2-real-v5.json`
+- `.artifacts/raw-audit/packed-w13-w2-real-48routes-v6.json`
+- `.artifacts/raw-audit/cublaslt-unrolled/cublaslt_fp16_algorithms_m16.json`
+
+Each portable report records CUDA/Torch, model layer/shard, source hash,
+route-file hashes (v3+), paired timing samples and numerical errors. Build
+with a task-owned `TORCH_EXTENSIONS_DIR`, CUDA 12.8 `CUDA_HOME`, and
+`TORCH_CUDA_ARCH_LIST=7.0`; use the task uv Python and frozen native `_C`.
+The tested native `_C` SHA256 is
+`6db72e5d72ed051423ce5dc62f5a935e716c02e85c3c423c92edc96fcce51fa3`;
+the W13-only unmasked prototype source SHA256 was
+`9bad8d300a3d8f96c697528a74cfd40e3a117c5a73c2c94cf4d494d94d4063e2`.
+The final W13+W2 source SHA256 is
+`b2ca971714153b83e81ff03cf7c51b8293e9723bfcaa5e8dd1427a424fdc125a`,
+and its tested extension SHA256 is
+`ebb7202f4462727db1345ad551f7d6f984363344024f84e440c9ba51a0768dc3`.
+All GPU runs used `.artifacts/raw-audit/.venv/bin/python`, a task-created uv
+environment, and the task native bootstrap. GPU1 was released after testing;
+no task-owned API or resident GPU worker was started. Other GPU workloads
+were not touched.
+
+Example benchmark arguments (model and route paths supplied locally):
+
+```bash
+.venv/bin/python benchmarks/kernels/benchmark_sm70_moe_packed_w13.py \
+  --model "$MODEL" --layer 0 --rank 0 --tokens 16 --splits 8 --interleaved --packed-w2 \
+  --route-glob "$ROUTE_GLOB" --samples 5 --repeats 10 --out "$RESULT_JSON"
+```
+
+Next: integrate the grouped W13/W2 candidate behind an experimental local
+capability/shape gate, then perform the planned control/candidate/control
+endpoint and score tests. Preserve C1 and prefill; no scheduler, KV-type or
+maximum-sequence-count binding. Dense multi-row fusion remains a separate
+unfinished optimization track.
+Keep Draft; neither default enablement nor a release claim is authorized by
+these microbenchmarks.
+
 ## Acceptance gates
 
 - A microbenchmark candidate must improve median CUDA Graph replay time at its

--- a/docs/design/sm70_qwen38_nomtp_concurrency.md
+++ b/docs/design/sm70_qwen38_nomtp_concurrency.md
@@ -1,0 +1,51 @@
+# SM70 Qwen3.8 No-MTP Concurrency Optimization
+
+## Scope
+
+This work improves Qwen3.8-Flash-Next NVFP4 no-MTP decode scaling on TP4 V100.
+It does not change MTP, sampling, KV-cache precision, or model weights.
+
+Integration base: `onecat/main@45a58ab6749096248dc15b1263bdf5faf51f5c70`.
+
+## Frozen baseline and targets
+
+The existing single-request contract is 70 tokens/s. The measured aggregate
+throughput from the same `max_num_seqs=16` engine is:
+
+| Concurrency | Aggregate tokens/s | Efficiency vs. 70 tokens/s | Target |
+| ---: | ---: | ---: | ---: |
+| 4 | 163.727 | 58.5% | 238 tokens/s (85%) |
+| 8 | 280.841 | 50.2% | 420 tokens/s (75%) |
+| 16 | 441.229 | 39.4% | 728 tokens/s (65%) |
+
+Raw baseline:
+`.artifacts/qwen38_flash_next_no_mtp_concurrency/result.json`.
+
+## Evidence-first sequence
+
+1. Generalize the native NVFP4 QPN expert route from token counts 1 and 5 to
+   exact no-MTP decode widths 4, 8, and 16. Compare the complete routed MoE
+   operation with the existing grouped path, including numerical error.
+2. Raise compact routed-slot coverage only if the 160-route C16 microbenchmark
+   beats the dense 512-expert dispatch and passes the same numerical oracle.
+3. Measure exact TP4 20/40/80 KiB collectives before adding push or fused-sum
+   variants.
+4. Screen small-M projection, HyperConnection, and GDN candidates only after
+   the MoE and collective contributions are known.
+5. Run one C1/C4/C8/C16 end-to-end acceptance test after admitted candidates
+   have enough projected savings; do not repeatedly relaunch the full model.
+
+## Acceptance gates
+
+- A microbenchmark candidate must improve median CUDA Graph replay time at its
+  production shape and must not regress any covered shape by more than 1%.
+- Native NVFP4 weights and FP16 activations remain unchanged. Report bitwise
+  equality, maximum absolute error, and relative L2 error against the current
+  production route.
+- Before default enablement, run long-output text health plus coding, tool-call,
+  and structured-output quality checks. A speedup with a quality regression is
+  rejected.
+- Runtime selection must be capability- and shape-based. It must not bind the
+  model to one concurrency, KV dtype, maximum sequence count, or scheduler
+  setting.
+

--- a/tests/kernels/moe/test_fused_topk.py
+++ b/tests/kernels/moe/test_fused_topk.py
@@ -55,7 +55,7 @@ def torch_topk(
 @pytest.mark.parametrize(
     "case", ["random", "ties", "signed_zero", "nan", "inf", "negative_inf"]
 )
-@pytest.mark.parametrize("num_tokens", [1, 5])
+@pytest.mark.parametrize("num_tokens", range(1, 17))
 def test_sm70_qwen38_router_topk(case: str, num_tokens: int):
     torch.manual_seed(0)
     gating_output = torch.randn(num_tokens, 512, dtype=torch.float16, device="cuda")

--- a/tests/kernels/quantization/test_sm70_moe_packed_w13.py
+++ b/tests/kernels/quantization/test_sm70_moe_packed_w13.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Benchmark-only grouped W13: no default runtime route is changed.
+"""Experimental grouped W13/W2: no default runtime route is changed.
 
 Set a task-owned TORCH_EXTENSIONS_DIR and build with CUDA 12.8 on SM70.
 """
@@ -21,14 +21,15 @@ def weights():
         pytest.skip("Set task-owned TORCH_EXTENSIONS_DIR")
     source = (
         Path(__file__).resolve().parents[3]
-        / "benchmarks/kernels/sm70_moe_packed_w13.cu"
+        / "csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu"
     )
-    load(
-        name="sm70_moe_packed_w13_screen",
-        sources=[str(source)],
-        extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
-        is_python_module=False,
-    )
+    if not hasattr(torch.ops._C, "nvfp4_grouped_w13_sm70_out"):
+        load(
+            name="sm70_moe_packed_w13_screen",
+            sources=[str(source)],
+            extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
+            is_python_module=False,
+        )
     torch.manual_seed(123)
     return (
         torch.randint(0, 2**31 - 1, (512, 2560, 40), device="cuda", dtype=torch.int32),
@@ -58,10 +59,10 @@ def test_regroup_graph_covers_every_route(weights, tokens):
     reference = torch.empty_like(reduced)
 
     def run():
-        torch.ops.sm70_packed_screen.run(
+        torch.ops._C.nvfp4_grouped_w13_sm70_out(
             out, x, w, s, ids, rows, experts, sizes, total, 8, False
         )
-        torch.ops.sm70_packed_screen.w2(
+        torch.ops._C.nvfp4_grouped_w2_sm70_out(
             reduced, routed, out, w2, s2, topk, rows, experts, sizes, total
         )
 
@@ -127,7 +128,7 @@ def test_same_split_matches_production(weights, tokens, split, interleaved):
     sizes = torch.empty_like(experts)
     total = torch.empty(1, device="cuda", dtype=torch.int32)
     ops.nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(expected, x, w, s, ids, interleaved)
-    torch.ops.sm70_packed_screen.run(
+    torch.ops._C.nvfp4_grouped_w13_sm70_out(
         out, x, w, s, ids, rows, experts, sizes, total, split, interleaved
     )
     torch.testing.assert_close(out, expected, rtol=0, atol=0)

--- a/tests/kernels/quantization/test_sm70_moe_packed_w13.py
+++ b/tests/kernels/quantization/test_sm70_moe_packed_w13.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark-only grouped W13: no default runtime route is changed.
+
+Set a task-owned TORCH_EXTENSIONS_DIR and build with CUDA 12.8 on SM70.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from torch.utils.cpp_extension import load
+
+
+@pytest.fixture(scope="module")
+def weights():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 GPU required")
+    if not os.environ.get("TORCH_EXTENSIONS_DIR"):
+        pytest.skip("Set task-owned TORCH_EXTENSIONS_DIR")
+    source = (
+        Path(__file__).resolve().parents[3]
+        / "benchmarks/kernels/sm70_moe_packed_w13.cu"
+    )
+    load(
+        name="sm70_moe_packed_w13_screen",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "-std=c++17", "-lineinfo"],
+        is_python_module=False,
+    )
+    torch.manual_seed(123)
+    return (
+        torch.randint(0, 2**31 - 1, (512, 2560, 40), device="cuda", dtype=torch.int32),
+        torch.rand(512, 160, 320, device="cuda", dtype=torch.float16) * 0.01,
+        torch.randint(0, 2**31 - 1, (512, 160, 320), device="cuda", dtype=torch.int32),
+        torch.rand(512, 10, 2560, device="cuda", dtype=torch.float16) * 0.01,
+    )
+
+
+@pytest.mark.parametrize("tokens", range(1, 17))
+def test_regroup_graph_covers_every_route(weights, tokens):
+    """Changing counts must not consume stale groups or miss the last pack."""
+    from vllm import _sm70_ops as ops
+
+    w, s, w2, s2 = weights
+    n = tokens * 10
+    x = torch.randn(tokens, 2560, device="cuda", dtype=torch.float16) * 0.1
+    ids = torch.zeros(n, device="cuda", dtype=torch.int32)
+    out = torch.empty(n, 160, device="cuda", dtype=torch.float16)
+    rows = torch.empty(n, 8, device="cuda", dtype=torch.int32)
+    experts = torch.empty(n, device="cuda", dtype=torch.int32)
+    sizes = torch.empty_like(experts)
+    total = torch.empty(1, device="cuda", dtype=torch.int32)
+    topk = torch.softmax(torch.randn(tokens, 10, device="cuda"), dim=-1)
+    routed = torch.empty(n, 2560, device="cuda", dtype=torch.float16)
+    reduced = torch.empty(tokens, 2560, device="cuda", dtype=torch.float16)
+    reference = torch.empty_like(reduced)
+
+    def run():
+        torch.ops.sm70_packed_screen.run(
+            out, x, w, s, ids, rows, experts, sizes, total, 8, False
+        )
+        torch.ops.sm70_packed_screen.w2(
+            reduced, routed, out, w2, s2, topk, rows, experts, sizes, total
+        )
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    for values in (
+        torch.arange(n, dtype=torch.int32),
+        torch.arange(n, dtype=torch.int32) % 10,
+        torch.zeros(n, dtype=torch.int32),  # up to 20 packs of one expert
+        torch.full((n,), -1, dtype=torch.int32),
+        torch.arange(n, dtype=torch.int32) % 17,
+    ):
+        x.normal_(0, 0.1)
+        ids.copy_(values)
+        for t in (rows, experts, sizes, total):
+            t.fill_(-9999)
+        out.fill_(float("nan"))
+        routed.fill_(float("nan"))
+        reduced.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize()
+        assert torch.isfinite(out).all()
+        ops.nvfp4_moe_qpn_w2_reduce_sm70_out(reference, out, w2, s2, ids, topk)
+        torch.testing.assert_close(reduced, reference, rtol=0, atol=0)
+        count = total.item()
+        assert 0 < count <= n
+        rr, ee, ss = rows.cpu(), experts.cpu(), sizes.cpu()
+        seen = []
+        for group in range(count):
+            size = ss[group].item()
+            assert 1 <= size <= 8
+            routes = rr[group, :size].tolist()
+            assert all(0 <= route < n for route in routes)
+            if ee[group] == 512:
+                assert (values[routes] == -1).all()
+            else:
+                assert (values[routes] == ee[group]).all()
+            seen.extend(routes)
+        assert sorted(seen) == list(range(n))
+        actual = out.clone()
+        run()
+        torch.testing.assert_close(out, actual, rtol=0, atol=0)
+        if (values == -1).all():
+            assert torch.count_nonzero(out) == 0
+
+
+@pytest.mark.parametrize("tokens,split", [(4, 5), (8, 4), (16, 1)])
+@pytest.mark.parametrize("interleaved", [False, True])
+def test_same_split_matches_production(weights, tokens, split, interleaved):
+    from vllm import _sm70_ops as ops
+
+    w, s, _, _ = weights
+    n = tokens * 10
+    x = torch.randn(tokens, 2560, device="cuda", dtype=torch.float16) * 0.1
+    ids = (torch.arange(n, device="cuda") % 13).int()
+    out = torch.empty(n, 160, device="cuda", dtype=torch.float16)
+    expected = torch.empty_like(out)
+    rows = torch.empty(n, 8, device="cuda", dtype=torch.int32)
+    experts = torch.empty(n, device="cuda", dtype=torch.int32)
+    sizes = torch.empty_like(experts)
+    total = torch.empty(1, device="cuda", dtype=torch.int32)
+    ops.nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(expected, x, w, s, ids, interleaved)
+    torch.ops.sm70_packed_screen.run(
+        out, x, w, s, ids, rows, experts, sizes, total, split, interleaved
+    )
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)

--- a/tests/kernels/quantization/test_sm70_nvfp4_raw_scales.py
+++ b/tests/kernels/quantization/test_sm70_nvfp4_raw_scales.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Raw-scale expansion and decode admission must cover E4M3 edge encodings."""
+
+import pytest
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    _raw_scales_match_prepared,
+)
+
+
+@pytest.fixture(autouse=True)
+def require_sm70_raw_scale_ops():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("requires SM70")
+    if not sm70_ops.has_nvfp4_qpn_raw_scale_dispatch():
+        pytest.skip("requires raw-scale native operators")
+
+
+@pytest.mark.parametrize(
+    "stage,interleaved", [("w13", False), ("w13", True), ("w2", False)]
+)
+def test_raw_scale_strict_expansion_all_e4m3_codes(stage, interleaved):
+    shape = (512, 160, 320) if stage == "w13" else (512, 10, 2560)
+    # CPU conversion is an independent reference, including signed zeros,
+    # subnormals and NaNs; no SM70 native FP8 arithmetic is assumed.
+    codebook = torch.arange(256, dtype=torch.uint8)
+    values = codebook.view(torch.float8_e4m3fn).float().cuda()
+    codes = codebook.cuda().repeat(torch.Size(shape).numel() // 256).view(shape)
+    globals_ = (
+        torch.tensor(
+            [0.0, 2**-24, 2**-10, 2**-4, 1.0, 2.0, -1.0, 256.0],
+            device="cuda",
+            dtype=torch.float32,
+        )
+        .repeat(128 if stage == "w13" else 64)
+        .view(512, -1)
+    )
+    if stage == "w13":
+        columns = torch.arange(shape[-1], device="cuda")
+        slots = ((columns // 32) % 2) if interleaved else (columns >= 160).long()
+        global_by_column = globals_[:, slots].unsqueeze(1)
+    else:
+        global_by_column = globals_.unsqueeze(1)
+    expected = (values[codes.long()] * global_by_column).half()
+    out = torch.empty(shape, dtype=torch.float16, device="cuda")
+    sm70_ops.nvfp4_expand_raw_scales_sm70_out(out, codes, globals_, interleaved, False)
+    finite = ~expected.isnan()
+    # Bitwise comparison also preserves signed zero; NaN payload is immaterial.
+    assert torch.equal(
+        out.view(torch.int16)[finite], expected.view(torch.int16)[finite]
+    )
+    assert torch.equal(out.isnan(), expected.isnan())
+
+    # Replay must read current code/global buffers, not capture-time values.
+    graph = torch.cuda.CUDAGraph()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        sm70_ops.nvfp4_expand_raw_scales_sm70_out(
+            out, codes, globals_, interleaved, False
+        )
+    codes.fill_(64)  # E4M3 2.0
+    globals_.fill_(2**-4)
+    graph.replay()
+    assert torch.equal(out, torch.full_like(out, 0.125))
+
+
+@pytest.mark.parametrize("code", [0, 1, 7, 128, 129, 255])
+def test_raw_scale_admission_rejects_unsupported_fast_encodings(code):
+    shape = (512, 10, 2560)
+    codes = torch.full(shape, code, dtype=torch.uint8, device="cuda")
+    globals_ = torch.full((512, 1), 2**-10, dtype=torch.float32, device="cuda")
+    prepared = torch.empty(shape, dtype=torch.float16, device="cuda")
+    sm70_ops.nvfp4_expand_raw_scales_sm70_out(prepared, codes, globals_, False, False)
+    assert not _raw_scales_match_prepared(
+        torch.empty_like(prepared), codes, globals_, prepared, False
+    )
+
+
+def test_raw_scale_admission_checks_effective_hmma_scale():
+    shape = (512, 10, 2560)
+    codes = torch.full(shape, 64, dtype=torch.uint8, device="cuda")
+    globals_ = torch.full((512, 1), 2**-10, dtype=torch.float32, device="cuda")
+    prepared = torch.full(shape, 2**-9, dtype=torch.float16, device="cuda")
+    out = torch.empty_like(prepared)
+    assert _raw_scales_match_prepared(out, codes, globals_, prepared, False)
+    assert torch.equal(out, prepared * 16384.0)

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -14,6 +14,7 @@ from vllm.models.qwen4_exp.nvidia.ops.qsa import (
     _qsa_sparse_launch_profile,
     _qsa_xqa_page4_shape_supported,
     _use_sm70_qsa_lexicographic_topk,
+    _use_sm70_qsa_two_warp_partial,
 )
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -28,6 +29,36 @@ def test_pre_ampere_qsa_prefill_uses_narrow_tiles_and_four_warps():
 def test_ampere_qsa_prefill_keeps_gb300_profile():
     assert _qsa_sparse_launch_profile(512, 8, False) == (64, 4, 2)
     assert _qsa_sparse_launch_profile(8192, 8, False) == (64, 1, 2)
+
+
+@pytest.mark.parametrize("rows", (1, 2, 4, 8, 16))
+def test_sm70_qsa_two_warp_partial_accepts_small_decode_family(monkeypatch, rows):
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 70,
+    )
+    assert _use_sm70_qsa_two_warp_partial(rows, 6, 256)
+    assert not _use_sm70_qsa_two_warp_partial(rows, 4, 256)
+    assert not _use_sm70_qsa_two_warp_partial(rows, 6, 128)
+
+
+def test_sm70_qsa_two_warp_partial_rejects_large_batch_and_other_arch(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: False,
+    )
+    assert not _use_sm70_qsa_two_warp_partial(8, 6, 256)
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 70,
+    )
+    assert not _use_sm70_qsa_two_warp_partial(0, 6, 256)
+    assert not _use_sm70_qsa_two_warp_partial(17, 6, 256)
 
 
 def test_qsa_indexer_cublas_accepts_only_exact_single_request_shape():

--- a/tests/models/qwen4_exp/test_sm70_fp16_gemv.py
+++ b/tests/models/qwen4_exp/test_sm70_fp16_gemv.py
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 
 import vllm.envs as envs
+from vllm.model_executor.models.qwen2_moe import (
+    _sm70_force_shared_expert_silu_custom_op,
+    _sm70_fused_shared_expert_gate_module_supported,
+    _sm70_fused_shared_expert_gate_shape_supported,
+)
 from vllm.models.qwen4_exp.nvidia.sm70_fp16_gemv import _plan_for
 
 
@@ -31,6 +39,51 @@ def test_qwen38_sm70_fp16_gdn_input_is_opt_in(
     assert not envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16
     monkeypatch.setenv(name, "1")
     assert envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16
+
+
+@pytest.mark.parametrize("tokens", (1, 4, 8, 16))
+def test_qwen38_sm70_fused_shared_gate_accepts_small_batch(tokens: int) -> None:
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    out = torch.empty_like(x)
+    assert _sm70_fused_shared_expert_gate_shape_supported(x, out)
+
+
+def test_qwen38_sm70_fused_shared_gate_rejects_unsupported_shape() -> None:
+    x = torch.empty(17, 2560, dtype=torch.float16)
+    assert not _sm70_fused_shared_expert_gate_shape_supported(x, torch.empty_like(x))
+    assert not _sm70_fused_shared_expert_gate_shape_supported(
+        x[:16], torch.empty(15, 2560, dtype=torch.float16)
+    )
+    assert not _sm70_fused_shared_expert_gate_shape_supported(
+        x[:16].float(), torch.empty(16, 2560, dtype=torch.float16)
+    )
+
+
+def test_qwen38_sm70_fused_shared_gate_uses_local_tp_shape() -> None:
+    gate_up = SimpleNamespace(
+        input_size_per_partition=2560,
+        output_partition_sizes=(160, 160),
+    )
+    down = SimpleNamespace(
+        input_size_per_partition=160,
+        output_size_per_partition=2560,
+    )
+    assert _sm70_fused_shared_expert_gate_module_supported(gate_up, down)
+
+    gate_up.output_partition_sizes = (640, 640)
+    assert not _sm70_fused_shared_expert_gate_module_supported(gate_up, down)
+
+
+def test_qwen38_sm70_shared_expert_custom_silu_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (7, 0))
+    assert _sm70_force_shared_expert_silu_custom_op("layers.0.mlp.shared_expert")
+    assert not _sm70_force_shared_expert_silu_custom_op("layers.0.mlp.experts")
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (8, 0))
+    assert not _sm70_force_shared_expert_silu_custom_op("layers.0.mlp.shared_expert")
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from vllm import _sm70_ops as sm70_ops
 from vllm import envs
 from vllm.model_executor.layers.quantization import modelopt
 from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
@@ -17,18 +18,34 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config,
 )
 from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    _QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K,
+    _QWEN38_QPN_BATCH_W13_SPLIT_K,
     ModelOptNvFp4SM70MoEMethod,
     _mtp_weighted_reduce,
     _prepare_compact_slot_groups,
     _prepare_single_token_slots,
+    _raw_scales_match_prepared,
     _single_token_weighted_reduce,
     _use_compact_grouped,
     _use_qwen38_indexed_prefill,
+    _use_qwen38_qpn_batch_decode,
+    _use_qwen38_qpn_batch_fused_w2,
+    _use_qwen38_qpn_batch_fused_w13,
     _use_qwen38_qpn_m1_decode,
     _use_qwen38_qpn_mtp5_decode,
     _validate_weight_layout,
     validate_nvfp4_sm70_moe_contract,
 )
+
+
+def test_qwen38_qpn_batch_uses_screened_splits():
+    assert _QWEN38_QPN_BATCH_W13_SPLIT_K == {2: 10, 4: 5, 8: 4, 16: 1}
+
+
+def test_qwen38_qpn_batch_covers_dynamic_graph_widths():
+    assert set(_QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K) == set(range(2, 17))
+    for tokens, split_k in _QWEN38_QPN_BATCH_W13_SPLIT_K.items():
+        assert _QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K[tokens] == split_k
 
 
 @pytest.mark.parametrize(
@@ -126,6 +143,13 @@ def test_qwen38_fast_prefill_defaults_on_and_can_be_disabled(monkeypatch):
     monkeypatch.setenv(name, "0")
     assert not envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
 
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE"
+    monkeypatch.delenv(name, raising=False)
+    assert not envs.VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE
+
+    monkeypatch.setenv(name, "1")
+    assert envs.VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE
+
 
 @pytest.mark.parametrize(
     ("field", "value"),
@@ -197,6 +221,161 @@ def test_qwen38_indexed_prefill_is_default_on_and_exact_shape_only(monkeypatch):
 
     layer.moe_config.tp_size = 2
     assert not _use_qwen38_indexed_prefill(layer, x, topk_ids)
+
+
+@pytest.mark.parametrize("tokens", (2, 4, 8, 16))
+def test_qwen38_qpn_batch_decode_defaults_on_and_is_shape_gated(monkeypatch, tokens):
+    layer = SimpleNamespace(
+        moe_config=_qwen4_moe_contract(),
+        sm70_nvfp4_num_experts=512,
+        sm70_nvfp4_hidden_size=2560,
+        sm70_nvfp4_intermediate_size=160,
+        sm70_nvfp4_top_k=10,
+    )
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(tokens, 10, dtype=torch.int32)
+
+    monkeypatch.delenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", raising=False)
+    assert _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", "0")
+    assert not _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", "1")
+    assert _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+    assert not _use_qwen38_qpn_batch_decode(layer, x[:, :-1], topk_ids)
+    assert not _use_qwen38_qpn_batch_decode(layer, x, topk_ids.long())
+
+    layer.moe_config.tp_size = 2
+    assert not _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+
+
+@pytest.mark.parametrize("tokens", (3, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15))
+@pytest.mark.parametrize("raw_scale", (False, True))
+def test_qwen38_qpn_dynamic_widths_are_independent_of_scale_storage(
+    monkeypatch, tokens, raw_scale
+):
+    layer = SimpleNamespace(
+        moe_config=_qwen4_moe_contract(),
+        sm70_nvfp4_num_experts=512,
+        sm70_nvfp4_hidden_size=2560,
+        sm70_nvfp4_intermediate_size=160,
+        sm70_nvfp4_top_k=10,
+        sm70_nvfp4_qwen38_raw_scale=raw_scale,
+    )
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(tokens, 10, dtype=torch.int32)
+    monkeypatch.delenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", raising=False)
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE"
+    monkeypatch.delenv(name, raising=False)
+    assert not _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+
+    monkeypatch.setenv(name, "1")
+    assert _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", "0")
+    assert not _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+
+
+@pytest.mark.parametrize("interleaved", (False, True))
+@pytest.mark.parametrize("mismatch", (None, "prefill", "decode"))
+def test_raw_scale_admission_checks_prefill_and_effective_decode(
+    monkeypatch, interleaved, mismatch
+):
+    # A decode-scale mismatch can disappear after dividing by 2**14 and
+    # rounding to stored FP16 subnormals. Admission must compare BEFORE that
+    # lossy division, exactly where the QPN HMMA consumes the scale.
+    prepared = torch.tensor([2**-24], dtype=torch.float16)
+    effective = prepared * 16384.0
+    changed_effective = torch.nextafter(
+        effective, torch.full_like(effective, torch.inf)
+    )
+    assert torch.equal(changed_effective / 16384.0, prepared)
+    workspace = torch.empty_like(prepared)
+    codes = torch.zeros(1, dtype=torch.uint8)
+    globals_ = torch.ones(1, dtype=torch.float32)
+    calls = []
+
+    def expand(out, actual_codes, actual_globals, actual_interleaved, fast):
+        assert actual_codes is codes
+        assert actual_globals is globals_
+        assert actual_interleaved == interleaved
+        calls.append(fast)
+        if fast:
+            out.copy_(changed_effective if mismatch == "decode" else effective)
+        else:
+            out.copy_(prepared * 2 if mismatch == "prefill" else prepared)
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_expand_raw_scales_sm70_out", expand)
+    assert _raw_scales_match_prepared(
+        workspace, codes, globals_, prepared, interleaved
+    ) == (mismatch is None)
+    assert calls == ([False] if mismatch == "prefill" else [False, True])
+
+
+@pytest.mark.parametrize("tokens", (4, 8, 16))
+def test_qwen38_qpn_batch_fused_w13_defaults_on_and_is_shape_gated(monkeypatch, tokens):
+    layer = SimpleNamespace(
+        moe_config=_qwen4_moe_contract(),
+        sm70_nvfp4_num_experts=512,
+        sm70_nvfp4_hidden_size=2560,
+        sm70_nvfp4_intermediate_size=160,
+        sm70_nvfp4_top_k=10,
+        sm70_nvfp4_qwen38_fused_swiglu_prefill=True,
+        swiglu_limit=None,
+    )
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(tokens, 10, dtype=torch.int32)
+    monkeypatch.setattr(
+        sm70_ops,
+        "has_nvfp4_qpn_w13_swiglu_batch_dispatch",
+        lambda: True,
+    )
+
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13"
+    monkeypatch.delenv(name, raising=False)
+    assert _use_qwen38_qpn_batch_fused_w13(layer, x, topk_ids)
+
+    monkeypatch.setenv(name, "0")
+    assert not _use_qwen38_qpn_batch_fused_w13(layer, x, topk_ids)
+
+    monkeypatch.setenv(name, "1")
+    assert not _use_qwen38_qpn_batch_fused_w13(layer, x[:1], topk_ids[:1])
+    layer.sm70_nvfp4_qwen38_fused_swiglu_prefill = False
+    assert _use_qwen38_qpn_batch_fused_w13(layer, x, topk_ids)
+
+
+@pytest.mark.parametrize("tokens", (2, 4, 8, 16))
+def test_qwen38_qpn_batch_fused_w2_defaults_on_and_is_shape_gated(monkeypatch, tokens):
+    layer = SimpleNamespace(
+        moe_config=_qwen4_moe_contract(),
+        sm70_nvfp4_num_experts=512,
+        sm70_nvfp4_hidden_size=2560,
+        sm70_nvfp4_intermediate_size=160,
+        sm70_nvfp4_top_k=10,
+    )
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    topk_ids = torch.empty(tokens, 10, dtype=torch.int32)
+    monkeypatch.setattr(
+        sm70_ops,
+        "has_nvfp4_qpn_w2_reduce_dispatch",
+        lambda: True,
+    )
+
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2"
+    monkeypatch.delenv(name, raising=False)
+    assert _use_qwen38_qpn_batch_fused_w2(layer, x, topk_ids)
+
+    monkeypatch.setenv(name, "0")
+    assert not _use_qwen38_qpn_batch_fused_w2(layer, x, topk_ids)
+
+    monkeypatch.setenv(name, "1")
+    assert not _use_qwen38_qpn_batch_fused_w2(layer, x[:1], topk_ids[:1])
+    monkeypatch.setattr(
+        sm70_ops,
+        "has_nvfp4_qpn_w2_reduce_dispatch",
+        lambda: False,
+    )
+    assert not _use_qwen38_qpn_batch_fused_w2(layer, x, topk_ids)
 
 
 def test_qwen38_qpn_mtp5_decode_is_opt_in_and_exact_shape_only(monkeypatch):

--- a/tests/quantization/test_sm70_nvfp4_grouped_decode_dispatch.py
+++ b/tests/quantization/test_sm70_nvfp4_grouped_decode_dispatch.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace as NS
+
+import pytest
+import torch
+
+from vllm import envs
+from vllm.model_executor.layers.quantization import nvfp4_sm70_moe as moe
+
+
+def set_context(monkeypatch, metadata):
+    ctx = NS(attn_metadata=metadata, additional_kwargs={})
+    monkeypatch.setattr(moe, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(moe, "get_forward_context", lambda: ctx)
+    return ctx
+
+
+def test_grouped_decode_defaults_off(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_GROUPED_DECODE", raising=False)
+    envs.disable_envs_cache()
+    assert not envs.VLLM_SM70_NVFP4_MOE_GROUPED_DECODE
+
+
+@pytest.mark.parametrize("tokens", [1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 32, 64, 2048])
+def test_runtime_shape_not_scheduler_configuration(monkeypatch, tokens):
+    # No TP, model name, KV dtype, max-num-seqs or chunk-size fields needed.
+    layer = NS(sm70_nvfp4_grouped_decode=True)
+    set_context(monkeypatch, {"attn": NS(max_query_len=1)})
+    x = torch.empty(tokens, 2560, dtype=torch.float16)
+    ids = torch.empty(tokens, 10, dtype=torch.int32)
+    assert moe._use_grouped_decode(layer, x, ids) == (tokens in (8, 16))
+    layer.sm70_nvfp4_grouped_decode = False
+    assert not moe._use_grouped_decode(layer, x, ids)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        [],
+        [{"attn": NS(max_query_len=1)}],
+        {"unknown": NS()},
+        {"prefill": NS(max_query_len=16)},
+        {"verify": NS(max_query_len=5)},
+        {"attn": NS(max_query_len=1), "gdn": NS(num_prefills=1)},
+        {"gdn": NS(num_prefills=0, num_decodes=2, num_decode_tokens=8)},
+        {"gdn": NS(num_prefills=0, num_prefill_tokens=4)},
+        {"attn": NS(max_query_len=torch.tensor(1))},
+        {"gdn": NS(num_decodes=8, num_decode_tokens=torch.tensor(8))},
+    ],
+)
+def test_metadata_fails_closed(monkeypatch, metadata):
+    set_context(monkeypatch, metadata)
+    assert not moe._grouped_decode_context_ok()
+
+
+def test_no_context_falls_back(monkeypatch):
+    monkeypatch.setattr(moe, "is_forward_context_available", lambda: False)
+    assert not moe._grouped_decode_context_ok()
+
+
+def test_grouped_ops_have_fake_implementations():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    from vllm import _sm70_ops as ops
+
+    if not ops.has_nvfp4_grouped_decode_dispatch():
+        pytest.skip("Build native grouped-decode ops first")
+    with FakeTensorMode():
+        x = torch.empty(16, 2560, dtype=torch.float16)
+        mid = torch.empty(160, 160, dtype=torch.float16)
+        routed = torch.empty(160, 2560, dtype=torch.float16)
+        ids = torch.empty(160, dtype=torch.int32)
+        rows = torch.empty(160, 8, dtype=torch.int32)
+        experts, sizes = torch.empty_like(ids), torch.empty_like(ids)
+        total = torch.empty(1, dtype=torch.int32)
+        w13 = torch.empty(512, 2560, 40, dtype=torch.int32)
+        s13 = torch.empty(512, 160, 320, dtype=torch.float16)
+        ops.nvfp4_grouped_w13_sm70_out(
+            mid, x, w13, s13, ids, rows, experts, sizes, total, 8, True
+        )
+        ops.nvfp4_grouped_w2_sm70_out(
+            torch.empty_like(x),
+            routed,
+            mid,
+            torch.empty(512, 160, 320, dtype=torch.int32),
+            torch.empty(512, 10, 2560, dtype=torch.float16),
+            torch.empty(16, 10),
+            rows,
+            experts,
+            sizes,
+            total,
+        )
+
+
+def test_cached_decision_is_per_forward(monkeypatch):
+    old = set_context(
+        monkeypatch, {"gdn": NS(num_prefills=0, num_decodes=16, num_decode_tokens=16)}
+    )
+    assert moe._grouped_decode_context_ok()
+    assert old.additional_kwargs["sm70_grouped_moe_decode"]
+    new = set_context(monkeypatch, {"attn": NS(max_query_len=32)})
+    assert not moe._grouped_decode_context_ok()
+    assert not new.additional_kwargs["sm70_grouped_moe_decode"]
+
+
+@pytest.mark.parametrize("bad", ["dtype", "ids", "strides", "hidden"])
+def test_bad_tensor_contract_falls_back(monkeypatch, bad):
+    set_context(monkeypatch, {"attn": NS(max_query_len=1)})
+    x = torch.empty(16, 2560, dtype=torch.float16)
+    ids = torch.empty(16, 10, dtype=torch.int32)
+    if bad == "dtype":
+        x = x.float()
+    elif bad == "ids":
+        ids = ids.long()
+    elif bad == "hidden":
+        x = x[:, :-1]
+    else:
+        x = torch.empty(2560, 16, dtype=torch.float16).t()
+    assert not moe._use_grouped_decode(NS(sm70_nvfp4_grouped_decode=True), x, ids)

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -231,6 +231,19 @@ def test_sm70_tp4_push_allreduce_mtp5_is_opt_in(monkeypatch):
         envs.disable_envs_cache()
 
 
+def test_sm70_tp4_push_allreduce_qwen38_batch_defaults_on(monkeypatch):
+    name = "VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH"
+    monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH
+        monkeypatch.setenv(name, "0")
+        envs.disable_envs_cache()
+        assert not envs.VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH
+    finally:
+        envs.disable_envs_cache()
+
+
 def _bare_dflash2_model() -> DFlash2Qwen3Model:
     model = DFlash2Qwen3Model.__new__(DFlash2Qwen3Model)
     torch.nn.Module.__init__(model)

--- a/tests/v1/worker/test_release_cleanup.py
+++ b/tests/v1/worker/test_release_cleanup.py
@@ -50,7 +50,11 @@ def test_compile_wrapper_cleanup_is_idempotent():
 
 
 def test_sm70_workspace_cleanup_releases_all_tensor_owners():
-    from vllm.model_executor.layers.quantization import fp8, sm70_turbomind
+    from vllm.model_executor.layers.quantization import (
+        fp8,
+        nvfp4_sm70_moe,
+        sm70_turbomind,
+    )
     from vllm.v1.attention.backends import flash_attn_v100
     from vllm.v1.worker.gpu.shutdown import _clear_loaded_gpu_workspaces
 
@@ -77,6 +81,7 @@ def test_sm70_workspace_cleanup_releases_all_tensor_owners():
     fp8._sm70_fp8_prefill_dense_workspaces[(0, tensor.dtype)] = tensor
     fp8._sm70_fp8_qpn8_pp2_tp4_workspaces[(0, tensor.dtype)] = tensor
     sm70_turbomind._nvfp4_qpn4_dense_workspaces[(0, tensor.dtype)] = tensor
+    nvfp4_sm70_moe._qwen38_raw_scale_workspaces[0] = tensor
 
     _clear_loaded_gpu_workspaces()
 
@@ -88,6 +93,7 @@ def test_sm70_workspace_cleanup_releases_all_tensor_owners():
     assert not fp8._sm70_fp8_prefill_dense_workspaces
     assert not fp8._sm70_fp8_qpn8_pp2_tp4_workspaces
     assert not sm70_turbomind._nvfp4_qpn4_dense_workspaces
+    assert not nvfp4_sm70_moe._qwen38_raw_scale_workspaces
 
 
 def test_mrv2_shutdown_drops_target_draft_graph_and_model_refs(monkeypatch):

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -77,8 +77,9 @@ def _maybe_load_nvfp4_qpn_m1_library() -> None:
     """Load the narrow Qwen3.8 NVFP4 experiment in spawned TP workers."""
     library_path = os.getenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY")
     m1_enabled = os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", "1") != "0"
+    batch_enabled = os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", "1") != "0"
     mtp5_enabled = os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_MTP5_DECODE", "0") != "0"
-    route_enabled = m1_enabled or mtp5_enabled
+    route_enabled = m1_enabled or batch_enabled or mtp5_enabled
     if library_path is not None and route_enabled:
         torch.ops.load_library(library_path)
 
@@ -154,11 +155,38 @@ def has_nvfp4_qpn_m1_dispatch() -> bool:
     )
 
 
+def has_nvfp4_qpn_raw_scale_dispatch() -> bool:
+    names = (
+        "nvfp4_expand_raw_scales_sm70_out",
+        "nvfp4_moe_qpn_raw_scale_sm70_out",
+        "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out",
+        "nvfp4_moe_qpn_raw_w2_reduce_sm70_out",
+    )
+    return all(
+        hasattr(torch.ops._C_qwen38, name) or hasattr(torch.ops._C, name)
+        for name in names
+    )
+
+
 def has_nvfp4_qpn_mtp5_dispatch() -> bool:
     """Reject extensions that only implement the legacy ten-route kernel."""
     return hasattr(torch.ops._C_qwen38, "nvfp4_moe_qpn_mtp5_sm70_out") or hasattr(
         torch.ops._C, "nvfp4_moe_qpn_mtp5_sm70_out"
     )
+
+
+def has_nvfp4_qpn_w13_swiglu_batch_dispatch() -> bool:
+    return hasattr(
+        torch.ops._C_qwen38,
+        "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out",
+    ) or hasattr(torch.ops._C, "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out")
+
+
+def has_nvfp4_qpn_w2_reduce_dispatch() -> bool:
+    return hasattr(
+        torch.ops._C_qwen38,
+        "nvfp4_moe_qpn_w2_reduce_sm70_out",
+    ) or hasattr(torch.ops._C, "nvfp4_moe_qpn_w2_reduce_sm70_out")
 
 
 def silu_and_mul_interleaved(out: torch.Tensor, input: torch.Tensor) -> None:
@@ -1512,6 +1540,178 @@ def nvfp4_moe_qpn_m1_sm70_out(
     )
 
 
+def nvfp4_moe_qpn_raw_scale_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scale_codes: torch.Tensor,
+    global_scales: torch.Tensor,
+    expert_ids: torch.Tensor,
+    broadcast_input: bool,
+    interleaved_w13: bool,
+    split_k: int,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_moe_qpn_raw_scale_sm70_out")(
+        out,
+        input,
+        weights,
+        scale_codes,
+        global_scales,
+        expert_ids,
+        broadcast_input,
+        interleaved_w13,
+        split_k,
+    )
+
+
+def nvfp4_expand_raw_scales_sm70_out(
+    out: torch.Tensor,
+    scale_codes: torch.Tensor,
+    global_scales: torch.Tensor,
+    interleaved_w13: bool,
+    fast_decode_rounding: bool = False,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_expand_raw_scales_sm70_out")(
+        out,
+        scale_codes,
+        global_scales,
+        interleaved_w13,
+        fast_decode_rounding,
+    )
+
+
+def nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scale_codes: torch.Tensor,
+    global_scales: torch.Tensor,
+    expert_ids: torch.Tensor,
+    interleaved: bool,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out")(
+        out,
+        input,
+        weights,
+        scale_codes,
+        global_scales,
+        expert_ids,
+        interleaved,
+    )
+
+
+def nvfp4_moe_qpn_raw_w2_reduce_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scale_codes: torch.Tensor,
+    global_scales: torch.Tensor,
+    expert_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_moe_qpn_raw_w2_reduce_sm70_out")(
+        out,
+        input,
+        weights,
+        scale_codes,
+        global_scales,
+        expert_ids,
+        topk_weights,
+    )
+
+
+def nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scales: torch.Tensor,
+    expert_ids: torch.Tensor,
+    interleaved: bool,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_moe_qpn_w13_swiglu_batch_sm70_out")(
+        out,
+        input,
+        weights,
+        scales,
+        expert_ids,
+        interleaved,
+    )
+
+
+def nvfp4_moe_qpn_w2_reduce_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scales: torch.Tensor,
+    expert_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> None:
+    _qwen38_qpn8_op("nvfp4_moe_qpn_w2_reduce_sm70_out")(
+        out,
+        input,
+        weights,
+        scales,
+        expert_ids,
+        topk_weights,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_qpn_w2_reduce_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_qpn_w2_reduce_sm70_out")
+    def _nvfp4_moe_qpn_w2_reduce_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C_qwen38, "nvfp4_moe_qpn_w2_reduce_sm70_out"):
+
+    @register_fake("_C_qwen38::nvfp4_moe_qpn_w2_reduce_sm70_out")
+    def _nvfp4_moe_qpn_w2_reduce_sm70_sidecar_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_qpn_w13_swiglu_batch_sm70_out")
+    def _nvfp4_moe_qpn_w13_swiglu_batch_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        interleaved: bool,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C_qwen38, "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out"):
+
+    @register_fake("_C_qwen38::nvfp4_moe_qpn_w13_swiglu_batch_sm70_out")
+    def _nvfp4_moe_qpn_w13_swiglu_batch_sm70_sidecar_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        interleaved: bool,
+    ) -> None:
+        return None
+
+
 if hasattr(torch.ops._C, "nvfp4_moe_qpn_m1_sm70_out"):
 
     @register_fake("_C::nvfp4_moe_qpn_m1_sm70_out")
@@ -1540,6 +1740,74 @@ if hasattr(torch.ops._C_qwen38, "nvfp4_moe_qpn_m1_sm70_out"):
         split_k: int,
     ) -> None:
         return None
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_qpn_raw_scale_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_qpn_raw_scale_sm70_out")
+    def _nvfp4_moe_qpn_raw_scale_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scale_codes: torch.Tensor,
+        global_scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        broadcast_input: bool,
+        interleaved_w13: bool,
+        split_k: int,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C_qwen38, "nvfp4_moe_qpn_raw_scale_sm70_out"):
+
+    @register_fake("_C_qwen38::nvfp4_moe_qpn_raw_scale_sm70_out")
+    def _nvfp4_moe_qpn_raw_scale_sm70_sidecar_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        scale_codes: torch.Tensor,
+        global_scales: torch.Tensor,
+        expert_ids: torch.Tensor,
+        broadcast_input: bool,
+        interleaved_w13: bool,
+        split_k: int,
+    ) -> None:
+        return None
+
+
+for _raw_namespace, _raw_prefix in (
+    (torch.ops._C, "_C"),
+    (torch.ops._C_qwen38, "_C_qwen38"),
+):
+    if hasattr(_raw_namespace, "nvfp4_expand_raw_scales_sm70_out"):
+        register_fake(f"{_raw_prefix}::nvfp4_expand_raw_scales_sm70_out")(
+            lambda out,
+            scale_codes,
+            global_scales,
+            interleaved_w13,
+            fast_decode_rounding: None
+        )
+    if hasattr(_raw_namespace, "nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out"):
+        register_fake(f"{_raw_prefix}::nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out")(
+            lambda out,
+            input,
+            weights,
+            scale_codes,
+            global_scales,
+            expert_ids,
+            interleaved: None
+        )
+    if hasattr(_raw_namespace, "nvfp4_moe_qpn_raw_w2_reduce_sm70_out"):
+        register_fake(f"{_raw_prefix}::nvfp4_moe_qpn_raw_w2_reduce_sm70_out")(
+            lambda out,
+            input,
+            weights,
+            scale_codes,
+            global_scales,
+            expert_ids,
+            topk_weights: None
+        )
 
 
 def nvfp4_moe_qpn_mtp5_sm70_out(

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -182,6 +182,61 @@ def has_nvfp4_qpn_w13_swiglu_batch_dispatch() -> bool:
     ) or hasattr(torch.ops._C, "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out")
 
 
+def has_nvfp4_grouped_decode_dispatch() -> bool:
+    return all(
+        hasattr(torch.ops._C, name)
+        for name in ("nvfp4_grouped_w13_sm70_out", "nvfp4_grouped_w2_sm70_out")
+    )
+
+
+def nvfp4_grouped_w13_sm70_out(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    w: torch.Tensor,
+    s: torch.Tensor,
+    ids: torch.Tensor,
+    rows: torch.Tensor,
+    experts: torch.Tensor,
+    sizes: torch.Tensor,
+    total: torch.Tensor,
+    split: int,
+    interleaved: bool,
+) -> None:
+    torch.ops._C.nvfp4_grouped_w13_sm70_out(
+        out, x, w, s, ids, rows, experts, sizes, total, split, interleaved
+    )
+
+
+def nvfp4_grouped_w2_sm70_out(
+    out: torch.Tensor,
+    routed: torch.Tensor,
+    x: torch.Tensor,
+    w: torch.Tensor,
+    s: torch.Tensor,
+    topk: torch.Tensor,
+    rows: torch.Tensor,
+    experts: torch.Tensor,
+    sizes: torch.Tensor,
+    total: torch.Tensor,
+) -> None:
+    torch.ops._C.nvfp4_grouped_w2_sm70_out(
+        out, routed, x, w, s, topk, rows, experts, sizes, total
+    )
+
+
+if has_nvfp4_grouped_decode_dispatch():
+
+    @register_fake("_C::nvfp4_grouped_w13_sm70_out")
+    def _grouped_w13_fake(
+        out, x, w, s, ids, rows, experts, sizes, total, split, interleaved
+    ):
+        return None
+
+    @register_fake("_C::nvfp4_grouped_w2_sm70_out")
+    def _grouped_w2_fake(out, routed, x, w, s, topk, rows, experts, sizes, total):
+        return None
+
+
 def has_nvfp4_qpn_w2_reduce_dispatch() -> bool:
     return hasattr(
         torch.ops._C_qwen38,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -340,10 +340,17 @@ class CustomAllreduce:
             mtp5_status = (
                 "enabled" if envs.VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5 else "disabled"
             )
+            qwen38_batch_status = (
+                "enabled"
+                if envs.VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH
+                else "disabled"
+            )
             logger.info(
                 "SM70 TP4 SGLang-style push all-reduce enabled for the "
                 "FP16 80-KiB verifier, 8-KiB decode, and 5-KiB Qwen4Exp "
-                "payloads; opt-in 25-KiB Qwen4Exp MTP4 payload is %s.",
+                "payloads; Qwen3.8 [4|8|16,2560] batch payloads are %s and "
+                "the opt-in 25-KiB Qwen4Exp MTP4 payload is %s.",
+                qwen38_batch_status,
                 mtp5_status,
             )
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -185,6 +185,11 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE: bool = False
+    VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2: bool = True
+    VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE: bool = False
     VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL: bool = True
@@ -231,6 +236,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5: bool = False
+    VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH: bool = True
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
@@ -1876,6 +1882,51 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", "1"))
     ),
+    # Direct Qwen3.8 expert route for CUDA Graph local widths 2, 4, 8, and 16. It
+    # retains native NVFP4 weights, FP16 activations, and FP32 accumulation
+    # while skipping expert sort and input expansion. Exact shape/capability
+    # gates preserve the generic fallback.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE", "1"))
+    ),
+    # Experimental extension to every live width in 2..16, independent of
+    # scale storage. Changing RAW_SCALE must not also change which widths use
+    # QPN versus grouped TurboMind (which can use a different reduction order).
+    # Keep off until dynamic-width endpoint quality admission is complete.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE", "0"))
+    ),
+    # Split-preserving M4/M8/M16 specializations for the direct Qwen3.8 expert
+    # route. They fuse the FP16 SwiGLU epilogue into W13 while reading the
+    # existing interleaved native-NVFP4 layout. M2 retains its faster separate
+    # activation. Set to 0 to retain the standalone activation path.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13": lambda: bool(
+        int(
+            os.getenv(
+                "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13",
+                "1",
+            )
+        )
+    ),
+    # Fuse the direct Qwen3.8 W2 projection with its fixed-order FP32 weighted
+    # reduction. Ten warps compute the ten routed slots in parallel; the
+    # capability and shape gate keeps every other MoE route unchanged.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2": lambda: bool(
+        int(
+            os.getenv(
+                "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2",
+                "1",
+            )
+        )
+    ),
+    # Keep native E4M3 block-scale codes resident and reconstruct their exact
+    # FP16 values in the QPN decode kernels. Generic/prefill TurboMind routes
+    # use one reusable expansion workspace, so this reduces persistent scale
+    # memory instead of retaining a second representation. Experimental until
+    # full-model prefill/decode quality admission is complete.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE", "0"))
+    ),
     # Exact TP4 Qwen3.8 W13 prefill route. It retains the stable expert sort
     # and unpermute maps but reads original token rows through TurboMind's
     # indexed-A iterator instead of materializing top-k replicated FP16 rows.
@@ -2111,6 +2162,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # only. Keep opt-in until the TP4 dynamic-graph gate is recorded.
     "VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5": lambda: bool(
         int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5", "0"))
+    ),
+    # Bitwise-equal push collectives for FP16 [4|8|16, 2560] payloads on
+    # fully-connected SM70 TP4 CUDA Graphs. Other shapes, topologies, devices,
+    # and eager execution retain the normal custom-allreduce path.
+    "VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH", "1"))
     ),
     # Optional task-built custom-AR fragment. Operators present in the sidecar
     # override the production namespace; every other operator falls back.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -238,6 +238,7 @@ if TYPE_CHECKING:
     VLLM_SM70_TP4_PUSH_ALLREDUCE: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH: bool = True
+    VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES: bool = False
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
@@ -2175,6 +2176,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and eager execution retain the normal custom-allreduce path.
     "VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH": lambda: bool(
         int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH", "1"))
+    ),
+    # Experimental ordinary all-reduce admission by aligned message size.
+    # SM70, fully connected TP4 and captured FP16 only; default off until the
+    # mixed-size graph replay, numerical and full-model quality gates pass.
+    "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "0"))
     ),
     # Optional task-built custom-AR fragment. Operators present in the sidecar
     # override the production namespace; every other operator falls back.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE: bool = False
+    VLLM_SM70_NVFP4_MOE_GROUPED_DECODE: bool = False
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE: bool = False
@@ -1895,6 +1896,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Keep off until dynamic-width endpoint quality admission is complete.
     "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE", "0"))
+    ),
+    # Experimental grouped native-NVFP4 W13/W2 decode. Local weight shapes and
+    # attention metadata gates preserve M1, prefill and multi-token verify.
+    # Default off pending endpoint and model-quality admission.
+    "VLLM_SM70_NVFP4_MOE_GROUPED_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_MOE_GROUPED_DECODE", "0"))
     ),
     # Split-preserving M4/M8/M16 specializations for the direct Qwen3.8 expert
     # route. They fuse the FP16 SwiGLU epilogue into W13 while reading the

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -184,7 +184,7 @@ def fused_topk(
     if scoring_func == "softmax":
         if (
             envs.VLLM_SM70_QWEN38_ROUTER_TOPK
-            and M in (1, 5)
+            and 1 <= M <= 16
             and gating_output.shape == (M, 512)
             and gating_output.dtype == torch.float16
             and gating_output.is_contiguous()

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -53,6 +53,71 @@ _QWEN38_QPN_M1_W13_SPLIT_K: Final = 8
 _QWEN38_QPN_M1_W2_SPLIT_K: Final = 1
 _QWEN38_INDEXED_PREFILL_MIN_TOKENS: Final = 128
 _QWEN38_QPN_MTP5_W13_SPLIT_K: Final = 4
+# Split choices retained by the per-width performance screen. The direct
+# kernel is deterministic, but TurboMind's grouped baseline can autotune to a
+# different reduction order in a new process; quality admission therefore
+# uses an independent FP32 oracle and endpoint datasets, not baseline bitwise
+# identity alone.
+_QWEN38_QPN_BATCH_W13_SPLIT_K: Final = {2: 10, 4: 5, 8: 4, 16: 1}
+_QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K: Final = {
+    2: 10,
+    3: 8,
+    4: 5,
+    5: 4,
+    6: 8,
+    7: 8,
+    8: 4,
+    9: 4,
+    10: 4,
+    11: 4,
+    12: 4,
+    13: 5,
+    14: 5,
+    15: 4,
+    16: 1,
+}
+_QWEN38_QPN_BATCH_FUSED_W13_TOKENS: Final = frozenset((4, 8, 16))
+_QWEN38_RAW_SCALE_WORKSPACE_ELEMENTS: Final = 512 * 160 * 320
+_qwen38_raw_scale_workspaces: dict[int, torch.Tensor] = {}
+
+
+def clear_sm70_nvfp4_moe_workspaces() -> None:
+    """Release process-global Qwen3.8 raw-scale expansion workspaces."""
+    _qwen38_raw_scale_workspaces.clear()
+
+
+def _raw_scales_match_prepared(
+    workspace: torch.Tensor,
+    codes: torch.Tensor,
+    globals_: torch.Tensor,
+    prepared: torch.Tensor,
+    interleaved: bool,
+) -> bool:
+    """Admit both prefill scales and the effective QPN decode scales."""
+    sm70_ops.nvfp4_expand_raw_scales_sm70_out(
+        workspace, codes, globals_, interleaved, False
+    )
+    if not torch.equal(workspace, prepared):
+        return False
+    sm70_ops.nvfp4_expand_raw_scales_sm70_out(
+        workspace, codes, globals_, interleaved, True
+    )
+    return torch.equal(workspace, prepared * 16384.0)
+
+
+def _get_qwen38_raw_scale_workspace(device: torch.device) -> torch.Tensor:
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    workspace = _qwen38_raw_scale_workspaces.get(device_index)
+    if workspace is None:
+        workspace = torch.empty(
+            _QWEN38_RAW_SCALE_WORKSPACE_ELEMENTS,
+            dtype=torch.float16,
+            device=device,
+        )
+        _qwen38_raw_scale_workspaces[device_index] = workspace
+    return workspace
 
 
 def _use_qwen38_qpn_m1_decode(
@@ -103,6 +168,63 @@ def _use_qwen38_indexed_prefill(
         and int(layer.sm70_nvfp4_hidden_size) == 2560
         and int(layer.sm70_nvfp4_intermediate_size) == 160
         and int(layer.sm70_nvfp4_top_k) == 10
+    )
+
+
+def _use_qwen38_qpn_batch_decode(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit the screened Qwen3.8 TP4 no-MTP CUDA Graph batch widths."""
+    tokens = x.shape[0]
+    split_table = (
+        _QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K
+        if envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE
+        else _QWEN38_QPN_BATCH_W13_SPLIT_K
+    )
+    return bool(
+        envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE
+        and tokens in split_table
+        and x.shape == (tokens, 2560)
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (tokens, 10)
+        and topk_ids.dtype == torch.int32
+        and topk_ids.is_contiguous()
+        and int(layer.moe_config.tp_size) == 4
+        and int(layer.sm70_nvfp4_num_experts) == 512
+        and int(layer.sm70_nvfp4_hidden_size) == 2560
+        and int(layer.sm70_nvfp4_intermediate_size) == 160
+        and int(layer.sm70_nvfp4_top_k) == 10
+    )
+
+
+def _use_qwen38_qpn_batch_fused_w13(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit the retained split-preserving W13+SwiGLU fusion widths."""
+    return bool(
+        envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13
+        and x.shape[0] in _QWEN38_QPN_BATCH_FUSED_W13_TOKENS
+        and layer.swiglu_limit is None
+        and sm70_ops.has_nvfp4_qpn_w13_swiglu_batch_dispatch()
+        and _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+    )
+
+
+def _use_qwen38_qpn_batch_fused_w2(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit the fixed-order parallel W2 reduction for direct batch QPN."""
+    return bool(
+        envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2
+        and sm70_ops.has_nvfp4_qpn_w2_reduce_dispatch()
+        and _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
     )
 
 
@@ -428,8 +550,8 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         missing = [name for name in required_ops if not hasattr(torch.ops._C, name)]
         if (
             envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE
-            and not sm70_ops.has_nvfp4_qpn_m1_dispatch()
-        ):
+            or envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE
+        ) and not sm70_ops.has_nvfp4_qpn_m1_dispatch():
             missing.append("nvfp4_moe_qpn_m1_sm70_out")
         if (
             envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_MTP5_DECODE
@@ -531,12 +653,38 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         fast_prefill = bool(
             fused_swiglu_prefill and envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
         )
+        raw_scale_requested = bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE
+            and int(layer.moe_config.tp_size) == 4
+            and num_experts == 512
+            and hidden == 2560
+            and intermediate == 160
+            and int(layer.moe_config.experts_per_token) == 10
+        )
+        raw_scale_available = sm70_ops.has_nvfp4_qpn_raw_scale_dispatch()
+        raw_scale_explicit = "VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE" in os.environ
+        if raw_scale_requested and not raw_scale_available and raw_scale_explicit:
+            raise RuntimeError(
+                "SM70 Qwen3.8 raw E4M3 scale storage requires the matching "
+                "QPN decode and prefill-expansion operators."
+            )
+        if raw_scale_requested and not raw_scale_available:
+            logger.warning_once(
+                "The default SM70 Qwen3.8 raw E4M3 scale operators are not "
+                "present; retaining persistent FP16 prepared scales. An "
+                "explicit opt-in fails closed."
+            )
+        raw_scale = bool(raw_scale_requested and raw_scale_available)
 
         w13_tm_weights: list[torch.Tensor] = []
         w13_tm_scales: list[torch.Tensor] = []
+        w13_raw_scale_codes: list[torch.Tensor] = []
+        w13_raw_global_scales: list[torch.Tensor] = []
         w13_meta: list[torch.Tensor] = []
         w2_tm_weights: list[torch.Tensor] = []
         w2_tm_scales: list[torch.Tensor] = []
+        w2_raw_scale_codes: list[torch.Tensor] = []
+        w2_raw_global_scales: list[torch.Tensor] = []
         w2_meta: list[torch.Tensor] = []
         for expert_id in range(num_experts):
             w13_packed = unpack_mxfp4_weight(layer.w13_weight[expert_id].data)
@@ -552,13 +700,25 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             )
             w13_tm_weights.append(prepared_w13[0])
             w13_tm_scales.append(prepared_w13[1])
+            if raw_scale:
+                if fused_swiglu_prefill:
+                    physical_global = w13_global.repeat(
+                        intermediate // 32
+                    ).repeat_interleave(32)
+                else:
+                    physical_global = w13_global.repeat_interleave(intermediate)
+                w13_raw_scale_codes.append(
+                    (prepared_w13[1].float() / physical_global[None, :].float())
+                    .to(torch.float8_e4m3fn)
+                    .view(torch.uint8)
+                    .contiguous()
+                )
+                w13_raw_global_scales.append(w13_global.contiguous())
             w13_meta.append(prepared_w13[2])
 
             w2_packed = unpack_mxfp4_weight(layer.w2_weight[expert_id].data)
-            w2_scales = (
-                layer.w2_weight_scale[expert_id].float()
-                * layer.w2_weight_scale_2[expert_id].float()
-            )
+            w2_global = layer.w2_weight_scale_2[expert_id].float().reshape(())
+            w2_scales = layer.w2_weight_scale[expert_id].float() * w2_global
             prepared_w2 = sm70_ops.nvfp4_sm70_prepare(
                 w2_packed,
                 w2_scales.half().t().contiguous(),
@@ -566,14 +726,71 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             )
             w2_tm_weights.append(prepared_w2[0])
             w2_tm_scales.append(prepared_w2[1])
+            if raw_scale:
+                w2_raw_scale_codes.append(
+                    (prepared_w2[1].float() / w2_global)
+                    .to(torch.float8_e4m3fn)
+                    .view(torch.uint8)
+                    .contiguous()
+                )
+                w2_raw_global_scales.append(w2_global.reshape(1))
             w2_meta.append(prepared_w2[2])
 
         layer.w13_tm_weight = Parameter(
             torch.stack(w13_tm_weights), requires_grad=False
         )
-        layer.w13_tm_scales = Parameter(torch.stack(w13_tm_scales), requires_grad=False)
         layer.w2_tm_weight = Parameter(torch.stack(w2_tm_weights), requires_grad=False)
-        layer.w2_tm_scales = Parameter(torch.stack(w2_tm_scales), requires_grad=False)
+        prepared_w13_scales = torch.stack(w13_tm_scales)
+        prepared_w2_scales = torch.stack(w2_tm_scales)
+        if raw_scale:
+            raw_w13_codes = torch.stack(w13_raw_scale_codes)
+            raw_w13_globals = torch.stack(w13_raw_global_scales).float()
+            raw_w2_codes = torch.stack(w2_raw_scale_codes)
+            raw_w2_globals = torch.stack(w2_raw_global_scales).float()
+            scale_workspace = _get_qwen38_raw_scale_workspace(
+                layer.w13_tm_weight.device
+            )
+            w13_workspace = scale_workspace.view(512, 160, 320)
+            w2_workspace = scale_workspace[: 512 * 10 * 2560].view(512, 10, 2560)
+            w13_exact = _raw_scales_match_prepared(
+                w13_workspace,
+                raw_w13_codes,
+                raw_w13_globals,
+                prepared_w13_scales,
+                fused_swiglu_prefill,
+            )
+            w2_exact = _raw_scales_match_prepared(
+                w2_workspace,
+                raw_w2_codes,
+                raw_w2_globals,
+                prepared_w2_scales,
+                False,
+            )
+            if not (w13_exact and w2_exact):
+                if raw_scale_explicit:
+                    raise RuntimeError(
+                        "SM70 Qwen3.8 raw E4M3 scale reconstruction is not "
+                        "bitwise equal to the prepared FP16 checkpoint scales."
+                    )
+                logger.warning_once(
+                    "SM70 Qwen3.8 raw E4M3 scale reconstruction did not match "
+                    "the prepared checkpoint scales; retaining the FP16 scale "
+                    "representation."
+                )
+                raw_scale = False
+
+        if raw_scale:
+            layer.w13_raw_scale_codes = Parameter(raw_w13_codes, requires_grad=False)
+            layer.w13_raw_global_scales = Parameter(
+                raw_w13_globals, requires_grad=False
+            )
+            layer.w2_raw_scale_codes = Parameter(raw_w2_codes, requires_grad=False)
+            layer.w2_raw_global_scales = Parameter(raw_w2_globals, requires_grad=False)
+            layer.w13_tm_scales = w13_workspace
+            layer.w2_tm_scales = w2_workspace
+        else:
+            layer.w13_tm_scales = Parameter(prepared_w13_scales, requires_grad=False)
+            layer.w2_tm_scales = Parameter(prepared_w2_scales, requires_grad=False)
 
         w13_k_ld = int(w13_meta[0][0].item())
         w13_q_ld = int(w13_meta[0][1].item())
@@ -646,6 +863,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         )
         layer.sm70_nvfp4_qwen38_fused_swiglu_prefill = fused_swiglu_prefill
         layer.sm70_nvfp4_qwen38_fast_prefill = fast_prefill
+        layer.sm70_nvfp4_qwen38_raw_scale = raw_scale
         layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
         layer.sm70_nvfp4_compact_grouped_max_slots = _COMPACT_GROUPED_MAX_SLOTS
         self._allocate_graph_safe_decode_buffers(layer)
@@ -669,6 +887,11 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             _GRAPH_SAFE_MAX_TOKENS,
             _COMPACT_GROUPED_MAX_SLOTS,
         )
+        if raw_scale:
+            logger.info_once(
+                "SM70 Qwen3.8 raw E4M3 expert-scale storage enabled; "
+                "generic and prefill routes share one FP16 expansion workspace."
+            )
         if fused_swiglu_prefill:
             logger.info_once(
                 "SM70 Qwen3.8 indexed-A fused-SwiGLU prefill candidate "
@@ -925,13 +1148,48 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         slots = num_tokens * top_k
         direct_single_token = num_tokens == 1
         direct_qpn_m1 = _use_qwen38_qpn_m1_decode(layer, x, topk_ids)
+        direct_qpn_batch = _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
         direct_qpn_mtp5 = _use_qwen38_qpn_mtp5_decode(layer, x, topk_ids)
-        if direct_qpn_m1 or direct_qpn_mtp5:
-            w13_split_k = (
-                _QWEN38_QPN_M1_W13_SPLIT_K
-                if direct_qpn_m1
-                else _QWEN38_QPN_MTP5_W13_SPLIT_K
+        raw_scale = bool(getattr(layer, "sm70_nvfp4_qwen38_raw_scale", False))
+        if os.getenv("VLLM_SM70_QWEN38_QPN_ROUTE_DEBUG") == "1" and num_tokens <= 16:
+            logger.warning_once(
+                "SM70 Qwen3.8 QPN route debug: tokens=%d x_shape=%s "
+                "x_stride=%s x_dtype=%s x_contiguous=%s ids_shape=%s "
+                "ids_stride=%s ids_dtype=%s ids_contiguous=%s tp=%s "
+                "experts=%s hidden=%s intermediate=%s top_k=%s "
+                "m1=%s batch=%s mtp5=%s compiling=%s capturing=%s.",
+                num_tokens,
+                tuple(x.shape),
+                tuple(x.stride()),
+                x.dtype,
+                x.is_contiguous(),
+                tuple(topk_ids.shape),
+                tuple(topk_ids.stride()),
+                topk_ids.dtype,
+                topk_ids.is_contiguous(),
+                layer.moe_config.tp_size,
+                layer.sm70_nvfp4_num_experts,
+                layer.sm70_nvfp4_hidden_size,
+                layer.sm70_nvfp4_intermediate_size,
+                layer.sm70_nvfp4_top_k,
+                direct_qpn_m1,
+                direct_qpn_batch,
+                direct_qpn_mtp5,
+                torch.compiler.is_compiling(),
+                torch.cuda.is_current_stream_capturing(),
             )
+        if direct_qpn_m1 or direct_qpn_batch or direct_qpn_mtp5:
+            if direct_qpn_m1:
+                w13_split_k = _QWEN38_QPN_M1_W13_SPLIT_K
+            elif direct_qpn_batch:
+                split_table = (
+                    _QWEN38_DYNAMIC_QPN_BATCH_W13_SPLIT_K
+                    if envs.VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE
+                    else _QWEN38_QPN_BATCH_W13_SPLIT_K
+                )
+                w13_split_k = split_table[num_tokens]
+            else:
+                w13_split_k = _QWEN38_QPN_MTP5_W13_SPLIT_K
             logger.info_once(
                 "SM70 Qwen3.8 NVFP4 direct expert path enabled "
                 "(TP4, E512/K10, tokens=%d, W13 split%d, W2 split1).",
@@ -940,34 +1198,112 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             )
             route_ids = topk_ids.view(-1)
             direct_op = (
-                sm70_ops.nvfp4_moe_qpn_m1_sm70_out
-                if direct_qpn_m1
-                else sm70_ops.nvfp4_moe_qpn_mtp5_sm70_out
+                sm70_ops.nvfp4_moe_qpn_mtp5_sm70_out
+                if direct_qpn_mtp5
+                else sm70_ops.nvfp4_moe_qpn_m1_sm70_out
             )
-            direct_op(
-                buffers["gate_up"],
-                x,
-                layer.w13_tm_weight,
-                layer.w13_tm_scales,
-                route_ids,
-                True,
-                w13_split_k,
-            )
-            self._apply_swiglu(
-                layer,
-                buffers["intermediate"],
-                buffers["gate_up"],
-                interleaved=interleaved_w13,
-            )
-            direct_op(
-                buffers["sorted_output"],
-                buffers["intermediate"],
-                layer.w2_tm_weight,
-                layer.w2_tm_scales,
-                route_ids,
-                False,
-                _QWEN38_QPN_M1_W2_SPLIT_K,
-            )
+            fused_batch_w13 = _use_qwen38_qpn_batch_fused_w13(layer, x, topk_ids)
+            if fused_batch_w13:
+                logger.info_once(
+                    "SM70 Qwen3.8 NVFP4 direct W13+SwiGLU fusion enabled (tokens=%d).",
+                    num_tokens,
+                )
+                if raw_scale:
+                    sm70_ops.nvfp4_moe_qpn_raw_w13_swiglu_batch_sm70_out(
+                        buffers["intermediate"],
+                        x,
+                        layer.w13_tm_weight,
+                        layer.w13_raw_scale_codes,
+                        layer.w13_raw_global_scales,
+                        route_ids,
+                        interleaved_w13,
+                    )
+                else:
+                    sm70_ops.nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+                        buffers["intermediate"],
+                        x,
+                        layer.w13_tm_weight,
+                        layer.w13_tm_scales,
+                        route_ids,
+                        interleaved_w13,
+                    )
+            else:
+                if raw_scale:
+                    sm70_ops.nvfp4_moe_qpn_raw_scale_sm70_out(
+                        buffers["gate_up"],
+                        x,
+                        layer.w13_tm_weight,
+                        layer.w13_raw_scale_codes,
+                        layer.w13_raw_global_scales,
+                        route_ids,
+                        True,
+                        interleaved_w13,
+                        w13_split_k,
+                    )
+                else:
+                    direct_op(
+                        buffers["gate_up"],
+                        x,
+                        layer.w13_tm_weight,
+                        layer.w13_tm_scales,
+                        route_ids,
+                        True,
+                        w13_split_k,
+                    )
+                self._apply_swiglu(
+                    layer,
+                    buffers["intermediate"],
+                    buffers["gate_up"],
+                    interleaved=interleaved_w13,
+                )
+            if _use_qwen38_qpn_batch_fused_w2(layer, x, topk_ids):
+                logger.info_once(
+                    "SM70 Qwen3.8 NVFP4 direct W2+weighted-reduce fusion "
+                    "enabled (tokens=%d).",
+                    num_tokens,
+                )
+                if raw_scale:
+                    sm70_ops.nvfp4_moe_qpn_raw_w2_reduce_sm70_out(
+                        output,
+                        buffers["intermediate"],
+                        layer.w2_tm_weight,
+                        layer.w2_raw_scale_codes,
+                        layer.w2_raw_global_scales,
+                        route_ids,
+                        topk_weights,
+                    )
+                else:
+                    sm70_ops.nvfp4_moe_qpn_w2_reduce_sm70_out(
+                        output,
+                        buffers["intermediate"],
+                        layer.w2_tm_weight,
+                        layer.w2_tm_scales,
+                        route_ids,
+                        topk_weights,
+                    )
+                return output
+            if raw_scale:
+                sm70_ops.nvfp4_moe_qpn_raw_scale_sm70_out(
+                    buffers["sorted_output"],
+                    buffers["intermediate"],
+                    layer.w2_tm_weight,
+                    layer.w2_raw_scale_codes,
+                    layer.w2_raw_global_scales,
+                    route_ids,
+                    False,
+                    False,
+                    _QWEN38_QPN_M1_W2_SPLIT_K,
+                )
+            else:
+                direct_op(
+                    buffers["sorted_output"],
+                    buffers["intermediate"],
+                    layer.w2_tm_weight,
+                    layer.w2_tm_scales,
+                    route_ids,
+                    False,
+                    _QWEN38_QPN_M1_W2_SPLIT_K,
+                )
             if direct_qpn_m1:
                 _single_token_weighted_reduce(
                     buffers["sorted_output"], topk_weights, output
@@ -1043,6 +1379,14 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             stage_offsets = buffers["expert_offsets"]
             stage_expert_ids = buffers["dense_expert_ids"]
             stage_experts = int(layer.sm70_nvfp4_num_experts)
+
+        if raw_scale:
+            sm70_ops.nvfp4_expand_raw_scales_sm70_out(
+                layer.w13_tm_scales,
+                layer.w13_raw_scale_codes,
+                layer.w13_raw_global_scales,
+                interleaved_w13,
+            )
 
         if split_fused_indexed_w13:
             logger.info_once(
@@ -1131,6 +1475,13 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 buffers["intermediate"],
                 buffers["gate_up"],
                 interleaved=interleaved_w13,
+            )
+        if raw_scale:
+            sm70_ops.nvfp4_expand_raw_scales_sm70_out(
+                layer.w2_tm_scales,
+                layer.w2_raw_scale_codes,
+                layer.w2_raw_global_scales,
+                False,
             )
         sm70_ops.nvfp4_moe_dense_stage_sm70_out(
             buffers["sorted_output"],

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -18,6 +18,7 @@ from torch.nn import Parameter
 
 from vllm import _sm70_ops as sm70_ops
 from vllm import envs
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -212,6 +213,67 @@ def _use_qwen38_qpn_batch_fused_w13(
         and layer.swiglu_limit is None
         and sm70_ops.has_nvfp4_qpn_w13_swiglu_batch_dispatch()
         and _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
+    )
+
+
+def _grouped_decode_context_ok() -> bool:
+    """Use CPU metadata, never GPU readback, to exclude prefill and verify."""
+    if not is_forward_context_available():
+        return False
+    context = get_forward_context()
+    metadata = context.attn_metadata
+    # DBO/list metadata needs per-microbatch ownership, not a shared decision.
+    if not isinstance(metadata, dict) or not metadata:
+        return False
+    key = "sm70_grouped_moe_decode"
+    if key not in context.additional_kwargs:
+        seen_decode = False
+        allowed = True
+        for meta in metadata.values():
+            prefills = getattr(meta, "num_prefills", 0)
+            prefill_tokens = getattr(meta, "num_prefill_tokens", 0)
+            if (
+                not isinstance(prefills, int)
+                or not isinstance(prefill_tokens, int)
+                or prefills != 0
+                or prefill_tokens != 0
+            ):
+                allowed = False
+                break
+            max_query = getattr(meta, "max_query_len", None)
+            if max_query is not None:
+                if not isinstance(max_query, int) or max_query != 1:
+                    allowed = False
+                    break
+                seen_decode = True
+            num_decodes = getattr(meta, "num_decodes", None)
+            if num_decodes is not None:
+                decode_tokens = getattr(meta, "num_decode_tokens", None)
+                if (
+                    not isinstance(num_decodes, int)
+                    or not isinstance(decode_tokens, int)
+                    or decode_tokens != num_decodes
+                ):
+                    allowed = False
+                    break
+                seen_decode |= num_decodes > 0
+        context.additional_kwargs[key] = bool(allowed and seen_decode)
+    return bool(context.additional_kwargs[key])
+
+
+def _use_grouped_decode(layer, x: torch.Tensor, topk_ids: torch.Tensor) -> bool:
+    """Local operator contract only; no TP/KV/scheduler/model-name binding."""
+    return bool(
+        getattr(layer, "sm70_nvfp4_grouped_decode", False)
+        and x.ndim == 2
+        and x.shape[0] in (8, 16)
+        and x.shape[1] == 2560
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (x.shape[0], 10)
+        and topk_ids.dtype == torch.int32
+        and topk_ids.is_contiguous()
+        and _grouped_decode_context_ok()
     )
 
 
@@ -866,6 +928,34 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         layer.sm70_nvfp4_qwen38_raw_scale = raw_scale
         layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
         layer.sm70_nvfp4_compact_grouped_max_slots = _COMPACT_GROUPED_MAX_SLOTS
+        grouped_requested = bool(
+            envs.VLLM_SM70_NVFP4_MOE_GROUPED_DECODE
+            and (num_experts, hidden, intermediate, layer.sm70_nvfp4_top_k)
+            == (512, 2560, 160, 10)
+            and not raw_scale
+            and layer.swiglu_limit is None
+        )
+        if grouped_requested and not sm70_ops.has_nvfp4_grouped_decode_dispatch():
+            raise RuntimeError(
+                "VLLM_SM70_NVFP4_MOE_GROUPED_DECODE requires a matching native build."
+            )
+        layer.sm70_nvfp4_grouped_decode = grouped_requested
+        if grouped_requested:
+            # Layer-owned metadata; W2 reuses sorted_output. No process-global
+            # cache or additional activation buffer inside graph capture.
+            device = layer.w13_tm_weight.device
+            layer._nvfp4_grouped_rows = torch.empty(
+                160, 8, dtype=torch.int32, device=device
+            )
+            layer._nvfp4_grouped_experts = torch.empty(
+                160, dtype=torch.int32, device=device
+            )
+            layer._nvfp4_grouped_sizes = torch.empty(
+                160, dtype=torch.int32, device=device
+            )
+            layer._nvfp4_grouped_total = torch.empty(
+                1, dtype=torch.int32, device=device
+            )
         self._allocate_graph_safe_decode_buffers(layer)
 
         del layer.w13_weight
@@ -1146,6 +1236,38 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         buffers = self._get_buffers(layer, num_tokens, indexed_w13)
         output = buffers["output"]
         slots = num_tokens * top_k
+        if _use_grouped_decode(layer, x, topk_ids):
+            sm70_ops.nvfp4_grouped_w13_sm70_out(
+                buffers["intermediate"],
+                x,
+                layer.w13_tm_weight,
+                layer.w13_tm_scales,
+                topk_ids.view(-1),
+                layer._nvfp4_grouped_rows,
+                layer._nvfp4_grouped_experts,
+                layer._nvfp4_grouped_sizes,
+                layer._nvfp4_grouped_total,
+                4 if num_tokens == 8 else 8,
+                interleaved_w13,
+            )
+            sm70_ops.nvfp4_grouped_w2_sm70_out(
+                output,
+                buffers["sorted_output"],
+                buffers["intermediate"],
+                layer.w2_tm_weight,
+                layer.w2_tm_scales,
+                topk_weights,
+                layer._nvfp4_grouped_rows,
+                layer._nvfp4_grouped_experts,
+                layer._nvfp4_grouped_sizes,
+                layer._nvfp4_grouped_total,
+            )
+            logger.info_once(
+                "Experimental SM70 grouped native-NVFP4 decode selected "
+                "(tokens=%d, W13/W2 share route groups).",
+                num_tokens,
+            )
+            return output
         direct_single_token = num_tokens == 1
         direct_qpn_m1 = _use_qwen38_qpn_m1_decode(layer, x, topk_ids)
         direct_qpn_batch = _use_qwen38_qpn_batch_decode(layer, x, topk_ids)

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -74,6 +74,8 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+_SM70_FUSED_SHARED_GATE_MAX_TOKENS = 16
+
 
 def _sm70_dump_qwen_mlp_tensor(
     label: str,
@@ -102,6 +104,39 @@ def _sm70_force_shared_expert_silu_custom_op(prefix: str) -> bool:
         return torch.cuda.get_device_capability() == (7, 0)
     except RuntimeError:
         return False
+
+
+def _sm70_fused_shared_expert_gate_shape_supported(
+    x: torch.Tensor,
+    out: torch.Tensor,
+) -> bool:
+    """Return whether the exact small-batch SM70 gate kernel can run.
+
+    The native kernel has always been row-independent and accepts arbitrary
+    ``M``.  Keep the optimized range bounded by the measured CUDA-graph
+    crossover instead of coupling it to the server's concurrency setting.
+    """
+    return bool(
+        x.ndim == 2
+        and out.ndim == 2
+        and 0 < x.shape[0] <= _SM70_FUSED_SHARED_GATE_MAX_TOKENS
+        and out.shape[0] == x.shape[0]
+        and x.dtype == torch.float16
+        and out.dtype == torch.float16
+    )
+
+
+def _sm70_fused_shared_expert_gate_module_supported(
+    gate_up_proj: torch.nn.Module,
+    down_proj: torch.nn.Module,
+) -> bool:
+    """Match the local TP projection shape used by the native gate kernel."""
+    return bool(
+        int(getattr(gate_up_proj, "input_size_per_partition", 0)) == 2560
+        and tuple(getattr(gate_up_proj, "output_partition_sizes", ())) == (160, 160)
+        and int(getattr(down_proj, "input_size_per_partition", 0)) == 160
+        and int(getattr(down_proj, "output_size_per_partition", 0)) == 2560
+    )
 
 
 class Qwen2MoeMLP(nn.Module):
@@ -147,12 +182,20 @@ class Qwen2MoeMLP(nn.Module):
             envs.VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION
             and expert_gate is not None
             and prefix.endswith(".mlp.shared_expert")
-            and hidden_size == 2560
-            and intermediate_size == 160
+            and _sm70_fused_shared_expert_gate_module_supported(
+                self.gate_up_proj,
+                self.down_proj,
+            )
             and not reduce_results
             and _sm70_force_shared_expert_silu_custom_op(prefix)
             and hasattr(torch.ops._C, "sm70_f16_gate_mul_out")
         )
+        if self._sm70_fused_shared_expert_gate:
+            logger.info_once(
+                "SM70 Qwen3Next shared-expert gate fusion enabled "
+                "(FP16, tokens=1..%d).",
+                _SM70_FUSED_SHARED_GATE_MAX_TOKENS,
+            )
 
     def forward(self, x):
         x = _sm70_dump_qwen_mlp_tensor("mlp_input", self.layer_idx, x)
@@ -168,9 +211,7 @@ class Qwen2MoeMLP(nn.Module):
 
         if (
             self._sm70_fused_shared_expert_gate
-            and x.shape[0] == 1
-            and x.dtype == torch.float16
-            and out.dtype == torch.float16
+            and _sm70_fused_shared_expert_gate_shape_supported(x, out)
         ):
             from vllm import _sm70_ops as sm70_ops
 

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -2010,13 +2010,8 @@ def qsa_sparse_paged_attention(
         not current_platform.has_device_capability(80),
     )
 
-    if (
-        q.shape[0] == 1
-        and group_size == 6
-        and head_dim == 256
-        and current_platform.is_device_capability(70)
-    ):
-        # Exact Qwen4Exp TP4 decode shape. Two warps preserve the existing
+    if _use_sm70_qsa_two_warp_partial(q.shape[0], group_size, head_dim):
+        # Exact Qwen4Exp TP4 decode family. Two warps preserve the existing
         # split/merge arithmetic and cut the partial-kernel time on V100.
         partial_warps = 2
 
@@ -2136,6 +2131,20 @@ def _qsa_sparse_launch_profile(
         partial_warps = 4
         block_n = 16
     return block_n, target_splits, partial_warps
+
+
+def _use_sm70_qsa_two_warp_partial(
+    num_query_tokens: int,
+    group_size: int,
+    head_dim: int,
+) -> bool:
+    """Gate the bitwise small-batch SM70 sparse-QSA launch policy."""
+    return bool(
+        0 < num_query_tokens <= 16
+        and group_size == 6
+        and head_dim == 256
+        and current_platform.is_device_capability(70)
+    )
 
 
 def qsa_store_cache_rows(

--- a/vllm/v1/worker/gpu/shutdown.py
+++ b/vllm/v1/worker/gpu/shutdown.py
@@ -23,6 +23,10 @@ def _clear_loaded_gpu_workspaces() -> None:
             "vllm.model_executor.layers.quantization.sm70_turbomind",
             "clear_sm70_turbomind_workspaces",
         ),
+        (
+            "vllm.model_executor.layers.quantization.nvfp4_sm70_moe",
+            "clear_sm70_nvfp4_moe_workspaces",
+        ),
     )
     for module_name, function_name in cleanup_functions:
         module = sys.modules.get(module_name)


### PR DESCRIPTION
## Purpose

Improve Qwen3.8-Flash-Next NVFP4 TP4/V100 **no-MTP concurrency** using measured batch kernels. Frozen C1 reference: 70 tok/s; C4/C8/C16 targets: 238/420/728 aggregate tok/s. Integration base: `45a58ab6749096248dc15b1263bdf5faf51f5c70`.

This is an AI-assisted WIP checkpoint. Human line-by-line review and quality admission are required before promotion or merge. It is **not a release-ready speed claim**.

Current checkpoint: `cc22156c2b` (DCO-signed). Grouped-MoE implementation remains `94dd55c899`; the latest native experiment adds opt-in small-message push admission and rejects unsafe batch block-count overrides. Integration was fetched before publication (`54478b9d289e`); this experiment deliberately retains its frozen base rather than silently incorporating newer main changes. Synchronization and clean-wheel validation remain required before merge.

The measured prepared-scale C1 is 80.657 tok/s and must be protected within 1%; the 70 tok/s reference is only the fixed concurrency-efficiency denominator, not permission to regress single-request performance.

## Scope and related PRs

- Extend direct native-NVFP4 expert dispatch, W13/SwiGLU and W2/reduction fusion, router, sparse-QSA launch geometry, shared gate, and TP4 push collectives to measured batch shapes.
- Preserve native NVFP4 weights, FP16 activation inputs, existing prefill, and no-MTP sampling settings.
- Experimental raw E4M3 scale residency saves memory, with exhaustive load-time checks for both strict prefill scales and effective HMMA decode scales. **Default off.**
- Dynamic M2--M16 QPN dispatch is independent of raw storage. **Default off** pending full-model quality admission.
- Add raw-scale workspace cleanup, native edge-encoding tests, and a portable real-checkpoint single-layer audit script.
- Add expert-grouped multi-row W13/SiLU with intra-CTA Split-K and grouped W2 reusing the same integer plan. Now built into `_C`, with fake ops and production `apply` dispatch behind **`VLLM_SM70_NVFP4_MOE_GROUPED_DECODE=1` (default off)**. Local shape and CPU metadata gates preserve single-token, prefill/mixed/verify fallbacks; no TP/KV/max-seqs/chunk binding. This differs from the rejected split singleton/repeated W2 implementation and avoids repeated planning.
- Related #481 focuses on single-request token latency. W13/shared-gate implementations overlap and need consolidation; do not merge both blindly or count savings twice. Its PLE/QSA epilogues are reuse candidates, not accepted batch gains here. #476 is the separate DFlash2 concurrency campaign; this PR does not change that model's contract.

## Test Plan

1. Real-checkpoint MoE loader/apply comparison and eager/CUDA Graph checks before any additional endpoint run.
2. Native E4M3 encoding, subnormal, signed-zero, NaN, global-slot layout, and effective-scale admission tests.
3. Focused route and cleanup regressions.
4. Finish C1 full-model mismatch localization; run coding, tool-call, structured-output and long-output quality scores before default enablement.
5. Only after sufficient operator gains, one paired fixed-workload C1/C4/C8/C16 throughput gate. No repeated full-model runs for noise-floor changes.

## Test Result

- Single-HC TP4 trace identifies a 10,752-byte intermediate reduction missing the push whitelist: local down/up GEMMs are faster, but pull communication and publication erase the saving. Profiled service is diagnostic, not endpoint latency.
- New `VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES` stays **default off**. It admits captured, fully-connected TP4 SM70 FP16 aligned messages within the existing 80-KiB buffer; no model/maxseq/chunk/KV binding and no communicator ABI change. When enabled, ordinary collectives use the smallest covering grid, including 40 instead of 80 CTAs for the 80-KiB payload. Flag-off geometry and sum2 admission/geometry remain unchanged.
- Fixed an unsafe pre-existing tuning override: block count below `ceil(bytes/2048)` could leave output tails unwritten. The undersized override now falls back to the established safe launch.
- New four-rank native gate passes 13 message sizes, three graph orders, eight cycles for each of random/signed-zero/special-value inputs. Finite outputs are bitwise equal to a rank-ordered FP32/FP16 oracle; poisoned outputs, tail canaries and rank skew are covered. Includes an intentionally undersized block override. Not a model-quality score pass. Existing CPU allocator/dispatch suite: 21 passed.
- Extended native gate: 64 cycles per pattern, four graph sequences, 13 sizes, all four ranks passed, including interleaved ordinary/sum2 calls with shared push storage. v4 DSO SHA256: `348b782113785d374d397362b37cc93dc06f445d595b7cd4a0d5e5f3fdaf3888`.
- Foreign-worker-contaminated timing attempts were discarded. Valid v4 HC hot-single-pair results were M4 31.235 -> 27.187 us, M8 31.872 -> 28.843 us, M16 33.781 -> 32.486 us. **Rotating 16 distinct allocations of the same real weights** instead gives 31.370 -> 31.198, 32.018 -> 33.462, and 33.947 -> 36.520 us: the apparent benefit does not survive a layer-like weight working set. This is a cache-footprint microbenchmark, not an actual 16-layer model or endpoint result. Raw timing outliers are retained.
- **HC sharding is rejected for production**; no endpoint run or promotion for this version. Keep generic push opt-in, and next screen fused local pointwise/disjoint-publication work with the rotating-weight case. No new accepted endpoint gain or model-quality pass is claimed.

- Rebuilt native `_C`; 52 focused admission/native tests passed.
- 108 CPU regression tests passed, 6 GPU-only cases skipped in that CPU run. These overlap the focused suite and are not a summed test count.
- Four timing-accounting regression tests passed.
- All applicable staged pre-commit hooks passed, including mypy, formatting, header checks and DCO sign-off. WIP implementation checkpoint: `d20a077bf4`.
- New grouped MoE tests: 22 GPU tests passed, including M1--M16 changing-route graph replay, poisoned buffers, all-singleton/repeated/invalid experts, exact grouped W2 versus native W2, and same-split W13 in both physical layouts. This is separate operator evidence, not a model-score pass.
- Actual layer-0/rank-0 weights, all 512 experts: raw/prepared outputs bitwise equal at M1--M16 and M784 prefill after separating storage from dispatch. Independent dynamic-QPN mode also matches between storage formats at M1--M16. Synthetic activations; this is not a model-quality score.
- Earlier boundary audit: all 30 combinations of layers 0/23/47, ranks 0/3 and M1/4/8/16/784 passed.
- Initial raw-on M3/M7 differences (up to `2.38e-7`) were traced to an unintended TurboMind-to-QPN dispatch change. That coupling is removed.
- Remaining full-model C1 completion-hash difference is **unresolved**. Autotuned prefill reduction is a hypothesis, not a confirmed cause. Raw storage stays off.

### Timing correction — targets remain unmet

Legacy fixed-width `get_output()` blocking wait excludes processing between receives and overestimates throughput. Original raw records are retained. Corrected aggregate uses emitted tokens divided by summed consecutive eligible engine timestamp intervals; input, seed and frozen 70 tok/s reference are unchanged.

| C | Prepared-scale candidate tok/s | Raw-scale experiment tok/s | Raw fixed-70 efficiency | Target efficiency |
|---:|---:|---:|---:|---:|
| 4 | 212.48 | 213.11 | 76.1% | 85% |
| 8 | 357.37 | 363.28 | 64.9% | 75% |
| 16 | 536.38 | 540.67 | 48.3% | 65% |

These paired diagnostics predate the latest admission fix. Raw saves about 1.73 GiB/worker but adds only 1.66%/0.80% aggregate throughput at C8/C16 in that pair. Both arms use identical pinned custom-AR/FlashQLA sidecars; this is not a clean-wheel gate. The original request-level baseline and fixed-width steady-state results remain distinct contracts.

## Evidence and risks

### HC follow-up: no candidate admitted

Offline complete-graph attribution splits dense service into HC projections 3.558 ms, GDN inputs 2.023 ms and other roles, 9.334 ms total inside the old model graph (excludes outside-graph LM-head/sampling). HC postops add 1.074 ms. It also corrects the old residual interpretation: service overlap is 1.334 ms and no-kernel gaps 1.929 ms in the complete graph. Wall minus service is not a closed CPU/GPU-idle decomposition.

New **benchmark-only** FP16 tensor-core HC fusion and batched output-sharding screens all fail the performance gate. Actual layer-0 attention-HC weights, synthetic inputs, CUDA graphs, full Mix chain including both projections/epilogues/communications as applicable:

| M16 experiment | Matched baseline | Candidate |
|---|---:|---:|
| Packed up/mix only | 33.726 us | 40.970 us |
| Packed full chain, best screened split20 | 34.571 us | 42.443 us |
| TP4 shard both ends, existing reductions | 33.992 us | 41.787 us |
| TP4 shard down only | 33.285 us | 43.504 us |

These are operator screens, not full-model latency. Changed-input/poisoned-workspace graph replay matches candidate eager results, but candidate-versus-control reductions differ and model scores remain untested. A vector-load follow-up had foreign GPU interference and unstable samples; its timings are not admissible. The distributed screens check process exclusivity before/after each timing group. No performance or quality promotion, new default, runtime dispatch or endpoint run results from this work. All staged pre-commit hooks pass, and task-owned GPU workers/locks are released.

This batch screen borrows the output-sharding idea from related #481, not its M1 kernel or communicator ABI. Local GEMM, scatter and collective costs must be broken down before a fused compute/publication design; do not repeat these losing implementations unchanged. Raw JSON/log names and commands are retained in the worklog.

### Guarded production engine result

The source-build control/candidate/control run completed on the fixed TP4/V100 no-MTP 8K/256 workload. Same native `_C` SHA256 `76f106f86f7e7bdf5f8a51b64378fee7ee09ba8a6d3cb51e699a944985711858`, prepared scales, FP32 GDN state, FP16 KV, prefix/Mamba align, 256K max length, 2048 prefill chunk, max-seqs16. Only grouped decode differs.

| C | Disabled baseline tok/s (bracket mean step) | Enabled tok/s | Change | Fixed-70 efficiency / target |
|---:|---:|---:|---:|---:|
| 1 | 81.493 | 81.435 | -0.07% | reference |
| 4 | 214.108 | 214.535 | +0.20% (route unchanged) | 76.62% / 85% |
| 8 | 359.942 | 362.981 | +0.84% | 64.82% / 75% |
| 16 | 540.951 | 584.568 | +8.06% | 52.19% / 65% |

C16 complete step: disabled **29.566/29.589 ms**, enabled **27.371 ms**; **2.207 ms actual saving**. Full-graph M8/M16 route hits confirmed. C1 protected; concurrency targets remain unmet. This is not a clean-wheel or model-quality gate. All task workers exited and GPUs were released.

Production loader/apply audit on real weights confirms M8/M16 hits, exact M1/M4/M8 and M17/M32/M784 fallbacks, M16 max abs `2.38419e-7` and relative L2 `1.38547e-4`, and exact graph/eager repetition. Mixed-NVFP4/dispatch CPU suites, the final 33-test dispatch suite and the 22 native GPU tests pass (CPU suites overlap, not additive). All applicable staged pre-commit hooks pass. No new quantization is introduced, but C16 FP32 association differs. Final CPU-integer metadata hardening fails closed for tensor metadata; the engine experiment predates this defensive check and whitespace-only CUDA formatting, neither changes the screened host-integer route.

All C1 completion hashes agree. Multi-request completions vary **even between the two disabled controls**; the cause and quality effect are not established. Quality scores, including actual decode-path rather than prefill-only perplexity, remain mandatory before enablement. No quality-pass or release-ready claim.

### Latest grouped-MoE screen (benchmark-only)

- Actual layer-0/rank-0 weights, all 512 experts, synthetic activations; 48 captured C16 route patterns. Alternating graph A/B, 16 complete calls per graph to amortize Python replay submission.
- Grouped W13 split8 + grouped W2: mean complete MoE call **164.404 -> 112.939 us (-31.30%)**; sum across the 48 route patterns **2.470 ms** saved. All 48 improved. This crosses the >=2 ms microbenchmark screen gate, **not** an actual full-model latency or throughput gate.
- The same layer's weights are reused with all 48 routing patterns. Do not describe it as a measured 48-layer round or convert it into released tok/s.
- Grouping and grouped W2 preserve same-split arithmetic. Split8 changes C16 FP32 association: max output absolute error `1.90735e-6`, relative L2 `1.97128e-4`; no model-quality scores have passed yet.
- This was the admission screen before the guarded production integration above. Default dispatch is still unchanged; quality scores and all 238/420/728 targets remain unaccepted.

Detailed commands, artifact names, binary SHA256s, prior rejected variants, overlap with #481 and all pending gates are in `docs/design/sm70_qwen38_nomtp_concurrency.md`.

Portable diagnostic: `benchmarks/kernels/verify_sm70_nvfp4_moe_raw_storage.py --model <checkpoint-dir> --layers 0,23,47 --ranks 0,3 --tokens 1,4,8,16,784 --out raw-storage.json` (one idle SM70 GPU).

No model files, generated libraries, profiler captures, environment caches or private credentials are included. Keep Draft; do not merge until quality, throughput, clean-wheel and human-review gates pass.
