### PR TITLE
[Bugfix][SM70] Release unused AWQ/NVFP4 MoE conversion cache between layers

### DIFF
--- a/tests/quantization/test_sm70_moe_load_cache_release.py
+++ b/tests/quantization/test_sm70_moe_load_cache_release.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU lifecycle tests; native repacking and GPU workspaces are stubbed.
+
+These exercise the real loading methods, not the numerical CUDA converters.
+Model-level GPU A/B validation remains necessary for peak-memory measurements.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization import awq_sm70_moe as awq
+from vllm.model_executor.layers.quantization import nvfp4_sm70_moe as nvfp4
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    # All tensors and native-op stubs in this module are CPU-only.
+    return False
+
+
+def _parameter(layer, name, shape, dtype):
+    value = torch.ones(shape, dtype=torch.float32).to(dtype)
+    setattr(layer, name, torch.nn.Parameter(value, requires_grad=False))
+
+
+def _ptrs(weight, scales, k_ld, q_ld, experts):
+    # Native pointer construction is not under test on CPU.
+    return torch.zeros(experts, 8, dtype=torch.uint8), torch.zeros(
+        experts, 8, dtype=torch.uint8
+    )
+
+
+def _awq_case(monkeypatch):
+    layer = torch.nn.Module()
+    layer.moe_config = SimpleNamespace(tp_size=1)
+    for prefix, k, n in (("w13", 64, 64), ("w2", 32, 64)):
+        _parameter(layer, f"{prefix}_qweight", (2, k, n // 8), torch.int32)
+        _parameter(layer, f"{prefix}_scales", (2, k // 32, n), torch.float16)
+        _parameter(layer, f"{prefix}_qzeros", (2, k // 32, n // 8), torch.int32)
+    monkeypatch.setattr(
+        awq,
+        "envs",
+        SimpleNamespace(
+            VLLM_SM70_AWQ_MOE_COMPACT_METADATA=False,
+            VLLM_SM70_AWQ_MOE_LEGACY_SINGLE_TOKEN_COMPACT=False,
+            VLLM_SM70_AWQ_QWEN38_MOE_INDEXED_PREFILL=False,
+            VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST=None,
+            VLLM_SM70_AWQ_MOE_BATCHED_LAYER_DENYLIST=None,
+        ),
+    )
+    monkeypatch.setattr(awq, "_batched_gemm_enabled_for_layer", lambda *_: False)
+    monkeypatch.setattr(awq, "_get_layer_id", lambda _: 0)
+
+    def prepare(weight, scales, zeros, group_size, interleaved):
+        return weight.clone(), scales.clone(), torch.tensor([64, 64])
+
+    monkeypatch.setattr(awq.sm70_ops, "awq_sm70_prepare", prepare)
+    method = SimpleNamespace(
+        group_size=32,
+        pack_factor=8,
+        use_batched_gemm=False,
+        _allocate_buffers=lambda layer: setattr(layer, "test_buffer", torch.ones(4)),
+    )
+    source_names = tuple(layer._parameters)
+    return (
+        awq.AWQSM70MoEMethod.process_weights_after_loading,
+        method,
+        layer,
+        source_names,
+    )
+
+
+def _nvfp4_case(monkeypatch):
+    layer = torch.nn.Module()
+    layer.moe_config = SimpleNamespace(
+        tp_size=1,
+        hidden_dim=64,
+        intermediate_size_per_partition=32,
+        experts_per_token=1,
+    )
+    layer.local_num_experts = layer.global_num_experts = 2
+    layer.activation = nvfp4.MoEActivation.SILU
+    layer.apply_router_weight_on_input = False
+    layer.expert_map = layer.swiglu_limit = None
+    for prefix, n, k in (("w13", 64, 64), ("w2", 64, 32)):
+        _parameter(layer, f"{prefix}_weight", (2, n, k // 2), torch.uint8)
+        _parameter(
+            layer, f"{prefix}_weight_scale", (2, n, k // 16), torch.float8_e4m3fn
+        )
+        shape = (2, 2) if prefix == "w13" else (2,)
+        _parameter(layer, f"{prefix}_weight_scale_2", shape, torch.float32)
+        _parameter(layer, f"{prefix}_input_scale", (2,), torch.float32)
+    flags = (
+        "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_MTP5_DECODE",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_W2_DIRECT_REDUCE",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE",
+        "VLLM_SM70_GLM53_MOE_FUSED_PERMUTE_Q8",
+        "VLLM_SM70_GLM53_MOE_QPN_W13_Q8",
+        "VLLM_SM70_NVFP4_MOE_GROUPED_DECODE",
+    )
+    monkeypatch.setattr(nvfp4, "envs", SimpleNamespace(**dict.fromkeys(flags, False)))
+    for name in (
+        "nvfp4_sm70_prepare",
+        "nvfp4_moe_dense_stage_sm70_out",
+        "awq_moe_build_strided_ptrs",
+    ):
+        monkeypatch.setattr(torch.ops._C, name, Mock(), raising=False)
+    monkeypatch.setattr(
+        torch.ops._moe_C, "moe_permute_with_scratch", Mock(), raising=False
+    )
+    # Use small tensors while retaining the real packed-weight layout validator.
+    monkeypatch.setattr(nvfp4, "validate_nvfp4_sm70_moe_contract", lambda _: None)
+
+    def prepare(weight, scales, group_size, **kwargs):
+        return weight.clone(), scales.clone(), torch.tensor([64, 64])
+
+    monkeypatch.setattr(nvfp4.sm70_ops, "nvfp4_sm70_prepare", prepare)
+    method = SimpleNamespace(
+        moe=SimpleNamespace(has_bias=False),
+        _allocate_graph_safe_decode_buffers=lambda layer: setattr(
+            layer, "test_buffer", torch.ones(4)
+        ),
+    )
+    source_names = tuple(layer._parameters)
+    return (
+        nvfp4.ModelOptNvFp4SM70MoEMethod.process_weights_after_loading,
+        method,
+        layer,
+        source_names,
+    )
+
+
+@pytest.mark.parametrize("make_case", [_awq_case, _nvfp4_case], ids=["awq", "nvfp4"])
+def test_release_once_after_source_removal_preserves_prepared_tensors(
+    monkeypatch, make_case
+):
+    monkeypatch.setattr(awq.sm70_ops, "awq_moe_build_strided_ptrs", _ptrs)
+    load, method, reference, _ = make_case(monkeypatch)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    load(method, reference)
+    expected = {name: value.clone() for name, value in reference.named_parameters()}
+    assert {"w13_tm_weight", "w2_tm_weight", "w13_tm_scales", "w2_tm_scales"} <= (
+        expected.keys()
+    )
+
+    # Two layer invocations ensure this is per-layer, not process-once cleanup.
+    for _ in range(2):
+        load, method, layer, source_names = make_case(monkeypatch)
+
+        def check_release(layer=layer, source_names=source_names):
+            assert all(not hasattr(layer, name) for name in source_names)
+            assert dict(layer.named_parameters()).keys() == expected.keys()
+            for name, tensor in layer.named_parameters():
+                assert torch.equal(tensor, expected[name])
+            assert torch.equal(layer.test_buffer, reference.test_buffer)
+
+        release = Mock(side_effect=check_release)
+        monkeypatch.setattr(torch.accelerator, "empty_cache", release)
+        load(method, layer)
+        release.assert_called_once_with()
+        check_release()
+
+
+@pytest.mark.parametrize("make_case", [_awq_case, _nvfp4_case], ids=["awq", "nvfp4"])
+def test_failed_conversion_does_not_run_success_cleanup(monkeypatch, make_case):
+    load, method, layer, source_names = make_case(monkeypatch)
+    failing_prepare = Mock(side_effect=RuntimeError("conversion failed"))
+    monkeypatch.setattr(awq.sm70_ops, "awq_sm70_prepare", failing_prepare)
+    monkeypatch.setattr(nvfp4.sm70_ops, "nvfp4_sm70_prepare", failing_prepare)
+    release = Mock()
+    monkeypatch.setattr(torch.accelerator, "empty_cache", release)
+    with pytest.raises(RuntimeError, match="conversion failed"):
+        load(method, layer)
+    release.assert_not_called()
+    assert all(hasattr(layer, name) for name in source_names)

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -807,6 +807,10 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
         self._allocate_buffers(layer)
         del layer.w13_qweight, layer.w13_scales, layer.w13_qzeros
         del layer.w2_qweight, layer.w2_scales, layer.w2_qzeros
+        # Release unused conversion blocks between layers instead of retaining
+        # their high-water mark throughout model loading. Live prepared weights
+        # and inference buffers are unaffected; this is not an inference hook.
+        torch.accelerator.empty_cache()
         if (
             envs.VLLM_SM70_AWQ_MOE_BATCHED_LAYER_ALLOWLIST is not None
             or envs.VLLM_SM70_AWQ_MOE_BATCHED_LAYER_DENYLIST is not None

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -1218,6 +1218,10 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         del layer.w2_weight_scale
         del layer.w2_weight_scale_2
         del layer.w2_input_scale
+        # Release unused conversion blocks between layers instead of retaining
+        # their high-water mark throughout model loading. Live prepared weights
+        # and inference buffers are unaffected; this is not an inference hook.
+        torch.accelerator.empty_cache()
         logger.info_once(
             "SM70 ModelOpt NVFP4 TurboMind MoE path enabled "
             "(hidden=%d, local_intermediate=%d, local_experts=%d, top_k=%d, "


### PR DESCRIPTION
## Purpose

Reduce the loading-time GPU memory peak of the SM70 AWQ and ModelOpt NVFP4 MoE paths without changing prepared weights or inference kernels.

After each layer finishes conversion, workspace allocation, and source-parameter removal, call `torch.accelerator.empty_cache()` once. This releases unused caching-allocator blocks between layers; live prepared weights and inference buffers remain allocated. The call is restricted to the two weight-loading methods, not the inference path.

Controlled loading probes identified cross-layer retention of temporary conversion allocations as the dominant observed peak. Output-bank preallocation alone had a much smaller effect, so this change keeps the existing conversion algorithm and avoids a larger preallocation/workspace rewrite. It is not an FP8 conversion port or a change to NVFP4 quantization semantics.

Duplicate check: no open 1Cat PR was found for these two layer-boundary cleanup calls. Earlier model/FP8 integration PRs #345 and #212 are merged, and current main still lacks the calls. This is separate from active-grouped-decode dispatch changes. Original validation/review record: [Leonccaa/1Cat-vLLM#9](https://github.com/Leonccaa/1Cat-vLLM/pull/9).

## Test Plan

Tested head: `ebf621e9f607cce5960843ae9926ff2c741a4b00`, against baseline `7e3efe7443cfd25285c31137cc9d767b48e84751`. At submission, upstream main is `755baae1d075ee04fa9096b23fc0225b23589a86`; its intervening changes are documentation-only, with no differences in `vllm/`, `csrc/`, or `tests/`.

CPU lifecycle regression commands (project virtual-environment path normalized):

```sh
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/quantization/test_sm70_moe_load_cache_release.py -q
pre-commit run --files vllm/model_executor/layers/quantization/awq_sm70_moe.py vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py tests/quantization/test_sm70_moe_load_cache_release.py
```

The tests call the real loading methods with native converters and GPU workspaces stubbed. They check once-per-layer cleanup after source removal, preservation of prepared tensors/buffers, and no success cleanup after a failed conversion. Removing both cleanup calls makes the two success-path tests fail.

GPU acceptance: two independent eager starts per variant and one CUDA Graph start per variant, for both AWQ and NVFP4: 12 model startups / 6 A/B pairs. Record prepared weight/scale hashes for all 4 ranks × 48 MoE layers, ready memory, source/native provenance, and four frozen short prompts per run. Compare prompt/output token IDs and stop reasons with natural EOS (`ignore_eos=false`, temperature 0, seed 0, max output 512); require nonempty output and finite selected-token logprobs.

Frozen configuration:

- Qwen3.8 Flash Next, one fixed checkpoint per format across A/B; 4×V100, TP4, MTP off, FP16 activations and KV.
- Context and batched-token limit 4096, max sequences 1, fixed KV allocation 512 MiB per GPU; prefix caching and async scheduling disabled.
- PyTorch 2.10.0+cu128 / CUDA 12.8, `expandable_segments:True`, MRv2, PYNCCL, matching hybrid PLE offload in both arms.
- Eager versus `FULL_AND_PIECEWISE` graph mode, capture sizes 1 and 2. Comparisons are within the same format and mode, not across AWQ/NVFP4 or eager/graph.
- NVML sampling every 50 ms measures startup through ready. This is a sampled startup peak, not an instantaneous converter-only peak. Ready allocated values measure live PyTorch allocations, not cached reservations.

## Test Result

All 12 starts and 48 natural-EOS requests pass. Every A/B pair has identical prepared-weight/scale hashes, prompt/generated token IDs and stop reasons, and exactly equal ready live allocations. All four eager repeatability groups pass. Both formats complete actual CUDA Graph capture and inference in both arms.

| Format | Mode / repeat | Worst-GPU startup peak, baseline → fix (MiB) | Ready live allocation per GPU, unchanged (MiB) |
| --- | --- | ---: | ---: |
| AWQ | eager 1 | 32,494 → 24,724 | 22,111.96 |
| AWQ | eager 2 | 32,488 → 24,724 | 22,111.96 |
| AWQ | graph | 32,492 → 24,658 | 22,196.23 |
| NVFP4 | eager 1 | 32,394 → 24,626 | 22,204.28 |
| NVFP4 | eager 2 | 32,328 → 24,626 | 22,204.28 |
| NVFP4 | graph | 32,494 → 24,494 | 22,220.55 |

Every GPU has a lower startup peak in every pair. Worst-GPU reductions are **7.52–7.81 GiB**. Ready live allocations are exactly equal before rounding: this reduces startup headroom requirements, not steady-state weight storage.

Four CPU regression tests pass, including a fresh rerun before upstream submission; all applicable pre-commit hooks passed on the unchanged commit. These local results are separate from upstream CI status.

### Scope and limitations

The GPU matrix used the same frozen `_C` binary in both arms. Its default AWQ indexed-prefill capability fallback remains active. NVFP4 used a matching QPN sidecar compiled from the unmodified current CUDA source through the existing registration hook, identically in both arms. Its batch-versus-serial bitwise and CUDA Graph replay checks pass for M=1/2/4/8/16. Other missing optional native capabilities retain their ordinary fallback. The sidecar and experiment harness are not product changes in this PR; this is not validation of every latest native kernel.

For the two eager repeats, maximum-rank `Model loading took` times were AWQ baseline 121.46–121.93 s versus fix 117.25–118.29 s; NVFP4 baseline 150.50–176.49 s versus fix 172.51–178.50 s. NVFP4's earlier checkpoint-read phase itself varied from 108.55–131.73 s versus 130.28–140.29 s. These samples do not isolate cleanup overhead; no startup-speedup or broad latency guarantee is claimed.

The short natural-EOS tests are a regression gate, not broad model-quality or throughput evaluation. MTP, larger batches, long contexts, and other models are outside this acceptance matrix. No model deployment or merge is included.

AI assistance was used for implementation, testing, and PR preparation. On 2026-09-05, Leon confirmed that he had reviewed the code and authorized marking this PR ready for review. The reported test runs were agent-executed; independent human test execution is not asserted.
