### PR TITLE
[Bugfix][MRV2] Port upstream weight offloader lifecycle

### DIFF
--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -3,6 +3,15 @@
 
 import pytest
 
+import vllm.envs as envs
+from vllm.model_executor.offloader import (
+    PrefetchOffloader,
+    UVAOffloader,
+    get_offloader,
+    set_offloader,
+)
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
 from ..utils import compare_two_settings
 
 
@@ -27,3 +36,49 @@ def test_cpu_offload(disable_pin_memory, disable_uva):
         env1=None,
         env2=env_vars,
     )
+
+
+@pytest.mark.parametrize(
+    ("offload_kwargs", "offloader_type"),
+    [
+        ({"cpu_offload_gb": 1}, UVAOffloader),
+        (
+            {
+                "offload_group_size": 1,
+                "offload_num_in_group": 1,
+                "offload_prefetch_step": 1,
+            },
+            PrefetchOffloader,
+        ),
+    ],
+)
+def test_mrv2_weight_offloading(
+    vllm_runner, monkeypatch, offload_kwargs, offloader_type
+):
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    envs.disable_envs_cache()
+    original_offloader = get_offloader()
+
+    try:
+        with vllm_runner(
+            "hmellor/tiny-random-LlamaForCausalLM",
+            enforce_eager=True,
+            gpu_memory_utilization=0.02,
+            max_model_len=128,
+            max_num_seqs=1,
+            **offload_kwargs,
+        ) as vllm_model:
+            engine_core = vllm_model.llm.llm_engine.engine_core.engine_core
+            model_runner = engine_core.model_executor.driver_worker.worker.model_runner
+            assert isinstance(model_runner, GPUModelRunner)
+
+            offloader = get_offloader()
+            assert isinstance(offloader, offloader_type)
+            if isinstance(offloader, UVAOffloader):
+                assert offloader.cpu_offload_bytes > 0
+            else:
+                assert offloader.total_offloaded_bytes > 0
+                assert offloader.buffer_pool is not None
+    finally:
+        set_offloader(original_offloader)
+        envs.disable_envs_cache()

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 
+from vllm.config.offload import OffloadConfig
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.worker.gpu import eplb_utils as eplb
 from vllm.v1.worker.gpu import model_runner as mrv2
@@ -65,6 +66,7 @@ def _make_runner(**overrides: Any) -> Any:
     runner.vllm_config = SimpleNamespace(
         load_config=runner.load_config,
         model_config=runner.model_config,
+        offload_config=OffloadConfig(),
     )
     runner.lora_config = None
     runner.use_aux_hidden_state_outputs = False
@@ -84,9 +86,45 @@ def _make_runner(**overrides: Any) -> Any:
     runner.eplb = eplb.EPLBController(runner.parallel_config, runner.device)
     runner.pooling_runner = None
     runner.execute_model_state = None
+    runner._sm70_v2_mtp_profile_pending = None
     for key, value in overrides.items():
         setattr(runner, key, value)
     return runner
+
+
+def test_v2_load_model_finalizes_offloader_after_model_construction(monkeypatch):
+    FakeEplbState.instances.clear()
+    events: list[str] = []
+    model = SimpleNamespace(is_moe=False)
+
+    def load_model(**kwargs):
+        events.append("load_model")
+        return model
+
+    def init_model_state(*args):
+        events.append("init_model_state")
+        return "model-state"
+
+    offloader = SimpleNamespace(post_init=lambda: events.append("post_init"))
+
+    monkeypatch.setattr(mrv2, "DeviceMemoryProfiler", FakeMemoryProfiler)
+    monkeypatch.setattr(eplb, "EplbState", FakeEplbState)
+    monkeypatch.setattr(
+        mrv2,
+        "get_model_loader",
+        lambda load_config: SimpleNamespace(load_model=load_model),
+    )
+    monkeypatch.setattr(mrv2, "get_offloader", lambda: offloader)
+    monkeypatch.setattr(mrv2, "prepare_communication_buffer_for_model", lambda *_: None)
+    monkeypatch.setattr(mrv2, "init_model_state", init_model_state)
+    monkeypatch.setattr(eplb, "is_mixture_of_experts", lambda *_: False)
+
+    runner = _make_runner()
+    mrv2.GPUModelRunner.load_model(runner)
+
+    assert runner.model is model
+    assert runner.model_state == "model-state"
+    assert events == ["load_model", "init_model_state", "post_init"]
 
 
 def test_v2_load_model_registers_moe_with_eplb(monkeypatch):

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -44,6 +44,11 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
 from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.offloader import (
+    create_offloader,
+    get_offloader,
+    set_offloader,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
@@ -295,6 +300,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Expert parallelism load balancer.
         self.eplb = EPLBController(self.parallel_config, self.device)
 
+        set_offloader(create_offloader(self.vllm_config.offload_config))
+
     def _sm70_v2_mtp_profile_enabled(self) -> bool:
         return (
             self.speculative_config is not None
@@ -499,6 +506,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dtype=self.model_config.dtype,
                 device=self.device,
             )
+
+        get_offloader().post_init()
 
     def get_model(self) -> nn.Module:
         return self.model


### PR DESCRIPTION
## Purpose

1Cat main contains the weight-offloader framework and merged PR #297's selective multimodal-tower support, but it does not contain the MRV2 lifecycle wiring merged upstream in vllm-project/vllm#51413 and tested in #51440.

Consequently, MRV2 accepts explicit settings such as:

```text
--cpu-offload-gb 1 --cpu-offload-params visual
```

but leaves the process-global `NoopOffloader` installed. This PR backports the complete upstream lifecycle so existing UVA and prefetch choices take effect on MRV2.

## Upstream provenance

- [vllm-project/vllm#51413](https://github.com/vllm-project/vllm/pull/51413), merged 2026-08-07, installs the configured offloader during MRV2 initialization and calls `post_init()` after model construction.
- [vllm-project/vllm#51440](https://github.com/vllm-project/vllm/pull/51440), merged 2026-08-07, adds a non-vacuous MRV2 test for both UVA and prefetch backends.
- [vllm-project/vllm#48468](https://github.com/vllm-project/vllm/pull/48468) was the earlier external diagnosis and minimal UVA-effective patch. It remains open but was functionally superseded by #51413; credit is retained.
- Upstream later merged generic tower traversal in [#53120](https://github.com/vllm-project/vllm/pull/53120). 1Cat already has its own generic tower lifecycle from merged PR #297, so that code is outside this backport.

## Change

- Install `create_offloader(self.vllm_config.offload_config)` at the end of MRV2 initialization, matching upstream #51413.
- Call `get_offloader().post_init()` after model construction and model-dependent initialization. This is a no-op for UVA/Noop and is required for prefetch static-buffer allocation and initial prefetches.
- Port upstream #51440's integration assertion that MRV2 genuinely offloads bytes for both UVA and prefetch.
- Add a lightweight ordering regression test proving `post_init()` runs only after the model and model state exist.

The default remains unchanged: zero offload budgets select `NoopOffloader`. This enables an explicit choice; it does not enable offloading by default.

## Why this is not a duplicate

- Open-PR searches in `1CatAI/1Cat-vLLM` found no existing MRV2 offloader-lifecycle port.
- The merged upstream commits `a671679e9f` (#51413) and `c39076feff` (#51440) are not ancestors of 1Cat `main`; this is a fork backport, not a competing upstream implementation.
- 1Cat PR #297 covers tower selection/traversal, while this PR covers activation and finalization of the configured offloader in MRV2. Both are needed for visual-UVA on this fork.

## Validation

CPU-safe tests from the isolated source worktree:

```text
pytest -q tests/v1/worker/test_gpu_model_runner_v2_eplb.py --confcutdir=tests/v1/worker
# 5 passed, 14 warnings

pytest -q tests/model_executor/test_uva_tower_offload.py --confcutdir=tests/model_executor
# 4 passed, 14 warnings

pytest --collect-only -q tests/basic_correctness/test_cpu_offload.py
# 6 tests collected, including UVA and Prefetch MRV2 cases
```

Changed-file validation:

```text
pre-commit run --files vllm/v1/worker/gpu/model_runner.py tests/v1/worker/test_gpu_model_runner_v2_eplb.py tests/basic_correctness/test_cpu_offload.py
# all applicable hooks passed

git diff --check
# passed
```

The two GPU integration parametrizations ported from #51440 were not rerun during this revision to avoid reclaiming shared GPUs. Upstream reports both passing with this lifecycle. The visual-UVA path itself was previously exercised end-to-end on 4x V100 32 GB with the same create/set behavior (`post_init()` is a no-op for UVA):

- Explicit visual-UVA arms logged `Offloader set to UVAOffloader` and about 0.22 GiB offloaded per rank (about 0.88 GiB total).
- With a fixed 3 GiB KV cache, request peak fell from 27,256 to 27,020 MiB per card (-236 MiB/card; -944 MiB across four cards).
- With automatic KV sizing, capacity rose from 258,658 to 273,996 tokens (+15,338, +5.93%).
- All four arms completed 9/9 image/video requests; response fields were identical within each baseline/offload pair.

## Runtime boundary

This remains an opt-in capacity control, not a recommendation to enable visual-UVA by default:

- Full-lifecycle startup peak did not improve. In the fixed-KV comparison it increased from 32,164 to 32,288 MiB per card; the automatic-KV run reached up to 32,495 MiB on one card.
- New-media encoder latency increased by about 2.23-2.24x for images and 3.63-3.79x for video. Encoder-cache hits were close to baseline.

## AI assistance

OpenAI Codex assisted with repository archaeology, backport preparation, test adaptation, validation, and PR drafting. Leon directed the scope and acceptance criteria and authorized submission. This PR remains a draft pending maintainer line-by-line review before it is marked ready.

Credit: upstream lifecycle and integration-test code are based on #51413/#51440 by @yewentao256; the earlier diagnosis/minimal fix came from #48468 by @Looong01. Both are retained in commit attribution.
