### PR TITLE
[Kernel][WIP] Continue exact single-token HC latency optimization

### DIFF
--- a/benchmarks/kernels/verify_sm70_hc_down_scatter.py
+++ b/benchmarks/kernels/verify_sm70_hc_down_scatter.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TP4 raw-bit and alignment oracle for the HC down all-gather; no model load.
+
+With four exclusively available V100s and the source-matched extension:
+VLLM_SM70_TP4_PUSH_ALLREDUCE=1 CUDA_VISIBLE_DEVICES=0,1,2,3 \
+  .venv/bin/python -m torch.distributed.run --standalone --nproc-per-node=4 \
+  benchmarks/kernels/verify_sm70_hc_down_scatter.py --out scatter.json
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    rank, local = int(os.environ["RANK"]), int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local)
+    if int(os.environ["WORLD_SIZE"]) != 4 or torch.cuda.get_device_capability() != (
+        7,
+        0,
+    ):
+        raise RuntimeError("Requires TP4 on four exclusively available SM70 GPUs")
+    dist.init_process_group("nccl")
+    group = dist.new_group(backend="gloo")
+    comm = CustomAllreduce(group=group, device=local, max_size=8 * 1024 * 1024)
+    try:
+        if not comm.supports_sm70_qwen38_hc_output_allgather():
+            raise RuntimeError("Load the source-matched HC custom-AR extension")
+        gen = torch.Generator(device="cuda").manual_seed(20260905 + rank)
+        inp = torch.empty(88, dtype=torch.int16, device="cuda")
+        peers = [torch.empty(176, dtype=torch.uint8, device="cuda") for _ in range(4)]
+        storage = [
+            torch.full((344,), 0x1234, dtype=torch.int16, device="cuda")
+            for _ in range(8)
+        ]
+        graphs = []
+        for offset, buffer in enumerate(storage):
+            graph = torch.cuda.CUDAGraph()
+            inp.zero_()
+            with comm.capture(), torch.cuda.graph(graph):
+                comm.sm70_qwen38_hc_down_allgather(
+                    inp.view(torch.float16),
+                    buffer[offset : offset + 336].view(torch.float16),
+                )
+            graphs.append(graph)
+        mismatches = 0
+        for case in range(16):
+            inp.random_(-32768, 32768, generator=gen)
+            # Exercise the protocol's existing reserved-NaN canonicalization
+            # in low-rank, injection, and padding positions on every rank.
+            inp[case % 80] = inp[80] = inp[81 + case % 3] = 0x7F7F
+            dist.all_gather(peers, inp.view(torch.uint8))
+            bits = torch.stack(peers).view(torch.int16).reshape(4, 88)
+            bits = torch.where(bits == 0x7F7F, 0x7E00, bits)
+            expected = torch.cat(
+                (bits[:, :80].reshape(-1), bits[:, 80], bits[:, 81:84].reshape(-1))
+            )
+            offset = case % 8
+            buffer = storage[offset]
+            for _ in range(16):
+                graphs[offset].replay()
+            torch.cuda.synchronize()
+            mismatches += int(
+                torch.count_nonzero(buffer[offset : offset + 336] != expected)
+            )
+            assert bool(torch.all(buffer[:offset] == 0x1234))
+            assert bool(torch.all(buffer[offset + 336 :] == 0x1234))
+        results = [None] * 4
+        dist.all_gather_object(
+            results, {"rank": rank, "bit_mismatches": mismatches}, group=group
+        )
+        if any(row["bit_mismatches"] for row in results):
+            raise RuntimeError(f"HC raw-bit gather mismatch: {results}")
+        if rank == 0:
+            report = {
+                "scope": "HC down scatter only, not full-model quality or speed",
+                "quality": results,
+                "cases": 16,
+                "fp16_output_offsets": list(range(8)),
+                "graph_replays": 256,
+            }
+            args.out.write_text(json.dumps(report, indent=2) + "\n")
+            print(json.dumps(report), flush=True)
+    finally:
+        comm.close()
+        dist.destroy_process_group(group)
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -161,25 +161,37 @@ __global__ void __launch_bounds__(128, 1)
       if (!has_empty_slot) break;
     }
 
+    // The first 80 values are contiguous low-rank rows. Keep them packed:
+    // scalar per-element routing otherwise emits dozens of predicated U16
+    // stores for every source rank. Only the last pack needs injection/padding
+    // scatter. Preserve support for a weak-contiguous unaligned output view.
+    static_assert(kQwen38HcDownLocalLoraElements % kElementsPerPack == 0);
+    static_assert(kQwen38HcDownLocalElements -
+                      kQwen38HcDownLocalLoraElements == kElementsPerPack);
   #pragma unroll
     for (int source_rank = 0; source_rank < ngpus; ++source_rank) {
+      if (offset < kQwen38HcDownLocalLoraElements / kElementsPerPack) {
+        auto* destination =
+            output + source_rank * kQwen38HcDownLocalLoraElements;
+        if (reinterpret_cast<uintptr_t>(destination) % alignof(P) == 0) {
+          reinterpret_cast<P*>(destination)[offset] = peer_values[source_rank];
+        } else {
   #pragma unroll
-      for (int element = 0; element < P::size; ++element) {
-        const int local_element = offset * kElementsPerPack + element;
-        if (local_element < kQwen38HcDownLocalLoraElements) {
-          output[source_rank * kQwen38HcDownLocalLoraElements + local_element] =
-              peer_values[source_rank].data[element];
-        } else if (local_element == kQwen38HcDownLocalLoraElements) {
-          output[ngpus * kQwen38HcDownLocalLoraElements + source_rank] =
-              peer_values[source_rank].data[element];
-        } else if (local_element < kQwen38HcDownLiveElements) {
-          const int local_padding = local_element -
-                                    kQwen38HcDownLocalLoraElements -
-                                    kQwen38HcDownLocalInjectionElements;
+          for (int element = 0; element < kElementsPerPack; ++element) {
+            destination[offset * kElementsPerPack + element] =
+                peer_values[source_rank].data[element];
+          }
+        }
+      } else {
+        output[ngpus * kQwen38HcDownLocalLoraElements + source_rank] =
+            peer_values[source_rank].data[0];
+  #pragma unroll
+        for (int padding = 0; padding < kQwen38HcDownLocalPaddingElements;
+             ++padding) {
           output[ngpus * (kQwen38HcDownLocalLoraElements +
-                          kQwen38HcDownLocalInjectionElements) +
-                 source_rank * kQwen38HcDownLocalPaddingElements +
-                 local_padding] = peer_values[source_rank].data[element];
+                         kQwen38HcDownLocalInjectionElements) +
+                 source_rank * kQwen38HcDownLocalPaddingElements + padding] =
+              peer_values[source_rank].data[1 + padding];
         }
       }
     }

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45901,3 +45901,60 @@ Interpretation:
   SHA256 `2b233da24cf9bba28d867fcdb364e6e8dafd873bf467755358bf169fa83f8ea4`.
   Test exited normally; GPUs0-3 measured 141/7/7/7 MiB. No own queue/model/API
   remains. Do not repeat this private-pointer H8/512 candidate unchanged.
+
+## HC down counter refresh and packed scatter, 2026-09-05
+
+- Previous goal turn made progress: refreshed full-model HC 2.208302 ms and
+  untraced decode 93.433729 tok/s, and rejected H8/512 private scheduling.
+  Full HC <=1.5 ms remains unachieved. No full-model startup in this turn.
+- Earlier NCU evidence (488 GB/s, 24.23% occupancy) profiled the old 324-row
+  replicated down projection, not today's 81-live-row TP shard. Profile only
+  `_qwen38_hc_down_local_shard_kernel`, grid88/block128, one real layer-0
+  weight on GPU0. Nsight Compute2022.4.1, clock-control none, cache-control all,
+  full counter set, one launch after warmup. New cold-replay diagnostic:
+  7.74 us, 216.88 GB/s, DRAM28.09%, SM5.85%, achieved occupancy6.51%, 40
+  registers, 0.08 eligible warps/scheduler, no-eligible91.84%; long-scoreboard
+  7.7 cycles/issue (63.9%). This is not wall HC timing and the clocks were
+  not locked. Evidence `.artifacts/hc_down_ncu_20260905/`: profile/run scripts,
+  retained NCU report and exported metrics. Privileged profiler exited normally.
+- Reuse the existing full-model SQLite, with no GPU rerun. Align all down
+  gathers by collective ordinal across ranks (2976 =31x96 each), verify
+  participant overlap, retain 29 middle whole-graph groups. Mean service
+  5.620995 us/call comprises 0.732571 us before the latest participant starts
+  and 4.888424 us after; last arrival to last completion5.188404 us. Retain
+  the step18 rank-skew outlier. These diagnostic boundaries differ from the
+  accepted CPU replay windows and do not replace the whole-HC report.
+- SASS confirms the old gather scatters contiguous low-rank rows through
+  scalar U16 stores and per-element routing branches. Change ONLY output
+  placement: aligned first80 values/rank use packed16-byte stores, the final
+  pack scatters one injection and three padding values. Keep the original
+  scalar output fallback for an unaligned weak-contiguous view. No changes
+  to arithmetic, sentinel handling, peer ordering, epoch, IPC layout, up or
+  norm. New gather44-46 registers versus old38; both zero stack/spills.
+- Build a single owner DSO containing production vector scatter and the
+  literal old scalar control, then run a paired full-HC benchmark. Pre-commit
+  source SHA4ef36a70d2 plus communication-file SHA256
+  `fea0d06d29cbcdcc3093a32ccd27aeac92e36e23342e5079063df58ba1b9bf64`.
+  Full HC **1.971644 ->1.899800 ms**, saving **0.071844 ms (3.64%)**;
+  vector samples1.899800/1.899861/1.899677. All four ranks pass raw-bit
+  aligned/unaligned comparisons and guards, 16 full-chain changing inputs,
+  512 actual auxiliary sum2 replays and post-timing bitwise checks. Keep this
+  candidate in DraftPR506; do not subtract its isolated gain directly from
+  the previous model trace or claim the 1.5-ms target.
+- Evidence `.artifacts/hc_down_vector_scatter/`: source-derived sidecar/control,
+  build script/log, paired benchmark/guarded runner, result and SASS. Result
+  SHA256 `f533515ef855ab0de4a1f39c71b5d43f96a7520705b38420288b76b8c94e3963`;
+  binary `fb5ee424a70c7532791d38918530d01f85ee99719a37b931c3c95762d3c0d023`.
+  Main was fetched and unchanged at755baae1d0 before publication.
+- Add the model-free public oracle
+  `benchmarks/kernels/verify_sm70_hc_down_scatter.py`: byte-gather reference,
+  all eight FP16 output alignments, reserved-NaN canonicalization in low-rank,
+  injection and padding positions, outside-buffer guards and CUDA Graph replay.
+  Ruff passes. Its focused GPU execution is queued behind the existing GPU
+  reservation; an earlier probe exited75 without starting a CUDA process.
+  This pending oracle is not yet reported as passed.
+- A separate explicit down register-lookahead screen (8/40 steps) was checked
+  OFFLINE ONLY. Compiler scheduling reduced both to32-register rolling-load
+  code, including a warp-ordering attempt, so the intended lookahead was not
+  established. Do not run these as purported prefetch variants or repeat the
+  previously rejected ordinary CUDA128 down. No GPU startup for this screen.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45345,3 +45345,36 @@ Interpretation:
   fused variants compile with 31 registers/16 bytes shared/zero stack or
   spills. Compare complete HC with the newly registered up fusion held fixed,
   including actual auxiliary sum2 and post-wrap checks. GPU gate pending.
+- The exact down packet screen completed and is rejected. Same-source
+  complete-HC control `1.989379 ms`, CUDA down plus separate gather
+  `2.072549 ms`, fused down/gather `2.218926 ms`. All intermediate/final
+  outputs and auxiliary sum2 are bitwise, including generation `195841`, but
+  both projection scheduling and distributed polling regress latency. Do
+  not repeat this 81-CTA packet variant unchanged. Evidence:
+  `.artifacts/hc_down_packet/result.json`; no production down route changed.
+
+## Decode-only HC norm weight prefetch, 2026-09-05
+
+- Previous goal turn made progress by registering and validating the up
+  fusion. Its final bounded down queue expired with exit75 before obtaining
+  GPUs, not after a failed GPU test. The same waiting job was resumed only
+  after its terminal status was verified; the down screen then completed.
+- The existing norm source documents that early weight reads help decode but
+  regress larger batches. A decode-only screen keeps the exact two-axis sum,
+  FP16 combine boundary, FP32 RMS/affine operations and their order; only the
+  weight load moves before combine/reduction. Offline SM70 compilation has
+  40 registers for late load and 66 for early, zero stack/local spills, and
+  64 bytes dynamic shared memory. This is not a repeat of failed norm/down
+  fusion or its down-weight-prefetch variants.
+- Complete-HC prototype control `1.982710 ms` -> early norm load
+  `1.942050 ms`, saving `0.040660 ms` (2.05%). Early samples
+  `1.942009/1.942050/1.942132 ms`. Four ranks x16 changing inputs and all
+  post-timing intermediate/final FP16 bits match. The already registered up
+  fusion is fixed on both sides; no new communication path is introduced.
+  Evidence: `.artifacts/hc_norm_prefetch/result.json` and `run.log`.
+- Port the load scheduling only for SM70, FP16, N=1, HC=4, H=2560. Other
+  shapes/dtypes/architectures and prefill retain deferred loads. Targeted CPU
+  dispatch tests **5 passed**, Ruff passed. The registered-kernel A/B with
+  explicit late/early control is pending; no whole-model claim from this
+  microbenchmark. Next also refresh the whole-model trace after the admitted
+  HC changes, with natural-output checks before profiling and one model load.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45830,3 +45830,58 @@ Interpretation:
   before the performance cases. These short checks are not the required final
   256K quality gate. GPU locks are released before CPU-only report import;
   an in-scope failure stops the job rather than automatically restarting it.
+
+## Completed HC full-model trace refresh, 2026-09-05
+
+- Corrected retry completed at frozen source `e76a9c8ca3` without further
+  model restarts. Two natural-EOS, thinking-enabled checks pass under official
+  sampling (temperature 1, top-p 0.95, top-k 20, seed 0): arithmetic 118 output
+  tokens and record-copy 110. These short checks do not establish full output
+  quality or the final 256K input boundary. The configured max context is
+  262144, but the timed prompt is 8192 tokens.
+- Same loaded engine: TP4 physical V100-SXM2-32GB GPUs 0-3, PP1, V2, no MTP,
+  no prefix cache, FP16 activations/KV, checkpoint-native NVFP4 experts,
+  online QPN8 disabled, q8192, shared-weight dual CUDA graphs, hybrid PLE.
+  Torch 2.10.0+cu128, CUDA runtime 12.8, Nsight Systems 2022.4.2.50.
+  Untraced 8K/513 case: pure decode **93.433729 tok/s**, **10.702773 ms/token**,
+  prefill 1.162319 s, TTFT 1.165618 s. One measured repeat after one warmup;
+  not a repeated endpoint stability claim. Traced 8K/32 request TPOT is
+  11.511879 ms; do not substitute it for the untraced speed.
+- Retained artifacts: `.artifacts/hc_trace_20260905_retry1/` contains the
+  exact contract/command, quality/result JSON, GPU sampler, raw qdstrm,
+  converted report/SQLite and `per_token.{json,md,csv}`. Manual same-version
+  QdstrmImporter conversion works; GPU reservation was released before this
+  CPU-only conversion. Owned engine/workers/PLE processes and sampler exited;
+  GPUs measured 144/10/10/10 MiB immediately after shutdown. No API is left
+  resident by this task.
+- Same parser rank/ordinal windows and NVTX label as the old trace: 31 x four
+  ranks, 29 middle steps. Kernel-name HC bucket **2.658072 -> 2.165077 ms**;
+  complete semantic HC **2.701252 -> 2.208302 ms** (18.25% reduction).
+  New full-HC p50 2.188509 ms, per-token rank-max mean 2.237414 ms. Preserve
+  the rank-skew/communication outlier; do not drop it to improve the mean.
+  No middle-window final-mixer attribution failures. CPU replay-window
+  boundaries produce small fractional launch-count averages; these are not
+  rounded into exact counts. Values are GPU service sums, not additive wall
+  critical-path TPOT. Full-HC **1.5 ms is not achieved**; remaining gap is
+  0.708302 ms (32.1% of the current measured HC time).
+- Current HC rank-average service: fused up/mix/gather 0.693805 ms; local down
+  0.559589; down gather 0.539501; combine/norm 0.367759; final gate 0.004423;
+  additional semantic work 0.043225. The trace confirms the actual fused
+  route. Endpoint improvement also includes earlier admitted W13/W2 and
+  other changes; do not attribute its entire delta solely to HC or norm.
+- Evidence SHA256: result
+  `83a381288a4fb1edc2966c323be567ace02c754fcc754a67778f73247d5df06a`;
+  quality `b4cb34908ca44eeac449104d2f87da77bcedd3345380876a574e5bbee32c0b33`;
+  nsys-rep `121c8bff98bce955ce13bb13501bcfc1021dffc31a214144191d1fcc7348673d`.
+- PR #481 was externally merged at `205acfb4da`, main merge `755baae1d0`.
+  Norm prefetch was pushed after that PR's merge point and needs a new Draft
+  PR. Continue in owned branch `codex/v100-qwen38-hc-15ms-20260905-1702`, same
+  artifact-preserving worktree. Merge main only AFTER the frozen trace ended
+  (`4b6c2daa1f`); this trace is not a speed claim for the integrated source.
+- Next bounded hypothesis: fused-up H8/512-thread scheduling provides eight
+  row pairs and two serial groups, unlike the rejected H8/256-thread schedule
+  with four serial groups. Keep the same FMA/reduction/rounding and packet
+  protocol; screen against admitted H4/256 on full HC with actual auxiliary
+  sum2 and post-tag-wrap checks. It is unimplemented/unmeasured at this update.
+  Existing logical-lane down split, producer publication, 81-CTA down fusion,
+  and norm/down variants remain rejected; do not repeat unchanged.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45885,3 +45885,19 @@ Interpretation:
   sum2 and post-tag-wrap checks. It is unimplemented/unmeasured at this update.
   Existing logical-lane down split, producer publication, 81-CTA down fusion,
   and norm/down variants remain rejected; do not repeat unchanged.
+- Post-integration targeted norm dispatch/communicator-owner CPU checks pass
+  **35 tests**. Continuation Draft PR:
+  [#506](https://github.com/1CatAI/1Cat-vLLM/pull/506).
+- H8/512 screen completed at `2c2ec3f38d`: production complete HC
+  **1.948767 ms**, private H4/256 control 1.970251 ms, private H8/512
+  **1.953417 ms**. H8 improves private geometry by 0.016835 ms, but the tested
+  candidate does not beat production (0.004649 ms slower); no production port
+  or endpoint promotion. This does not prove that every source-integrated H8
+  implementation would lose, but it is not sufficient evidence to admit one.
+  Both fused kernels use 30 registers, zero stack/spills; H4 has 192 shared
+  bytes and H8 384. All four ranks x16 changing inputs, 512 actual auxiliary
+  sum2 replays, and post-timing checks are bitwise; generations 146593/195841
+  cross the 16-bit tag boundary. Evidence `.artifacts/hc_up_h8_threads/`, result
+  SHA256 `2b233da24cf9bba28d867fcdb364e6e8dafd873bf467755358bf169fa83f8ea4`.
+  Test exited normally; GPUs0-3 measured 141/7/7/7 MiB. No own queue/model/API
+  remains. Do not repeat this private-pointer H8/512 candidate unchanged.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45378,3 +45378,34 @@ Interpretation:
   explicit late/early control is pending; no whole-model claim from this
   microbenchmark. Next also refresh the whole-model trace after the admitted
   HC changes, with natural-output checks before profiling and one model load.
+- Registered norm kernel A/B at `8f74e4b88b3e2ec63c14d6be69c833e5a569822a`
+  passes all four-rank initial/post-timing FP16 checks. Explicit late-load
+  control `1.982525 ms`, early-load `1.944255 ms`, saving `0.038270 ms`
+  (1.93%); early samples `1.942992/1.944972/1.944255 ms`. The up fusion remains
+  fixed on both sides. Evidence: `.artifacts/hc_norm_prefetch/registered_result.json`.
+- A complete model/trace attempt loaded and captured the actual fused HC
+  route, then failed before generation: the quality harness passed the chat
+  tokenizer's Mapping result as token IDs. This is a harness failure, not a
+  model-output quality result. Engine shutdown released all task GPUs; the
+  failure is retained under `.artifacts/hc_trace_20260905/`. Do not count it
+  as a successful trace or hide the model startup from the attempt record.
+- Fix/preflight before retry: explicitly request `return_dict=False`, normalize
+  Mapping outputs, and validate nonempty integer IDs and vocabulary bounds on
+  CPU before creating the LLM. Both quality prompts pass (71/82 tokens). The
+  installed Nsight CLI and matching QdstrmImporter live under different library
+  roots; invoking the importer directly successfully converts the retained old
+  qdstrm entirely on CPU. No new profiler version or tracing criterion is used.
+- Reuse the skill parser's exact rank/ordinal windows with the old trace's
+  actual NVTX label `execute_context_0(0)_generation_1(1)`. A second SQL pass
+  selects the final mixer's same-stream work after its last HC norm, excluding
+  auxiliary-stream kernels and deduplicating named HC work. The old core bucket
+  is reproduced as `2.658072 ms` rank-average service; additional named HC and
+  final-mixer work brings the semantic total to `2.701252 ms` (rank-max mean
+  `2.726784 ms`). No steady-window final-mixer attribution failures. These
+  service statistics are not an additive whole-model wall-clock TPOT table.
+- A corrected retry is queued in `.artifacts/hc_trace_20260905_retry1/`, using
+  the same 8K/513 untraced and 8K/32 traced cases, current source-matched HC/W2
+  sidecars, and two short natural-EOS/thinking-enabled official-sampling checks
+  before the performance cases. These short checks are not the required final
+  256K quality gate. GPU locks are released before CPU-only report import;
+  an in-scope failure stops the job rather than automatically restarting it.

--- a/tests/models/qwen4_exp/test_hc_norm_dispatch.py
+++ b/tests/models/qwen4_exp/test_hc_norm_dispatch.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+import vllm.models.qwen4_exp.nvidia.ops.hc as hc
+
+
+@pytest.mark.parametrize(
+    "rows,hidden,dtype,sm70,expected",
+    [
+        (1, 2560, torch.float16, True, True),
+        (2, 2560, torch.float16, True, False),
+        (1, 2560, torch.float32, True, False),
+        (1, 1280, torch.float16, True, False),
+        (1, 2560, torch.float16, False, False),
+    ],
+)
+def test_hc_norm_prefetch_is_exact_decode_shape_only(
+    monkeypatch, rows, hidden, dtype, sm70, expected
+) -> None:
+    kernel = MagicMock()
+    monkeypatch.setattr(hc, "_hc_combine_norm_kernel", kernel)
+    monkeypatch.setattr(hc.current_platform, "is_device_capability", lambda cap: sm70)
+    monkeypatch.setattr(hc.current_platform, "is_arch_support_pdl", lambda: False)
+    residual = torch.empty(rows, 4 * hidden, dtype=dtype)
+    combined, normalized = hc._hc_combine_norm(
+        residual,
+        torch.empty(rows, hidden, dtype=dtype),
+        torch.empty(rows, 4, dtype=dtype),
+        torch.empty(hidden, dtype=dtype),
+        1e-6,
+        4,
+    )
+    assert combined.shape == normalized.shape == residual.shape
+    launch = kernel.__getitem__.return_value
+    launch.assert_called_once()
+    assert launch.call_args.kwargs["PREFETCH_WEIGHT"] is expected

--- a/vllm/models/qwen4_exp/nvidia/ops/hc.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/hc.py
@@ -282,6 +282,7 @@ def _hc_combine_norm_kernel(
     EPS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     launch_pdl: tl.constexpr,
+    PREFETCH_WEIGHT: tl.constexpr = False,
 ) -> None:
     HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
     NUM_TILES: tl.constexpr = triton.cdiv(HC_DIM, BLOCK_SIZE)
@@ -307,6 +308,8 @@ def _hc_combine_norm_kernel(
     res = tl.load(res_ptr + row * stride_res + offs, mask_inner, other=0.0)
     inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
     block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    if PREFETCH_WEIGHT:
+        w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
     inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
     inj = tl.sum(tl.where(offs_hc == stream, inj, 0.0))
     # Round the materialized combine result before normalization. This matches
@@ -323,9 +326,10 @@ def _hc_combine_norm_kernel(
     if launch_pdl:
         tl.extra.cuda.gdc_launch_dependents()
 
-    # Loading the weight earlier helps decode but keeps the tile live across
-    # the reduction and regresses larger batches, so defer it to the norm.
-    w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
+    # Decode can hide this load behind combine/reduction. Keep prefill's
+    # deferred load: the longer live range regresses larger batches.
+    if not PREFETCH_WEIGHT:
+        w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
     y = out * rrms
     y += y * w.to(tl.float32)
     tl.store(y_ptr + row * stride_y + offs, y, mask_inner)
@@ -355,7 +359,8 @@ def _hc_combine_norm(
     # The M=1 SM70 path is register-bound with the generic 512-wide tile.
     # A 1024-wide tile keeps identical reduction/rounding results and is
     # measurably faster on V100; retain the generic tile for larger batches.
-    BLOCK_SIZE = 1024 if N == 1 and current_platform.is_device_capability(70) else 512
+    sm70_decode = N == 1 and current_platform.is_device_capability(70)
+    BLOCK_SIZE = 1024 if sm70_decode else 512
     _hc_combine_norm_kernel[(N, hc_count)](
         block_output,
         residual,
@@ -374,6 +379,12 @@ def _hc_combine_norm(
         EPS=eps,
         BLOCK_SIZE=BLOCK_SIZE,
         launch_pdl=current_platform.is_arch_support_pdl(),
+        PREFETCH_WEIGHT=(
+            sm70_decode
+            and hc_dim == 2560
+            and hc_count == 4
+            and residual.dtype == torch.float16
+        ),
         num_warps=4,
     )
     return out, y


### PR DESCRIPTION
## Purpose

Continue the single-request/no-MTP Qwen3.8 HC <=1.5 ms work after #481 merged.
Integration base: public/main `755baae1d0`; integration merge `4b6c2daa1f`.
This is separate from #504's batched HC scope. Do not merge/promote on the
basis of microbenchmark numbers: the 1.5 ms full-HC target is NOT achieved.

## Implementation

- Decode-only HC norm weight prefetch, source `8f74e4b88b`: only SM70, FP16,
  N=1, HC=4, H=2560. Other shapes/dtypes/architectures and prefill unchanged.
- Preserve original FP32 arithmetic/reduction order and FP16 boundaries.
  Only move the weight load; no public flag or extra weight copy.
- #481 already contains the registered exact up/mix/gather fusion. It is a
  dependency, not a new implementation claim in this PR.

## Test Plan and Result

- Registered full-HC paired microbenchmark: late 1.982525 -> early 1.944255 ms
  (1.93%); all intermediate/final FP16 bits match on 4 ranks x16 inputs and
  after timing. Up fusion fixed on both sides. No new communication here.
- Post-integration targeted CPU dispatch/owner tests: **35 passed**.
- One full-model retry at frozen PRE-integration source `e76a9c8ca3` succeeds:
  two thinking-enabled natural-EOS official-sampling checks pass (118/110
  outputs). 8K/513 untraced pure decode 93.433729 tok/s, 10.702773 ms/token;
  prefill 1.162319 s. This is one measured repeat, not an endpoint campaign.
- Same Nsight 2022.4.2.50 graph-node/rank-ordinal criterion, 29 middle tokens:
  old HC bucket 2.658072 -> 2.165077 ms; complete semantic HC
  2.701252 -> 2.208302 ms. Rank-max mean 2.237414, rank-average p50 2.188509.
  Outliers are retained. GPU service sums are not additive wall critical path.
- Exact workload: Qwen3.8-Flash-Next-NVFP4, 4x V100-SXM2-32GB GPUs0-3, TP4/PP1,
  V2, FP16 A/KV, checkpoint-native NVFP4, no online QPN8, no MTP, no prefix
  cache, max context262144, q8192, dual graphs, hybrid PLE; Torch2.10.0+cu128.
- Tests release all owned GPU/model/PLE processes. No task API left resident.

## Evidence and Remaining Gates

Retained worktree:
`/home/ymzx/桌面/1cat-vllm/worktrees/v100-qwen38-nomtp-token-trace-20260903-173451`.
Artifacts `.artifacts/hc_norm_prefetch/registered_result.json` and
`.artifacts/hc_trace_20260905_retry1/` include contract, logs, quality/result,
raw/converted trace and per-token tables. Hashes and rejected variants are
recorded in `docs/design/sm70_v100_migration_control.md`.

First full-model attempt failed BEFORE generation because the quality harness
passed tokenizer Mapping keys as IDs. CPU-validated correction precedes the
single successful retry; preserve the failed logs. Do not call it a model
quality failure or hide the startup.

The 256K INPUT quality boundary, repeated endpoint evidence, integration-head
GPU validation and <=1.5 ms acceptance remain pending. The new trace includes
earlier W13/W2 changes too; do not attribute all endpoint gains to HC. Next
bounded candidate is H8/512-thread fused-up scheduling, not the rejected
H8/256-thread geometry. No numerical contract change is allowed.

AI assistance: OpenAI Codex. Commits are DCO-signed; human review is required.

### H8 scheduling screen completed

At `2c2ec3f38d`, full-HC production 1.948767 ms, private H4 control 1.970251,
private H8/512 candidate 1.953417. Although geometry improves the private
control by 0.016835 ms, the candidate does not beat production and is NOT
ported/admitted. All 4 ranks x16 inputs, 512 actual auxiliary sum2 replays and
post-wrap generation195841 checks are bitwise. Both fused kernels 30 registers,
zero spills. Artifact `.artifacts/hc_up_h8_threads/result.json`. All test
processes exited and GPUs0-3 returned to 141/7/7/7 MiB. No further model start.

### Current down counters and vector output scatter (4ae6a0005a)

The old NCU report measured 324 replicated down rows. A focused current
81-live-row/grid88/block128 profile instead finds 6.51% achieved occupancy,
216.88 GB/s, 91.84% no-eligible scheduler cycles and long-scoreboard 63.9%.
Clock-control none/cache-control all; cold NCU duration is not endpoint timing.
Existing trace collective-ordinal analysis shows 4.888424 us/call remain after
the last rank starts (5.620995 us total average service).

SASS identifies scalar scatter/routing overhead. Keep contiguous low-rank rows
packed as 16-byte output stores; separately scatter injection/padding, retain
unaligned scalar fallback. No arithmetic/protocol/IPC/epoch/up/norm change.
Paired full-HC test with old scalar and new vector in the SAME owner DSO:
**1.971644 -> 1.899800 ms**, saving **0.071844 ms (3.64%)**. All four ranks pass
raw-bit aligned/unaligned/guard tests, 16 changing full-HC inputs, 512 actual
auxiliary sum2 replays and post-timing bitwise checks. The source and independent
model-free public verifier are committed. The public verifier's additional
eight-alignment/reference GPU run is queued behind another task's reservation,
not yet claimed passed. This turn performed NO full-model start.

Evidence `.artifacts/hc_down_ncu_20260905/` and
`.artifacts/hc_down_vector_scatter/`; result/binary/source hashes in worklog.
Do not subtract the micro gain directly from the previous 2.208302-ms model
trace. Full-model/256K/1.5-ms gates remain pending. An explicit down load-ahead
attempt was rejected offline because compiler rescheduling erased the intended
lookahead; no redundant GPU experiment was run for it.
