### PR TITLE
[Core][SM70] Validate quantized KV and DFlash2 head compatibility

### DIFF
--- a/tests/quantization/test_sm70_quantized_model_compat.py
+++ b/tests/quantization/test_sm70_quantized_model_compat.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention import attention as attention_module
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsKVCacheMethod,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+from vllm.model_executor.models import qwen3_dflash2 as dflash2_module
+
+
+def _compressed_config(strategy, method_cls=CompressedTensorsKVCacheMethod):
+    scheme = None
+    if strategy is not None:
+        scheme = dict(type="float", num_bits=8, strategy=strategy, symmetric=True)
+    config = SimpleNamespace(kv_cache_scheme=scheme)
+    config.get_quant_method = lambda layer, prefix: method_cls(config)
+    return config
+
+
+def _set_platform(monkeypatch, capability=70, enabled=True, cuda=True):
+    monkeypatch.setattr(
+        attention_module,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: cuda,
+            has_device_capability=lambda required: capability >= required,
+        ),
+    )
+    monkeypatch.setattr(attention_module.envs, "VLLM_SM70_FLASH_ATTN_V100", enabled)
+
+
+@pytest.mark.parametrize("strategy", [None, "tensor", "attn_head"])
+@pytest.mark.parametrize("kv_dtype", ["fp8_e5m2", "fp8_e4m3"])
+def test_compressed_checkpoint_scale_processing(monkeypatch, strategy, kv_dtype):
+    _set_platform(monkeypatch)
+    layer = torch.nn.Module()
+    layer.kv_cache_dtype = kv_dtype
+    layer.num_kv_heads = 4
+    attention_module._init_kv_cache_quant(layer, _compressed_config(strategy), "attn")
+    for name, value in (("k", 7.0), ("v", 11.0), ("q", 13.0)):
+        getattr(layer, f"{name}_scale").data.fill_(value)
+    layer.quant_method.process_weights_after_loading(layer)
+    for name, loaded in (("k", 7.0), ("v", 11.0), ("q", 13.0)):
+        expected = 1.0 if kv_dtype == "fp8_e5m2" else loaded
+        actual = getattr(layer, f"_{name}_scale")
+        torch.testing.assert_close(actual, torch.full_like(actual, expected))
+        assert getattr(layer, f"_{name}_scale_float") == expected
+        assert not hasattr(layer, f"{name}_scale")
+        assert not hasattr(layer, f"{name}_zero_point")
+    assert layer._prob_scale.item() == 1.0
+
+
+@pytest.mark.parametrize(
+    "capability,enabled,cuda",
+    [(75, True, True), (80, True, True), (70, False, True), (70, True, False)],
+)
+def test_compressed_e5m2_rejects_unsupported_route(
+    monkeypatch, capability, enabled, cuda
+):
+    _set_platform(monkeypatch, capability, enabled, cuda)
+    layer = torch.nn.Module()
+    layer.kv_cache_dtype = "fp8_e5m2"
+    with pytest.raises(ValueError, match="unit-scale override"):
+        attention_module._init_kv_cache_quant(
+            layer, _compressed_config("tensor"), "attn"
+        )
+    assert not hasattr(layer, "_force_unit_fp8_e5m2_kv_scales")
+
+
+def test_compressed_subclass_cannot_bypass_scale_processing_guard(monkeypatch):
+    class DifferentScaleMethod(CompressedTensorsKVCacheMethod):
+        def process_weights_after_loading(self, layer):
+            pass
+
+    _set_platform(monkeypatch)
+    layer = torch.nn.Module()
+    layer.kv_cache_dtype = "fp8_e5m2"
+    with pytest.raises(ValueError, match="unit-scale override"):
+        attention_module._init_kv_cache_quant(
+            layer, _compressed_config("tensor", DifferentScaleMethod), "attn"
+        )
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4])
+@pytest.mark.parametrize("softcap", [None, 3.0])
+@pytest.mark.parametrize("quantized", [False, True])
+def test_dflash2_dense_candidates_padding_tp_and_scaling(
+    monkeypatch, world_size, softcap, quantized
+):
+    monkeypatch.setattr(dflash2_module.envs, "VLLM_SM70_DFLASH2_QUANT_LM_HEAD", True)
+    monkeypatch.setattr(
+        dflash2_module, "get_tensor_model_parallel_world_size", lambda: world_size
+    )
+    # Padded entries would win both rows if masking were omitted.
+    local_logits = torch.tensor([[1, 4, 2, 99, 100], [5, 1, 3, 98, 99.0]])
+    apply = Mock(return_value=local_logits.clone())
+    method = SimpleNamespace(apply=apply) if quantized else UnquantizedEmbeddingMethod()
+    method.apply = apply
+    fast_path = Mock(return_value=None)
+    if quantized:
+        fast_path.side_effect = AssertionError("quantized heads must use dense apply")
+    lm_head = SimpleNamespace(
+        quant_method=method,
+        maybe_get_sm70_dflash2_top20=fast_path,
+        shard_indices=SimpleNamespace(
+            num_org_vocab_padding=2, org_vocab_start_index=10
+        ),
+    )
+    outer = SimpleNamespace(
+        lm_head=lm_head,
+        model=SimpleNamespace(candidate_selector=SimpleNamespace(top_k=2)),
+        output_multiplier=0.5,
+        final_logit_softcapping=softcap,
+    )
+    local_values, local_ids = torch.topk(local_logits[:, :3], 2, dim=-1)
+    shard_scores = [local_logits[:, :3]]
+    shard_ids = [torch.tensor([[10, 11, 12], [10, 11, 12]])]
+    for rank in range(1, world_size):
+        shard_scores.append(torch.tensor([[2.5, 6.0, 0.5], [4.0, 0.5, 7.0]]) + rank)
+        shard_ids.append(torch.tensor([[20, 21, 22], [20, 21, 22]]) + rank * 10)
+
+    def all_gather(tensor, dim):
+        assert dim == -1
+        if tensor.dtype == torch.int64:
+            torch.testing.assert_close(tensor, local_ids + 10)
+        else:
+            torch.testing.assert_close(tensor, local_values)
+        parts = [tensor]
+        for scores, ids in zip(shard_scores[1:], shard_ids[1:]):
+            values, indices = torch.topk(scores, 2, dim=-1)
+            parts.append(
+                ids.gather(-1, indices) if tensor.dtype == torch.int64 else values
+            )
+        return torch.cat(parts, dim=-1)
+
+    gather = Mock(side_effect=all_gather)
+    monkeypatch.setattr(dflash2_module, "tensor_model_parallel_all_gather", gather)
+    hidden = torch.zeros((2, 8))
+    ids, values = dflash2_module.DFlash2Qwen3ForCausalLM.compute_candidates(
+        outer, hidden
+    )
+    expected, indices = torch.topk(torch.cat(shard_scores, dim=-1), 2, dim=-1)
+    expected_ids = torch.cat(shard_ids, dim=-1).gather(-1, indices)
+    expected *= 0.5
+    if softcap is not None:
+        expected = torch.tanh(expected / softcap) * softcap
+    torch.testing.assert_close(ids, expected_ids)
+    torch.testing.assert_close(values, expected)
+    apply.assert_called_once_with(lm_head, hidden, bias=None)
+    assert gather.call_count == (2 if world_size > 1 else 0)
+    if quantized:
+        fast_path.assert_not_called()
+    else:
+        fast_path.assert_called_once_with(hidden, 2)
+
+
+def test_quantized_dflash2_head_keeps_explicit_opt_in(monkeypatch):
+    monkeypatch.setattr(dflash2_module.envs, "VLLM_SM70_DFLASH2_QUANT_LM_HEAD", False)
+    apply = Mock()
+    outer = SimpleNamespace(
+        lm_head=SimpleNamespace(quant_method=SimpleNamespace(apply=apply))
+    )
+    with pytest.raises(ValueError, match="VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1"):
+        dflash2_module.DFlash2Qwen3ForCausalLM.compute_candidates(
+            outer, torch.zeros((1, 8))
+        )
+    apply.assert_not_called()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -228,6 +228,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DFLASH2_FUSED_GEMMA_RMS: bool = False
     VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION: bool = False
     VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC: bool = False
+    VLLM_SM70_DFLASH2_QUANT_LM_HEAD: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE: bool = True
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
@@ -2082,6 +2083,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # production-weight TP4 microbenchmark.
     "VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_SHARDED_CONTEXT_FC", "0"))
+    ),
+    # Allow DFlash2 candidate TopK when the shared target LM head is
+    # quantized (e.g. compressed-tensors NVFP4 checkpoints, whose
+    # unquantized-head guard predates this deployment). The dense-logit
+    # fallback (quant_method.apply over the full vocabulary) produces the
+    # candidates instead of the QPN8 fast path. Opt-in because draft
+    # acceptance may differ from the unquantized baseline; quality gates
+    # must follow before broad rollout.
+    "VLLM_SM70_DFLASH2_QUANT_LM_HEAD": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_QUANT_LM_HEAD", "0"))
     ),
     # Default-on SGLang-style push collective for the validated FP16 80-KiB
     # verifier and 8-KiB decode payloads on fully-connected SM70 TP4 CUDA

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -173,15 +173,29 @@ def _init_kv_cache_quant(
                 and not current_platform.has_device_capability(75)
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             )
+            # Lazy import: the quantization package imports Attention at module
+            # scope, so importing it here avoids a circular import.
+            from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+                CompressedTensorsKVCacheMethod,
+            )
             uses_base_scale_processing = (
                 type(quant_method).process_weights_after_loading
                 is BaseKVCacheMethod.process_weights_after_loading
+            )
+            # CompressedTensorsKVCacheMethod overrides process_weights_after_loading
+            # to load checkpoint KV scales, but its override also implements the
+            # SM70 unit-scale override (its _force_unit_fp8_e5m2_kv_scales branch),
+            # so it is compatible with the unit-scale override path.
+            is_compressed_tensors_kv = isinstance(
+                quant_method, CompressedTensorsKVCacheMethod
             )
             has_checkpoint_kv_scheme = (
                 getattr(quant_method.quant_config, "kv_cache_scheme", None) is not None
             )
             unit_scale_compatible = (
-                uses_base_scale_processing or not has_checkpoint_kv_scheme
+                uses_base_scale_processing
+                or is_compressed_tensors_kv
+                or not has_checkpoint_kv_scheme
             )
             if not sm70_flash_v100 or not unit_scale_compatible:
                 raise ValueError(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -178,24 +178,21 @@ def _init_kv_cache_quant(
             from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
                 CompressedTensorsKVCacheMethod,
             )
-            uses_base_scale_processing = (
-                type(quant_method).process_weights_after_loading
-                is BaseKVCacheMethod.process_weights_after_loading
-            )
-            # CompressedTensorsKVCacheMethod overrides process_weights_after_loading
-            # to load checkpoint KV scales, but its override also implements the
-            # SM70 unit-scale override (its _force_unit_fp8_e5m2_kv_scales branch),
-            # so it is compatible with the unit-scale override path.
-            is_compressed_tensors_kv = isinstance(
-                quant_method, CompressedTensorsKVCacheMethod
+
+            # Both implementations honor the unit-scale override. Check the
+            # effective method so a subclass with different scale processing
+            # does not silently inherit permission to ignore checkpoint scales.
+            uses_unit_scale_processing = type(
+                quant_method
+            ).process_weights_after_loading in (
+                BaseKVCacheMethod.process_weights_after_loading,
+                CompressedTensorsKVCacheMethod.process_weights_after_loading,
             )
             has_checkpoint_kv_scheme = (
                 getattr(quant_method.quant_config, "kv_cache_scheme", None) is not None
             )
             unit_scale_compatible = (
-                uses_base_scale_processing
-                or is_compressed_tensors_kv
-                or not has_checkpoint_kv_scheme
+                uses_unit_scale_processing or not has_checkpoint_kv_scheme
             )
             if not sm70_flash_v100 or not unit_scale_compatible:
                 raise ValueError(

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -443,10 +443,11 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
     def compute_candidates(
         self, hidden_states: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not isinstance(
+        unquantized_head = isinstance(
             self.lm_head.quant_method,
             (UnquantizedEmbeddingMethod, UnquantizedLinearMethod),
-        ):
+        )
+        if not unquantized_head:
             if not envs.VLLM_SM70_DFLASH2_QUANT_LM_HEAD:
                 raise ValueError(
                     "DFlash2 requires an unquantized target LM head for "
@@ -463,8 +464,10 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
             )
 
         selector = self.model.candidate_selector
-        local_candidates = self.lm_head.maybe_get_sm70_dflash2_top20(
-            hidden_states, selector.top_k
+        local_candidates = (
+            self.lm_head.maybe_get_sm70_dflash2_top20(hidden_states, selector.top_k)
+            if unquantized_head
+            else None
         )
         if local_candidates is None:
             logits = self.lm_head.quant_method.apply(

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -447,9 +447,19 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
             self.lm_head.quant_method,
             (UnquantizedEmbeddingMethod, UnquantizedLinearMethod),
         ):
-            raise ValueError(
-                "DFlash2 requires an unquantized target LM head for candidate TopK; "
-                f"got {type(self.lm_head.quant_method).__name__}."
+            if not envs.VLLM_SM70_DFLASH2_QUANT_LM_HEAD:
+                raise ValueError(
+                    "DFlash2 requires an unquantized target LM head for "
+                    "candidate TopK; got "
+                    f"{type(self.lm_head.quant_method).__name__}. Set "
+                    "VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1 to use the "
+                    "dense-logit fallback over the quantized head."
+                )
+            logger.info_once(
+                "VLLM_SM70_DFLASH2_QUANT_LM_HEAD=1: DFlash2 candidate TopK "
+                "uses the dense-logit fallback over the quantized target "
+                "LM head (%s).",
+                type(self.lm_head.quant_method).__name__,
             )
 
         selector = self.model.candidate_selector


### PR DESCRIPTION
## Purpose

AI-assisted maintainer integration audit of #450 and #451, explicitly requested by the repository owner. This preserves both original PR histories and supplies focused regressions against current `onecat/main`; it is not a competing implementation.

Integration base: `55aa15d38287b16c370301534fe3590a25168b1f`.

## Test Plan

- Audit compressed-tensors explicit E5M2 unit-scale initialization and post-load handling, including checkpoint tensor/head scales and unsupported platform rejection.
- Audit quantized DFlash2 dense candidate generation, padded vocabulary and TP gather/top-k behavior, retaining unquantized fast paths.
- Run focused CPU regressions and applicable pre-commit checks. Use submitted GPU deployment evidence without attributing comparisons between different quantizations to this compatibility fix.
- No broad model E2E rerun, wheel release, or service interruption.

## Test Result

- Source audit complete for both compatibility changes against the integration base.
- Tightened #450 to recognize the effective scale-processing implementation, not every compressed-tensors subclass. Existing tensor/head checkpoint scales become unit scales only on explicit SM70 Flash-V100 E5M2; E4M3 and unsupported-platform behavior are preserved.
- Tightened #451 so quantized heads explicitly bypass the FP16/QPN8 helper and call their quantization method. The opt-in remains opt-in: submitted NVFP4-versus-AWQ numbers are not a same-quantization acceleration claim.
- New focused suite: **24 passed**. Re-executing the original PR functions in the same module namespaces yields **7 failed / 17 passed**, covering the overridden scale processor and six quantized dense-route cases. An earlier isolated-namespace diagnostic had invalid monkeypatch isolation and is not counted as evidence.
- Existing E5M2 regressions: **3 passed / 18 unrelated deselected**.
- Changed-file pre-commit: all applicable hooks pass.
- Local Python 3.12, Torch 2.10.0+cu128. Existing `_C`, `_C_stable_libtorch`, `_moe_C` binaries are linked for imports only; tests execute CPU tensors/mocked collectives and do not claim distributed CUDA validation.
- Commands: `PYTHONPATH=. .venv/bin/python -m pytest -q tests/quantization/test_sm70_quantized_model_compat.py --confcutdir=tests/quantization`; `... tests/quantization/test_fp8.py -k 'checkpoint_override or compressed_checkpoint_without' --confcutdir=tests/quantization`; `pre-commit run --files` for the four changed files.
- No model E2E test or deployment mutation. Original heads remain ancestors of this integration PR.
