### PR TITLE
[Bugfix][SM70] Enable Qwen3.8 AWQ in dual-compile lane

### DIFF
--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -13,6 +13,40 @@ from vllm.compilation.sm70_decode_graph import (
 from vllm.config.vllm import _is_sm70_qwen38_nomtp_dual_compile_contract
 
 
+def _qwen38_model_config(
+    architecture: str,
+    *,
+    language_model_only: bool | None = None,
+    quantization: str | None = None,
+) -> SimpleNamespace:
+    text_config = SimpleNamespace(
+        hidden_size=2560,
+        num_hidden_layers=48,
+        num_experts=512,
+        num_experts_per_tok=10,
+        moe_intermediate_size=640,
+        hc_count=4,
+        hc_lowrank=320,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+    )
+    multimodal_config = (
+        None
+        if language_model_only is None
+        else SimpleNamespace(language_model_only=language_model_only)
+    )
+    return SimpleNamespace(
+        architectures=(architecture,),
+        dtype=torch.float16,
+        hf_text_config=text_config,
+        multimodal_config=multimodal_config,
+        quantization=quantization,
+    )
+
+
 def test_sm70_decode_graph_compilation_context(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_SM70_QWEN38_DUAL_COMPILE", "1")
 
@@ -30,25 +64,7 @@ def test_sm70_decode_graph_legacy_semantics(monkeypatch) -> None:
 
 
 def test_qwen38_nomtp_dual_compile_contract() -> None:
-    text_config = SimpleNamespace(
-        hidden_size=2560,
-        num_hidden_layers=48,
-        num_experts=512,
-        num_experts_per_tok=10,
-        moe_intermediate_size=640,
-        hc_count=4,
-        hc_lowrank=320,
-        num_attention_heads=24,
-        num_key_value_heads=2,
-        indexer_head_dim=128,
-        indexer_budget=2048,
-        indexer_compress_ratio=4,
-    )
-    model_config = SimpleNamespace(
-        architectures=("Qwen4ExpForCausalLM",),
-        dtype=torch.float16,
-        hf_text_config=text_config,
-    )
+    model_config = _qwen38_model_config("Qwen4ExpForCausalLM")
     parallel_config = SimpleNamespace(
         tensor_parallel_size=4,
         pipeline_parallel_size=1,
@@ -61,6 +77,32 @@ def test_qwen38_nomtp_dual_compile_contract() -> None:
         model_config, SimpleNamespace(method="mtp"), parallel_config
     )
     parallel_config.tensor_parallel_size = 2
+    assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, None, parallel_config
+    )
+
+
+def test_qwen38_nomtp_dual_compile_contract_accepts_awq_lm_only_wrapper() -> None:
+    model_config = _qwen38_model_config(
+        "Qwen4ExpForConditionalGeneration",
+        language_model_only=True,
+        quantization="awq",
+    )
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=4,
+        pipeline_parallel_size=1,
+    )
+
+    assert _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, None, parallel_config
+    )
+
+    model_config.multimodal_config.language_model_only = False
+    assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
+        model_config, None, parallel_config
+    )
+
+    model_config.multimodal_config = None
     assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
         model_config, None, parallel_config
     )

--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from types import SimpleNamespace
 
 import torch
@@ -10,7 +11,11 @@ from vllm.compilation.sm70_decode_graph import (
     sm70_decode_graph_compilation,
     use_sm70_decode_graph_semantics,
 )
-from vllm.config.vllm import _is_sm70_qwen38_nomtp_dual_compile_contract
+from vllm.config.parallel import ParallelConfig
+from vllm.config.vllm import (
+    _apply_sm70_qwen38_hybrid_ple_defaults,
+    _is_sm70_qwen38_nomtp_dual_compile_contract,
+)
 
 
 def _qwen38_model_config(
@@ -106,6 +111,29 @@ def test_qwen38_nomtp_dual_compile_contract_accepts_awq_lm_only_wrapper() -> Non
     assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
         model_config, None, parallel_config
     )
+
+
+def test_parallel_config_initializes_ple_ipc_after_late_auto_enable(
+    monkeypatch,
+) -> None:
+    for env_name in (
+        "VLLM_SM70_QWEN38_HYBRID_PLE",
+        "VLLM_PLE_CPU_OFFLOAD",
+        "VLLM_PLE_DISK_OFFLOAD",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    parallel_config = ParallelConfig()
+    assert parallel_config._ple_offload_ipc_path == ""
+
+    _apply_sm70_qwen38_hybrid_ple_defaults(parallel_config)
+    ipc_path = parallel_config._ple_offload_ipc_path
+
+    assert os.environ["VLLM_SM70_QWEN38_HYBRID_PLE"] == "1"
+    assert os.environ["VLLM_PLE_CPU_OFFLOAD"] == "1"
+    assert os.environ["VLLM_PLE_DISK_OFFLOAD"] == "1"
+    assert ipc_path.startswith("ipc://")
+    parallel_config.ensure_ple_offload_ipc_path()
+    assert parallel_config._ple_offload_ipc_path == ipc_path
 
 
 def test_qwen38_hybrid_ple_decode_uses_local_module(monkeypatch) -> None:

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -431,8 +431,8 @@ class ParallelConfig:
                 f"but found: {self._api_process_rank}"
             )
 
-        if envs.VLLM_PLE_CPU_OFFLOAD and not self._ple_offload_ipc_path:
-            self._ple_offload_ipc_path = get_open_zmq_ipc_path()
+        if envs.VLLM_PLE_CPU_OFFLOAD:
+            self.ensure_ple_offload_ipc_path()
 
         if self.all2all_backend in ["pplx", "naive"]:
             logger.warning(
@@ -500,6 +500,11 @@ class ParallelConfig:
             )
 
         return self
+
+    def ensure_ple_offload_ipc_path(self) -> None:
+        """Initialize the shared PLE endpoint after late config defaults."""
+        if not self._ple_offload_ipc_path:
+            self._ple_offload_ipc_path = get_open_zmq_ipc_path()
 
     @property
     def world_size_across_dp(self) -> int:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -203,6 +203,19 @@ def _apply_sm70_dflash2_verifier_defaults() -> tuple[str, ...]:
     return tuple(applied)
 
 
+def _apply_sm70_qwen38_hybrid_ple_defaults(
+    parallel_config: ParallelConfig,
+) -> None:
+    """Enable hybrid PLE and complete its late-bound parallel config."""
+    os.environ["VLLM_SM70_QWEN38_HYBRID_PLE"] = "1"
+    os.environ["VLLM_PLE_CPU_OFFLOAD"] = "1"
+    os.environ["VLLM_PLE_DISK_OFFLOAD"] = "1"
+    # ParallelConfig is validated before these model-aware defaults are
+    # applied, so initialize the endpoint that its validator would have
+    # created for an explicit PLE configuration.
+    parallel_config.ensure_ple_offload_ipc_path()
+
+
 def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
     max_graph_reqs = min(max(int(max_num_seqs), 1), 16)
     capture_sizes = {
@@ -1695,9 +1708,7 @@ class VllmConfig:
                     )
                 )
             ):
-                os.environ["VLLM_SM70_QWEN38_HYBRID_PLE"] = "1"
-                os.environ["VLLM_PLE_CPU_OFFLOAD"] = "1"
-                os.environ["VLLM_PLE_DISK_OFFLOAD"] = "1"
+                _apply_sm70_qwen38_hybrid_ple_defaults(self.parallel_config)
                 logger.info_once(
                     "Auto-enabling hybrid PLE for the SM70 Qwen3.8 "
                     "dual-compile lane: async disk-mmap prefill plus local "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -167,8 +167,14 @@ def _is_sm70_qwen38_nomtp_dual_compile_contract(
 
     hf_text_config = getattr(model_config, "hf_text_config", None)
     architectures = set(getattr(model_config, "architectures", ()) or ())
+    multimodal_config = getattr(model_config, "multimodal_config", None)
+    supported_architecture = "Qwen4ExpForCausalLM" in architectures or (
+        "Qwen4ExpForConditionalGeneration" in architectures
+        and multimodal_config is not None
+        and getattr(multimodal_config, "language_model_only", False)
+    )
     return bool(
-        "Qwen4ExpForCausalLM" in architectures
+        supported_architecture
         and getattr(model_config, "dtype", None) == torch.float16
         and getattr(hf_text_config, "hidden_size", None) == 2560
         and getattr(hf_text_config, "num_hidden_layers", None) == 48


### PR DESCRIPTION
## Purpose

Follow up on #477 by admitting the Qwen3.8 AWQ text-only runtime to the
existing SM70 dual-compile lane.

The checkpoint keeps the outer `Qwen4ExpForConditionalGeneration`
architecture even when it is loaded with `--language-model-only`, while the
#477 contract admitted only `Qwen4ExpForCausalLM`. This change also accepts the
conditional-generation wrapper, but only when
`multimodal_config.language_model_only` is explicitly true. Full multimodal
loading and a missing multimodal config remain rejected.

Real TP4 validation then exposed a second late-binding issue. #477 enables
hybrid PLE from `VllmConfig.__post_init__`, after `ParallelConfig` validation
would normally allocate the shared PLE IPC endpoint. As a result, all workers
attempted to connect to an empty address and failed with
`zmq.error.ZMQError: Invalid argument (addr='')`.

This PR makes PLE endpoint initialization idempotent and invokes it when the
model-aware defaults enable PLE late. Explicit PLE configuration retains the
same behavior.

There are no AWQ kernel, quantization-math, weight-format, or scheduler
changes. Operator capability checks and existing fallbacks remain in place.
In particular, this PR does not address mixed-phase latency from chunked
prefill scheduling.

## Test Plan

- Run the focused dual-compile/config tests on the final branch.
- Run changed-file pre-commit checks.
- Start the real Qwen3.8 native-g32 AWQ checkpoint on 4x V100, TP4, FP16
  activations, KV auto, MTP0, prefix caching off, and
  `FULL_AND_PIECEWISE` compilation without explicitly setting the PLE envs.
- Exercise C1 x 64K, C4 x 64K, and C8 x 16K once per cell with streaming token
  timestamps, 320 requested output tokens, and `ignore_eos=false`.
- Repeat the same runtime contract with #464/#465/#470/#473 enabled together
  as an integration check.

## Test Result

- `.venv/bin/pytest -q --confcutdir=tests/compile tests/compile/test_sm70_decode_graph.py`:
  **7 passed**.
- Changed-file pre-commit suite: all applicable hooks passed, including Ruff,
  formatting, mypy, SPDX, configuration validation, and forbidden-import
  checks.
- Before the IPC fix, the real model completed weight loading but all four GPU
  workers reproduced the empty-address ZMQ failure.
- After the fix, both the post-#477 main-only arm and the four-PR integration
  arm completed startup. All four workers used the same non-empty IPC endpoint,
  PLE registered 4/4 workers, and the service built the large prefill graph plus
  decode capture sizes `[1, 8]`.
- Each arm completed all 13 requests in the three-cell contract. Every request
  returned 320 tokens with `finish_reason=length`; no traceback, OOM, or
  runtime worker exit was observed.
- The four-PR integration arm retained its memory benefit: model loading
  `21.24 -> 20.24 GiB/rank` and KV capacity `386,392 -> 505,574` tokens
  (`+30.85%`) versus the matched post-#477 main-only arm.
- The same run still measured C4 x 64K mixed-phase mean ITL at 2.841 s on
  main-only and 2.719 s on the four-PR stack. That scheduler behavior remains
  separate follow-up work.

AI assistance disclosure: OpenAI Codex assisted with implementation, test
execution, runtime evidence collation, and PR preparation. The submitter
reviewed the changes and validation results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and relationship to #477 are documented.
- [x] The test plan and commands are documented.
- [x] Unit, pre-commit, and real V100 results are documented.
- [x] Scope and remaining scheduler boundary are documented.

</details>
