### PR TITLE
[Bugfix] Preserve Mamba prefill progress with alignment regressions

### DIFF
--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -62,3 +62,37 @@ def test_chunks_stop_at_every_mamba_state_boundary() -> None:
         chunk_ends.append(position)
 
     assert chunk_ends == [816, 1632, 2448, prompt_len]
+
+
+@pytest.mark.parametrize("start", [0, 100, 816, 1000])
+def test_sub_block_encoder_budget_makes_progress(start: int) -> None:
+    request = SimpleNamespace(
+        num_computed_tokens=start,
+        num_prompt_tokens=3 * MAMBA_BLOCK_SIZE,
+        num_tokens=3 * MAMBA_BLOCK_SIZE,
+    )
+    # An encoder-cache boundary can limit this request even when the global
+    # token budget can accommodate a whole Mamba block.
+    assert _split(request, 79) == 79
+
+
+def test_repeated_sub_block_chunks_preserve_state_boundaries() -> None:
+    prompt_len = 2 * MAMBA_BLOCK_SIZE + 30
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=prompt_len,
+        num_tokens=prompt_len,
+    )
+    boundaries = []
+    while request.num_computed_tokens < prompt_len:
+        remaining = prompt_len - request.num_computed_tokens
+        chunk = _split(request, min(100, remaining))
+        assert 0 < chunk <= min(100, remaining)
+        previous = request.num_computed_tokens
+        request.num_computed_tokens += chunk
+        next_boundary = (previous // MAMBA_BLOCK_SIZE + 1) * MAMBA_BLOCK_SIZE
+        assert request.num_computed_tokens <= next_boundary
+        if request.num_computed_tokens == next_boundary:
+            boundaries.append(next_boundary)
+
+    assert boundaries == [816, 1632]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -441,12 +441,18 @@ class Scheduler(SchedulerInterface):
 
         end = start + num_new_tokens
         if end < prefill_end:
-            max_prefill_tokens = self.max_num_scheduled_tokens
-            long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
-            if long_prefill_threshold > 0:
-                max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
             aligned_end = end // block_size * block_size
-            if aligned_end > start or block_size <= max_prefill_tokens:
+            # Only take the aligned end when it advances past `start`. Otherwise
+            # this returns 0, the caller treats that as "cannot schedule", and
+            # the request is skipped on every step while it holds its KV blocks
+            # and encoder-cache entries. The condition recurs whenever the chunk
+            # available this step is shorter than one state block -- e.g. when
+            # the encoder-cache gate caps it just before an image placeholder --
+            # so the request starves indefinitely. Scheduling the shorter,
+            # unaligned chunk only skips this block's Mamba state checkpoint, and
+            # it cannot straddle two state blocks because `aligned_end <= start`
+            # implies `end < next_block_boundary`.
+            if aligned_end > start:
                 end = aligned_end
 
         # The align allocator materializes one recurrent-state column per


### PR DESCRIPTION
## Purpose

Integrate #472's fix for Mamba-aligned prefills that repeatedly receive less than one state block of work and stop making progress. Preserve the original scheduler fix and add regression coverage for short chunks at aligned and unaligned positions, repeated progress, and state-boundary preservation.

This is the maintainer's integration of #472, not a competing implementation. Base: `84c72f349d25c38e708943602ab976953b97a5d3`.

## Test Plan

Demonstrate the added regressions fail on main, then run the Mamba alignment suite with #472 applied and run changed-file pre-commit checks. No model E2E is planned.

## Test Result

All 5 added regressions fail on the original main because the split returns zero. With #472 applied, the complete `tests/v1/core/test_mamba_align_chunk_split.py` file passes (7 tests), including the existing state-boundary checks. Changed-file pre-commit checks pass. The original PR commit is retained as a merge parent and the integration commit is DCO-signed. No E2E run.

AI assistance: OpenAI Codex performed source review and test construction under the maintainer's authorization.
