### PR TITLE
[Kernel][WIP] Tune exact M1 output projections and NVFP4 W13

### DIFF
--- a/benchmarks/kernels/build_sm70_w13_exact_sidecar.py
+++ b/benchmarks/kernels/build_sm70_w13_exact_sidecar.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Build the exact W13 scheduling screen without initializing CUDA."""
+
+import argparse
+from pathlib import Path
+
+from torch.utils.cpp_extension import load
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--build-dir", type=Path, required=True)
+args = parser.parse_args()
+args.build_dir.mkdir(parents=True, exist_ok=True)
+print(
+    load(
+        name="vllm_w13_exact_sm70",
+        sources=[str(Path(__file__).with_name("sm70_w13_exact_sidecar.cu"))],
+        extra_cflags=["-O3"],
+        extra_cuda_cflags=["-O3", "-lineinfo", "-Xptxas=-v"],
+        build_directory=str(args.build_dir),
+        is_python_module=False,
+        verbose=True,
+    ),
+    flush=True,
+)

--- a/benchmarks/kernels/sm70_w13_exact_sidecar.cu
+++ b/benchmarks/kernels/sm70_w13_exact_sidecar.cu
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <torch/library.h>
+
+#include "../../csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu"
+
+namespace {
+
+__global__ void merge_w13_partials(const float* partials, half* output) {
+  const int tile = blockIdx.x;
+  const int route = blockIdx.y;
+  const int lane = threadIdx.x;
+  float value = 0.0f;
+#pragma unroll
+  for (int warp = 0; warp < 16; ++warp) {
+    value += partials[((route * 10 + tile) * 16 + warp) * 32 + lane];
+  }
+  const half rounded = __float2half(value);
+  const int source_lane = (lane & 15) * 2;
+  const unsigned bits = __half_as_ushort(rounded);
+  const half gate = __ushort_as_half(static_cast<unsigned short>(
+      __shfl_sync(0xffffffffu, bits, source_lane)));
+  const half up = __ushort_as_half(static_cast<unsigned short>(
+      __shfl_sync(0xffffffffu, bits, source_lane + 1)));
+  if (lane < 16) {
+    const float gate_f = __half2float(gate);
+    const half silu = __float2half(gate_f / (1.0f + expf(-gate_f)));
+    output[route * 160 + tile * 16 + lane] = __hmul(silu, up);
+  }
+}
+
+void screen_w13(torch::Tensor out, torch::Tensor input, torch::Tensor weights,
+                torch::Tensor scales, torch::Tensor ids, torch::Tensor scratch,
+                int64_t mode) {
+  TORCH_CHECK(mode >= 0 && mode <= 4);
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && weights.is_cuda() &&
+              scales.is_cuda() && ids.is_cuda());
+  TORCH_CHECK(out.scalar_type() == at::kHalf && input.scalar_type() == at::kHalf &&
+              weights.scalar_type() == at::kInt && scales.scalar_type() == at::kHalf &&
+              ids.scalar_type() == at::kInt);
+  const int routes = static_cast<int>(ids.numel());
+  TORCH_CHECK((routes == 10 || routes == 50) && input.dim() == 2 &&
+              input.size(0) == routes / 10 && input.size(1) == 2560 &&
+              out.sizes() == torch::IntArrayRef({routes, 160}) &&
+              weights.sizes() == torch::IntArrayRef({512, 2560, 40}) &&
+              scales.sizes() == torch::IntArrayRef({512, 160, 320}));
+  for (const auto& t : {out, input, weights, scales, ids}) {
+    TORCH_CHECK(t.is_contiguous() && t.device() == input.device());
+  }
+  const c10::cuda::CUDAGuard guard(input.device());
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  const auto* x = reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  const auto* w = reinterpret_cast<const uint32_t*>(weights.data_ptr<int32_t>());
+  const auto* s = reinterpret_cast<const half*>(scales.data_ptr<at::Half>());
+  auto* y = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+  if (mode >= 3) {
+    TORCH_CHECK(scratch.device() == input.device() && scratch.is_contiguous() &&
+                scratch.scalar_type() == at::kFloat &&
+                scratch.numel() == routes * 10 * 16 * 32);
+    if (mode == 3) {
+      nvfp4_qpn_m1_sm70_kernel<16, true, true, true, 2>
+          <<<dim3(10, routes, 2), 256, 0, stream>>>(
+              x, w, s, ids.data_ptr<int32_t>(), y, 320, 2560, true,
+              scratch.data_ptr<float>());
+    } else {
+      nvfp4_qpn_m1_sm70_kernel<16, true, true, true, 4>
+          <<<dim3(10, routes, 4), 128, 0, stream>>>(
+              x, w, s, ids.data_ptr<int32_t>(), y, 320, 2560, true,
+              scratch.data_ptr<float>());
+    }
+    merge_w13_partials<<<dim3(10, routes), 32, 0, stream>>>(
+        scratch.data_ptr<float>(), y);
+  } else if (mode == 2) {
+    nvfp4_qpn_m1_sm70_kernel<16, true, true, true>
+        <<<dim3(10, routes), 512, 0, stream>>>(
+            x, w, s, ids.data_ptr<int32_t>(), y, 320, 2560, true);
+  } else if (mode == 1) {
+    nvfp4_qpn_m1_sm70_kernel<16, true, true>
+        <<<dim3(10, routes), 512, 0, stream>>>(
+            x, w, s, ids.data_ptr<int32_t>(), y, 320, 2560, true);
+  } else {
+    nvfp4_qpn_m1_sm70_kernel<16, true, false>
+        <<<dim3(10, routes), 512, 0, stream>>>(
+            x, w, s, ids.data_ptr<int32_t>(), y, 320, 2560, true);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace
+
+TORCH_LIBRARY_FRAGMENT(_C_w13_exact, ops) {
+  ops.def("run(Tensor(a!) out, Tensor input, Tensor weights, Tensor scales, "
+          "Tensor ids, Tensor(b!) scratch, int mode) -> ()");
+  ops.impl("run", torch::kCUDA, &screen_w13);
+}

--- a/benchmarks/kernels/verify_sm70_output_projection_policy.py
+++ b/benchmarks/kernels/verify_sm70_output_projection_policy.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Real-weight M1 output projection policy A/B, no model initialization."""
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from verify_sm70_qsa_router_exact import capture, paired_timing
+
+from vllm.models.qwen4_exp.nvidia.sm70_fp16_gemv import (
+    _qwen38_fp16_row_gemv_kernel as kernel,
+)
+
+
+def load_weights(model, rank):
+    index = json.loads((model / "model.safetensors.index.json").read_text())
+    names = sorted(
+        (
+            key
+            for key in index["weight_map"]
+            if key.endswith(
+                (".linear_attn.out_proj.weight", ".self_attn.o_proj.weight")
+            )
+            and key.startswith("model.language_model.layers.")
+        ),
+        key=lambda key: int(key.split(".layers.")[1].split(".")[0]),
+    )
+    assert len(names) == 48
+    weights = []
+    for name in names:
+        with safe_open(model / index["weight_map"][name], framework="pt") as f:
+            view = f.get_slice(name)
+            assert view.get_shape() == [2560, 6144], (name, view.get_shape())
+            weights.append(
+                view[:, rank * 1536 : (rank + 1) * 1536]
+                .to(device="cuda", dtype=torch.float16)
+                .contiguous()
+            )
+    return names, weights
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--rank", type=int, choices=range(4), default=0)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    torch.cuda.set_device(0)
+    assert torch.cuda.get_device_capability() == (7, 0)
+    torch.manual_seed(20260905)
+    names, weights = load_weights(args.model, args.rank)
+    x = torch.randn(48, 1536, device="cuda", dtype=torch.float16)
+    a = torch.empty(48, 2560, device="cuda", dtype=torch.float16)
+    b = torch.empty_like(a)
+    role_policy = [int("linear_attn" in name) for name in names]
+
+    def run(dst, role_specific):
+        for i, weight in enumerate(weights):
+            kernel[(2560,)](
+                x[i],
+                weight,
+                dst[i],
+                K=1536,
+                BLOCK_K=512,
+                LOAD_POLICY=role_policy[i] if role_specific else 0,
+                num_warps=4,
+            )
+
+    ga, gb = capture(lambda: run(a, False)), capture(lambda: run(b, True))
+    for replay in range(64):
+        x.normal_()
+        if replay % 4 == 0:
+            x.mul_(1e-3)
+        elif replay % 4 == 1:
+            x.mul_(10)
+        elif replay % 4 == 2:
+            x[:, ::3] = -0.0
+        b.fill_(float("nan"))
+        ga.replay()
+        gb.replay()
+        assert torch.equal(a.view(torch.int16), b.view(torch.int16)), replay
+    result = {
+        "scope": "operator-only, real48-layer FP16 runtime output weights",
+        "tp_rank": args.rank,
+        "weight_shapes": [2560, 1536],
+        "gdn_calls": sum(role_policy),
+        "qsa_calls": len(names) - sum(role_policy),
+        "bitwise_changed_input_graph_replays": 64,
+        "times": paired_timing(ga, gb),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+    }
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/verify_sm70_output_projection_policy.py
+++ b/benchmarks/kernels/verify_sm70_output_projection_policy.py
@@ -93,6 +93,28 @@ def main():
         "torch": torch.__version__,
         "cuda": torch.version.cuda,
     }
+    live_outputs = []
+
+    def production():
+        live_outputs.clear()
+        for i, weight in enumerate(weights):
+            live_outputs.append(
+                torch.ops.vllm.qwen38_sm70_fp16_gemv(
+                    x[i : i + 1], weight, names[i].removesuffix(".weight")
+                )
+            )
+
+    gp = capture(production)
+    for replay in range(16):
+        x.normal_()
+        for value in live_outputs:
+            value.fill_(float("nan"))
+        ga.replay()
+        gp.replay()
+        assert torch.equal(
+            a.view(torch.int16), torch.cat(live_outputs).view(torch.int16)
+        ), replay
+    result["production_custom_op_graph_replays"] = 16
     args.out.write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2), flush=True)
 

--- a/benchmarks/kernels/verify_sm70_w13_exact.py
+++ b/benchmarks/kernels/verify_sm70_w13_exact.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W13 scheduling screen with frozen-binary oracle and changing graph inputs."""
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from verify_sm70_qsa_router_exact import capture, paired_timing
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library", type=Path, required=True)
+    parser.add_argument("--old-library", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--profile-only", action="store_true")
+    parser.add_argument("--mode", type=int, choices=(1, 2, 3, 4), default=1)
+    args = parser.parse_args()
+    torch.cuda.set_device(0)
+    assert torch.cuda.get_device_capability() == (7, 0)
+    torch.manual_seed(20260906)
+    torch.ops.load_library(str(args.old_library))
+    torch.ops.load_library(str(args.library))
+    old = torch.ops._C_qwen38.nvfp4_qwen38_w13_fused_swiglu_out
+    op = torch.ops._C_w13_exact.run
+    weights = torch.randint(
+        -(2**31), 2**31 - 1, (512, 2560, 40), dtype=torch.int32, device="cuda"
+    )
+    scales = torch.empty(512, 160, 320, dtype=torch.float16, device="cuda")
+    scales.uniform_(2**-10, 2**-6)
+    x = torch.randn(48, 1, 2560, dtype=torch.float16, device="cuda")
+    ids = torch.randint(512, (48, 10), dtype=torch.int32, device="cuda")
+    a = torch.empty(48, 10, 160, dtype=torch.float16, device="cuda")
+    b, c = torch.empty_like(a), torch.empty_like(a)
+    scratch = torch.empty(48, 10, 10, 16, 32, dtype=torch.float32, device="cuda")
+
+    def run(dst, mode):
+        for i in range(48):
+            if mode == "installed":
+                old(dst[i], x[i], weights, scales, ids[i])
+            else:
+                op(
+                    dst[i],
+                    x[i],
+                    weights,
+                    scales,
+                    ids[i],
+                    scratch[i],
+                    args.mode if mode == "static" else 0,
+                )
+
+    ga = capture(lambda: run(a, "installed"))
+    gb = capture(lambda: run(b, "dynamic"))
+    gc = capture(lambda: run(c, "static"))
+    if args.profile_only:
+        for _ in range(300):
+            gb.replay()
+            gc.replay()
+        torch.cuda.synchronize()
+        torch.cuda.cudart().cudaProfilerStart()
+        op(b[0], x[0], weights, scales, ids[0], scratch[0], 0)
+        op(c[0], x[0], weights, scales, ids[0], scratch[0], args.mode)
+        torch.cuda.synchronize()
+        torch.cuda.cudart().cudaProfilerStop()
+        return
+
+    for replay in range(64):
+        x.normal_()
+        ids.random_(512)
+        if replay % 8 == 0:
+            ids[:, ::3] = -1
+        elif replay % 8 == 1:
+            ids[:, ::3] = 512
+        elif replay % 8 == 2:
+            ids.zero_()
+        if replay % 4 == 0:
+            x.mul_(1e-3)
+        elif replay % 4 == 1:
+            x.mul_(16)
+        elif replay % 4 == 2:
+            x[:, :, ::3] = -0.0
+        b.fill_(float("nan"))
+        c.fill_(float("nan"))
+        scratch.fill_(float("nan"))
+        ga.replay()
+        gb.replay()
+        gc.replay()
+        assert torch.equal(a.view(torch.int16), b.view(torch.int16)), (replay, "build")
+        assert torch.equal(a.view(torch.int16), c.view(torch.int16)), (replay, "static")
+    # Time varied valid experts, not an all-invalid or repeated-expert case.
+    ids.copy_(
+        (
+            torch.arange(10, device="cuda")
+            + 13 * torch.arange(48, device="cuda")[:, None]
+        )
+        % 512
+    )
+    x.normal_()
+    result = {
+        "scope": "synthetic packed NVFP4 payload/scale screen, not model quality",
+        "calls": 48,
+        "candidate_mode": args.mode,
+        "split_k": 16,
+        "m1_changed_input_graph_replays": 64,
+        "exact_vs_installed_old_and_rebuilt_control": True,
+        "times": paired_timing(gb, gc),
+    }
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
+++ b/csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu
@@ -193,22 +193,33 @@ __global__ void mxfp4_qpn_m1_sm70_kernel(const half* __restrict__ input,
   }
 }
 
-template <int kSplitK, bool kFusedSwiGLU = false>
+template <int kSplitK, bool kFusedSwiGLU = false, bool kStaticW13 = false,
+          bool kPrefetch = false, int kSplitBlocks = 1>
 __global__ void nvfp4_qpn_m1_sm70_kernel(const half* __restrict__ input,
                                          const uint32_t* __restrict__ weights,
                                          const half* __restrict__ scales,
                                          const int32_t* __restrict__ expert_ids,
-                                         half* __restrict__ output, int n,
-                                         int k, bool broadcast_input) {
+                                         half* __restrict__ output, int runtime_n,
+                                         int runtime_k, bool broadcast_input,
+                                         float* split_partials = nullptr) {
+  static_assert(kSplitK % kSplitBlocks == 0);
+  static_assert(!kStaticW13 || (kFusedSwiGLU && kSplitK == 16));
+  static_assert(kSplitBlocks == 1 || kStaticW13);
+  const int n = kStaticW13 ? 320 : runtime_n;
+  const int k = kStaticW13 ? 2560 : runtime_k;
   __shared__ float partials[kSplitK][32];
 
   const int lane = threadIdx.x & 31;
-  const int warp = threadIdx.x >> 5;
+  const int warp = (threadIdx.x >> 5) +
+                   (kSplitBlocks > 1 ? blockIdx.z * (kSplitK / kSplitBlocks) : 0);
   const int tile = blockIdx.x;
   const int route = blockIdx.y;
   const int expert = __ldg(expert_ids + route);
   if (expert < 0 || expert >= 512) {
-    if constexpr (kFusedSwiGLU) {
+    if constexpr (kSplitBlocks > 1) {
+      split_partials[((route * (n / 32) + tile) * kSplitK + warp) * 32 + lane] =
+          0.0f;
+    } else if constexpr (kFusedSwiGLU) {
       if (threadIdx.x < 16) {
         output[static_cast<size_t>(route) * (n / 2) + tile * 16 + threadIdx.x] =
             __float2half(0.0f);
@@ -242,17 +253,44 @@ __global__ void nvfp4_qpn_m1_sm70_kernel(const half* __restrict__ input,
   const int input_route = broadcast_input ? route / 10 : route;
   const half* input_row = input + static_cast<size_t>(input_route) * k;
 
+  unsigned next_packed0 = 0;
+  unsigned next_packed1 = 0;
+  half next_scale = __float2half(0.0f);
+  if constexpr (kPrefetch) {
+    const size_t base =
+        (static_cast<size_t>(tile) * groups_k8 + group_begin * 2) * 32 + packed_col;
+    next_packed0 = __ldcs(expert_weights + base);
+    next_packed1 = __ldcs(expert_weights + base + 32);
+    next_scale = __ldg(expert_scales +
+                      (static_cast<size_t>(group_begin) * tiles_n32 + tile) * 32 +
+                      packed_col);
+  }
+
   float accum[8] = {};
 #pragma unroll 4
   for (int group = group_begin; group < group_begin + groups_per_warp;
        ++group) {
     const size_t tile_group_base =
         (static_cast<size_t>(tile) * groups_k8 + group * 2) * 32 + packed_col;
-    const unsigned packed0 = __ldcs(expert_weights + tile_group_base);
-    const unsigned packed1 = __ldcs(expert_weights + tile_group_base + 32);
+    unsigned packed0;
+    unsigned packed1;
     const size_t scale_index =
         (static_cast<size_t>(group) * tiles_n32 + tile) * 32 + packed_col;
-    const half scalar = __ldg(expert_scales + scale_index);
+    half scalar;
+    if constexpr (kPrefetch) {
+      packed0 = next_packed0;
+      packed1 = next_packed1;
+      scalar = next_scale;
+      if (group + 1 < group_begin + groups_per_warp) {
+        next_packed0 = __ldcs(expert_weights + tile_group_base + 64);
+        next_packed1 = __ldcs(expert_weights + tile_group_base + 96);
+        next_scale = __ldg(expert_scales + scale_index + tiles_n32 * 32);
+      }
+    } else {
+      packed0 = __ldcs(expert_weights + tile_group_base);
+      packed1 = __ldcs(expert_weights + tile_group_base + 32);
+      scalar = __ldg(expert_scales + scale_index);
+    }
     // dequant_e2m1x8 materializes the FP4 payload with a 2^-14 exponent
     // offset so that every E2M1 value can be formed with integer bit ops.
     // MXFP4 folds the matching 2^14 correction into its exponent scale;
@@ -286,10 +324,16 @@ __global__ void nvfp4_qpn_m1_sm70_kernel(const half* __restrict__ input,
       for (int offset = 0; offset < 2; ++offset) {
         const int index = pair * 4 + offset;
         const int local_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
-        partials[warp][quadpair * 8 + local_col] = accum[index];
+        if constexpr (kSplitBlocks > 1) {
+          split_partials[((route * tiles_n32 + tile) * kSplitK + warp) * 32 +
+                         quadpair * 8 + local_col] = accum[index];
+        } else {
+          partials[warp][quadpair * 8 + local_col] = accum[index];
+        }
       }
     }
   }
+  if constexpr (kSplitBlocks > 1) return;
   __syncthreads();
 
   if (warp == 0) {

--- a/docs/design/sm70_qwen38_projection_w13_followup.md
+++ b/docs/design/sm70_qwen38_projection_w13_followup.md
@@ -40,8 +40,73 @@ Do not claim100 tok/s or HC1.5ms without matching endpoint evidence.
 Open PRs were checked: #504 is batchedHC/QSA, #509 is load-time conversion
 cache release, #494 is page4 allocation ordering. None implements this scope.
 
-## Evidence
+## Evidence, 2026-09-06
 
-Pending. Task-owned raw artifacts are under `.artifacts/`; compiler caches,
-GPU leases and outputs are isolated. The Python environment and unchanged
-native DSOs are borrowed read-only from the previous accepted runtime.
+Draft #510 is stacked on #507. No model initialization or service has run in
+this follow-up. Task-owned raw artifacts are under `.artifacts/`; compiler
+caches, GPU leases and outputs are isolated. The project Python environment
+and native frozen DSOs are borrowed read-only.
+
+### Role-aware output projection
+
+The custom op now accepts an optional role string, passed by the model layer.
+Explicit roles use the existing role plans; legacy two-argument callers keep
+their former shape-only behavior. Unmatched roles/shapes or unsupported inputs
+fall back. Dtype, reduction tree, tile size and arithmetic are unchanged.
+
+Real checkpoint weights from all48 layers (36GDN/12QSA), TP rank0's
+2560x1536 column shard,64 changing/poisoned CUDA Graph replays: bitwise equal.
+Eight warmed, alternating-order paired timing samples measure48 calls at
+0.551990 ->0.543309ms, saving0.008681ms. The production registered custom op
+also passes16 changing-input graph replays over all48 real weights. This is
+a dispatch repair with a small operator gain, not an endpoint speed claim.
+
+CPU routing/allowlist/fallback suite:29 passed,3 unrelated HC GPU tests
+deselected. The first CPU-only invocation included those GPU tests and failed
+because the NVML-based SM70 marker did not respect hidden CUDA devices; it
+was not a source/numerical failure. Do not repeat that invocation or broaden
+this task into unrelated HC test-marker edits. Targeted Ruff checks pass.
+One additional FakeTensor/export test passes and retains the role string in
+the exported custom-op node; this is not a full-model graph compilation gate.
+
+Artifacts: `projection_policy.json`, `projection_dispatch.log`, `cpu_tests.log`.
+
+### W13 small-grid and load-dependency diagnosis
+
+Installed frozen W13 binary and rebuilt generic control are bitwise equal.
+The fixed-shape candidate keeps split16/MMA/SwiGLU boundaries and passes64
+changing-input graph replays (48 calls each, changing experts/invalid IDs,
+duplicates, signed zero and input scales). It reduces registers60 ->48, but
+paired latency is0.537928 ->0.537213ms: only0.000714ms saved, not a useful
+standalone change. It is not enabled in production.
+
+One model-free privileged NCU capture profiles the dynamic/static kernels.
+Original:100 CTAs x512 threads, achieved occupancy30.55%, DRAM352.19GB/s,
+no-eligible scheduler cycles66.95%, long-scoreboard stalls46.6% of average
+cycles between issued instructions. The grid covers only about0.6 theoretical
+waves. Static geometry still gives353.05GB/s and72.32% no-eligible cycles.
+NCU durations16.29/15.58us have differing clocks and replay overhead; do not
+replace paired graph timings with those values or claim a peak-bandwidth wall.
+Do not follow NCU's generic FMA/precision advice: reduction order stays fixed.
+
+These counters justify the next small experiment: prefetch the next packed
+weight pair and scale into registers before consuming the current group.
+The prefetched candidate also passes64 changing graph replays against the
+installed oracle. Paired48-call latency0.539162 ->0.531574ms saves0.007588ms;
+registers56, no spills. Still not a sufficient endpoint gain by itself.
+
+Next screen distributes the SAME16 ordered FP32 partials across2/4 CTAs,
+then merges in the original0..15 order and retains FP16/SwiGLU boundaries.
+This is not changing the numerical split-K grouping. It adds a small FP32
+workspace and one merge launch, both included in timing. Pending validation;
+no candidate flag is selected by a production launcher.
+
+Artifacts: `w13_static.json`, `w13_prefetch.json`, `w13_counters.ncu-rep`,
+`w13_counters_details.txt`, and separate static/prefetch/split-block build logs.
+The two initial NCU attempts stopped before profiling (protected `/tmp` lock
+open, then per-terminal sudo authentication); use read-only lock descriptors
+and explicit sudo authentication. The subsequent capture completed and exited.
+
+Avoid more speculative row-GEMV vectorization: the actual output-projection
+PTX already uses64-bit vectorized loads (`ld.global.v2.b32`). A rewrite must
+show a different confirmed bottleneck, not assume scalar weight loads.

--- a/docs/design/sm70_qwen38_projection_w13_followup.md
+++ b/docs/design/sm70_qwen38_projection_w13_followup.md
@@ -1,0 +1,47 @@
+# Qwen3.8 exact projection and W13 follow-up
+
+Integration: public/main755baae1d075ee04fa9096b23fc0225b23589a86.
+Stacked on #507, bbdf0af5c999fa14e2167620921b1173c4ccad76, to preserve the
+98.965175 tok/s no-MTP baseline. AI assistance: OpenAI Codex; human review is
+required. No integration/main mutation or resident service is authorized here.
+
+## Frozen scope
+
+V100-SXM2-32GB TP4 GPU0–3, Torch2.10.0+cu128, native NVFP4 experts,
+FP16 activation/KV/projections, V2 dual graph, hybrid PLE, no MTP or prefix
+cache, max262144, chunk8192, M1, deterministic8K/513 performance samples.
+Official-sampling natural-output checks are separate. Existing output drift
+also occurs on clean old source; see #507's old-source control. Do not hide it
+or change arithmetic/NCCL policy to force a particular token sequence.
+
+The latest trace separates row GEMV1.448ms/rank/token into output projections
+0.626694 (48 calls), router projection0.420866 (48), QSA QKV0.317551 (12),
+and indexer0.082991 (12). W130.670ms, W20.449ms. These are diagnostic GPU
+service sums, not additive endpoint wall time.
+
+## Ordered decisions
+
+1. Test the GDN/QSA same-shape plan collision: GDN output load-policy1 is
+   overwritten by QSA load-policy0 in the shape-only dictionary. Compare
+   actual48 checkpoint output projections with the original FP32 tree and
+   CUDA Graph. Do not assume the intended role policy is faster.
+2. Only screen a materially different exact loading schedule if the first
+   screen and counters justify it. Do not repeat rejected rowblock/CUDA dot
+   trees, GDN row-tiling, output-projection/HC fusion, or HC cache sweeps.
+3. Optimize native NVFP4 W13 unpack/load scheduling without changing current
+   split-K, MMA order, group scaling, FP16 rounding or SwiGLU boundaries.
+   Establish narrow kernel counters if proposing software pipelining.
+
+First operator screens; admit only bitwise, changing-input graph-stable
+candidates with paired timing gains. A full model run is conditional on
+useful gains; zero additional model launches is preferable for failed ideas.
+Do not claim100 tok/s or HC1.5ms without matching endpoint evidence.
+
+Open PRs were checked: #504 is batchedHC/QSA, #509 is load-time conversion
+cache release, #494 is page4 allocation ordering. None implements this scope.
+
+## Evidence
+
+Pending. Task-owned raw artifacts are under `.artifacts/`; compiler caches,
+GPU leases and outputs are isolated. The Python environment and unchanged
+native DSOs are borrowed read-only from the previous accepted runtime.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45958,3 +45958,26 @@ Interpretation:
   code, including a warp-ordering attempt, so the intended lookahead was not
   established. Do not run these as purported prefetch variants or repeat the
   previously rejected ordinary CUDA128 down. No GPU startup for this screen.
+
+## 2026-09-06 exact M1 projection and W13 follow-up (#510)
+
+Stacked on #507/bbdf0af5c9; integration remains public/main755baae1d0.
+The latest measured endpoint remains98.965175 tok/s, not100. This follow-up
+has launched no full model. Details and artifacts are in
+`docs/design/sm70_qwen38_projection_w13_followup.md`.
+
+- Fix the same-shape GDN/QSA role-policy overwrite while preserving legacy
+  two-argument calls and all FP16/FP32 arithmetic.48 real output projections
+  save0.008681ms;64 input-changing graph checks and16 production-op graph
+  checks are bitwise. CPU29 pass/3 GPU-only deselections plus1 export pass.
+- W13 fixed geometry saves only0.000714ms/48 calls; register reduction alone
+  did not remove the small-grid/load-dependency bottleneck. Do not repeat as
+  a proposed large speedup. Counter baseline:352GB/s,30.55% occupancy,
+  66.95% no-eligible cycles,46.6% long-scoreboard share.
+- Next-group weight/scale prefetch is exact over64 changing graph replays
+  but saves only0.007588ms/48 calls. No production launcher enables it.
+- Same16-partial-group distribution across2/4 CTAs is a benchmark-only
+  candidate awaiting idle GPU time. Merge/workspace cost must be included;
+  do not confuse it with changing numerical split-K grouping.
+- Ordinary output GEMV already uses64-bit vectorized loads in its PTX.
+  Do not repeat speculative scalar-to-vector rewrites without new evidence.

--- a/tests/models/qwen4_exp/test_sm70_projection_role_dispatch.py
+++ b/tests/models/qwen4_exp/test_sm70_projection_role_dispatch.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia import sm70_fp16_gemv as gemv
+
+
+@pytest.mark.parametrize(
+    "role,policy",
+    [("layers.0.linear_attn.out_proj", 1), ("layers.3.self_attn.o_proj", 0), ("", 0)],
+)
+def test_same_shape_roles_reach_kernel(monkeypatch, role, policy):
+    launches = []
+
+    class Kernel:
+        def __getitem__(self, grid):
+            return lambda *args, **kwargs: launches.append((grid, kwargs))
+
+    monkeypatch.setattr(gemv, "_runtime_ok", lambda *args: True)
+    monkeypatch.setattr(gemv, "_qwen38_fp16_row_gemv_kernel", Kernel())
+    x = torch.empty(1, 1536, dtype=torch.float16, device="meta")
+    w = torch.empty(2560, 1536, dtype=torch.float16, device="meta")
+    out = gemv._qwen38_sm70_fp16_gemv(x, w, role)
+    assert out.shape == (1, 2560)
+    assert launches == [
+        ((2560,), {"K": 1536, "BLOCK_K": 512, "LOAD_POLICY": policy, "num_warps": 4})
+    ]
+
+
+def test_linear_method_forwards_role(monkeypatch):
+    seen = []
+    monkeypatch.setattr(gemv, "use_sm70_decode_graph_semantics", lambda: True)
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "qwen38_sm70_fp16_gemv",
+        lambda x, weight, role: seen.append(role) or x,
+    )
+    x = torch.empty(1, 1536, device="meta")
+    layer = SimpleNamespace(weight=x, prefix="layers.0.linear_attn.out_proj")
+    gemv.Qwen38SM70FP16LinearMethod().apply(layer, x)
+    assert seen == [layer.prefix]
+
+
+@pytest.mark.parametrize("role", ["other.proj", "layers.0.linear_attn.out_proj"])
+def test_unsupported_input_keeps_linear_fallback(role):
+    x = torch.arange(6, dtype=torch.float32).view(2, 3)
+    w = torch.arange(12, dtype=torch.float32).view(4, 3)
+    assert torch.equal(gemv._qwen38_sm70_fp16_gemv(x, w, role), x @ w.T)
+
+
+def test_role_is_preserved_through_fake_export():
+    class Projection(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(
+                torch.empty(2560, 1536, dtype=torch.float16, device="meta")
+            )
+
+        def forward(self, x):
+            return torch.ops.vllm.qwen38_sm70_fp16_gemv(
+                x, self.weight, "layers.0.linear_attn.out_proj"
+            )
+
+    program = torch.export.export(
+        Projection(), (torch.empty(1, 1536, dtype=torch.float16, device="meta"),)
+    )
+    calls = [
+        node
+        for node in program.graph.nodes
+        if node.target == torch.ops.vllm.qwen38_sm70_fp16_gemv.default
+    ]
+    assert len(calls) == 1
+    assert calls[0].args[2] == "layers.0.linear_attn.out_proj"

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
@@ -55,6 +55,8 @@ _ROLE_PLANS: tuple[tuple[str, tuple[int, int], _GemvPlan], ...] = (
     (_ROUTER_SUFFIX, (512, 2560), _GemvPlan(1024, 8, 0)),
 )
 
+# Retain the legacy two-argument custom-op behavior for external callers.
+# Model layers pass their role explicitly: same-shape GDN/QSA plans differ.
 _SHAPE_PLANS = {shape: plan for _, shape, plan in _ROLE_PLANS}
 
 
@@ -161,8 +163,11 @@ def _runtime_ok(x: torch.Tensor, weight: torch.Tensor) -> bool:
     )
 
 
-def _qwen38_sm70_fp16_gemv(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-    plan = _SHAPE_PLANS.get((weight.shape[0], weight.shape[1]))
+def _qwen38_sm70_fp16_gemv(
+    x: torch.Tensor, weight: torch.Tensor, role: str = ""
+) -> torch.Tensor:
+    shape = (weight.shape[0], weight.shape[1])
+    plan = _plan_for(role, shape) if role else _SHAPE_PLANS.get(shape)
     if plan is None or not _runtime_ok(x, weight):
         return torch.nn.functional.linear(x, weight)
 
@@ -180,7 +185,9 @@ def _qwen38_sm70_fp16_gemv(x: torch.Tensor, weight: torch.Tensor) -> torch.Tenso
     return out
 
 
-def _qwen38_sm70_fp16_gemv_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+def _qwen38_sm70_fp16_gemv_fake(
+    x: torch.Tensor, weight: torch.Tensor, role: str = ""
+) -> torch.Tensor:
     return x.new_empty((*x.shape[:-1], weight.shape[0]))
 
 
@@ -266,7 +273,9 @@ class Qwen38SM70FP16LinearMethod(UnquantizedLinearMethod):
         # decision inside the opaque op so decode does not inherit a baked-in
         # prefill branch.
         if bias is None and use_sm70_decode_graph_semantics():
-            return torch.ops.vllm.qwen38_sm70_fp16_gemv(x, layer.weight)
+            return torch.ops.vllm.qwen38_sm70_fp16_gemv(
+                x, layer.weight, getattr(layer, "prefix", "")
+            )
         return super().apply(layer, x, bias)
 
 


### PR DESCRIPTION
# Qwen3.8 exact projection and W13 follow-up

Integration: public/main755baae1d075ee04fa9096b23fc0225b23589a86.
Stacked on #507, bbdf0af5c999fa14e2167620921b1173c4ccad76, to preserve the
98.965175 tok/s no-MTP baseline. AI assistance: OpenAI Codex; human review is
required. No integration/main mutation or resident service is authorized here.

## Frozen scope

V100-SXM2-32GB TP4 GPU0–3, Torch2.10.0+cu128, native NVFP4 experts,
FP16 activation/KV/projections, V2 dual graph, hybrid PLE, no MTP or prefix
cache, max262144, chunk8192, M1, deterministic8K/513 performance samples.
Official-sampling natural-output checks are separate. Existing output drift
also occurs on clean old source; see #507's old-source control. Do not hide it
or change arithmetic/NCCL policy to force a particular token sequence.

The latest trace separates row GEMV1.448ms/rank/token into output projections
0.626694 (48 calls), router projection0.420866 (48), QSA QKV0.317551 (12),
and indexer0.082991 (12). W130.670ms, W20.449ms. These are diagnostic GPU
service sums, not additive endpoint wall time.

## Ordered decisions

1. Test the GDN/QSA same-shape plan collision: GDN output load-policy1 is
   overwritten by QSA load-policy0 in the shape-only dictionary. Compare
   actual48 checkpoint output projections with the original FP32 tree and
   CUDA Graph. Do not assume the intended role policy is faster.
2. Only screen a materially different exact loading schedule if the first
   screen and counters justify it. Do not repeat rejected rowblock/CUDA dot
   trees, GDN row-tiling, output-projection/HC fusion, or HC cache sweeps.
3. Optimize native NVFP4 W13 unpack/load scheduling without changing current
   split-K, MMA order, group scaling, FP16 rounding or SwiGLU boundaries.
   Establish narrow kernel counters if proposing software pipelining.

First operator screens; admit only bitwise, changing-input graph-stable
candidates with paired timing gains. A full model run is conditional on
useful gains; zero additional model launches is preferable for failed ideas.
Do not claim100 tok/s or HC1.5ms without matching endpoint evidence.

Open PRs were checked: #504 is batchedHC/QSA, #509 is load-time conversion
cache release, #494 is page4 allocation ordering. None implements this scope.

## Evidence, 2026-09-06

Draft #510 is stacked on #507. No model initialization or service has run in
this follow-up. Task-owned raw artifacts are under `.artifacts/`; compiler
caches, GPU leases and outputs are isolated. The project Python environment
and native frozen DSOs are borrowed read-only.

### Role-aware output projection

The custom op now accepts an optional role string, passed by the model layer.
Explicit roles use the existing role plans; legacy two-argument callers keep
their former shape-only behavior. Unmatched roles/shapes or unsupported inputs
fall back. Dtype, reduction tree, tile size and arithmetic are unchanged.

Real checkpoint weights from all48 layers (36GDN/12QSA), TP rank0's
2560x1536 column shard,64 changing/poisoned CUDA Graph replays: bitwise equal.
Eight warmed, alternating-order paired timing samples measure48 calls at
0.551990 ->0.543309ms, saving0.008681ms. The production registered custom op
also passes16 changing-input graph replays over all48 real weights. This is
a dispatch repair with a small operator gain, not an endpoint speed claim.

CPU routing/allowlist/fallback suite:29 passed,3 unrelated HC GPU tests
deselected. The first CPU-only invocation included those GPU tests and failed
because the NVML-based SM70 marker did not respect hidden CUDA devices; it
was not a source/numerical failure. Do not repeat that invocation or broaden
this task into unrelated HC test-marker edits. Targeted Ruff checks pass.
One additional FakeTensor/export test passes and retains the role string in
the exported custom-op node; this is not a full-model graph compilation gate.

Artifacts: `projection_policy.json`, `projection_dispatch.log`, `cpu_tests.log`.

### W13 small-grid and load-dependency diagnosis

Installed frozen W13 binary and rebuilt generic control are bitwise equal.
The fixed-shape candidate keeps split16/MMA/SwiGLU boundaries and passes64
changing-input graph replays (48 calls each, changing experts/invalid IDs,
duplicates, signed zero and input scales). It reduces registers60 ->48, but
paired latency is0.537928 ->0.537213ms: only0.000714ms saved, not a useful
standalone change. It is not enabled in production.

One model-free privileged NCU capture profiles the dynamic/static kernels.
Original:100 CTAs x512 threads, achieved occupancy30.55%, DRAM352.19GB/s,
no-eligible scheduler cycles66.95%, long-scoreboard stalls46.6% of average
cycles between issued instructions. The grid covers only about0.6 theoretical
waves. Static geometry still gives353.05GB/s and72.32% no-eligible cycles.
NCU durations16.29/15.58us have differing clocks and replay overhead; do not
replace paired graph timings with those values or claim a peak-bandwidth wall.
Do not follow NCU's generic FMA/precision advice: reduction order stays fixed.

These counters justify the next small experiment: prefetch the next packed
weight pair and scale into registers before consuming the current group.
The prefetched candidate also passes64 changing graph replays against the
installed oracle. Paired48-call latency0.539162 ->0.531574ms saves0.007588ms;
registers56, no spills. Still not a sufficient endpoint gain by itself.

Next screen distributes the SAME16 ordered FP32 partials across2/4 CTAs,
then merges in the original0..15 order and retains FP16/SwiGLU boundaries.
This is not changing the numerical split-K grouping. It adds a small FP32
workspace and one merge launch, both included in timing. Pending validation;
no candidate flag is selected by a production launcher.

Artifacts: `w13_static.json`, `w13_prefetch.json`, `w13_counters.ncu-rep`,
`w13_counters_details.txt`, and separate static/prefetch/split-block build logs.
The two initial NCU attempts stopped before profiling (protected `/tmp` lock
open, then per-terminal sudo authentication); use read-only lock descriptors
and explicit sudo authentication. The subsequent capture completed and exited.

Avoid more speculative row-GEMV vectorization: the actual output-projection
PTX already uses64-bit vectorized loads (`ld.global.v2.b32`). A rewrite must
show a different confirmed bottleneck, not assume scalar weight loads.
