### PR TITLE
[Bugfix][SM70] Don't hand unvalidated shapes to the channel-FP8 GEMM

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -84,6 +84,35 @@ def _sm70_channel_fp8_qpn8_config(
     return _SM70_CHANNEL_FP8_QPN8_CONFIGS.get((k_dim, n_dim))
 
 
+def _sm70_channel_fp8_shape_is_validated(layer: torch.nn.Module) -> bool:
+    """Whether an SM70 channel-FP8 GEMM has been validated for this shape.
+
+    ``_SM70_CHANNEL_FP8_QPN8_SHAPES`` is the only record of which dense shapes
+    have been exercised on SM70. ``fp8_gemm_sm70_out`` does not raise on the
+    others -- it spins without returning -- so the layout conversion below is
+    gated on this instead of on the QPN8 route being selected.
+    """
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    return tuple(layer.weight.shape) == _SM70_CHANNEL_FP8_QPN8_SHAPES.get(suffix)
+
+
+def _sm70_unpack_channel_fp8(layer: torch.nn.Module) -> None:
+    """Dequantize channel-FP8 weights to the model dtype, in place.
+
+    FP8 E4M3 to FP16 is exact, so this costs one extra byte per element on the
+    affected projections and nothing in accuracy.
+    """
+    scale = layer.weight_scale.data.to(torch.float32)
+    if scale.ndim == 1:
+        scale = scale.view(-1, 1)
+    dequantized = (layer.weight.data.to(torch.float32) * scale).to(layer.orig_dtype)
+    replace_parameter(layer, "weight", dequantized)
+    for stale in ("weight_scale", "weight_scale_inv", "input_scale"):
+        if stale in layer._parameters:
+            del layer._parameters[stale]
+    layer.sm70_fp8_fp16_dequant = True
+
+
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def __init__(
         self,
@@ -271,6 +300,20 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
                         "Insufficient memory for the SM70 channel-FP8 QPN8 "
                         "prefill workspace; retaining the TurboMind layout."
                     )
+            if not _sm70_channel_fp8_shape_is_validated(layer):
+                # No validated SM70 tile covers this shape. fp8_gemm_sm70_out
+                # neither falls back nor raises on such shapes: it spins,
+                # leaving the GPU at 100% utilization near idle power with no
+                # progress and no error. Unpack instead, which is exact.
+                logger.warning_once(
+                    "No validated SM70 channel-FP8 GEMM covers %s with shape "
+                    "%s; unpacking these weights to %s instead.",
+                    getattr(layer, "prefix", "<unknown>"),
+                    tuple(layer.weight.shape),
+                    layer.orig_dtype,
+                )
+                _sm70_unpack_channel_fp8(layer)
+                return
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 layer.weight, weight_scale, 128, False
             )
@@ -317,6 +360,8 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "sm70_fp8_fp16_dequant", False):
+            return torch.nn.functional.linear(x, layer.weight, bias)
         if getattr(layer, "sm70_fp8_turbomind", False):
             if x.dtype != torch.float16:
                 raise RuntimeError(


### PR DESCRIPTION
## The bug

On SM70, `CompressedTensorsW8A16Fp8.process_weights_after_loading` converts **every** channel-FP8 dense layer to the TurboMind layout when the QPN8 route isn't taken — including when it was skipped because `_sm70_channel_fp8_qpn8_config()` found no entry for the layer's shape:

```python
            if qpn8_config is not None and qpn8_concurrency:
                ...
                    return                      # QPN8 route
                if missing_ops: ...
                else: ...
            tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(...)   # <- everything else lands here
            layer.sm70_fp8_turbomind = True
```

`fp8_gemm_sm70_out` has no tile for those shapes, and it neither falls back nor raises — **it spins**. The symptom is a load that never finishes, GPUs pinned at 100% utilization near idle power, no progress, no error, no timeout.

`_SM70_CHANNEL_FP8_QPN8_SHAPES` currently lists one model's six per-rank shapes, so **any other channel-FP8 checkpoint hits this on its first forward pass**.

## Reproduction

4× V100-SXM2 32GB, TP4, CUDA 12.8, `VLLM_SM70_FP8_TURBOMIND=1`, with a hidden=2560 Qwen3.8-Flash-Next checkpoint whose dense projections are channel-FP8. Per-rank shapes, none of which are in the table:

| projection | per-rank (N, K) |
|---|---|
| `in_proj_qkvz` | (4096, 2560) |
| `qkv_proj` | (3328, 2560) |
| `o_proj` / `out_proj` | (2560, 1536) |
| `gate_up_proj` | (320, 2560) |
| `down_proj` | (2560, 160) |

Startup reaches the first forward pass and stops there indefinitely.

## The fix

Gate the layout conversion on the shape being in the table, and dequantize the rest to the model dtype. FP8 E4M3 → FP16 is exact, so this costs one extra byte per element on the affected projections and **nothing in accuracy**.

Purely additive — 45 lines, no deletions, no changes to the shape table or to any tuning data.

**Shapes that are in the table are untouched.** That includes the deliberate non-QPN8 TurboMind path taken when MTP is enabled or `max_num_seqs` exceeds 8, and the `tp_size != 4` case. Checked directly against the current table:

```
in_proj_qkvz  (4096, 5120)  -> validated=True    # unchanged, TurboMind
qkv_proj      (3584, 5120)  -> validated=True    # unchanged, TurboMind
down_proj     (5120, 4352)  -> validated=True    # unchanged, TurboMind
in_proj_qkvz  (4096, 2560)  -> validated=False   # was: hang.  now: unpack
qkv_proj      (3328, 2560)  -> validated=False   # was: hang.  now: unpack
o_proj        (2560, 1536)  -> validated=False   # was: hang.  now: unpack
gate_up_proj  ( 320, 2560)  -> validated=False   # was: hang.  now: unpack
down_proj     (2560,  160)  -> validated=False   # was: hang.  now: unpack
```

`ruff check` and `ruff format` clean on the touched file.

## One thing I'd like your call on

Reading `_SM70_CHANNEL_FP8_QPN8_SHAPES` as "the validated set for the TurboMind GEMM" is an inference — it's the only such record in the file, but it's named for QPN8. If you'd rather **raise a clear error** than silently unpack, or track TurboMind tile coverage separately from QPN8 coverage, say so and I'll rework it. Either beats the current hang.
