### PR TITLE
[Doc] Integrate v100-skinny QPN provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,7 @@ Join the **1Cat-vLLM Open-Source Community Group 5** by scanning the latest QR c
 - [lmdeploy / TurboMind](https://github.com/InternLM/lmdeploy)
 - [flash-attention-v100](https://github.com/ai-bond/flash-attention-v100)
 - [marlin_v100](https://github.com/zhinianqin/marlin_v100)
+- [v100-skinny](https://github.com/dnv2003/v100-skinny) — QPN quadpair-N `m8n8k4` decode layout behind the SM70 QPN2 / QPN4 / QPN8 and MXFP4-QPN kernels (MIT; notice retained in `csrc/sm70_turbomind/ops/LICENSE.v100-skinny`)
 
 Special thanks to [@yangzhuxinyzx](https://github.com/yangzhuxinyzx) and [@1CatTCat](https://github.com/1CatTCat) for their outstanding contributions to the continued evolution and performance breakthroughs of **1Cat-vLLM**.
 

--- a/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
+++ b/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright contributors to the vLLM project
+//
+// The MXFP4 M=1 quadpair-N m8n8k4 layout is derived from dnv2003/v100-skinny (MIT).
+// See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
 #include <torch/all.h>
 

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Qwen3.8 NVFP4 M=1 decode kernels for NVIDIA Volta SM70.
+//
+// The QPN4 quadpair-N m8n8k4 layout is derived from dnv2003/v100-skinny (MIT).
+// See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
 #include <torch/all.h>
 #include <torch/library.h>


### PR DESCRIPTION
## Purpose

Integrate #443's missing v100-skinny attribution on the QPN4 and MXFP4-QPN adaptations, retaining the original contributor commit. Wrap one new source comment to satisfy the repository's clang-format gate. No executable code changes.

This is the maintainer's integration repair for #443, not a competing implementation. Base: `84c72f349d25c38e708943602ab976953b97a5d3`.

## Test Plan

Verify the retained MIT notice and corresponding QPN2/QPN8 attribution, then run changed-file pre-commit checks and inspect the final diff for comment/documentation-only changes.

## Test Result

All changed-file pre-commit checks pass. Verified that the MIT notice is present, attribution matches the existing QPN2/QPN8 source notices, and the diff changes only comments and README acknowledgement. The original PR commit is retained as a merge parent and the integration commit is DCO-signed. No runtime tests are needed for this documentation-only change.

AI assistance: OpenAI Codex performed review and formatting repair under the maintainer's authorization.
