### PR TITLE
[Bugfix][SM70] Skip final mixer weights on non-last PP ranks

### DIFF
--- a/tests/models/qwen4_exp/test_weight_loading.py
+++ b/tests/models/qwen4_exp/test_weight_loading.py
@@ -405,3 +405,41 @@ def test_qsa_e4m3_skips_scale_gate_in_ple_offload_process(
     assert not attention._qsa_kv_scales_finalized
     assert attention.k_scale.item() == -1.0
     assert attention.v_scale.item() == -1.0
+
+
+def test_loader_skips_final_mixer_on_non_last_pp_rank(monkeypatch) -> None:
+    """The final hyper-connection mixer exists only on the last PP rank;
+    other ranks must skip its checkpoint tensors instead of failing."""
+    captured: dict[str, list[str]] = {}
+
+    class _CaptureLoader:
+        def __init__(self, module, *, skip_substrs=None, ignore_unexpected_suffixes=None):
+            captured["skip"] = list(skip_substrs or [])
+
+        def load_weights(self, weights, mapper=None):
+            list(weights)
+            return set()
+
+    monkeypatch.setattr(qwen4_exp_model, "AutoWeightsLoader", _CaptureLoader)
+    self_stub = SimpleNamespace(
+        _qsa_layer_ids=frozenset(),
+        config=SimpleNamespace(num_experts=0),
+        hf_to_vllm_mapper=None,
+    )
+
+    monkeypatch.setattr(
+        qwen4_exp_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=False),
+    )
+    Qwen4ExpModel.load_weights(self_stub, iter([]))
+    assert "hyper_connection_mixer." in captured["skip"]
+
+    monkeypatch.setattr(
+        qwen4_exp_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True),
+    )
+    Qwen4ExpModel.load_weights(self_stub, iter([]))
+    assert "hyper_connection_mixer." not in captured["skip"]
+    assert "hyper_connection_mixer.block_inject_weight" in captured["skip"]

--- a/vllm/models/qwen4_exp/amd/model.py
+++ b/vllm/models/qwen4_exp/amd/model.py
@@ -596,6 +596,11 @@ class Qwen4ExpModel(nn.Module):
             "token_lookup",
             "hyper_connection_mixer.block_inject_weight",
         ]
+        if not get_pp_group().is_last_rank:
+            # The final hyper-connection mixer only exists on the last
+            # pipeline rank (see __init__); other ranks must skip its
+            # checkpoint tensors instead of failing the load.
+            skip_substrs.append("hyper_connection_mixer.")
         loader = AutoWeightsLoader(
             self,
             skip_substrs=skip_substrs,

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -700,6 +700,11 @@ class Qwen4ExpModel(nn.Module):
             "token_lookup",
             "hyper_connection_mixer.block_inject_weight",
         ]
+        if not get_pp_group().is_last_rank:
+            # The final hyper-connection mixer only exists on the last
+            # pipeline rank (see __init__); other ranks must skip its
+            # checkpoint tensors instead of failing the load.
+            skip_substrs.append("hyper_connection_mixer.")
         loader = AutoWeightsLoader(
             self,
             skip_substrs=skip_substrs,


### PR DESCRIPTION
## Purpose

Qwen4Exp instantiates the final `hyper_connection_mixer` only on the last pipeline rank (`if get_pp_group().is_last_rank` in `Qwen4ExpModel.__init__`), but `load_weights` only skips its `block_inject_weight` alias. On every other rank the remaining mixer tensors (`hc_norm.weight`, `input_mix_weight_*`) crash the load with *"There is no module or parameter named 'hyper_connection_mixer' in Qwen4ExpModel"*, so the model cannot boot under pipeline parallelism at all — for any TP size, since the condition only depends on the PP rank. This is the loader-level blocker described in #479; the two intentional PLE gates discussed there are untouched. The fix extends `skip_substrs` with the whole mixer prefix on non-last ranks, symmetrically in the `nvidia/` and `amd/` trees.

## Test Plan

- New test `test_loader_skips_final_mixer_on_non_last_pp_rank` in `tests/models/qwen4_exp/test_weight_loading.py`: captures the `skip_substrs` handed to `AutoWeightsLoader` and asserts the mixer prefix is skipped on non-last ranks and *not* skipped on the last rank (where `block_inject_weight` alone must remain).
- Reproduction before the fix: `RadixArk/Qwen3.8-Flash-Next-NVFP4`, TP2/PP2, `--language-model-only` → rank-0 load crash as above; with the fix the load proceeds to the (separate) PLE gates.

## Test Result

- Targeted test passes against the 1.5.0 wheel plus this patch (the full current suite imports main-only symbols such as `_finalize_qsa_e4m3_scale_load`, so it needs your CI's source tree; the new test itself has no such dependency).
- The identical change has been serving in our fork's PP bring-up (mixed 2x RTX 8000 + 3x V100) since 2026-09-03.

This PR was prepared with AI assistance (Claude); reviewed and submitted by Peuqui.
