### PR TITLE
[Model] Accept the qwen_sparse_attention layer_type spelling

### DIFF
--- a/vllm/models/qwen4_exp/config.py
+++ b/vllm/models/qwen4_exp/config.py
@@ -64,6 +64,16 @@ class Qwen4ExpTextConfig(Qwen3NextConfig):
 
         rope_scaling = kwargs.get("rope_scaling")
         rope_theta = kwargs.get("rope_theta", 10_000.0)
+        # Newer Qwen4Exp exports spell the QSA attention layers
+        # "qwen_sparse_attention"; older ones say "full_attention". They select
+        # the same path (Qwen4ExpQSAAttention is used whenever indexer_n_heads
+        # is set), so normalize here -- one place covers the decoder layers, the
+        # MTP head and the KV-cache spec.
+        if layer_types is not None:
+            layer_types = [
+                "full_attention" if lt == "qwen_sparse_attention" else lt
+                for lt in layer_types
+            ]
         super().__init__(layer_types=layer_types, **kwargs)
 
         normalized_rope_parameters = self.rope_parameters


### PR DESCRIPTION
Newer Qwen4Exp exports label the QSA attention layers `qwen_sparse_attention`; older ones say `full_attention`. Both select the same code path — the decoder layer picks `Qwen4ExpQSAAttention` for `full_attention` whenever `indexer_n_heads` is set, and it is set (4) in both configs — so a checkpoint using the newer spelling fails at startup with `Invalid layer_type qwen_sparse_attention`.

Normalizing once in `Qwen4ExpTextConfig` covers the decoder layers, the MTP head and the KV-cache spec in one place.

`git grep qwen_sparse_attention -- vllm/` is empty on `main`, so nothing else handles the spelling today.

**Tested:** 4× V100-SXM2, TP4, CUDA 12.8, a Qwen3.8-Flash-Next checkpoint whose `config.json` uses the newer spelling. Fails to start without this, serves normally with it. `ruff check` and `ruff format` clean.
