### PR TITLE
[Bugfix][Spec Decode] Report SM70 MTP profiles from the last PP stage (#414)

### DIFF
--- a/tests/v1/spec_decode/test_sm70_mtp_safety.py
+++ b/tests/v1/spec_decode/test_sm70_mtp_safety.py
@@ -8,6 +8,9 @@ import numpy as np
 import pytest
 import torch
 
+import vllm.distributed.parallel_state as parallel_state
+import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer_module
+import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.spec_decode.llm_base_proposer import (
@@ -320,3 +323,119 @@ def test_dynamic_vocab_merge_preserves_finite_top20_order():
         pairs[:, 1].to(torch.int64).cpu(),
         all_ids[expected_positions].cpu(),
     )
+
+
+class _FakeEvent:
+    def __init__(self, elapsed_ms: float = 0.0):
+        self.elapsed_ms = elapsed_ms
+
+    def elapsed_time(self, end: "_FakeEvent") -> float:
+        del end
+        return self.elapsed_ms
+
+    def synchronize(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    ("pp_is_last_rank", "tp_rank_in_group", "expected"),
+    [
+        (True, 0, True),
+        (True, 1, False),
+        (False, 0, False),
+        (False, 1, False),
+    ],
+)
+def test_is_last_pp_first_tp_rank(
+    monkeypatch, pp_is_last_rank, tp_rank_in_group, expected
+):
+    monkeypatch.setattr(
+        parallel_state, "_PP", SimpleNamespace(is_last_rank=pp_is_last_rank)
+    )
+    monkeypatch.setattr(
+        parallel_state, "_TP", SimpleNamespace(rank_in_group=tp_rank_in_group)
+    )
+    assert parallel_state.is_last_pp_first_tp_rank() is expected
+
+
+def test_is_last_pp_first_tp_rank_without_model_parallel_groups(monkeypatch):
+    monkeypatch.setattr(parallel_state, "_PP", None)
+    monkeypatch.setattr(parallel_state, "_TP", None)
+    assert parallel_state.is_last_pp_first_tp_rank() is True
+
+
+def _record_info(monkeypatch, module) -> list[str]:
+    messages: list[str] = []
+    monkeypatch.setattr(
+        module.logger, "info", lambda msg, *args, **kwargs: messages.append(msg)
+    )
+    return messages
+
+
+# (global first rank, last PP stage, TP rank in group) -> report expected.
+# PP=2: the last stage never holds the global first rank -- that is #414.
+_REPORT_RANK_CASES = [
+    pytest.param(False, True, 0, True, id="pp2-last-stage-leader"),
+    pytest.param(False, True, 1, False, id="pp2-last-stage-tp1"),
+    pytest.param(True, False, 0, False, id="pp2-first-stage"),
+]
+
+
+def _simulate_rank(monkeypatch, global_first: bool, pp_last: bool, tp_rank: int):
+    monkeypatch.setattr(
+        parallel_state, "_WORLD", SimpleNamespace(is_first_rank=global_first)
+    )
+    monkeypatch.setattr(parallel_state, "_PP", SimpleNamespace(is_last_rank=pp_last))
+    monkeypatch.setattr(parallel_state, "_TP", SimpleNamespace(rank_in_group=tp_rank))
+
+
+@pytest.mark.parametrize(
+    ("global_first", "pp_last", "tp_rank", "expected"), _REPORT_RANK_CASES
+)
+def test_runner_mtp_profile_reports_from_last_pp_stage(
+    monkeypatch, global_first, pp_last, tp_rank, expected
+):
+    """Regression for #414: the events are recorded on the last PP stage,
+    so the report must come from there, not from the global first rank."""
+    monkeypatch.setenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "1")
+    _simulate_rank(monkeypatch, global_first, pp_last, tp_rank)
+    messages = _record_info(monkeypatch, gpu_model_runner_module)
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    ctx = {
+        "events": [
+            ("target_forward", _FakeEvent(24.3), _FakeEvent()),
+            ("draft_total", _FakeEvent(83.9), _FakeEvent()),
+        ],
+        "cpu_ms": {"draft_wall_cpu": 90.0},
+        "has_spec_decode_metadata": True,
+        "num_tokens": 6,
+        "num_reqs": 1,
+    }
+
+    runner._sm70_mtp_profile_report(ctx)
+
+    # Totals accumulate on every rank; only the report rank logs them.
+    assert runner._sm70_mtp_runner_profile_totals["draft_total"] == 83.9
+    assert any("SM70 spec runner profile" in m for m in messages) is expected
+
+
+@pytest.mark.parametrize(
+    ("global_first", "pp_last", "tp_rank", "expected"), _REPORT_RANK_CASES
+)
+def test_proposer_mtp_profile_reports_from_last_pp_stage(
+    monkeypatch, global_first, pp_last, tp_rank, expected
+):
+    monkeypatch.setenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "1")
+    _simulate_rank(monkeypatch, global_first, pp_last, tp_rank)
+    messages = _record_info(monkeypatch, llm_base_proposer_module)
+    proposer = SpecDecodeBaseProposer.__new__(SpecDecodeBaseProposer)
+
+    proposer._sm70_mtp_profile_report(
+        events=[("total_gpu", _FakeEvent(83.9), _FakeEvent())],
+        cpu_ms={"total_wall_cpu": 90.0},
+        batch_size=1,
+        num_tokens=6,
+    )
+
+    assert proposer._sm70_mtp_profile_totals["total_gpu"] == 83.9
+    assert bool(messages) is expected

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import vllm.distributed.parallel_state as parallel_state
 from vllm.v1.kv_cache_interface import (
     CircularBufferSpec,
     FullAttentionSpec,
@@ -47,7 +48,8 @@ def test_sm70_v2_mtp_profile_composes_target_verifier(monkeypatch):
 
     runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
     monkeypatch.setenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "1")
-    monkeypatch.setattr(mrv2, "is_global_first_rank", lambda: True)
+    monkeypatch.setattr(parallel_state, "_PP", None)
+    monkeypatch.setattr(parallel_state, "_TP", None)
     ctx = {
         "events": [
             ("target_forward", FakeEvent(10.0), FakeEvent()),
@@ -68,6 +70,53 @@ def test_sm70_v2_mtp_profile_composes_target_verifier(monkeypatch):
     assert runner._sm70_v2_mtp_profile_totals["target_verifier_wall_cpu"] == 14.0
     assert runner._sm70_v2_mtp_profile_totals["draft_total"] == 5.0
     assert runner._sm70_v2_mtp_profile_totals["total_gpu"] == 20.0
+
+
+@pytest.mark.parametrize(
+    ("global_first", "pp_last", "tp_rank", "expected"),
+    [
+        pytest.param(False, True, 0, True, id="pp2-last-stage-leader"),
+        pytest.param(False, True, 1, False, id="pp2-last-stage-tp1"),
+        pytest.param(True, False, 0, False, id="pp2-first-stage"),
+    ],
+)
+def test_sm70_v2_mtp_profile_reports_from_last_pp_stage(
+    monkeypatch, global_first, pp_last, tp_rank, expected
+):
+    """Regression for #414: profiling is enabled on the last PP stage only,
+    so the report must not be gated on the global first rank."""
+
+    class FakeEvent:
+        def elapsed_time(self, end: "FakeEvent") -> float:
+            del end
+            return 1.0
+
+        def synchronize(self) -> None:
+            pass
+
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    monkeypatch.setenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "1")
+    monkeypatch.setattr(
+        parallel_state, "_WORLD", SimpleNamespace(is_first_rank=global_first)
+    )
+    monkeypatch.setattr(parallel_state, "_PP", SimpleNamespace(is_last_rank=pp_last))
+    monkeypatch.setattr(parallel_state, "_TP", SimpleNamespace(rank_in_group=tp_rank))
+    messages: list[str] = []
+    monkeypatch.setattr(
+        mrv2.logger, "info", lambda msg, *args, **kwargs: messages.append(msg)
+    )
+    ctx = {
+        "events": [("target_forward", FakeEvent(), FakeEvent())],
+        "num_tokens": 1,
+        "num_draft_tokens": 0,
+        "target_verifier_wall_cpu": 1.0,
+        "total_wall_start": time.perf_counter(),
+    }
+
+    runner._sm70_v2_mtp_profile_report(ctx)
+
+    assert runner._sm70_v2_mtp_profile_totals["target_forward"] == 1.0
+    assert bool(messages) is expected
 
 
 def test_qsa_circular_group_uses_custom_slot_mapping(monkeypatch):

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2458,6 +2458,26 @@ def is_global_first_rank() -> bool:
         return True
 
 
+def is_last_pp_first_tp_rank() -> bool:
+    """
+    Check if the current process is the first tensor-parallel rank of the
+    last pipeline-parallel stage.
+
+    Sampling and speculative decoding only run on the last PP stage, so
+    per-step reports about them have to be emitted from that stage; the
+    global first rank (see `is_global_first_rank`) is never on it when
+    PP > 1.
+
+    Returns:
+        bool: True on the first TP rank of the last PP stage. Returns True
+              if the model-parallel groups are not initialized
+              (single process).
+    """
+    if _PP is None or _TP is None:
+        return True
+    return _PP.is_last_rank and _TP.rank_in_group == 0
+
+
 def is_local_first_rank() -> bool:
     """
     Check if the current process is the first local rank (rank 0 on its node).

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -19,7 +19,7 @@ from vllm.config import (
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
-    is_global_first_rank,
+    is_last_pp_first_tp_rank,
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
@@ -848,11 +848,9 @@ class SpecDecodeBaseProposer:
 
         if calls != 1 and calls % _sm70_mtp_profile_interval() != 0:
             return
-        try:
-            should_log = is_global_first_rank()
-        except RuntimeError:
-            should_log = True
-        if not should_log:
+        # The drafter lives on the last PP stage; the global first rank
+        # never runs it when PP > 1.
+        if not is_last_pp_first_tp_rank():
             return
 
         preferred = [

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -35,7 +35,7 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import (
     get_dcp_group,
     get_pp_group,
-    is_global_first_rank,
+    is_last_pp_first_tp_rank,
     prepare_communication_buffer_for_model,
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
@@ -376,7 +376,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         interval = envs.VLLM_SM70_MTP_PROFILE_INTERVAL
         if calls != 1 and calls % interval != 0:
             return
-        if not is_global_first_rank():
+        # Profiling is enabled on the last PP stage only (see
+        # _sm70_v2_mtp_profile_enabled); report from that stage as well.
+        if not is_last_pp_first_tp_rank():
             return
 
         preferred = (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -52,6 +52,7 @@ from vllm.distributed.parallel_state import (
     get_tp_group,
     graph_capture,
     is_global_first_rank,
+    is_last_pp_first_tp_rank,
     prepare_communication_buffer_for_model,
 )
 from vllm.forward_context import (
@@ -1262,7 +1263,9 @@ class GPUModelRunner(
 
         if calls != 1 and calls % _sm70_mtp_profile_interval() != 0:
             return
-        if not is_global_first_rank():
+        # The events come from the sampling path, which only the last PP
+        # stage runs; the global first rank never sees them when PP > 1.
+        if not is_last_pp_first_tp_rank():
             return
 
         preferred = [


### PR DESCRIPTION
## Purpose

Fixes #414 (`VLLM_SM70_MTP_PROFILE` report never prints under pipeline
parallelism).

All three SM70 MTP profile reports collect their events on the last PP
stage and log them only from the global first rank:

- `GPUModelRunner._sm70_mtp_profile_report` (v1): the profile context is
  created after sampling in `execute_model`, a path the non-last stages
  leave early with their `IntermediateTensors`; the report then returns on
  `not is_global_first_rank()`.
- `GPUModelRunner._sm70_v2_mtp_profile_report` (v2): profiling is enabled
  only when `self.is_last_pp_rank` (see `_sm70_v2_mtp_profile_enabled`),
  the report is again gated on `is_global_first_rank()`.
- `SpecDecodeBaseProposer._sm70_mtp_profile_report`: the drafter lives on
  the last stage; same gate.

With PP > 1 the global first rank is on the first stage, so the reports
are accumulated every interval and discarded. With PP = 1 they work, which
is why this went unnoticed.

This PR adds `is_last_pp_first_tp_rank()` to `parallel_state` next to
`is_global_first_rank()` (True on the first TP rank of the last PP stage,
True when the model-parallel groups are not initialised) and gates the
three reports on it. The proposer's `try/except RuntimeError` around the
old check was dead code: `is_global_first_rank()` catches everything
itself.

Tests simulate PP=2 through the `parallel_state` group objects rather than
by patching the imported name, so they exercise the real gate: on
origin/main the last-stage leader stays silent and the first stage logs a
report it has no events for.

Duplicate check (per AGENTS.md): `gh issue view 414 --comments` (no
follow-up), `gh pr list --state open --search "414 in:body"` (none),
`--search "profile report"` and `--search "is_global_first_rank"` (no PR
touches these gates). Verified against origin/main 755baae today.

## Test Plan

Environment: 1Cat-vLLM 1.5.0 wheel venv (Python 3.12), checkout at
origin/main 755baae with the compiled extensions linked in, single Tesla
V100 (`CUDA_VISIBLE_DEVICES=4`).

    # both touched test files, with the fix
    python -m pytest tests/v1/spec_decode/test_sm70_mtp_safety.py tests/v1/worker/test_gpu_model_runner_v2.py -q

    # same, with the four source files reverted to origin/main (git stash), tests kept
    python -m pytest tests/v1/spec_decode/test_sm70_mtp_safety.py tests/v1/worker/test_gpu_model_runner_v2.py -q

    # lint / types (mypy 1.19.1 as pinned; ruff 0.15.8 vs pinned 0.14.0)
    ruff check <6 files>
    ruff format --check <6 files>
    mypy --python-version 3.10 vllm/distributed/parallel_state.py vllm/v1/spec_decode/llm_base_proposer.py vllm/v1/worker/gpu/model_runner.py vllm/v1/worker/gpu_model_runner.py
    mypy --python-version 3.10 --follow-imports skip tests/v1/spec_decode/test_sm70_mtp_safety.py tests/v1/worker/test_gpu_model_runner_v2.py

## Test Result

Both test files on origin/main 755baae, before the change:

    10 passed, 2 skipped in 5.55s

Both test files with the fix (14 new test cases):

    24 passed, 2 skipped in 8.92s

Tests kept, source files reverted to origin/main:

    11 failed, 13 passed, 2 skipped
    test_runner_mtp_profile_reports_from_last_pp_stage[pp2-last-stage-leader]   assert False is True  (no report from the stage that has the events)
    test_runner_mtp_profile_reports_from_last_pp_stage[pp2-first-stage]         assert True is False  (report from a stage without events)
    test_proposer_mtp_profile_reports_from_last_pp_stage[pp2-last-stage-leader] assert False is True
    test_proposer_mtp_profile_reports_from_last_pp_stage[pp2-first-stage]       assert True is False
    test_sm70_v2_mtp_profile_reports_from_last_pp_stage[pp2-last-stage-leader]  assert False is True
    test_sm70_v2_mtp_profile_reports_from_last_pp_stage[pp2-first-stage]        assert True is False
    test_is_last_pp_first_tp_rank[*] (5 cases)                                   AttributeError: no attribute 'is_last_pp_first_tp_rank'

ruff check / ruff format --check: clean on all six files.
mypy on both test files: no issues.
mypy on the four source files: 144 errors before and after, identical set
(all pre-existing, none in the touched lines).

End-to-end check on our rig (2x RTX 8000 + 2x V100, TP2 x PP2,
Qwen3.8-27B-NVFP4 with MTP k=5, the same three changes applied to our
1.5.0 deployment, `VLLM_SM70_MTP_PROFILE=1` on the server entry): all four
workers (PP0_TP0, PP0_TP1, PP1_TP0, PP1_TP1) are up; over a ~2000-step chat
both reports come from `Worker_PP1_TP0` only -- 125 runner reports and 125
proposer reports, none from the first stage or from TP rank 1:

    (Worker_PP1_TP0 pid=2217869) INFO 09-05 18:47:29 [gpu_model_runner.py:2212] SM70 spec runner profile avg_ms calls=1984 spec_steps=1977 num_tokens=6 num_reqs=1 target_forward=17.466 target_logits=1.565 target_rejection_sample=1.575 target_sample_no_spec=0.002 state_update_wall_cpu=0.419 state_update_validate_cpu=0.012 state_update_attn_compact_cpu=0.001 state_update_mamba_compact_cpu=0.001 state_update_input_batch_cpu=0.399 state_update_drafter_context_cpu=0.003 draft_total=10.787 draft_wall_cpu=11.394 bookkeeping=0.053 bookkeeping_wall_cpu=0.063
    (Worker_PP1_TP0 pid=2217869) INFO 09-05 18:47:29 [llm_base_proposer.py:873] SM70 MTP proposer profile avg_ms calls=1984 batch=1 tokens=6 total_gpu=9.916 total_wall_cpu=5.328 first_setup_cpu=0.584 first_forward=1.571 first_sample=0.700 loop_metadata_cpu=0.777 loop0_forward=1.010 loop0_sample=0.700 loop1_forward=1.006 loop1_sample=0.700 loop2_forward=1.013 loop2_sample=0.700 loop0_metadata_cpu=0.289

(Line numbers in that log are from our patched deployment, not from this
branch.)

AI assistance: this change was developed with Claude (Anthropic) as a
coding assistant. Every changed line was reviewed by me and the test runs
above were executed on my hardware; I can defend the change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
