### PR TITLE
[Kernel] Integrate compact AWQ metadata with current prefill buffers

### DIFF
--- a/benchmarks/benchmark_sm70_awq_compact_metadata.py
+++ b/benchmarks/benchmark_sm70_awq_compact_metadata.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validate compact SM70 AWQ metadata against the regular representation.
+
+The synthetic shapes match one Qwen3.8 TP4 expert shard.  The check is strict:
+the reconstructed metadata and every GEMM output must be bitwise identical.
+"""
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+
+GROUP_SIZE = 32
+QWEN38_NUM_EXPERTS = 512
+QWEN38_NUM_MOE_LAYERS = 48
+SHAPES = {
+    "w13": (2560, 320),
+    "w2": (160, 2560),
+}
+
+
+def _require_sm70() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+    capability = torch.cuda.get_device_capability()
+    if capability != (7, 0):
+        raise RuntimeError(f"Expected SM70, got sm_{capability[0]}{capability[1]}.")
+    if not hasattr(torch.ops._C, "awq_sm70_prepare_compact"):
+        raise RuntimeError("The build does not contain awq_sm70_prepare_compact.")
+
+
+def _make_awq_inputs(
+    k: int, n: int, seed: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    qweight = torch.randint(
+        -(1 << 31),
+        1 << 31,
+        (k, n // 8),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    qzeros = torch.randint(
+        -(1 << 31),
+        1 << 31,
+        (k // GROUP_SIZE, n // 8),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    scales = (
+        torch.rand(
+            (k // GROUP_SIZE, n),
+            dtype=torch.float16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.02
+        + 0.0001
+    )
+    return qweight, scales, qzeros
+
+
+def _bitwise_equal(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    return (
+        lhs.shape == rhs.shape
+        and lhs.dtype == rhs.dtype
+        and torch.equal(
+            lhs.contiguous().view(torch.uint8), rhs.contiguous().view(torch.uint8)
+        )
+    )
+
+
+def _prepare_pair(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    interleave_gated_silu: bool = False,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    regular = sm70_ops.awq_sm70_prepare(
+        qweight, scales, qzeros, GROUP_SIZE, interleave_gated_silu
+    )
+    compact = sm70_ops.awq_sm70_prepare_compact(
+        qweight, scales, qzeros, GROUP_SIZE, interleave_gated_silu
+    )
+    torch.cuda.synchronize()
+    return regular, compact
+
+
+def _rebuild_regular_stats(compact: torch.Tensor) -> torch.Tensor:
+    scale = compact[..., :2].contiguous().view(torch.float16).squeeze(-1)
+    zero = compact[..., 2].to(torch.float16)
+    bias = (-zero * scale).to(torch.float16)
+    rebuilt = torch.empty(
+        (*compact.shape[:-1], 4), dtype=torch.uint8, device=compact.device
+    )
+    rebuilt[..., :2] = compact[..., :2]
+    rebuilt[..., 2:] = (
+        bias.contiguous().view(torch.uint8).reshape(*compact.shape[:-1], 2)
+    )
+    return rebuilt.contiguous().view(torch.int32).squeeze(-1)
+
+
+def _gemm_out(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    prepared: list[torch.Tensor],
+) -> None:
+    weight, stats, meta = prepared
+    sm70_ops.awq_gemm_sm70_out(
+        out,
+        x,
+        weight,
+        stats,
+        GROUP_SIZE,
+        int(meta[0].item()),
+        int(meta[1].item()),
+        False,
+    )
+
+
+def _time_ms(fn: Any, warmup: int, iters: int, rounds: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(rounds):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) / iters)
+    return statistics.median(samples)
+
+
+def _check_dense_case(
+    name: str,
+    k: int,
+    n: int,
+    rows: list[int],
+    warmup: int,
+    iters: int,
+    rounds: int,
+) -> dict[str, Any]:
+    qweight, scales, qzeros = _make_awq_inputs(k, n, seed=100)
+    regular, compact = _prepare_pair(
+        qweight, scales, qzeros, interleave_gated_silu=name == "w13"
+    )
+    regular_weight, regular_stats, regular_meta = regular
+    compact_weight, compact_stats, compact_meta = compact
+
+    rebuilt = _rebuild_regular_stats(compact_stats)
+    checks = {
+        "weight_equal": torch.equal(regular_weight, compact_weight),
+        "stats_rebuild_equal": torch.equal(regular_stats, rebuilt),
+        "k_ld_equal": int(regular_meta[0]) == int(compact_meta[0]),
+        "q_ld_sign_contract": int(regular_meta[1]) == -int(compact_meta[1]),
+    }
+    if not all(checks.values()):
+        raise AssertionError(f"{name} prepare mismatch: {checks}")
+
+    timings = []
+    for m in rows:
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(1000 + m)
+        x = torch.randn((m, k), dtype=torch.float16, device="cuda", generator=generator)
+        regular_out = torch.empty((m, n), dtype=torch.float16, device="cuda")
+        compact_out = torch.empty_like(regular_out)
+        _gemm_out(regular_out, x, regular)
+        _gemm_out(compact_out, x, compact)
+        torch.cuda.synchronize()
+        if not _bitwise_equal(regular_out, compact_out):
+            max_diff = float((regular_out - compact_out).abs().max().item())
+            raise AssertionError(f"{name} m={m} output mismatch: {max_diff=}")
+
+        regular_ms = _time_ms(
+            lambda out=regular_out, input_x=x: _gemm_out(out, input_x, regular),
+            warmup,
+            iters,
+            rounds,
+        )
+        compact_ms = _time_ms(
+            lambda out=compact_out, input_x=x: _gemm_out(out, input_x, compact),
+            warmup,
+            iters,
+            rounds,
+        )
+        timings.append(
+            {
+                "m": m,
+                "regular_ms": regular_ms,
+                "compact_ms": compact_ms,
+                "compact_overhead_pct": (compact_ms / regular_ms - 1.0) * 100.0,
+                "output_equal": True,
+            }
+        )
+
+    graph_x = torch.randn((1, k), dtype=torch.float16, device="cuda")
+    graph_out = torch.empty((1, n), dtype=torch.float16, device="cuda")
+    _gemm_out(graph_out, graph_x, compact)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _gemm_out(graph_out, graph_x, compact)
+    graph_x.copy_(torch.randn_like(graph_x))
+    graph.replay()
+    regular_graph_out = torch.empty_like(graph_out)
+    _gemm_out(regular_graph_out, graph_x, regular)
+    torch.cuda.synchronize()
+    if not _bitwise_equal(graph_out, regular_graph_out):
+        raise AssertionError(f"{name} CUDA Graph replay mismatch")
+
+    return {
+        "name": name,
+        "k": k,
+        "n": n,
+        "checks": checks,
+        "regular_bytes": regular_stats.nbytes,
+        "compact_bytes": compact_stats.nbytes,
+        "saving_bytes": regular_stats.nbytes - compact_stats.nbytes,
+        "saving_pct": (regular_stats.nbytes - compact_stats.nbytes)
+        / regular_stats.nbytes
+        * 100.0,
+        "cuda_graph_equal": True,
+        "timings": timings,
+    }
+
+
+def _prepare_moe_stack(
+    name: str, experts: int
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+]:
+    k, n = SHAPES[name]
+    regular_weights = []
+    regular_stats = []
+    compact_weights = []
+    compact_stats = []
+    regular_meta = compact_meta = None
+    for expert_id in range(experts):
+        inputs = _make_awq_inputs(k, n, seed=200 + expert_id + 1000 * n)
+        regular, compact = _prepare_pair(*inputs, interleave_gated_silu=name == "w13")
+        regular_weights.append(regular[0])
+        regular_stats.append(regular[1])
+        compact_weights.append(compact[0])
+        compact_stats.append(compact[1])
+        regular_meta, compact_meta = regular[2], compact[2]
+
+    assert regular_meta is not None and compact_meta is not None
+    regular_weights_t = torch.stack(regular_weights)
+    regular_stats_t = torch.stack(regular_stats)
+    compact_weights_t = torch.stack(compact_weights)
+    compact_stats_t = torch.stack(compact_stats)
+    if not torch.equal(regular_weights_t, compact_weights_t):
+        raise AssertionError(f"{name} stacked weights differ")
+    if not torch.equal(regular_stats_t, _rebuild_regular_stats(compact_stats_t)):
+        raise AssertionError(f"{name} stacked metadata reconstruction differs")
+    regular_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+        regular_weights_t,
+        regular_stats_t,
+        int(regular_meta[0]),
+        int(regular_meta[1]),
+        experts,
+    )
+    compact_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+        compact_weights_t,
+        compact_stats_t,
+        int(compact_meta[0]),
+        int(compact_meta[1]),
+        experts,
+    )
+    return (
+        (regular_weights_t, regular_stats_t),
+        (compact_weights_t, compact_stats_t),
+        regular_ptrs,
+        compact_ptrs,
+    )
+
+
+def _check_moe_pointer_path(experts: int, rows_per_expert: int) -> dict[str, Any]:
+    if experts != QWEN38_NUM_EXPERTS:
+        raise ValueError(f"--experts must be {QWEN38_NUM_EXPERTS}.")
+    regular_w13, _compact_w13, regular_ptrs, compact_ptrs = _prepare_moe_stack(
+        "w13", experts
+    )
+    regular_w2, _compact_w2, regular_w2_ptrs, compact_w2_ptrs = _prepare_moe_stack(
+        "w2", experts
+    )
+    # StridedPtr stores raw, non-owning device addresses. Keep both stacked
+    # weight/stat tensors alive until every pointer-path launch has completed.
+
+    k, n = SHAPES["w13"]
+    total_rows = experts * rows_per_expert
+    x = torch.randn((total_rows, k), dtype=torch.float16, device="cuda")
+    offsets = torch.arange(
+        0,
+        total_rows + 1,
+        rows_per_expert,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    regular_out = torch.empty((total_rows, n), dtype=torch.float16, device="cuda")
+    compact_out = torch.empty_like(regular_out)
+    sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+        regular_out,
+        x,
+        offsets,
+        *regular_ptrs,
+        experts,
+        k,
+        n,
+        GROUP_SIZE,
+        False,
+    )
+    torch.cuda.synchronize()
+    regular_snapshot = regular_out.clone()
+    sm70_ops.awq_moe_gemm_sm70_per_expert_dispatch_out(
+        compact_out,
+        x,
+        offsets,
+        *compact_ptrs,
+        experts,
+        k,
+        n,
+        GROUP_SIZE,
+        False,
+    )
+    torch.cuda.synchronize()
+    if not _bitwise_equal(regular_snapshot, compact_out):
+        finite = torch.isfinite(regular_snapshot) & torch.isfinite(compact_out)
+        max_diff = (
+            float((regular_snapshot[finite] - compact_out[finite]).abs().max().item())
+            if finite.any()
+            else None
+        )
+        details = {
+            "max_finite_diff": max_diff,
+            "different_bytes": int(
+                (
+                    regular_snapshot.contiguous().view(torch.uint8)
+                    != compact_out.contiguous().view(torch.uint8)
+                )
+                .sum()
+                .item()
+            ),
+            "regular_nan": int(torch.isnan(regular_snapshot).sum().item()),
+            "compact_nan": int(torch.isnan(compact_out).sum().item()),
+            "regular_inf": int(torch.isinf(regular_snapshot).sum().item()),
+            "compact_inf": int(torch.isinf(compact_out).sum().item()),
+            "regular_corrupted_after_compact": not _bitwise_equal(
+                regular_snapshot, regular_out
+            ),
+        }
+        raise AssertionError(f"MoE pointer path mismatch: {details}")
+
+    top_k = min(experts, 10)
+    topk_ids = torch.arange(top_k - 1, -1, -1, dtype=torch.int32, device="cuda").view(
+        1, top_k
+    )
+    topk_weights = torch.arange(1, top_k + 1, dtype=torch.float32, device="cuda").view(
+        1, top_k
+    )
+    topk_weights /= topk_weights.sum()
+    single_input = torch.randn((1, k), dtype=torch.float16, device="cuda")
+
+    def _legacy_single_token(
+        w13_ptrs: list[torch.Tensor], w2_ptrs: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        row_bytes = int(w13_ptrs[0].numel() // experts)
+        final_output = torch.zeros((1, k), dtype=torch.float16, device="cuda")
+        intermediate = torch.empty(
+            (top_k, SHAPES["w2"][0]), dtype=torch.float16, device="cuda"
+        )
+        sorted_output = torch.empty(
+            (top_k, SHAPES["w2"][1]), dtype=torch.float16, device="cuda"
+        )
+        sm70_ops.awq_moe_single_token_sm70_out(
+            final_output,
+            single_input,
+            topk_weights,
+            topk_ids,
+            w13_ptrs[0].view(experts, row_bytes),
+            w13_ptrs[1].view(experts, row_bytes),
+            w2_ptrs[0].view(experts, row_bytes),
+            w2_ptrs[1].view(experts, row_bytes),
+            torch.empty((top_k, k), dtype=torch.float16, device="cuda"),
+            intermediate,
+            sorted_output,
+            torch.empty(top_k, dtype=torch.float32, device="cuda"),
+            torch.empty((top_k, row_bytes), dtype=torch.uint8, device="cuda"),
+            torch.empty((top_k, row_bytes), dtype=torch.uint8, device="cuda"),
+            torch.empty((top_k, row_bytes), dtype=torch.uint8, device="cuda"),
+            torch.empty((top_k, row_bytes), dtype=torch.uint8, device="cuda"),
+            torch.empty(top_k + 1, dtype=torch.int32, device="cuda"),
+            torch.empty(top_k, dtype=torch.int32, device="cuda"),
+            int(regular_w13[0].shape[1]),
+            SHAPES["w13"][1],
+            int(regular_w2[0].shape[1]),
+            SHAPES["w2"][1],
+            GROUP_SIZE,
+            k,
+        )
+        return final_output, intermediate, sorted_output
+
+    regular_single = _legacy_single_token(regular_ptrs, regular_w2_ptrs)
+    compact_single = _legacy_single_token(compact_ptrs, compact_w2_ptrs)
+    torch.cuda.synchronize()
+    single_token_equal = all(
+        _bitwise_equal(regular_tensor, compact_tensor)
+        for regular_tensor, compact_tensor in zip(regular_single, compact_single)
+    )
+    if not single_token_equal:
+        raise AssertionError("Legacy single-token MoE path mismatch")
+    return {
+        "experts": experts,
+        "rows_per_expert": rows_per_expert,
+        "output_equal": True,
+        "legacy_single_token_equal": single_token_equal,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", default="1,8,64,512")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--experts", type=int, default=QWEN38_NUM_EXPERTS)
+    parser.add_argument("--rows-per-expert", type=int, default=4)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    _require_sm70()
+    rows = [int(value) for value in args.rows.split(",")]
+    cases = [
+        _check_dense_case(
+            name,
+            *shape,
+            rows,
+            args.warmup,
+            args.iters,
+            args.rounds,
+        )
+        for name, shape in SHAPES.items()
+    ]
+    moe_pointer = _check_moe_pointer_path(args.experts, args.rows_per_expert)
+    per_card_saving = sum(case["saving_bytes"] for case in cases)
+    projected_saving = per_card_saving * QWEN38_NUM_EXPERTS * QWEN38_NUM_MOE_LAYERS
+    report = {
+        "device": torch.cuda.get_device_name(),
+        "capability": list(torch.cuda.get_device_capability()),
+        "strict_bitwise": True,
+        "cases": cases,
+        "moe_pointer_path": moe_pointer,
+        "qwen38_tp4_projected_saving_bytes_per_card": projected_saving,
+        "qwen38_tp4_projected_saving_gib_per_card": projected_saving / (1 << 30),
+    }
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out is not None:
+        args.json_out.write_text(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_awq_compact_metadata.py
+++ b/benchmarks/benchmark_sm70_awq_compact_metadata.py
@@ -7,6 +7,7 @@ the reconstructed metadata and every GEMM output must be bitwise identical.
 """
 
 import argparse
+import hashlib
 import json
 import statistics
 from pathlib import Path
@@ -33,6 +34,8 @@ def _require_sm70() -> None:
         raise RuntimeError(f"Expected SM70, got sm_{capability[0]}{capability[1]}.")
     if not hasattr(torch.ops._C, "awq_sm70_prepare_compact"):
         raise RuntimeError("The build does not contain awq_sm70_prepare_compact.")
+    if not hasattr(torch.ops._C, "uint4_sm70_prepare"):
+        raise RuntimeError("The build does not contain uint4_sm70_prepare.")
 
 
 def _make_awq_inputs(
@@ -77,6 +80,11 @@ def _bitwise_equal(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
             lhs.contiguous().view(torch.uint8), rhs.contiguous().view(torch.uint8)
         )
     )
+
+
+def _tensor_sha256(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
 
 
 def _prepare_pair(
@@ -234,6 +242,61 @@ def _check_dense_case(
         * 100.0,
         "cuda_graph_equal": True,
         "timings": timings,
+    }
+
+
+def _check_dense_uint4_case() -> dict[str, Any]:
+    """Exercise the untagged uint32 statistics iterator used by dense uint4."""
+    k, n, m = 2560, 320, 64
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260903)
+    qweight = torch.randint(
+        0,
+        16,
+        (k, n),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    )
+    scales = (
+        torch.rand(
+            (k // GROUP_SIZE, n),
+            dtype=torch.float16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.02
+        + 0.0001
+    )
+    zeros = torch.randint(
+        0,
+        16,
+        (k // GROUP_SIZE, n),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    ).to(torch.float16)
+    prepared = sm70_ops.uint4_sm70_prepare(qweight, scales, zeros, GROUP_SIZE, False)
+    if int(prepared[2][1].item()) <= 0:
+        raise AssertionError("dense uint4 must retain an untagged positive q_ld")
+
+    x = torch.randn((m, k), dtype=torch.float16, device="cuda", generator=generator)
+    first = torch.empty((m, n), dtype=torch.float16, device="cuda")
+    second = torch.empty_like(first)
+    _gemm_out(first, x, prepared)
+    _gemm_out(second, x, prepared)
+    torch.cuda.synchronize()
+    if not _bitwise_equal(first, second):
+        raise AssertionError("dense uint4 repeat output mismatch")
+
+    return {
+        "m": m,
+        "k": k,
+        "n": n,
+        "group_size": GROUP_SIZE,
+        "q_ld": int(prepared[2][1].item()),
+        "repeat_bitwise_equal": True,
+        "output_sha256": _tensor_sha256(first),
     }
 
 
@@ -457,6 +520,7 @@ def main() -> int:
         )
         for name, shape in SHAPES.items()
     ]
+    dense_uint4 = _check_dense_uint4_case()
     moe_pointer = _check_moe_pointer_path(args.experts, args.rows_per_expert)
     per_card_saving = sum(case["saving_bytes"] for case in cases)
     projected_saving = per_card_saving * QWEN38_NUM_EXPERTS * QWEN38_NUM_MOE_LAYERS
@@ -465,6 +529,7 @@ def main() -> int:
         "capability": list(torch.cuda.get_device_capability()),
         "strict_bitwise": True,
         "cases": cases,
+        "dense_uint4": dense_uint4,
         "moe_pointer_path": moe_pointer,
         "qwen38_tp4_projected_saving_bytes_per_card": projected_saving,
         "qwen38_tp4_projected_saving_gib_per_card": projected_saving / (1 << 30),

--- a/benchmarks/benchmark_sm70_turbomind_exactness.py
+++ b/benchmarks/benchmark_sm70_turbomind_exactness.py
@@ -683,8 +683,13 @@ def _prepare_awq_moe_weights(
     interleave_gated_silu: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
     tm_weights, tm_scales, metas = [], [], []
+    prepare_awq = (
+        sm70_ops.awq_sm70_prepare_compact
+        if os.getenv("VLLM_SM70_AWQ_MOE_COMPACT_METADATA") == "1"
+        else sm70_ops.awq_sm70_prepare
+    )
     for expert_id in range(qweights.shape[0]):
-        tm_weight, tm_scale, meta = sm70_ops.awq_sm70_prepare(
+        tm_weight, tm_scale, meta = prepare_awq(
             qweights[expert_id],
             scales[expert_id],
             qzeros[expert_id],
@@ -2791,6 +2796,7 @@ def main() -> int:
         "awq_moe_top_k": args.awq_moe_top_k,
         "awq_moe_actual": awq_moe_actual,
         "awq_moe_dispatch_policy_env": os.getenv("VLLM_SM70_AWQ_MOE_DISPATCH_POLICY"),
+        "awq_moe_compact_metadata_env": os.getenv("VLLM_SM70_AWQ_MOE_COMPACT_METADATA"),
         "fp8_model": str(args.fp8_model) if args.fp8_model else None,
         "fp8_layer": args.fp8_layer,
         "fp8_moe_model": str(args.fp8_moe_model) if args.fp8_moe_model else None,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -101,6 +101,10 @@ std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor _kernel,
                                             int64_t group_size,
                                             bool interleave_gated_silu);
 
+std::vector<torch::Tensor> awq_sm70_prepare_compact(
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, torch::Tensor _zeros,
+    int64_t group_size, bool interleave_gated_silu);
+
 void awq_sm70_dequantize_out(torch::Tensor out, torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
                              int64_t group_size);

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
@@ -66,6 +66,13 @@ struct GmemIteratorSm70 {
 
   bool g_mask{true};
 
+  // AWQ may keep its persistent per-group statistics as the packed byte
+  // sequence {scale_lo, scale_hi, zero}. The aligned source pointer's low bit
+  // marks the compact format. Shared memory still contains the regular uint32
+  // {half scale, half bias} value consumed by the existing transform. Keeping
+  // the expansion here avoids a persistent or per-layer workspace.
+  bool compact_awq_stats_{false};
+
   SmemAccessor<T, SmemLayout> smem_data_;
 
   static constexpr int2 kMK0 = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
@@ -93,8 +100,16 @@ struct GmemIteratorSm70 {
     const int warp_id = threadIdx.x / WARP_SIZE;
     const int lane_id = threadIdx.x % WARP_SIZE;
 
-    const Pointer data{(T*)mat.ptr.ptr};
-    const int ld = mat.ptr.stride;
+    const uintptr_t tagged_ptr = reinterpret_cast<uintptr_t>(mat.ptr.ptr);
+    const int raw_ld = mat.ptr.stride;
+    if constexpr (std::is_same_v<T, uint32_t>) {
+      compact_awq_stats_ = (tagged_ptr & uintptr_t{1}) != 0 || raw_ld < 0;
+    }
+    const uintptr_t data_ptr =
+        compact_awq_stats_ ? tagged_ptr & ~uintptr_t{1} : tagged_ptr;
+    const Pointer data{reinterpret_cast<T*>(data_ptr)};
+    const int ld = raw_ld < 0 ? -raw_ld : raw_ld;
+    const int source_bits = compact_awq_stats_ ? 24 : bitsof<T>;
 
     const int2 offsets = Map::get_offset(warp_id, lane_id);
 
@@ -129,13 +144,14 @@ struct GmemIteratorSm70 {
 
     const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
 
-    src_offset_ = src_offset * bitsof<T> / bitsof<char>;
+    src_offset_ = src_offset * source_bits / bitsof<char>;
 
-    src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
-    src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
+    src_step_c_ = source_bits * Map::kDeltaC / bitsof<char>;
+    src_step_s_ = source_bits * Map::kDeltaS * ld / bitsof<char>;
 
     src_step_k_ =
-        bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
+        source_bits * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y /
+        bitsof<char>;
 
     // initialize for the first tile
     if constexpr (is_indexed) {
@@ -143,13 +159,27 @@ struct GmemIteratorSm70 {
       for (int s = 0; s < ITER_S; ++s) {
         const int ss = cta_cs.y + offset_s_ + s * Map::kDeltaS;
         const int idx = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
-        const auto tmp = data + cs2idx({cta_cs.x, idx}, ld);
-        src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
+        const int logical_offset = cs2idx({cta_cs.x, idx}, ld);
+        if (compact_awq_stats_) {
+          src_data_vec_[s] = reinterpret_cast<const char*>(data_ptr) +
+                             logical_offset * 3 + src_offset_;
+        } else {
+          const auto tmp = data + logical_offset;
+          src_data_vec_[s] =
+              reinterpret_cast<const char*>((T*)tmp) + src_offset_;
+        }
       }
     } else {
-      auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
-      src_data_ = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
+      const int logical_offset = cs2idx(to_cs(pack(offset)), ld);
+      if (compact_awq_stats_) {
+        src_data_ = reinterpret_cast<const char*>(data_ptr) +
+                    logical_offset * 3 + src_offset_;
+      } else {
+        auto src_data = data + logical_offset;
+        src_data_ = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
+      }
     }
+
   }
 
   __device__ constexpr int _src_step_k() const { return src_step_k_; }
@@ -240,6 +270,25 @@ struct GmemIteratorSm70 {
   __device__ void Copy2(AccessType& frag, const char* __restrict__ src,
                         bool mask) {
     if (mask) {
+      if constexpr (std::is_same_v<T, uint32_t>) {
+        if (compact_awq_stats_) {
+          PRAGMA_UNROLL
+          for (int i = 0; i < Map::kAccessC; ++i) {
+            const auto* bytes =
+                reinterpret_cast<const uint8_t*>(src + i * 3);
+            const uint16_t scale_bits =
+                static_cast<uint16_t>(__ldg(bytes)) |
+                (static_cast<uint16_t>(__ldg(bytes + 1)) << 8);
+            const uint8_t zero_u8 = __ldg(bytes + 2);
+            const half scale = __ushort_as_half(scale_bits);
+            const half zero = __int2half_rn(static_cast<int>(zero_u8));
+            const half bias = __hmul(__hneg(zero), scale);
+            frag[i] = static_cast<uint32_t>(scale_bits) |
+                      (static_cast<uint32_t>(__half_as_ushort(bias)) << 16);
+          }
+          return;
+        }
+      }
       if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
         _Ld(frag, (const T*)src);
       } else {

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
@@ -101,14 +101,13 @@ struct GmemIteratorSm70 {
     const int lane_id = threadIdx.x % WARP_SIZE;
 
     const uintptr_t tagged_ptr = reinterpret_cast<uintptr_t>(mat.ptr.ptr);
-    const int raw_ld = mat.ptr.stride;
+    const int ld = mat.ptr.stride;
     if constexpr (std::is_same_v<T, uint32_t>) {
-      compact_awq_stats_ = (tagged_ptr & uintptr_t{1}) != 0 || raw_ld < 0;
+      compact_awq_stats_ = (tagged_ptr & uintptr_t{1}) != 0;
     }
     const uintptr_t data_ptr =
         compact_awq_stats_ ? tagged_ptr & ~uintptr_t{1} : tagged_ptr;
     const Pointer data{reinterpret_cast<T*>(data_ptr)};
-    const int ld = raw_ld < 0 ? -raw_ld : raw_ld;
     const int source_bits = compact_awq_stats_ ? 24 : bitsof<T>;
 
     const int2 offsets = Map::get_offset(warp_id, lane_id);

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -2839,11 +2839,35 @@ torch::Tensor interleave_gated_silu_cols(torch::Tensor tensor) {
   return torch::stack({first, second}, -1).reshape(tensor.sizes());
 }
 
-std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor qweight,
-                                            torch::Tensor scales,
-                                            torch::Tensor qzeros,
-                                            int64_t group_size,
-                                            bool interleave_gated_silu) {
+__global__ void pack_awq_compact_source_kernel(uint32_t* packed,
+                                               const half* scales,
+                                               const uint8_t* zeros,
+                                               int64_t numel) {
+  const int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < numel) {
+    const uint16_t scale_bits = __half_as_ushort(scales[idx]);
+    packed[idx] = static_cast<uint32_t>(scale_bits) |
+                  (static_cast<uint32_t>(zeros[idx]) << 16);
+  }
+}
+
+__global__ void compact_awq_stats_kernel(uint8_t* compact,
+                                         const uint32_t* packed,
+                                         int64_t numel) {
+  const int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < numel) {
+    const uint32_t value = packed[idx];
+    compact[idx * 3] = static_cast<uint8_t>(value);
+    compact[idx * 3 + 1] = static_cast<uint8_t>(value >> 8);
+    compact[idx * 3 + 2] = static_cast<uint8_t>(value >> 16);
+  }
+}
+
+std::vector<torch::Tensor> awq_sm70_prepare_impl(
+    torch::Tensor qweight, torch::Tensor scales, torch::Tensor qzeros,
+    int64_t group_size, bool interleave_gated_silu, bool compact_metadata) {
   validate_awq_inputs(qweight, scales, qzeros);
 
   qweight = qweight.contiguous();
@@ -2952,21 +2976,36 @@ std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor qweight,
   for (int i = 0; i < 8; ++i) {
     zordered.push_back(zslices[awq_order[i]]);
   }
-  auto zeros_half =
-      torch::stack(zordered, -1).reshape({num_groups, n}).to(torch::kFloat16);
+  auto zeros_u8 = torch::stack(zordered, -1).reshape({num_groups, n});
   if (interleave_gated_silu) {
     scales = interleave_gated_silu_cols(scales);
-    zeros_half = interleave_gated_silu_cols(zeros_half);
+    zeros_u8 = interleave_gated_silu_cols(zeros_u8);
   }
 
-  auto fused = torch::empty(
-      {num_groups, n * 2},
-      torch::TensorOptions().device(scales.device()).dtype(torch::kFloat16));
-  turbomind::fuse_scales_and_zeros(
-      reinterpret_cast<half*>(fused.data_ptr<at::Half>()),
-      reinterpret_cast<const half*>(scales.data_ptr<at::Half>()),
-      reinterpret_cast<half*>(zeros_half.data_ptr<at::Half>()), scales.numel(),
-      stream);
+  torch::Tensor source_stats;
+  if (compact_metadata) {
+    source_stats = torch::empty(
+        {num_groups, n},
+        torch::TensorOptions().device(scales.device()).dtype(torch::kInt32));
+    constexpr int kThreads = 256;
+    const int blocks =
+        static_cast<int>((scales.numel() + kThreads - 1) / kThreads);
+    pack_awq_compact_source_kernel<<<blocks, kThreads, 0, stream>>>(
+        reinterpret_cast<uint32_t*>(source_stats.data_ptr<int32_t>()),
+        reinterpret_cast<const half*>(scales.data_ptr<at::Half>()),
+        zeros_u8.data_ptr<uint8_t>(), scales.numel());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  } else {
+    auto zeros_half = zeros_u8.to(torch::kFloat16);
+    source_stats = torch::empty(
+        {num_groups, n * 2},
+        torch::TensorOptions().device(scales.device()).dtype(torch::kFloat16));
+    turbomind::fuse_scales_and_zeros(
+        reinterpret_cast<half*>(source_stats.data_ptr<at::Half>()),
+        reinterpret_cast<const half*>(scales.data_ptr<at::Half>()),
+        reinterpret_cast<half*>(zeros_half.data_ptr<at::Half>()),
+        scales.numel(), stream);
+  }
 
   const auto order_s = conv_s->order;
   const bool is_A_s = turbomind::gemm::get_operand_tag(conv_s->pack) ==
@@ -2989,18 +3028,52 @@ std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor qweight,
     q_desc = turbomind::gemm::transpose(q_desc);
   }
 
-  auto tm_scales = torch::empty(
+  auto tm_stats = torch::empty(
       {num_groups, n},
       torch::TensorOptions().device(scales.device()).dtype(torch::kInt32));
-  TORCH_CHECK(conv_s->Convert(fused.data_ptr(), s_desc, tm_scales.data_ptr(),
-                              q_desc, stream) == 0,
+  TORCH_CHECK(conv_s->Convert(source_stats.data_ptr(), s_desc,
+                              tm_stats.data_ptr(), q_desc, stream) == 0,
               "awq_sm70_prepare: scale conversion failed.");
+
+  torch::Tensor tm_scales = tm_stats;
+  if (compact_metadata) {
+    tm_scales = torch::empty(
+        {num_groups, n, 3},
+        torch::TensorOptions().device(scales.device()).dtype(torch::kUInt8));
+    constexpr int kThreads = 256;
+    const int blocks =
+        static_cast<int>((tm_stats.numel() + kThreads - 1) / kThreads);
+    compact_awq_stats_kernel<<<blocks, kThreads, 0, stream>>>(
+        tm_scales.data_ptr<uint8_t>(),
+        reinterpret_cast<const uint32_t*>(tm_stats.data_ptr<int32_t>()),
+        tm_stats.numel());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
 
   auto meta = torch::empty({2}, torch::TensorOptions().dtype(torch::kInt64));
   meta.index_put_({0}, k_desc.ld);
-  meta.index_put_({1}, q_desc.ld);
+  // q_ld is an internal contract between prepare, pointer construction and
+  // the SM70 iterator.  Its sign distinguishes compact 3-byte statistics;
+  // the magnitude remains the logical TurboMind leading dimension.
+  meta.index_put_({1}, compact_metadata ? -q_desc.ld : q_desc.ld);
 
   return {tm_weight, tm_scales, meta};
+}
+
+std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor qweight,
+                                            torch::Tensor scales,
+                                            torch::Tensor qzeros,
+                                            int64_t group_size,
+                                            bool interleave_gated_silu) {
+  return awq_sm70_prepare_impl(qweight, scales, qzeros, group_size,
+                               interleave_gated_silu, false);
+}
+
+std::vector<torch::Tensor> awq_sm70_prepare_compact(
+    torch::Tensor qweight, torch::Tensor scales, torch::Tensor qzeros,
+    int64_t group_size, bool interleave_gated_silu) {
+  return awq_sm70_prepare_impl(qweight, scales, qzeros, group_size,
+                               interleave_gated_silu, true);
 }
 
 std::vector<torch::Tensor> uint4_sm70_prepare(torch::Tensor qweight,
@@ -3533,6 +3606,7 @@ void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
                        int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu,
                        const turbomind::gemm::TileAllReduceParam* tile_reduce) {
+  const bool compact_metadata = q_ld < 0;
   TORCH_CHECK(in_feats.is_cuda(), "awq_gemm_sm70: input must be CUDA.");
   TORCH_CHECK(tm_weight.is_cuda(), "awq_gemm_sm70: weight must be CUDA.");
   TORCH_CHECK(tm_scales.is_cuda(), "awq_gemm_sm70: scales must be CUDA.");
@@ -3541,8 +3615,10 @@ void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
               "awq_gemm_sm70: input must be float16.");
   TORCH_CHECK(tm_weight.scalar_type() == torch::kInt32,
               "awq_gemm_sm70: weight must be int32.");
-  TORCH_CHECK(tm_scales.scalar_type() == torch::kInt32,
-              "awq_gemm_sm70: scales must be int32.");
+  TORCH_CHECK(
+      (!compact_metadata && tm_scales.scalar_type() == torch::kInt32) ||
+          (compact_metadata && tm_scales.scalar_type() == torch::kUInt8),
+      "awq_gemm_sm70: scales must be int32, or uint8 with compact q_ld.");
   TORCH_CHECK(out.scalar_type() == torch::kFloat16,
               "awq_gemm_sm70: output must be float16.");
 
@@ -3559,6 +3635,14 @@ void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   TORCH_CHECK(tm_scales.size(0) == k / group_size,
               "awq_gemm_sm70: scale groups mismatch.");
   TORCH_CHECK(tm_scales.size(1) == n, "awq_gemm_sm70: scale shape mismatch.");
+  if (compact_metadata) {
+    TORCH_CHECK(tm_scales.dim() == 3 && tm_scales.size(2) == 3 &&
+                    tm_scales.is_contiguous(),
+                "awq_gemm_sm70: compact scales must be contiguous [G,N,3].");
+  } else {
+    TORCH_CHECK(tm_scales.dim() == 2,
+                "awq_gemm_sm70: regular scales must be rank 2.");
+  }
   TORCH_CHECK(out.size(0) == m,
               "awq_gemm_sm70: output rows must match input rows.");
   TORCH_CHECK(out.stride(1) == 1,
@@ -3634,7 +3718,7 @@ void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   if (is_A_s) {
     desc_V = turbomind::gemm::transpose(desc_V);
   }
-  desc_V.ld = static_cast<int>(q_ld);
+  desc_V.ld = static_cast<int>(compact_metadata ? -q_ld : q_ld);
 
   turbomind::gemm::MatrixLayout desc_D{
       turbomind::kHalf,    turbomind::gemm::kRowMajor,      static_cast<int>(m),
@@ -3663,10 +3747,15 @@ void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   auto& workspace_holder = get_workspace(device, stream);
   auto& gemm = get_gemm(device);
 
+  void* stats_ptr = tm_scales.data_ptr();
+  if (compact_metadata) {
+    stats_ptr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(stats_ptr) |
+                                        uintptr_t{1});
+  }
   const int ec = gemm.Run(op, 1.f, in_feats.data_ptr(), desc_A, nullptr, desc_U,
-                          tm_weight.data_ptr(), desc_B, tm_scales.data_ptr(),
-                          desc_V, 0.f, out.data_ptr(), desc_D, out.data_ptr(),
-                          desc_D, workspace_holder.workspace, stream);
+                          tm_weight.data_ptr(), desc_B, stats_ptr, desc_V, 0.f,
+                          out.data_ptr(), desc_D, out.data_ptr(), desc_D,
+                          workspace_holder.workspace, stream);
   TORCH_CHECK(ec == 0, "awq_gemm_sm70: TurboMind GEMM failed.");
 }
 
@@ -5758,6 +5847,13 @@ std::vector<torch::Tensor> awq_sm70_prepare(torch::Tensor _kernel,
                                           group_size, interleave_gated_silu);
 }
 
+std::vector<torch::Tensor> awq_sm70_prepare_compact(
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, torch::Tensor _zeros,
+    int64_t group_size, bool interleave_gated_silu) {
+  return vllm::awq_sm70::awq_sm70_prepare_compact(
+      _kernel, _scaling_factors, _zeros, group_size, interleave_gated_silu);
+}
+
 void awq_sm70_dequantize_out(torch::Tensor out, torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
                              int64_t group_size) {
@@ -6134,12 +6230,15 @@ namespace {
 
 __global__ void awq_moe_fill_strided_ptrs_kernel(
     turbomind::gemm::StridedPtr* ptrs, char* base, int64_t expert_stride,
-    int stride, int64_t num_experts) {
+    int stride, int64_t num_experts, bool compact_metadata) {
   const int64_t expert_id =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (expert_id < num_experts) {
+    const uintptr_t data_ptr =
+        reinterpret_cast<uintptr_t>(base + expert_id * expert_stride);
     ptrs[expert_id] = {
-        base + expert_id * expert_stride,
+        reinterpret_cast<void*>(
+            data_ptr | (compact_metadata ? uintptr_t{1} : uintptr_t{0})),
         stride,
     };
   }
@@ -6161,6 +6260,13 @@ std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
               "awq_moe_build_strided_ptrs: weights dim0 != num_experts.");
   TORCH_CHECK(tm_scales.size(0) == num_experts,
               "awq_moe_build_strided_ptrs: scales dim0 != num_experts.");
+  if (q_ld < 0) {
+    TORCH_CHECK(tm_scales.scalar_type() == torch::kUInt8 &&
+                    tm_scales.dim() == 4 && tm_scales.size(3) == 3 &&
+                    tm_scales.is_contiguous(),
+                "awq_moe_build_strided_ptrs: compact scales must be "
+                "contiguous uint8 [E,G,N,3].");
+  }
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(tm_weights));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -6171,6 +6277,7 @@ std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
       tm_scales.stride(0) * tm_scales.element_size();
   char* w_base = static_cast<char*>(tm_weights.data_ptr());
   char* s_base = static_cast<char*>(tm_scales.data_ptr());
+  const bool compact_metadata = q_ld < 0;
 
   // StridedPtr is 16 bytes (__align__(16): void* ptr + int stride + padding).
   const int64_t buf_bytes = num_experts * 16;
@@ -6182,10 +6289,12 @@ std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
   const int blocks = static_cast<int>((num_experts + kThreads - 1) / kThreads);
   awq_moe_fill_strided_ptrs_kernel<<<blocks, kThreads, 0, stream>>>(
       reinterpret_cast<turbomind::gemm::StridedPtr*>(w_tensor.data_ptr()),
-      w_base, w_expert_stride, static_cast<int>(k_ld), num_experts);
+      w_base, w_expert_stride, static_cast<int>(k_ld), num_experts, false);
   awq_moe_fill_strided_ptrs_kernel<<<blocks, kThreads, 0, stream>>>(
       reinterpret_cast<turbomind::gemm::StridedPtr*>(s_tensor.data_ptr()),
-      s_base, s_expert_stride, static_cast<int>(q_ld), num_experts);
+      s_base, s_expert_stride,
+      static_cast<int>(compact_metadata ? -q_ld : q_ld), num_experts,
+      compact_metadata);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return {w_tensor, s_tensor};

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -176,6 +176,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("awq_sm70_prepare", torch::kCUDA, &awq_sm70_prepare);
 
   ops.def(
+      "awq_sm70_prepare_compact(Tensor _kernel, Tensor _scaling_factors, "
+      "Tensor _zeros, int group_size, bool interleave_gated_silu) -> "
+      "Tensor[]");
+  ops.impl("awq_sm70_prepare_compact", torch::kCUDA, &awq_sm70_prepare_compact);
+
+  ops.def(
       "awq_sm70_dequantize_out(Tensor(a!) out, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size) -> ()");
   ops.impl("awq_sm70_dequantize_out", torch::kCUDA, &awq_sm70_dequantize_out);

--- a/tests/quantization/test_sm70_awq_compact_metadata.py
+++ b/tests/quantization/test_sm70_awq_compact_metadata.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm import envs
+from vllm.model_executor.layers.quantization.awq_sm70_moe import (
+    _is_qwen38_tp4_compact_metadata_shape,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _layer(
+    *,
+    experts: int = 512,
+    w2_experts: int | None = None,
+    w13_shape: tuple[int, int] = (2560, 40),
+    w2_shape: tuple[int, int] = (160, 320),
+) -> SimpleNamespace:
+    if w2_experts is None:
+        w2_experts = experts
+    return SimpleNamespace(
+        w13_qweight=SimpleNamespace(shape=(experts, *w13_shape)),
+        w2_qweight=SimpleNamespace(shape=(w2_experts, *w2_shape)),
+    )
+
+
+def test_awq_compact_metadata_is_default_off() -> None:
+    assert envs.VLLM_SM70_AWQ_MOE_COMPACT_METADATA is False
+
+
+def test_awq_compact_metadata_shape_gate_accepts_qwen38_tp4() -> None:
+    assert _is_qwen38_tp4_compact_metadata_shape(_layer(), 32)
+
+
+def test_awq_compact_metadata_shape_gate_rejects_other_contracts() -> None:
+    assert not _is_qwen38_tp4_compact_metadata_shape(_layer(experts=256), 32)
+    assert not _is_qwen38_tp4_compact_metadata_shape(_layer(w2_experts=256), 32)
+    assert not _is_qwen38_tp4_compact_metadata_shape(_layer(), 64)
+    assert not _is_qwen38_tp4_compact_metadata_shape(_layer(w13_shape=(2560, 48)), 32)
+    assert not _is_qwen38_tp4_compact_metadata_shape(_layer(w2_shape=(192, 320)), 32)

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -208,6 +208,41 @@ if hasattr(torch.ops._C, "awq_sm70_prepare"):
         return [tm_weight, tm_scales, meta]
 
 
+def awq_sm70_prepare_compact(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    group_size: int,
+    interleave_gated_silu: bool = False,
+) -> list[torch.Tensor]:
+    return _op("awq_sm70_prepare_compact")(
+        qweight, scales, qzeros, group_size, interleave_gated_silu
+    )
+
+
+if hasattr(torch.ops._C, "awq_sm70_prepare_compact"):
+
+    @register_fake("_C::awq_sm70_prepare_compact")
+    def _awq_sm70_prepare_compact_fake(
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        qzeros: torch.Tensor,
+        group_size: int,
+        interleave_gated_silu: bool,
+    ) -> list[torch.Tensor]:
+        del qzeros, group_size, interleave_gated_silu
+        n = qweight.size(1) * 8
+        num_groups = scales.size(0)
+        tm_weight = torch.empty_like(qweight)
+        tm_scales = torch.empty(
+            (num_groups, n, 3),
+            dtype=torch.uint8,
+            device=qweight.device,
+        )
+        meta = torch.empty((2,), dtype=torch.int64, device=qweight.device)
+        return [tm_weight, tm_scales, meta]
+
+
 def awq_sm70_dequantize_out(
     out: torch.Tensor,
     qweight: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -122,6 +122,7 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_MOE_BATCHED_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_ACTIVE_EXACT_W2: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS: int = 0
+    VLLM_SM70_AWQ_MOE_COMPACT_METADATA: bool = False
     VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST: str | None = None
     VLLM_SM70_AWQ_MOE_BATCHED_LAYER_DENYLIST: str | None = None
     VLLM_SM70_AWQ_MOE_COMPARE_DENSE_DIR: str | None = None
@@ -1636,6 +1637,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_BATCHED_DECODE_MAX_TOKENS", "0")
+    ),
+    # Exact Qwen3.8 TP4 AWQ experiment: persist each per-group statistic as
+    # {FP16 scale, uint8 zero} and reconstruct the FP16 bias in the SM70
+    # iterator. Keep opt-in until model-level latency has been accepted.
+    "VLLM_SM70_AWQ_MOE_COMPACT_METADATA": lambda: bool(
+        int(os.getenv("VLLM_SM70_AWQ_MOE_COMPACT_METADATA", "0"))
     ),
     "VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST": lambda: os.getenv(
         "VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST", None

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -29,6 +29,10 @@ logger = init_logger(__name__)
 
 _DEFAULT_PERSISTENT_MAX_TOKENS = 32
 
+_QWEN38_TP4_NUM_EXPERTS = 512
+_QWEN38_TP4_W13_QWEIGHT_SHAPE = (2560, 40)
+_QWEN38_TP4_W2_QWEIGHT_SHAPE = (160, 320)
+
 
 def _log_runtime_route_once(message: str, *args) -> None:
     if torch.compiler.is_compiling():
@@ -80,6 +84,19 @@ def _legacy_single_token_compact_enabled() -> bool:
     if not envs.VLLM_SM70_AWQ_MOE_LEGACY_SINGLE_TOKEN_COMPACT:
         return False
     return hasattr(torch.ops._C, "awq_moe_single_token_sm70_out")
+
+
+def _is_qwen38_tp4_compact_metadata_shape(
+    layer: RoutedExperts, group_size: int
+) -> bool:
+    """Return whether the loaded tensors match the validated compact lane."""
+    return (
+        group_size == 32
+        and tuple(layer.w13_qweight.shape)
+        == (_QWEN38_TP4_NUM_EXPERTS, *_QWEN38_TP4_W13_QWEIGHT_SHAPE)
+        and tuple(layer.w2_qweight.shape)
+        == (_QWEN38_TP4_NUM_EXPERTS, *_QWEN38_TP4_W2_QWEIGHT_SHAPE)
+    )
 
 
 def _silu_and_mul_w13(
@@ -556,6 +573,23 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             )
 
         num_experts = int(layer.w13_qweight.shape[0])
+        compact_metadata = envs.VLLM_SM70_AWQ_MOE_COMPACT_METADATA
+        if compact_metadata:
+            if not hasattr(torch.ops._C, "awq_sm70_prepare_compact"):
+                raise RuntimeError(
+                    "VLLM_SM70_AWQ_MOE_COMPACT_METADATA=1 requires an SM70 "
+                    "build with awq_sm70_prepare_compact."
+                )
+            if not _is_qwen38_tp4_compact_metadata_shape(layer, self.group_size):
+                raise RuntimeError(
+                    "VLLM_SM70_AWQ_MOE_COMPACT_METADATA=1 currently requires "
+                    "the exact Qwen3.8 TP4 E512 native-g32 W13/W2 shapes."
+                )
+        prepare_awq = (
+            sm70_ops.awq_sm70_prepare_compact
+            if compact_metadata
+            else sm70_ops.awq_sm70_prepare
+        )
         w13_tm_weights, w13_tm_scales, w13_meta = [], [], []
         w2_tm_weights, w2_tm_scales, w2_meta = [], [], []
         build_legacy_w13 = (
@@ -568,7 +602,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         # carrying a second per-expert W13 TurboMind copy.
         w13_interleaved = build_legacy_w13
         for expert_id in range(num_experts):
-            r13 = sm70_ops.awq_sm70_prepare(
+            r13 = prepare_awq(
                 layer.w13_qweight[expert_id],
                 layer.w13_scales[expert_id],
                 layer.w13_qzeros[expert_id],
@@ -579,7 +613,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             w13_tm_scales.append(r13[1])
             w13_meta.append(r13[2])
 
-            r2 = sm70_ops.awq_sm70_prepare(
+            r2 = prepare_awq(
                 layer.w2_qweight[expert_id],
                 layer.w2_scales[expert_id],
                 layer.w2_qzeros[expert_id],
@@ -649,6 +683,7 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         layer.sm70_awq_moe_layer_id = _get_layer_id(layer)
         layer.sm70_awq_moe_w13_interleaved = w13_interleaved
         layer.sm70_awq_moe_legacy_single_token_compact = build_legacy_w13
+        layer.sm70_awq_moe_compact_metadata = compact_metadata
 
         self._allocate_buffers(layer)
         del layer.w13_qweight, layer.w13_scales, layer.w13_qzeros
@@ -667,6 +702,10 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
             "batched" if batched_gemm else "per-expert dense",
             num_experts,
         )
+        if compact_metadata:
+            logger.info_once(
+                "SM70 Qwen3.8 TP4 AWQ compact scale/zero metadata enabled."
+            )
 
     def _allocate_buffers(self, layer: RoutedExperts) -> None:
         device = layer.w13_tm_weight.device


### PR DESCRIPTION
## Purpose

Integrate #473's compact SM70 AWQ metadata with the now-merged #464 indexed prefill and #465 resident-scratch sizing. Resolve the two adjacent environment-definition conflicts by retaining both settings. Preserve the original contributor commit and all production behavior from #473.

The feature remains opt-in: `VLLM_SM70_AWQ_MOE_COMPACT_METADATA=1`. It is a capacity tradeoff, with about 0.879 GiB persistent saving per GPU on the validated TP4/E512/native-g32 shape. The submitted matched server experiment reports +19.36% KV capacity, +1.22% prefill latency and +0.27% decode latency; it is not a default-on speed improvement.

This is the maintainer's integration repair for #473, not a competing implementation. Base: `9ed8697ac03207ffb1c5e34e208ff50121fc8e94`.

## Test Plan

Run combined compact-metadata, indexed-prefill and persistent-cap regressions and changed-file pre-commit checks. Inspect pointer tagging, expert strides and reconstruction against existing half scale/bias arithmetic. GPU evidence comes from #473's rebuilt V100 extension, real-weight preparation, dense/blocked-MoE/legacy dispatch and CUDA Graph comparisons; no repeated E2E run is planned.

## Test Result

Combined compact-metadata, indexed-prefill and persistent-cap regressions: 36 passed. All 10 changed files pass pre-commit, including CUDA formatting and Python mypy. The conflict resolution retains both environment settings and all #464/#465 production changes. GPU results are the original #473 evidence, not a new local run; the integration repair changes no kernel arithmetic beyond that reviewed PR.

AI assistance: OpenAI Codex performed review and conflict resolution under the maintainer's authorization.
