### PR TITLE
[CI] Fix Qwen3.8 pre-commit gates

### DIFF
--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -102,9 +102,7 @@ def test_qwen38_hybrid_ple_skips_decode_offload_request(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_SM70_QWEN38_HYBRID_PLE", "1")
     launches: list[tuple[int, int]] = []
     connector = SimpleNamespace(
-        _launch=lambda num_reqs, num_tokens: launches.append(
-            (num_reqs, num_tokens)
-        )
+        _launch=lambda num_reqs, num_tokens: launches.append((num_reqs, num_tokens))
     )
 
     PleOffloadConnector.prepare_forward(

--- a/tests/v1/worker/test_ple_offload_worker.py
+++ b/tests/v1/worker/test_ple_offload_worker.py
@@ -664,18 +664,24 @@ def test_delayed_ple_spawn_uses_pre_load_config_snapshot(
         _ple_offload_ipc_path="ipc:///tmp/test-ple-offload",
     )
 
+    def fake_make_process(*args: object) -> object:
+        calls.append(args)
+        return object()
+
     monkeypatch.setattr(
         ple_offload_worker.PleOffloadWorker,
         "make_process",
-        lambda *args: calls.append(args) or object(),
+        fake_make_process,
     )
 
     worker.prepare_ple_offload_spawn()
     worker.vllm_config.markers.append("model-load-mutation")
     worker.spawn_ple_offload()
 
-    assert calls[0][0].markers == []
-    assert calls[0][0] is not worker.vllm_config
+    spawn_config = calls[0][0]
+    assert isinstance(spawn_config, SimpleNamespace)
+    assert spawn_config.markers == []
+    assert spawn_config is not worker.vllm_config
     assert worker._ple_offload_spawn_config is None
 
 

--- a/vllm/model_executor/layers/ple_offload_layer.py
+++ b/vllm/model_executor/layers/ple_offload_layer.py
@@ -253,10 +253,7 @@ class PleOffloadLayer(nn.Module, ABC):
     ) -> torch.Tensor:
         """Wait for an offloaded result or delegate to ``forward_impl``."""
         if self._is_cpu_offloaded:
-            if (
-                envs.VLLM_SM70_QWEN38_HYBRID_PLE
-                and use_sm70_decode_graph_semantics()
-            ):
+            if envs.VLLM_SM70_QWEN38_HYBRID_PLE and use_sm70_decode_graph_semantics():
                 return self.forward_impl(hidden_states, input_ids, *args, **kwargs)
             torch.ops.vllm.ple_offload_wait(
                 self._sem.flag_tensor,

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -612,10 +612,7 @@ class WorkerProc:
 
         # Load model
         self.worker.init_device()
-        if (
-            envs.VLLM_PLE_CPU_OFFLOAD
-            and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
-        ):
+        if envs.VLLM_PLE_CPU_OFFLOAD and not envs.VLLM_SM70_QWEN38_HYBRID_PLE:
             self.worker.spawn_ple_offload()
         elif envs.VLLM_SM70_QWEN38_HYBRID_PLE:
             self.worker.prepare_ple_offload_spawn()

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -63,10 +63,7 @@ class UniProcExecutor(Executor):
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
 
-        if (
-            envs.VLLM_PLE_CPU_OFFLOAD
-            and not envs.VLLM_SM70_QWEN38_HYBRID_PLE
-        ):
+        if envs.VLLM_PLE_CPU_OFFLOAD and not envs.VLLM_SM70_QWEN38_HYBRID_PLE:
             self.driver_worker.spawn_ple_offload()
         elif envs.VLLM_SM70_QWEN38_HYBRID_PLE:
             self.driver_worker.prepare_ple_offload_spawn()


### PR DESCRIPTION
## Purpose

Fix the post-merge pre-commit failures from #477 without changing runtime semantics.

## Base and scope

- Base SHA: `b295ab94afeddb875b03ddbd0f0171fa3ab83f38`
- Head SHA: `7388c6f98c`
- Replace a mypy-invalid mock lambda with an explicit function and narrow the captured config type.
- Apply the exact Ruff formatter output reported by CI to four files.

## Test Plan and Result

- Focused hybrid PLE/dual-graph tests: 6 passed
- Ruff format: passed
- Ruff check: passed
- mypy Python 3.11: passed
- mypy Python 3.12: passed
- mypy Python 3.13: passed
- `git diff --check`: passed

No production behavior or performance path changes.