### PR TITLE
[Core][SM70] Split Qwen3.8 prefill and decode compilation

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44969,3 +44969,27 @@ Interpretation:
   pickle. Hybrid startup now snapshots the small clean offload configuration
   before model loading and consumes that snapshot after loading; the failed
   attempt ended before mmap loading or compilation and produced no benchmark.
+- The corrected hybrid service started with zero systemd restarts. The large
+  graph contains `ple_offload_wait` and no Qwen3.8 M=1 operators; the small
+  graph contains the rank-local pinned PLE gather and decode-only FP16 GEMV,
+  fused HC, and fused GDN operators. No engine, weights, KV cache, or state
+  cache is duplicated.
+- An initial combined run measured only `5433` and `5495 tok/s` on the exact
+  8192-token hash `8aab945ad780...`, despite PLE mmap gather falling to
+  `31.3 ms`. The graph was structurally equivalent to the accepted disk graph;
+  the remaining regression was the launcher's explicit
+  `VLLM_SM70_FLASHQLA_ORIGINAL_PREFILL=0`. Restoring the default original
+  FlashQLA-SM70 TileLang GDN prefill route recovered `6878` and `6984 tok/s`
+  warm, within `0.6%` of the historical `7026 tok/s` result.
+- The same final no-MTP TP4 service measured `513 / 5.9602 = 86.07 tok/s`
+  pure decode. A full-context request accepted `262143` prompt tokens plus one
+  generated token and reported `51.8063 s` prefill, or `5060 tok/s`; prefix
+  caching remained disabled. Deterministic quality probes returned `5017` for
+  `173 * 29`, `1517` for `41 * 37`, and an accurate Chinese two-sentence lunar
+  phase explanation. Thinking is enabled and exposed through
+  `message.reasoning` by the selected Qwen3 parser.
+- The final API advertises maximum model length `262144`, remains served by
+  1cattunnel, and its authenticated public `/v1/models` probe returned HTTP
+  200. The service retained the 47.684-GiB file-backed PLE mapping with about
+  1.3 GiB worker RSS; startup's cgroup peak includes reclaimable/shared file
+  mappings and did not trigger `systemd-oomd` after sequencing was repaired.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44964,3 +44964,8 @@ Interpretation:
   failure occurred before compile or requests and all GPUs were released. In
   hybrid mode only, executor startup now loads the main model first and spawns
   the file-backed worker afterward; non-hybrid offload ordering is unchanged.
+- Delaying process creation exposed that model loading attaches local weight
+  loader closures to the live configuration object graph, which `spawn` cannot
+  pickle. Hybrid startup now snapshots the small clean offload configuration
+  before model loading and consumes that snapshot after loading; the failed
+  attempt ended before mmap loading or compilation and produced no benchmark.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44944,3 +44944,17 @@ Interpretation:
   transfer before the existing byte-exact dequantization kernel. A 131072-row
   CPU microbenchmark with 32703 unique local rows settles at `28.7-28.9 ms`;
   the current random UVA path accounts for roughly 0.3 s at this shape.
+- The synchronous local staging candidate disproved the final sentence above:
+  matched warm prefill was only `5355-5399 tok/s`, while decode remained
+  `85.72 tok/s`. Its measured gather was `60-76 ms`; it could not reproduce
+  the accepted offload graph because GPU N-gram calculation and CPU gathering
+  still began at the PLE layer instead of being submitted before model forward.
+  That candidate was stopped and the local-staging code was removed.
+- The replacement hybrid uses the already validated offload connector for
+  prefill and the already validated rank-local pinned shard for decode. Both
+  storage views coexist in one model process topology: file-backed mmap pages
+  are loaded only by the asynchronous CPU worker, while each TP rank retains
+  its checkpoint-native pinned shard. The compile-phase context makes the large
+  graph wait for the async result and the small graph call local UVA; V2 FULL
+  replay suppresses unnecessary CPU requests. This route still needs one
+  combined real-model quality/performance gate before acceptance.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44958,3 +44958,9 @@ Interpretation:
   graph wait for the async result and the small graph call local UVA; V2 FULL
   replay suppresses unnecessary CPU requests. This route still needs one
   combined real-model quality/performance gate before acceptance.
+- The first hybrid startup was killed by `systemd-oomd` after reaching
+  `108.7 GiB` unit memory: the existing executor spawned the mmap worker before
+  loading four local pinned shards, so both checkpoint scans overlapped. The
+  failure occurred before compile or requests and all GPUs were released. In
+  hybrid mode only, executor startup now loads the main model first and spawns
+  the file-backed worker afterward; non-hybrid offload ordering is unchanged.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44895,3 +44895,30 @@ Interpretation:
   arithmetic path: it makes default capacity select the same previously
   quality-audited, checkpoint-code-preserving B1 operator path. Test services
   were stopped after collection and all four V100s returned to idle memory.
+
+## 2026-09-03 Qwen3.8 unified prefill/decode compilation
+
+- The matched TP4/no-MTP evidence separated the regression from PLE residency.
+  The current source with the prefill graph policy measured `7026 tok/s` on the
+  repeated 8192-token prompt, while the combined decode graph service measured
+  about `5480 tok/s` after PLE major faults fell to two and PLE CPU time was
+  about 70 ms. The remaining roughly 330 ms was therefore inside the GPU graph.
+- The combined service compiled one dynamic backbone range `(1, 8193)`. Its FX
+  graph contained the M=1 FP16 GEMV, fused HC, fused GDN input, sum2 all-reduce,
+  graph-safe GDN slicing, and native Gemma RMS paths even for M=8192. The 7k
+  graph instead retained ordinary prefill linear/HC/GDN/RMS operations. This is
+  a phase-specialization bug, not evidence that two services or two weight
+  copies are required.
+- The candidate keeps one engine, one parameter set, and one KV/state cache. It
+  traces the existing dynamic prefill backbone first, then creates a non-owning
+  shared-parameter compiler limited to the FULL decode capture range. A capture
+  context selects decode-only graph semantics only while tracing FULL graphs;
+  normal prefill and PIECEWISE capture retain the established prefill graph.
+- Admission is limited to the exact Qwen4Exp 48-layer, H2560, E512/K10, HC4,
+  QSA TP4, FP16, PP1, no-MTP contract with at least one Qwen3.8 decode operator
+  enabled. `VLLM_SM70_QWEN38_DUAL_COMPILE=0` is the explicit rollback.
+- CPU-only gates pass: the phase context produces independent Dynamo branches,
+  the shared-weight proxy compiles without registering or copying target
+  parameters, focused config/route tests report `20 passed`, Ruff passes, and
+  GPUs 4-7 remain at zero allocated MiB. Real-model quality/performance evidence
+  is pending one combined candidate startup; no result is claimed yet.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -44922,3 +44922,25 @@ Interpretation:
   parameters, focused config/route tests report `20 passed`, Ruff passes, and
   GPUs 4-7 remain at zero allocated MiB. Real-model quality/performance evidence
   is pending one combined candidate startup; no result is claimed yet.
+- The first routed real-model capture proved that the large backbone remains an
+  independent `(1, 8193)` graph (44.73 s compile), then stopped before any
+  request because the late-created decode wrapper was outside vLLM's model-load
+  config context. Commit `d6d72cd30b` scopes its construction with the derived
+  decode config; a focused lifecycle probe confirms that the wrapper observes
+  that config and limits its token range to `[1, 2]`. This failed capture is not
+  a performance or quality result and systemd was stopped before retry.
+- The corrected combined candidate produced two cache families on every rank:
+  `(1, 8193)` contains no Qwen3.8 M=1 GEMV/fused-HC/fused-GDN operators, while
+  `(1, 2)` contains the decode-only operators and captured successfully. Its
+  no-MTP steady decode is `85.80 tok/s`, but matched warm 8192-token prefill is
+  only `5525-5532 tok/s`, so this candidate is not the final 7k service.
+- AST call-count comparison against the accepted 7k graph leaves one material
+  runtime difference: the accepted graph calls CPU PLE gather plus FP8 byte
+  dequantization, whereas the combined candidate calls random UVA reads from
+  the pinned shard. Even the exact natural calibration hash regressed from
+  `6986` to `5522 tok/s`. The next candidate therefore preserves direct UVA for
+  decode, but deduplicates large-prefill row IDs on CPU, gathers from the same
+  pinned TP shard into a 20-MiB staging buffer, and performs one contiguous H2D
+  transfer before the existing byte-exact dequantization kernel. A 131072-row
+  CPU microbenchmark with 32703 unique local rows settles at `28.7-28.9 ms`;
+  the current random UVA path accounts for roughly 0.3 s at this shape.

--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.compilation.sm70_decode_graph import (
+    is_sm70_decode_graph_compiling,
+    sm70_decode_graph_compilation,
+    use_sm70_decode_graph_semantics,
+)
+from vllm.config.vllm import _is_sm70_qwen38_nomtp_dual_compile_contract
+
+
+def test_sm70_decode_graph_compilation_context(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "1")
+
+    assert not is_sm70_decode_graph_compiling()
+    assert not use_sm70_decode_graph_semantics()
+    with sm70_decode_graph_compilation():
+        assert is_sm70_decode_graph_compiling()
+        assert use_sm70_decode_graph_semantics()
+    assert not is_sm70_decode_graph_compiling()
+
+
+def test_sm70_decode_graph_legacy_semantics(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "0")
+    assert use_sm70_decode_graph_semantics()
+
+
+def test_qwen38_nomtp_dual_compile_contract() -> None:
+    text_config = SimpleNamespace(
+        hidden_size=2560,
+        num_hidden_layers=48,
+        num_experts=512,
+        num_experts_per_tok=10,
+        moe_intermediate_size=640,
+        hc_count=4,
+        hc_lowrank=320,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+    )
+    model_config = SimpleNamespace(
+        architectures=("Qwen4ExpForCausalLM",),
+        dtype=torch.float16,
+        hf_text_config=text_config,
+    )
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=4,
+        pipeline_parallel_size=1,
+    )
+
+    assert _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, None, parallel_config
+    )
+    assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, SimpleNamespace(method="mtp"), parallel_config
+    )
+    parallel_config.tensor_parallel_size = 2
+    assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, None, parallel_config
+    )

--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -66,16 +66,52 @@ def test_qwen38_nomtp_dual_compile_contract() -> None:
     )
 
 
-def test_qwen38_pinned_ple_cpu_gather_preserves_rows() -> None:
-    from vllm.models.qwen4_exp.nvidia.ple_layer import (
-        _gather_pinned_ple_rows_cpu,
+def test_qwen38_hybrid_ple_decode_uses_local_module(monkeypatch) -> None:
+    from vllm.model_executor.layers.ple_offload_layer import PleOffloadLayer
+
+    monkeypatch.setenv("VLLM_PLE_CPU_OFFLOAD", "1")
+    monkeypatch.setenv("VLLM_SM70_QWEN38_HYBRID_PLE", "1")
+    monkeypatch.setenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "1")
+
+    class ToyPle(PleOffloadLayer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.initialized_locally = True
+            self._is_cpu_offloaded = True
+
+        def forward_impl(
+            self,
+            hidden_states: torch.Tensor,
+            input_ids: torch.Tensor,
+            *args: object,
+            **kwargs: object,
+        ) -> torch.Tensor:
+            return hidden_states + input_ids
+
+    layer = ToyPle()
+    with sm70_decode_graph_compilation():
+        output = layer(torch.tensor([2]), torch.tensor([3]))
+
+    assert layer.initialized_locally
+    torch.testing.assert_close(output, torch.tensor([5]))
+
+
+def test_qwen38_hybrid_ple_skips_decode_offload_request(monkeypatch) -> None:
+    from vllm.v1.ple_offload.connector import PleOffloadConnector
+
+    monkeypatch.setenv("VLLM_SM70_QWEN38_HYBRID_PLE", "1")
+    launches: list[tuple[int, int]] = []
+    connector = SimpleNamespace(
+        _launch=lambda num_reqs, num_tokens: launches.append(
+            (num_reqs, num_tokens)
+        )
     )
 
-    weight = torch.arange(48, dtype=torch.uint8).reshape(8, 6)
-    input_ids = torch.tensor([5, 1, 5, 0, 7, 1], dtype=torch.int64)
-    output = torch.empty((input_ids.numel(), weight.shape[1]), dtype=torch.uint8)
+    PleOffloadConnector.prepare_forward(
+        connector, 1, 1, dummy_run=False, use_local_model=True
+    )
+    PleOffloadConnector.prepare_forward(
+        connector, 1, 8192, dummy_run=False, use_local_model=False
+    )
 
-    unique_rows = _gather_pinned_ple_rows_cpu(weight, input_ids, output)
-
-    assert unique_rows == 4
-    torch.testing.assert_close(output, weight[input_ids])
+    assert launches == [(1, 8192)]

--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -64,3 +64,18 @@ def test_qwen38_nomtp_dual_compile_contract() -> None:
     assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
         model_config, None, parallel_config
     )
+
+
+def test_qwen38_pinned_ple_cpu_gather_preserves_rows() -> None:
+    from vllm.models.qwen4_exp.nvidia.ple_layer import (
+        _gather_pinned_ple_rows_cpu,
+    )
+
+    weight = torch.arange(48, dtype=torch.uint8).reshape(8, 6)
+    input_ids = torch.tensor([5, 1, 5, 0, 7, 1], dtype=torch.int64)
+    output = torch.empty((input_ids.numel(), weight.shape[1]), dtype=torch.uint8)
+
+    unique_rows = _gather_pinned_ple_rows_cpu(weight, input_ids, output)
+
+    assert unique_rows == 4
+    torch.testing.assert_close(output, weight[input_ids])

--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -56,6 +56,11 @@ def test_uniproc_executor_starts_ple_worker_around_model_load(monkeypatch):
     monkeypatch.setattr(uniproc_executor_module.envs, "VLLM_PLE_CPU_OFFLOAD", True)
     monkeypatch.setattr(
         uniproc_executor_module.envs,
+        "VLLM_SM70_QWEN38_HYBRID_PLE",
+        False,
+    )
+    monkeypatch.setattr(
+        uniproc_executor_module.envs,
         "VLLM_ELASTIC_EP_SCALE_UP_LAUNCH",
         False,
     )
@@ -77,6 +82,47 @@ def test_uniproc_executor_starts_ple_worker_around_model_load(monkeypatch):
         "init_device",
         "spawn_ple_offload",
         "load_model",
+        "wait_ple_offload_ready",
+    ]
+
+
+def test_uniproc_executor_delays_hybrid_ple_spawn(monkeypatch):
+    driver_worker = MagicMock()
+    monkeypatch.setattr(
+        uniproc_executor_module,
+        "WorkerWrapperBase",
+        MagicMock(return_value=driver_worker),
+    )
+    monkeypatch.setattr(uniproc_executor_module.envs, "VLLM_PLE_CPU_OFFLOAD", True)
+    monkeypatch.setattr(
+        uniproc_executor_module.envs,
+        "VLLM_SM70_QWEN38_HYBRID_PLE",
+        True,
+    )
+    monkeypatch.setattr(
+        uniproc_executor_module.envs,
+        "VLLM_ELASTIC_EP_SCALE_UP_LAUNCH",
+        False,
+    )
+    monkeypatch.setattr(
+        uniproc_executor_module,
+        "set_worker_net_device",
+        lambda *args: None,
+    )
+    monkeypatch.setattr(uniproc_executor_module, "current_platform", MagicMock())
+
+    executor = UniProcExecutor.__new__(UniProcExecutor)
+    executor.vllm_config = object()
+    monkeypatch.setattr(executor, "_distributed_args", lambda: ("local://", 0, 0))
+
+    executor._init_executor()
+
+    assert [call[0] for call in driver_worker.method_calls] == [
+        "init_worker",
+        "init_device",
+        "prepare_ple_offload_spawn",
+        "load_model",
+        "spawn_ple_offload",
         "wait_ple_offload_ready",
     ]
 

--- a/tests/v1/worker/test_ple_offload_worker.py
+++ b/tests/v1/worker/test_ple_offload_worker.py
@@ -610,6 +610,7 @@ def test_only_dp0_tp0_spawns_shared_ple_offload_worker(
     worker = Worker.__new__(Worker)
     worker._ple_offload_enabled = True
     worker._ple_offload_worker_handle = None
+    worker._ple_offload_spawn_config = None
     worker.rank = 0
     worker.local_rank = 0
     worker.vllm_config = SimpleNamespace()
@@ -643,6 +644,39 @@ def test_only_dp0_tp0_spawns_shared_ple_offload_worker(
             )
         ]
         assert worker._ple_offload_worker_handle is handle
+
+
+def test_delayed_ple_spawn_uses_pre_load_config_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    worker = Worker.__new__(Worker)
+    worker._ple_offload_enabled = True
+    worker._ple_offload_worker_handle = None
+    worker._ple_offload_spawn_config = None
+    worker.rank = 0
+    worker.local_rank = 0
+    worker.vllm_config = SimpleNamespace(markers=[])
+    worker.parallel_config = SimpleNamespace(
+        data_parallel_rank=0,
+        data_parallel_size=1,
+        tensor_parallel_size=4,
+        _ple_offload_ipc_path="ipc:///tmp/test-ple-offload",
+    )
+
+    monkeypatch.setattr(
+        ple_offload_worker.PleOffloadWorker,
+        "make_process",
+        lambda *args: calls.append(args) or object(),
+    )
+
+    worker.prepare_ple_offload_spawn()
+    worker.vllm_config.markers.append("model-load-mutation")
+    worker.spawn_ple_offload()
+
+    assert calls[0][0].markers == []
+    assert calls[0][0] is not worker.vllm_config
+    assert worker._ple_offload_spawn_config is None
 
 
 def test_offload_distributed_sets_config_only_for_model_parallel(

--- a/vllm/compilation/sm70_decode_graph.py
+++ b/vllm/compilation/sm70_decode_graph.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compile-phase selection for the SM70 Qwen3.8 decode graph.
+
+The Qwen3.8 V100 serving lane uses two compiled backbones that share the same
+module parameters: a dynamic prefill graph and a small-shape decode graph.
+This context is active only while tracing/capturing the latter.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+import torch
+
+import vllm.envs as envs
+
+_sm70_decode_graph_compilation = ContextVar(
+    "sm70_decode_graph_compilation", default=False
+)
+
+
+@contextmanager
+def sm70_decode_graph_compilation(enabled: bool = True) -> Generator[None, None, None]:
+    token = _sm70_decode_graph_compilation.set(enabled)
+    try:
+        yield
+    finally:
+        _sm70_decode_graph_compilation.reset(token)
+
+
+@torch.compiler.assume_constant_result
+def is_sm70_decode_graph_compiling() -> bool:
+    """Return a trace-time constant for the selected SM70 compilation phase."""
+    return _sm70_decode_graph_compilation.get()
+
+
+def use_sm70_decode_graph_semantics() -> bool:
+    """Preserve legacy behavior unless the dual-compile lane is active."""
+    return not envs.VLLM_SM70_QWEN38_DUAL_COMPILE or is_sm70_decode_graph_compiling()
+
+
+__all__ = [
+    "is_sm70_decode_graph_compiling",
+    "sm70_decode_graph_compilation",
+    "use_sm70_decode_graph_semantics",
+]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1673,6 +1673,21 @@ class VllmConfig:
                     "Auto-enabling the SM70 Qwen3.8 dual-compile lane: "
                     "large prefill and FULL decode graphs share one model."
                 )
+            if (
+                _is_sm70_qwen38_nomtp_dual_compile_contract(
+                    self.model_config,
+                    self.speculative_config,
+                    self.parallel_config,
+                )
+                and envs.VLLM_SM70_QWEN38_DUAL_COMPILE
+                and "VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL"
+                not in os.environ
+            ):
+                os.environ["VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL"] = "1"
+                logger.info_once(
+                    "Auto-enabling staged pinned-PLE prefill for the SM70 "
+                    "Qwen3.8 dual-compile lane; decode keeps direct UVA gathers."
+                )
             if _is_sm70_dflash2_verifier_contract(
                 self.model_config,
                 self.speculative_config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -152,6 +152,41 @@ def _is_sm70_dflash2_verifier_contract(
     )
 
 
+def _is_sm70_qwen38_nomtp_dual_compile_contract(
+    model_config: Any,
+    speculative_config: Any,
+    parallel_config: Any,
+) -> bool:
+    """Admit only the exact Qwen3.8 TP4 no-MTP dual-compile topology."""
+    if (
+        model_config is None
+        or parallel_config is None
+        or speculative_config is not None
+    ):
+        return False
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    architectures = set(getattr(model_config, "architectures", ()) or ())
+    return bool(
+        "Qwen4ExpForCausalLM" in architectures
+        and getattr(model_config, "dtype", None) == torch.float16
+        and getattr(hf_text_config, "hidden_size", None) == 2560
+        and getattr(hf_text_config, "num_hidden_layers", None) == 48
+        and getattr(hf_text_config, "num_experts", None) == 512
+        and getattr(hf_text_config, "num_experts_per_tok", None) == 10
+        and getattr(hf_text_config, "moe_intermediate_size", None) == 640
+        and getattr(hf_text_config, "hc_count", None) == 4
+        and getattr(hf_text_config, "hc_lowrank", None) == 320
+        and getattr(hf_text_config, "num_attention_heads", None) == 24
+        and getattr(hf_text_config, "num_key_value_heads", None) == 2
+        and getattr(hf_text_config, "indexer_head_dim", None) == 128
+        and getattr(hf_text_config, "indexer_budget", None) == 2048
+        and getattr(hf_text_config, "indexer_compress_ratio", None) == 4
+        and getattr(parallel_config, "tensor_parallel_size", None) == 4
+        and getattr(parallel_config, "pipeline_parallel_size", None) == 1
+    )
+
+
 def _apply_sm70_dflash2_verifier_defaults() -> tuple[str, ...]:
     """Set quality-audited defaults while preserving every explicit override."""
     applied = []
@@ -1619,6 +1654,25 @@ class VllmConfig:
                         env_name,
                         env_value,
                     )
+            if (
+                _is_sm70_qwen38_nomtp_dual_compile_contract(
+                    self.model_config,
+                    self.speculative_config,
+                    self.parallel_config,
+                )
+                and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+                and (
+                    envs.VLLM_SM70_QWEN38_FP16_GEMV
+                    or envs.VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16
+                    or envs.VLLM_SM70_QWEN38_FUSED_HC_FP16
+                )
+                and "VLLM_SM70_QWEN38_DUAL_COMPILE" not in os.environ
+            ):
+                os.environ["VLLM_SM70_QWEN38_DUAL_COMPILE"] = "1"
+                logger.info_once(
+                    "Auto-enabling the SM70 Qwen3.8 dual-compile lane: "
+                    "large prefill and FULL decode graphs share one model."
+                )
             if _is_sm70_dflash2_verifier_contract(
                 self.model_config,
                 self.speculative_config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1680,13 +1680,22 @@ class VllmConfig:
                     self.parallel_config,
                 )
                 and envs.VLLM_SM70_QWEN38_DUAL_COMPILE
-                and "VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL"
-                not in os.environ
+                and not any(
+                    name in os.environ
+                    for name in (
+                        "VLLM_SM70_QWEN38_HYBRID_PLE",
+                        "VLLM_PLE_CPU_OFFLOAD",
+                        "VLLM_PLE_DISK_OFFLOAD",
+                    )
+                )
             ):
-                os.environ["VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL"] = "1"
+                os.environ["VLLM_SM70_QWEN38_HYBRID_PLE"] = "1"
+                os.environ["VLLM_PLE_CPU_OFFLOAD"] = "1"
+                os.environ["VLLM_PLE_DISK_OFFLOAD"] = "1"
                 logger.info_once(
-                    "Auto-enabling staged pinned-PLE prefill for the SM70 "
-                    "Qwen3.8 dual-compile lane; decode keeps direct UVA gathers."
+                    "Auto-enabling hybrid PLE for the SM70 Qwen3.8 "
+                    "dual-compile lane: async disk-mmap prefill plus local "
+                    "pinned-UVA decode."
                 )
             if _is_sm70_dflash2_verifier_contract(
                 self.model_config,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -170,6 +170,7 @@ if TYPE_CHECKING:
     VLLM_SM70_QWEN38_FP16_GEMV: bool = False
     VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16: bool = False
     VLLM_SM70_QWEN38_FUSED_HC_FP16: bool = False
+    VLLM_SM70_QWEN38_DUAL_COMPILE: bool = False
     VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = True
     VLLM_SM70_FP8_QPN8_PP2_TP4: bool = False
     VLLM_SM70_FP8_QPN8_PP2_TP4_SHARED_GATE: bool = False
@@ -3341,6 +3342,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
         )
         .strip()
         .lower()
+        in ("1", "true", "yes", "on")
+    ),
+    # Exact Qwen3.8 TP4 lane: trace the large dynamic prefill backbone and the
+    # small FULL decode backbone independently while sharing parameters/KV.
+    # Config auto-enables this only for the admitted no-MTP model contract.
+    "VLLM_SM70_QWEN38_DUAL_COMPILE": lambda: bool(
+        os.getenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "0").strip().lower()
         in ("1", "true", "yes", "on")
     ),
     # Diagnostic-only profiling knob. The SM70 compile-graph quality profile

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -561,6 +561,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
+    VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL: bool = False
     VLLM_SM70_ALLOW_COMPILE_CACHE_FOR_PROFILING: bool = False
     VLLM_SM70_SYNC_BEFORE_COMPILE_GRAPH_FORWARD: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_ELIMINATE_NOOPS: bool = False
@@ -3349,6 +3350,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Config auto-enables this only for the admitted no-MTP model contract.
     "VLLM_SM70_QWEN38_DUAL_COMPILE": lambda: bool(
         os.getenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "0").strip().lower()
+        in ("1", "true", "yes", "on")
+    ),
+    # Keep Qwen3.8 decode on low-latency UVA row reads, while large prefill
+    # gathers the same pinned-host shard into a contiguous transfer buffer.
+    "VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL": lambda: bool(
+        os.getenv("VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL", "0")
+        .strip()
+        .lower()
         in ("1", "true", "yes", "on")
     ),
     # Diagnostic-only profiling knob. The SM70 compile-graph quality profile

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -561,7 +561,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
-    VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL: bool = False
+    VLLM_SM70_QWEN38_HYBRID_PLE: bool = False
     VLLM_SM70_ALLOW_COMPILE_CACHE_FOR_PROFILING: bool = False
     VLLM_SM70_SYNC_BEFORE_COMPILE_GRAPH_FORWARD: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_ELIMINATE_NOOPS: bool = False
@@ -3352,12 +3352,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "0").strip().lower()
         in ("1", "true", "yes", "on")
     ),
-    # Keep Qwen3.8 decode on low-latency UVA row reads, while large prefill
-    # gathers the same pinned-host shard into a contiguous transfer buffer.
-    "VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL": lambda: bool(
-        os.getenv("VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL", "0")
-        .strip()
-        .lower()
+    # Keep local pinned-host PLE shards for Qwen3.8 decode while its prefill
+    # uses the asynchronous CPU/disk-mmap offload result.
+    "VLLM_SM70_QWEN38_HYBRID_PLE": lambda: bool(
+        os.getenv("VLLM_SM70_QWEN38_HYBRID_PLE", "0").strip().lower()
         in ("1", "true", "yes", "on")
     ),
     # Diagnostic-only profiling knob. The SM70 compile-graph quality profile

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn.functional as F
 
 import vllm.envs as envs
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.distributed import (
     get_ep_group,
     get_pcp_group,
@@ -598,6 +599,8 @@ class MoERunner(MoERunnerInterface):
         fused_output: torch.Tensor,
     ) -> bool:
         if shared_output is None or not envs.VLLM_SM70_MOE_ADD_ALLREDUCE:
+            return False
+        if envs.VLLM_SM70_QWEN38_DUAL_COMPILE and not use_sm70_decode_graph_semantics():
             return False
         if not current_platform.is_cuda():
             return False

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 # Import kernels
 import vllm.kernels  # noqa: F401
 from vllm import envs, ir
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
@@ -395,6 +396,7 @@ class GemmaRMSNorm(CustomOp):
         return (
             envs.VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE
             and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+            and use_sm70_decode_graph_semantics()
             and torch.compiler.is_compiling()
             and x.is_cuda
         )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -15,6 +15,7 @@ from torch import nn
 from vllm import _sm70_ops as sm70_ops
 from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     divide,
@@ -1353,7 +1354,11 @@ def _sm70_compile_graph_slice_dim(
 ) -> torch.Tensor:
     if dim < 0:
         dim += tensor.ndim
-    if start == 0 or not envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH:
+    if (
+        start == 0
+        or not envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+        or not use_sm70_decode_graph_semantics()
+    ):
         slices = [slice(None)] * tensor.ndim
         slices[dim] = slice(start, start + size)
         return tensor[tuple(slices)]
@@ -2676,7 +2681,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         group_width_qkvz = q_size + k_size + v_size + z_size
         group_width_ba = 2 * ba_size
 
-        if envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH:
+        if (
+            envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+            and use_sm70_decode_graph_semantics()
+        ):
             q_idx = _sm70_compile_graph_interleaved_indices(
                 ng, group_width_qkvz, 0, q_size, mixed_qkvz.device
             )
@@ -2790,7 +2798,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         z_start = value_start + v_size
         a_start = ba_size
 
-        if envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH:
+        if (
+            envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+            and use_sm70_decode_graph_semantics()
+        ):
             q_idx = _sm70_compile_graph_interleaved_indices(
                 ng, group_width_qkvz, 0, q_size, mixed_qkvz.device
             )
@@ -4135,6 +4146,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
         use_qwen38_fused_input = bool(
             getattr(self, "sm70_qwen38_fp16_fused_input", False)
+            and use_sm70_decode_graph_semantics()
             and not _sm70_gdn_projection_dump_requested(layer_name)
         )
         if use_qwen38_fused_input:

--- a/vllm/model_executor/layers/ple_offload_layer.py
+++ b/vllm/model_executor/layers/ple_offload_layer.py
@@ -28,6 +28,7 @@ from cuda.bindings.driver import CUstreamWaitValue_flags
 from torch import nn
 
 import vllm.envs as envs
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.utils.torch_utils import direct_register_custom_op
 
 # Module-level flag set to True inside the offload subprocess.
@@ -198,7 +199,11 @@ class PleOffloadLayer(nn.Module, ABC):
         def guarded_init(
             self: "PleOffloadLayer", *args: object, **kwargs: object
         ) -> None:
-            if envs.VLLM_PLE_CPU_OFFLOAD and not is_offload_process():
+            if (
+                envs.VLLM_PLE_CPU_OFFLOAD
+                and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
+                and not is_offload_process()
+            ):
                 nn.Module.__init__(self)
                 return
             original_init(self, *args, **kwargs)
@@ -208,7 +213,9 @@ class PleOffloadLayer(nn.Module, ABC):
     @classmethod
     def get_target_device(cls) -> torch.device:
         """Return CPU for the offload process and the active GPU otherwise."""
-        if envs.VLLM_PLE_CPU_OFFLOAD:
+        if envs.VLLM_PLE_CPU_OFFLOAD and not (
+            envs.VLLM_SM70_QWEN38_HYBRID_PLE and not is_offload_process()
+        ):
             return torch.device("cpu")
         return torch.device("cuda", torch.accelerator.current_device_index())
 
@@ -246,6 +253,11 @@ class PleOffloadLayer(nn.Module, ABC):
     ) -> torch.Tensor:
         """Wait for an offloaded result or delegate to ``forward_impl``."""
         if self._is_cpu_offloaded:
+            if (
+                envs.VLLM_SM70_QWEN38_HYBRID_PLE
+                and use_sm70_decode_graph_semantics()
+            ):
+                return self.forward_impl(hidden_states, input_ids, *args, **kwargs)
             torch.ops.vllm.ple_offload_wait(
                 self._sem.flag_tensor,
                 self._gpu_output_buffer,

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen4Exp model."""
 
+import copy
 from collections.abc import Iterable
 from itertools import islice
 
@@ -10,6 +11,7 @@ from torch import nn
 
 from vllm import envs
 from vllm.compilation.decorators import support_torch_compile
+from vllm.compilation.sm70_decode_graph import is_sm70_decode_graph_compiling
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
@@ -710,6 +712,70 @@ class Qwen4ExpModel(nn.Module):
         return loaded
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "query_start_loc": 0,
+        "ngram_context": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class _Qwen4ExpDecodeGraphModel(nn.Module):
+    """Second compiled view of a Qwen4Exp backbone with shared parameters."""
+
+    def __init__(
+        self,
+        *,
+        target_model: Qwen4ExpModel,
+        vllm_config: VllmConfig,
+    ) -> None:
+        super().__init__()
+        # This is a non-owning view. Registering the target as a child would
+        # duplicate every checkpoint key and runtime-state traversal.
+        object.__setattr__(self, "_target_model", target_model)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        query_start_loc: torch.Tensor | None = None,
+        ngram_context: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self._target_model.forward(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            query_start_loc,
+            ngram_context,
+            deepstack_input_embeds,
+        )
+
+
+def _make_qwen38_decode_compile_config(vllm_config: VllmConfig) -> VllmConfig:
+    """Build a small-shape compiler config without copying model state."""
+    decode_config = copy.copy(vllm_config)
+    decode_config.scheduler_config = copy.copy(vllm_config.scheduler_config)
+    decode_config.compilation_config = copy.copy(vllm_config.compilation_config)
+
+    compilation_config = decode_config.compilation_config
+    capture_sizes = compilation_config.cudagraph_capture_sizes or [1]
+    max_decode_tokens = max(capture_sizes)
+    decode_config.scheduler_config.max_num_batched_tokens = max_decode_tokens
+    compilation_config.compile_ranges_endpoints = [max_decode_tokens]
+    compilation_config.compile_sizes = []
+    compilation_config.cache_dir = ""
+    compilation_config.local_cache_dir = ""
+    compilation_config.traced_files = set()
+    return decode_config
+
+
 class Qwen4ExpForCausalLM(
     nn.Module,
     HasInnerState,
@@ -767,6 +833,25 @@ class Qwen4ExpForCausalLM(
         enable_qwen38_sm70_fp16_fused_hc(
             self, self.model_config.dtype, self.vllm_config
         )
+        object.__setattr__(self, "_sm70_decode_graph_model", None)
+
+    def prepare_sm70_decode_graph_model(self) -> bool:
+        """Create the shared-weight decode compiler just before graph capture."""
+        if not envs.VLLM_SM70_QWEN38_DUAL_COMPILE:
+            return False
+        if self._sm70_decode_graph_model is None:
+            decode_config = _make_qwen38_decode_compile_config(self.vllm_config)
+            decode_model = _Qwen4ExpDecodeGraphModel(
+                target_model=self.model,
+                vllm_config=decode_config,
+            )
+            object.__setattr__(self, "_sm70_decode_graph_model", decode_model)
+            logger.info_once(
+                "Prepared shared-weight SM70 Qwen3.8 decode compiler for token "
+                "range [1, %d]; large prefill keeps its independent graph.",
+                decode_config.scheduler_config.max_num_batched_tokens,
+            )
+        return True
 
     @staticmethod
     def get_model_state_cls():
@@ -784,7 +869,15 @@ class Qwen4ExpForCausalLM(
     ) -> torch.Tensor | IntermediateTensors:
         # Forward kwargs unchanged so the runner's _maybe_add_ngram_kwargs
         # path (query_start_loc / ngram_context) reaches Qwen4ExpModel.
-        return self.model(
+        backbone = self.model
+        if envs.VLLM_SM70_QWEN38_DUAL_COMPILE and is_sm70_decode_graph_compiling():
+            decode_backbone = self._sm70_decode_graph_model
+            if decode_backbone is None:
+                raise RuntimeError(
+                    "SM70 Qwen3.8 decode graph compiler was not prepared"
+                )
+            backbone = decode_backbone
+        return backbone(
             input_ids,
             positions,
             intermediate_tensors,

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -12,7 +12,7 @@ from torch import nn
 from vllm import envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.compilation.sm70_decode_graph import is_sm70_decode_graph_compiling
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
@@ -841,10 +841,11 @@ class Qwen4ExpForCausalLM(
             return False
         if self._sm70_decode_graph_model is None:
             decode_config = _make_qwen38_decode_compile_config(self.vllm_config)
-            decode_model = _Qwen4ExpDecodeGraphModel(
-                target_model=self.model,
-                vllm_config=decode_config,
-            )
+            with set_current_vllm_config(decode_config):
+                decode_model = _Qwen4ExpDecodeGraphModel(
+                    target_model=self.model,
+                    vllm_config=decode_config,
+                )
             object.__setattr__(self, "_sm70_decode_graph_model", decode_model)
             logger.info_once(
                 "Prepared shared-weight SM70 Qwen3.8 decode compiler for token "

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -1198,6 +1198,10 @@ class Qwen4ExpForConditionalGeneration(
     def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.language_model.get_top_tokens(hidden_states)
 
+    def prepare_sm70_decode_graph_model(self) -> bool:
+        """Forward decode compiler setup to the wrapped language model."""
+        return self.language_model.prepare_sm70_decode_graph_model()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
@@ -1215,7 +1219,7 @@ class Qwen4ExpForConditionalGeneration(
         else:
             deepstack_input_embeds = None
 
-        hidden_states = self.language_model.model(
+        hidden_states = self.language_model(
             input_ids=input_ids,
             positions=positions,
             intermediate_tensors=intermediate_tensors,

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -369,33 +369,6 @@ def _should_use_pinned_host_ple(config: Qwen4ExpTextConfig) -> bool:
     return capability is not None and capability.to_int() == 70
 
 
-def _gather_pinned_ple_rows_cpu(
-    weight_bytes: torch.Tensor,
-    input_ids: torch.Tensor,
-    output_bytes: torch.Tensor,
-) -> int:
-    """Gather local PLE rows through a deduplicated CPU memory access."""
-    if weight_bytes.device.type != "cpu" or weight_bytes.dtype != torch.uint8:
-        raise TypeError("PLE staged weight must be a CPU uint8 tensor")
-    if input_ids.device.type != "cpu" or input_ids.dtype != torch.int64:
-        raise TypeError("PLE staged IDs must be a CPU int64 tensor")
-    if output_bytes.device.type != "cpu" or output_bytes.dtype != torch.uint8:
-        raise TypeError("PLE staged output must be a CPU uint8 tensor")
-
-    ids_numpy = input_ids.reshape(-1).numpy()
-    unique_ids, inverse = np.unique(ids_numpy, return_inverse=True)
-    if unique_ids.size and (
-        unique_ids[0] < 0 or unique_ids[-1] >= weight_bytes.shape[0]
-    ):
-        raise IndexError(
-            "PLE staged row id out of range: "
-            f"[{unique_ids[0]}, {unique_ids[-1]}] for {weight_bytes.shape[0]} rows"
-        )
-    selected = weight_bytes.numpy()[unique_ids]
-    np.take(selected, inverse, axis=0, out=output_bytes.numpy())
-    return int(unique_ids.size)
-
-
 class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
     """TP-sharded FP8 PLE table backed directly by pinned host memory.
 
@@ -412,8 +385,6 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         params_dtype: torch.dtype | None,
         padding_size: int,
         prefix: str,
-        layer_name: str,
-        max_lookup_rows: int,
         quant_method: QuantizeMethodBase,
     ) -> None:
         if not is_pin_memory_available():
@@ -459,26 +430,7 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         )
         self._accelerator_weight_views: dict[int, torch.Tensor] = {}
         self._accelerator_weight_ptrs: dict[int, int] = {}
-        self._staged_device_bytes: dict[int, torch.Tensor] = {}
         self._output_dtype = self.weight_scale.dtype
-        self.layer_name = layer_name
-        self.max_lookup_rows = max_lookup_rows
-        self._staged_prefill_enabled = (
-            envs.VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL
-        )
-        if self._staged_prefill_enabled:
-            self._staged_host_ids = torch.empty(
-                max_lookup_rows,
-                dtype=torch.int64,
-                device="cpu",
-                pin_memory=True,
-            )
-            self._staged_host_bytes = torch.empty(
-                (max_lookup_rows, self.embedding_dim),
-                dtype=torch.uint8,
-                device="cpu",
-                pin_memory=True,
-            )
         logger.info(
             "Qwen4Exp PLE shard allocated in pinned host memory: %s",
             format_gib(self.weight.numel() * self.weight.element_size()),
@@ -504,15 +456,6 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 view = get_accelerator_view_from_cpu_tensor(self.weight)
             self._accelerator_weight_views[device_index] = view
             self._accelerator_weight_ptrs[device_index] = view.data_ptr()
-        if (
-            self._staged_prefill_enabled
-            and device_index not in self._staged_device_bytes
-        ):
-            self._staged_device_bytes[device_index] = torch.empty(
-                (self.max_lookup_rows, self.embedding_dim),
-                dtype=torch.uint8,
-                device=device,
-            )
         return view
 
     def prepare_accelerator_weight(self) -> None:
@@ -543,53 +486,8 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
             self.weight_scale,
             weight_ptr,
             self.embedding_dim,
-            self.layer_name,
         )
         return output
-
-    def staged_prefill_lookup(
-        self,
-        input_: torch.Tensor,
-        output: torch.Tensor,
-        weight_scale: torch.Tensor,
-    ) -> None:
-        """Gather pinned FP8 rows on CPU, then issue one contiguous H2D copy."""
-        flat_ids = input_.reshape(-1)
-        num_rows = flat_ids.numel()
-        if num_rows > self.max_lookup_rows:
-            raise RuntimeError(
-                "Qwen3.8 staged PLE prefill exceeds its workspace: "
-                f"{num_rows} > {self.max_lookup_rows} rows"
-            )
-        device_index = (
-            torch.accelerator.current_device_index()
-            if input_.device.index is None
-            else input_.device.index
-        )
-        device_bytes = self._staged_device_bytes.get(device_index)
-        if device_bytes is None:
-            raise RuntimeError("Qwen3.8 staged PLE device buffer was not prepared")
-
-        started = time.perf_counter()
-        host_ids = self._staged_host_ids[:num_rows]
-        host_ids.copy_(flat_ids, non_blocking=True)
-        torch.cuda.current_stream(input_.device).synchronize()
-        host_bytes = self._staged_host_bytes[:num_rows]
-        unique_rows = _gather_pinned_ple_rows_cpu(
-            self.weight.view(torch.uint8),
-            host_ids,
-            host_bytes,
-        )
-        device_slice = device_bytes[:num_rows]
-        device_slice.copy_(host_bytes, non_blocking=True)
-        qwen4_exp_ple_fp8_bytes_dequant(device_slice, weight_scale, output)
-        logger.info_once(
-            "Qwen3.8 staged pinned-PLE prefill active: rows=%d unique=%d "
-            "D2H+CPU-gather=%.3f ms; decode retains direct UVA.",
-            num_rows,
-            unique_rows,
-            (time.perf_counter() - started) * 1000.0,
-        )
 
 
 class Qwen4ExpNGramEmbedding(PleOffloadLayer):
@@ -731,8 +629,6 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                 params_dtype=params_dtype,
                 padding_size=divisor,
                 prefix=embedding_prefix,
-                layer_name=layer_name,
-                max_lookup_rows=max_total_tokens * self.ngram_heads,
                 quant_method=quant_method,
             )
         else:
@@ -1021,7 +917,11 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
         # GPU workers keep only the scale required to dequantize the FP8 rows
         # returned by the CPU process. The embedding weights live exclusively
         # in that process.
-        if envs.VLLM_PLE_CPU_OFFLOAD and not is_offload_process():
+        if (
+            envs.VLLM_PLE_CPU_OFFLOAD
+            and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
+            and not is_offload_process()
+        ):
             retained: set[str] = set()
             for name, loaded_weight in weights:
                 if name != "ngram_embedding.weight_scale":
@@ -1901,21 +1801,8 @@ def qwen4_exp_ple_pinned_gather(
     weight_scale: torch.Tensor,
     weight_ptr: int,
     embedding_dim: int,
-    layer_name: str,
 ) -> None:
     if input_ids.numel() == 0:
-        return
-    if (
-        envs.VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL
-        and input_ids.numel() >= 1024
-    ):
-        layer = get_forward_context().no_compile_layers[layer_name]
-        embedding = layer.ple_embedding.ngram_embedding
-        if not isinstance(embedding, Qwen4ExpPinnedHostEmbedding):
-            raise TypeError(
-                "Qwen3.8 staged PLE route requires Qwen4ExpPinnedHostEmbedding"
-            )
-        embedding.staged_prefill_lookup(input_ids, output, weight_scale)
         return
     block_d = triton.next_power_of_2(embedding_dim)
     _gather_ple_fp8_from_pinned_kernel[(input_ids.numel(),)](
@@ -1935,7 +1822,6 @@ def qwen4_exp_ple_pinned_gather_fake(
     weight_scale: torch.Tensor,
     weight_ptr: int,
     embedding_dim: int,
-    layer_name: str,
 ) -> None:
     return
 

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -369,6 +369,33 @@ def _should_use_pinned_host_ple(config: Qwen4ExpTextConfig) -> bool:
     return capability is not None and capability.to_int() == 70
 
 
+def _gather_pinned_ple_rows_cpu(
+    weight_bytes: torch.Tensor,
+    input_ids: torch.Tensor,
+    output_bytes: torch.Tensor,
+) -> int:
+    """Gather local PLE rows through a deduplicated CPU memory access."""
+    if weight_bytes.device.type != "cpu" or weight_bytes.dtype != torch.uint8:
+        raise TypeError("PLE staged weight must be a CPU uint8 tensor")
+    if input_ids.device.type != "cpu" or input_ids.dtype != torch.int64:
+        raise TypeError("PLE staged IDs must be a CPU int64 tensor")
+    if output_bytes.device.type != "cpu" or output_bytes.dtype != torch.uint8:
+        raise TypeError("PLE staged output must be a CPU uint8 tensor")
+
+    ids_numpy = input_ids.reshape(-1).numpy()
+    unique_ids, inverse = np.unique(ids_numpy, return_inverse=True)
+    if unique_ids.size and (
+        unique_ids[0] < 0 or unique_ids[-1] >= weight_bytes.shape[0]
+    ):
+        raise IndexError(
+            "PLE staged row id out of range: "
+            f"[{unique_ids[0]}, {unique_ids[-1]}] for {weight_bytes.shape[0]} rows"
+        )
+    selected = weight_bytes.numpy()[unique_ids]
+    np.take(selected, inverse, axis=0, out=output_bytes.numpy())
+    return int(unique_ids.size)
+
+
 class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
     """TP-sharded FP8 PLE table backed directly by pinned host memory.
 
@@ -385,6 +412,8 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         params_dtype: torch.dtype | None,
         padding_size: int,
         prefix: str,
+        layer_name: str,
+        max_lookup_rows: int,
         quant_method: QuantizeMethodBase,
     ) -> None:
         if not is_pin_memory_available():
@@ -430,7 +459,26 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         )
         self._accelerator_weight_views: dict[int, torch.Tensor] = {}
         self._accelerator_weight_ptrs: dict[int, int] = {}
+        self._staged_device_bytes: dict[int, torch.Tensor] = {}
         self._output_dtype = self.weight_scale.dtype
+        self.layer_name = layer_name
+        self.max_lookup_rows = max_lookup_rows
+        self._staged_prefill_enabled = (
+            envs.VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL
+        )
+        if self._staged_prefill_enabled:
+            self._staged_host_ids = torch.empty(
+                max_lookup_rows,
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=True,
+            )
+            self._staged_host_bytes = torch.empty(
+                (max_lookup_rows, self.embedding_dim),
+                dtype=torch.uint8,
+                device="cpu",
+                pin_memory=True,
+            )
         logger.info(
             "Qwen4Exp PLE shard allocated in pinned host memory: %s",
             format_gib(self.weight.numel() * self.weight.element_size()),
@@ -456,6 +504,15 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 view = get_accelerator_view_from_cpu_tensor(self.weight)
             self._accelerator_weight_views[device_index] = view
             self._accelerator_weight_ptrs[device_index] = view.data_ptr()
+        if (
+            self._staged_prefill_enabled
+            and device_index not in self._staged_device_bytes
+        ):
+            self._staged_device_bytes[device_index] = torch.empty(
+                (self.max_lookup_rows, self.embedding_dim),
+                dtype=torch.uint8,
+                device=device,
+            )
         return view
 
     def prepare_accelerator_weight(self) -> None:
@@ -486,8 +543,53 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
             self.weight_scale,
             weight_ptr,
             self.embedding_dim,
+            self.layer_name,
         )
         return output
+
+    def staged_prefill_lookup(
+        self,
+        input_: torch.Tensor,
+        output: torch.Tensor,
+        weight_scale: torch.Tensor,
+    ) -> None:
+        """Gather pinned FP8 rows on CPU, then issue one contiguous H2D copy."""
+        flat_ids = input_.reshape(-1)
+        num_rows = flat_ids.numel()
+        if num_rows > self.max_lookup_rows:
+            raise RuntimeError(
+                "Qwen3.8 staged PLE prefill exceeds its workspace: "
+                f"{num_rows} > {self.max_lookup_rows} rows"
+            )
+        device_index = (
+            torch.accelerator.current_device_index()
+            if input_.device.index is None
+            else input_.device.index
+        )
+        device_bytes = self._staged_device_bytes.get(device_index)
+        if device_bytes is None:
+            raise RuntimeError("Qwen3.8 staged PLE device buffer was not prepared")
+
+        started = time.perf_counter()
+        host_ids = self._staged_host_ids[:num_rows]
+        host_ids.copy_(flat_ids, non_blocking=True)
+        torch.cuda.current_stream(input_.device).synchronize()
+        host_bytes = self._staged_host_bytes[:num_rows]
+        unique_rows = _gather_pinned_ple_rows_cpu(
+            self.weight.view(torch.uint8),
+            host_ids,
+            host_bytes,
+        )
+        device_slice = device_bytes[:num_rows]
+        device_slice.copy_(host_bytes, non_blocking=True)
+        qwen4_exp_ple_fp8_bytes_dequant(device_slice, weight_scale, output)
+        logger.info_once(
+            "Qwen3.8 staged pinned-PLE prefill active: rows=%d unique=%d "
+            "D2H+CPU-gather=%.3f ms; decode retains direct UVA.",
+            num_rows,
+            unique_rows,
+            (time.perf_counter() - started) * 1000.0,
+        )
 
 
 class Qwen4ExpNGramEmbedding(PleOffloadLayer):
@@ -629,6 +731,8 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                 params_dtype=params_dtype,
                 padding_size=divisor,
                 prefix=embedding_prefix,
+                layer_name=layer_name,
+                max_lookup_rows=max_total_tokens * self.ngram_heads,
                 quant_method=quant_method,
             )
         else:
@@ -1797,8 +1901,21 @@ def qwen4_exp_ple_pinned_gather(
     weight_scale: torch.Tensor,
     weight_ptr: int,
     embedding_dim: int,
+    layer_name: str,
 ) -> None:
     if input_ids.numel() == 0:
+        return
+    if (
+        envs.VLLM_SM70_QWEN38_PINNED_PLE_STAGED_PREFILL
+        and input_ids.numel() >= 1024
+    ):
+        layer = get_forward_context().no_compile_layers[layer_name]
+        embedding = layer.ple_embedding.ngram_embedding
+        if not isinstance(embedding, Qwen4ExpPinnedHostEmbedding):
+            raise TypeError(
+                "Qwen3.8 staged PLE route requires Qwen4ExpPinnedHostEmbedding"
+            )
+        embedding.staged_prefill_lookup(input_ids, output, weight_scale)
         return
     block_d = triton.next_power_of_2(embedding_dim)
     _gather_ple_fp8_from_pinned_kernel[(input_ids.numel(),)](
@@ -1818,6 +1935,7 @@ def qwen4_exp_ple_pinned_gather_fake(
     weight_scale: torch.Tensor,
     weight_ptr: int,
     embedding_dim: int,
+    layer_name: str,
 ) -> None:
     return
 

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
@@ -15,6 +15,7 @@ import torch
 from torch import nn
 
 import vllm.envs as envs
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
@@ -264,7 +265,7 @@ class Qwen38SM70FP16LinearMethod(UnquantizedLinearMethod):
         # The first dynamic compile sees prefill (M > 1). Keep the M=1
         # decision inside the opaque op so decode does not inherit a baked-in
         # prefill branch.
-        if bias is None:
+        if bias is None and use_sm70_decode_graph_semantics():
             return torch.ops.vllm.qwen38_sm70_fp16_gemv(x, layer.weight)
         return super().apply(layer, x, bias)
 

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_hc.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_hc.py
@@ -8,6 +8,7 @@ import torch
 from torch import nn
 
 import vllm.envs as envs
+from vllm.compilation.sm70_decode_graph import use_sm70_decode_graph_semantics
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -193,7 +194,7 @@ def maybe_apply_qwen38_sm70_fp16_fused_hc(
     x: torch.Tensor,
     enabled: bool,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
-    if not enabled:
+    if not enabled or not use_sm70_decode_graph_semantics():
         return None
     down_weight = getattr(down_layer, "weight", None)
     up_weight = getattr(up_layer, "weight", None)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -612,7 +612,10 @@ class WorkerProc:
 
         # Load model
         self.worker.init_device()
-        if envs.VLLM_PLE_CPU_OFFLOAD:
+        if (
+            envs.VLLM_PLE_CPU_OFFLOAD
+            and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
+        ):
             self.worker.spawn_ple_offload()
         # Update process title now that parallel groups are initialized
         self.setup_proc_title_and_log_prefix(
@@ -622,6 +625,11 @@ class WorkerProc:
             self.worker.elastic_ep_execute("load_model")
         else:
             self.worker.load_model()
+        if envs.VLLM_SM70_QWEN38_HYBRID_PLE:
+            # Hybrid mode retains a large pinned shard in every TP worker.
+            # Load those shards before the file-backed PLE worker scans the
+            # checkpoint so startup does not create avoidable memory pressure.
+            self.worker.spawn_ple_offload()
         if envs.VLLM_PLE_CPU_OFFLOAD:
             self.worker.wait_ple_offload_ready()
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -617,6 +617,8 @@ class WorkerProc:
             and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
         ):
             self.worker.spawn_ple_offload()
+        elif envs.VLLM_SM70_QWEN38_HYBRID_PLE:
+            self.worker.prepare_ple_offload_spawn()
         # Update process title now that parallel groups are initialized
         self.setup_proc_title_and_log_prefix(
             enable_ep=vllm_config.parallel_config.enable_expert_parallel

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -63,13 +63,18 @@ class UniProcExecutor(Executor):
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
 
-        if envs.VLLM_PLE_CPU_OFFLOAD:
+        if (
+            envs.VLLM_PLE_CPU_OFFLOAD
+            and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
+        ):
             self.driver_worker.spawn_ple_offload()
 
         if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
             self.driver_worker.elastic_ep_execute("load_model")
         else:
             self.driver_worker.load_model()
+        if envs.VLLM_SM70_QWEN38_HYBRID_PLE:
+            self.driver_worker.spawn_ple_offload()
         if envs.VLLM_PLE_CPU_OFFLOAD:
             self.driver_worker.wait_ple_offload_ready()
         current_platform.update_block_size_for_backend(self.vllm_config)

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -68,6 +68,8 @@ class UniProcExecutor(Executor):
             and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
         ):
             self.driver_worker.spawn_ple_offload()
+        elif envs.VLLM_SM70_QWEN38_HYBRID_PLE:
+            self.driver_worker.prepare_ple_offload_spawn()
 
         if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
             self.driver_worker.elastic_ep_execute("load_model")

--- a/vllm/v1/ple_offload/connector.py
+++ b/vllm/v1/ple_offload/connector.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import zmq
 from cuda.bindings import driver as cuda_driver
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_dp_group, get_tp_group
 from vllm.logger import init_logger
@@ -432,10 +433,13 @@ class PleOffloadConnector:
         num_reqs: int,
         num_tokens: int,
         dummy_run: bool,
+        use_local_model: bool = False,
     ) -> None:
         """Submit real inputs or satisfy the PLE wait for a dummy forward."""
         if dummy_run:
             self.signal_dummy_outputs(num_tokens)
+            return
+        if envs.VLLM_SM70_QWEN38_HYBRID_PLE and use_local_model:
             return
         self._launch(num_reqs, num_tokens)
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
+from vllm.compilation.sm70_decode_graph import sm70_decode_graph_compilation
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.config.speculative import (
@@ -465,14 +466,17 @@ class ModelCudaGraphManager(CudaGraphManager):
                     batch_descriptor = BatchDescriptor(
                         num_tokens=num_tokens, has_lora=has_lora
                     )
-                with set_forward_context(
-                    attn_metadata,
-                    self.vllm_config,
-                    num_tokens=num_tokens,
-                    cudagraph_runtime_mode=cg_mode,
-                    num_tokens_across_dp=num_tokens_across_dp,
-                    slot_mapping=slot_mappings,
-                    batch_descriptor=batch_descriptor,
+                with (
+                    sm70_decode_graph_compilation(desc.cg_mode == CUDAGraphMode.FULL),
+                    set_forward_context(
+                        attn_metadata,
+                        self.vllm_config,
+                        num_tokens=num_tokens,
+                        cudagraph_runtime_mode=cg_mode,
+                        num_tokens_across_dp=num_tokens_across_dp,
+                        slot_mapping=slot_mappings,
+                        batch_descriptor=batch_descriptor,
+                    ),
                 ):
                     model_output = model(**model_inputs)
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -889,6 +889,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if self._ple_offload_connector is not None:
             self._ple_offload_connector.signal_dummy_outputs(self.max_num_tokens)
+        prepare_decode_graph_model = getattr(
+            self.model, "prepare_sm70_decode_graph_model", None
+        )
+        if prepare_decode_graph_model is not None:
+            prepare_decode_graph_model()
         with self.maybe_setup_dummy_loras(self.lora_config):
             captured_attn_states = self.cudagraph_manager.capture(
                 self.model,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1482,6 +1482,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 input_batch.num_reqs,
                 input_batch.num_tokens_after_padding,
                 dummy_run,
+                use_local_model=batch_desc.cg_mode == CUDAGraphMode.FULL,
             )
         if not self.is_first_pp_rank:
             # Update for non-first PP ranks.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -155,6 +155,15 @@ class Worker(WorkerBase):
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
         self._ple_offload_worker_handle: Any | None = None
+        if envs.VLLM_SM70_QWEN38_HYBRID_PLE and not (
+            envs.VLLM_SM70_QWEN38_DUAL_COMPILE
+            and envs.VLLM_PLE_CPU_OFFLOAD
+            and envs.VLLM_PLE_DISK_OFFLOAD
+        ):
+            raise ValueError(
+                "VLLM_SM70_QWEN38_HYBRID_PLE requires dual compilation plus "
+                "PLE CPU and disk offload"
+            )
         if envs.VLLM_PLE_DISK_OFFLOAD and not envs.VLLM_PLE_CPU_OFFLOAD:
             raise ValueError("VLLM_PLE_DISK_OFFLOAD requires VLLM_PLE_CPU_OFFLOAD=1")
         self._ple_offload_enabled = self._has_ple_layers()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -6,6 +6,7 @@ import gc
 import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
+from copy import deepcopy
 from datetime import timedelta
 from types import NoneType
 from typing import TYPE_CHECKING, Any
@@ -155,6 +156,7 @@ class Worker(WorkerBase):
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
         self._ple_offload_worker_handle: Any | None = None
+        self._ple_offload_spawn_config: VllmConfig | None = None
         if envs.VLLM_SM70_QWEN38_HYBRID_PLE and not (
             envs.VLLM_SM70_QWEN38_DUAL_COMPILE
             and envs.VLLM_PLE_CPU_OFFLOAD
@@ -248,11 +250,27 @@ class Worker(WorkerBase):
             num_workers,
             ipc_addr,
         )
+        spawn_config = self._ple_offload_spawn_config or self.vllm_config
+        self._ple_offload_spawn_config = None
         self._ple_offload_worker_handle = PleOffloadWorker.make_process(
-            self.vllm_config,
+            spawn_config,
             num_workers,
             ipc_addr,
         )
+
+    def prepare_ple_offload_spawn(self) -> None:
+        """Freeze the small pre-load config used by delayed hybrid spawn."""
+        if (
+            not self._ple_offload_enabled
+            or self.rank != 0
+            or self.parallel_config.data_parallel_rank != 0
+        ):
+            return
+        # Model loading attaches local weight-loader closures to parameters.
+        # Those closures make the live config graph unpicklable under spawn.
+        # The offload process historically received the pre-load config, so
+        # retain that exact contract while delaying only process creation.
+        self._ple_offload_spawn_config = deepcopy(self.vllm_config)
 
     def wait_ple_offload_ready(self) -> None:
         if self._ple_offload_worker_handle is None:


### PR DESCRIPTION
## Purpose

Keep the established Qwen3.8 large-prefill graph and no-MTP decode fast graph in one TP4 service without duplicating parameters or KV/state caches. Prefill uses async disk-mmap PLE plus the original FlashQLA-SM70 TileLang GDN path; FULL decode uses rank-local pinned PLE and the M=1 graph operators.

## Test Plan

- Focused CPU config/phase and delayed-spawn tests
- Exact TP4 NVFP4 no-MTP repeated 8K and 256K prefill
- Exact TP4 513-token pure decode throughput
- Greedy arithmetic, Chinese response, and thinking-parser quality gates
- Authenticated local and 1cattunnel API probes

## Test Result

- Focused dual-graph tests: 5 passed
- Delayed PLE spawn/executor tests: 3 passed
- Ruff, py_compile, and `git diff --check`: passed
- Startup: zero systemd restarts; mmap worker retained 47.684 GiB in file-backed mappings with about 1.3 GiB RSS
- Graph audit: `(1,8193)` contains `ple_offload_wait` and no decode-only M=1 operators; `(1,2)` contains local pinned PLE gather plus FP16 GEMV/fused HC/fused GDN
- 8K exact hash `8aab945ad780...`: 6,878 and 6,984 prompt tok/s warm (historical matched result: 7,026 tok/s)
- No-MTP decode: 513 tokens / 5.9602 s = 86.07 tok/s
- 256K gate: 262,143 prompt + 1 output; 51.8063 s pure prefill = 5,060 tok/s
- Prefix caching disabled; maximum model length 262,144; V2 runner; TP4 V100; FP16 KV; NVFP4 checkpoint
- Quality: `173*29 -> 5017`, `41*37 -> 1517`, accurate two-sentence Chinese lunar-phase answer; thinking exposed in `message.reasoning`
- Authenticated local and public `/v1/models`: HTTP 200
