### PR TITLE
[Kernel][SM70] Port actual FlashInfer CUDA decode to sparse QSA (prototype)

### DIFF
--- a/benchmarks/csrc/sm70_flashinfer_qsa_decode.cu
+++ b/benchmarks/csrc/sm70_flashinfer_qsa_decode.cu
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+#include <torch/types.h>
+
+#include <flashinfer/attention/sm70/qsa_decode.cuh>
+
+namespace {
+using namespace flashinfer::attention::sm70;
+
+void run(torch::Tensor q, torch::Tensor k, torch::Tensor v,
+         torch::Tensor indices, torch::Tensor table, torch::Tensor requests,
+         torch::Tensor offsets, torch::Tensor metadata, torch::Tensor zero,
+         torch::Tensor partial, torch::Tensor lse, torch::Tensor output,
+         int64_t splits) {
+  const c10::cuda::CUDAGuard guard(q.device());
+  for (const auto& t : {q, k, v, indices, table, requests, offsets, metadata,
+                        zero, partial, lse, output}) {
+    TORCH_CHECK(t.is_cuda() && t.device() == q.device());
+  }
+  TORCH_CHECK(at::cuda::getCurrentDeviceProperties()->major == 7 &&
+                  at::cuda::getCurrentDeviceProperties()->minor == 0,
+              "This benchmark entry is SM70 only; upstream gates unchanged");
+  TORCH_CHECK(q.dim() == 3 && k.dim() == 4 && v.sizes() == k.sizes());
+  TORCH_CHECK(q.scalar_type() == at::kHalf && k.scalar_type() == at::kHalf &&
+              v.scalar_type() == at::kHalf &&
+              output.scalar_type() == at::kHalf &&
+              zero.scalar_type() == at::kHalf);
+  TORCH_CHECK(q.size(2) == 256 && k.size(3) == 256 && q.stride(2) == 1 &&
+              k.stride(3) == 1 && v.strides() == k.strides());
+  for (const auto& t : {q, k, v}) {
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(t.data_ptr()) % 16 == 0,
+                "Vector loads require 16-byte aligned inputs");
+    for (int axis = 0; axis + 1 < t.dim(); ++axis)
+      TORCH_CHECK(t.stride(axis) % 8 == 0,
+                  "Vector loads require aligned row/head strides");
+  }
+  TORCH_CHECK(q.stride(0) <= UINT32_MAX && q.stride(1) <= UINT32_MAX);
+  const int rows = q.size(0), heads = q.size(1), kv_heads = k.size(2);
+  TORCH_CHECK(rows > 0 && heads > 0 && heads <= 32 && kv_heads > 0 &&
+              heads % kv_heads == 0 && k.size(0) > 0 && k.size(1) > 0);
+  const int group = heads / kv_heads;
+  TORCH_CHECK(group == 1 || group == 2 || group == 4 || group == 6 ||
+              group == 8);
+  TORCH_CHECK(indices.dim() == 2 && indices.size(0) == rows &&
+              indices.size(1) > 0 && indices.stride(1) == 1);
+  TORCH_CHECK(table.dim() == 2 && table.size(0) > 0 && table.size(1) > 0 &&
+              table.stride(1) == 1);
+  TORCH_CHECK(requests.dim() == 1 && requests.numel() == rows &&
+              requests.is_contiguous());
+  for (const auto& t : {indices, table, requests, metadata})
+    TORCH_CHECK(t.scalar_type() == at::kInt);
+  TORCH_CHECK(splits > 0 && splits <= 64);
+  const int selected = indices.size(1);
+  const int width = ((selected + splits - 1) / splits) * splits;
+  TORCH_CHECK(int64_t(rows) * width < INT32_MAX);
+  TORCH_CHECK(offsets.scalar_type() == at::kLong && offsets.is_contiguous() &&
+              offsets.numel() == int64_t(rows) * width);
+  TORCH_CHECK(metadata.is_contiguous() &&
+              metadata.numel() == rows + 2 + 2 * rows * splits);
+  TORCH_CHECK(zero.is_contiguous() && zero.numel() == 256);
+  TORCH_CHECK(partial.scalar_type() == at::kFloat && partial.is_contiguous() &&
+              partial.numel() == int64_t(rows) * splits * heads * 256);
+  TORCH_CHECK(lse.scalar_type() == at::kFloat && lse.is_contiguous() &&
+              lse.numel() == int64_t(rows) * splits * heads);
+  TORCH_CHECK(output.sizes() == q.sizes() && output.is_contiguous());
+  const auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
+  auto* meta = metadata.data_ptr<int32_t>();
+  PrepareQSA<<<rows, 256, 0, stream>>>(
+      indices.data_ptr<int32_t>(), table.data_ptr<int32_t>(),
+      requests.data_ptr<int32_t>(), offsets.data_ptr<int64_t>(), meta, rows,
+      selected, width, splits, k.size(1), table.size(1), table.size(0),
+      k.size(0), indices.stride(0), table.stride(0), k.stride(0), k.stride(1));
+  QSAParams p{};
+  p.q = reinterpret_cast<const half*>(q.data_ptr());
+  p.o = partial.data_ptr<float>();
+  p.lse = lse.data_ptr<float>();
+  p.paged_kv.batch_size = rows;
+  p.paged_kv.num_heads = kv_heads;
+  p.paged_kv.width = width;
+  p.paged_kv.head_stride = k.stride(2);
+  p.paged_kv.k_data = {reinterpret_cast<const half*>(k.data_ptr()),
+                       reinterpret_cast<const half*>(zero.data_ptr())};
+  p.paged_kv.v_data = {reinterpret_cast<const half*>(v.data_ptr()),
+                       reinterpret_cast<const half*>(zero.data_ptr())};
+  p.paged_kv.indptr = meta;
+  p.paged_kv.offsets = offsets.data_ptr<int64_t>();
+  p.padded_batch_size = rows * splits;
+  p.num_qo_heads = heads;
+  p.request_indices = meta + rows + 1;
+  p.kv_tile_indices = p.request_indices + rows * splits;
+  p.kv_chunk_size_ptr = p.kv_tile_indices + rows * splits;
+  p.q_stride_n = q.stride(0);
+  p.q_stride_h = q.stride(1);
+#define DISPATCH(G)                                                         \
+  case G:                                                                   \
+    LaunchQSADecode<G>(p, reinterpret_cast<half*>(output.data_ptr()), rows, \
+                       splits, stream);                                     \
+    break
+  switch (group) {
+    DISPATCH(1);
+    DISPATCH(2);
+    DISPATCH(4);
+    DISPATCH(6);
+    DISPATCH(8);
+  }
+#undef DISPATCH
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+}  // namespace
+
+TORCH_LIBRARY_FRAGMENT(_C_flashinfer_qsa_sm70, m) {
+  m.def(
+      "run(Tensor q, Tensor k, Tensor v, Tensor indices, Tensor table, "
+      "Tensor requests, Tensor(a!) offsets, Tensor(b!) metadata, Tensor zero, "
+      "Tensor(c!) partial, Tensor(d!) lse, Tensor(e!) output, int splits) -> "
+      "()");
+}
+TORCH_LIBRARY_IMPL(_C_flashinfer_qsa_sm70, CUDA, m) { m.impl("run", &run); }

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_qsa.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_qsa.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Actual FlashInfer SM70 QSA screening, not a serving performance claim.
+
+All candidates include index preparation and final merge. No GPU allocations
+occur within the candidate forward. Run on an exclusively reserved GPU.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.flashinfer_sm70_qsa import (
+    UPSTREAM_SHA,
+    FlashInferQSA,
+    build,
+)
+
+
+def make_case(rows, selected=2051, page=784, kv_heads=1, group=6, length=8192):
+    """Independent requests, permuted physical pages, ordered sparse indices."""
+    blocks = (length + page - 1) // page
+    q = torch.randn(rows, kv_heads * group, 256, device="cuda", dtype=torch.float16)
+    k = torch.randn(
+        rows * blocks, page, kv_heads, 256, device="cuda", dtype=torch.float16
+    )
+    v = torch.randn_like(k)
+    table = torch.randperm(rows * blocks, device="cuda", dtype=torch.int32)
+    table = table.reshape(rows, blocks)
+    requests = torch.arange(rows, device="cuda", dtype=torch.int32)
+    # Random order is deliberate, with no physical sorting or deduplication.
+    indices = torch.stack(
+        [
+            torch.randperm(length, device="cuda", dtype=torch.int32)[:selected]
+            for _ in range(rows)
+        ]
+    )
+    if selected == 2051:
+        # Runtime uses 512 four-token blocks and up to three tail positions.
+        pages = torch.stack(
+            [
+                torch.randperm(length // 4 - 1, device="cuda", dtype=torch.int32)[:512]
+                for _ in range(rows)
+            ]
+        )
+        indices[:, :2048] = (
+            pages[:, :, None] * 4 + torch.arange(4, device="cuda")
+        ).reshape(rows, 2048)
+        indices[:, 2048:] = -1  # 8192 has zero tail residue.
+    return q, k, v, indices, table, requests
+
+
+def oracle(q, k, v, indices, table, requests):
+    """FP32 arithmetic with the same visible-index contract, preserving repeats."""
+    out = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+    page = k.shape[1]
+    group = q.shape[1] // k.shape[2]
+    for row in range(q.shape[0]):
+        request = int(requests[row])
+        if not 0 <= request < table.shape[0]:
+            continue
+        logical = indices[row].long()
+        valid = (logical >= 0) & (logical // page < table.shape[1])
+        logical = logical[valid]
+        physical = table[request, logical // page].long()
+        valid = (physical >= 0) & (physical < k.shape[0])
+        logical, physical = logical[valid], physical[valid]
+        if logical.numel() == 0:
+            continue
+        keys = k[physical, logical % page].float().repeat_interleave(group, 1)
+        values = v[physical, logical % page].float().repeat_interleave(group, 1)
+        scores = torch.einsum("hd,shd->hs", q[row].float(), keys) / 16
+        out[row] = torch.einsum("hs,shd->hd", scores.softmax(-1), values)
+    return out
+
+
+def check_exclusive():
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if not visible or "," in visible:
+        raise RuntimeError("Choose exactly one reserved CUDA_VISIBLE_DEVICES GPU")
+    report = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "-i",
+            visible,
+            "--query-compute-apps=pid,process_name",
+            "--format=csv,noheader",
+        ],
+        text=True,
+    )
+    for line in report.splitlines():
+        pid, _, name = line.partition(",")
+        if (
+            pid.strip().isdigit()
+            and int(pid) != os.getpid()
+            and "snapd-desktop-integration" not in name
+        ):
+            raise RuntimeError(f"Foreign GPU process; discard timing: {line}")
+
+
+def capture(call, repeats):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            call()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        for _ in range(repeats):
+            call()
+    return graph
+
+
+def elapsed_us(graph, calls):
+    start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    start.record()
+    graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000 / calls
+
+
+@torch.inference_mode()
+def screen(rows, args):
+    case = make_case(rows, length=args.length)
+    q, k, v, indices, table, req = case
+    names, calls = [], []
+    reference_sha = None
+    if args.compare_triton:
+        from vllm.models.qwen4_exp.nvidia.ops import qsa as ops
+
+        # No query_positions supplied: this forces actual Triton sparse QSA,
+        # bypassing the native page4 dispatcher. No env heuristic override.
+        out = torch.empty_like(q)
+        calls.append(
+            lambda: ops.qsa_sparse_paged_attention(
+                q, k, v, indices, table, req, out=out
+            )
+        )
+        names.append("current_triton")
+        reference_sha = hashlib.sha256(Path(ops.__file__).read_bytes()).hexdigest()
+    candidates = []
+    for splits in args.splits:
+        candidate = FlashInferQSA(q, indices.shape[1], splits)
+        candidates.append(candidate)
+        calls.append(lambda candidate=candidate: candidate(*case))
+        names.append(f"flashinfer_s{splits}")
+    graphs = [capture(call, args.calls) for call in calls]
+    checks = []
+    for cycle in range(4):
+        q.normal_().mul_((0.25, 1.0, 3.0, 1.0)[cycle])
+        indices[:, 2048:] = -1
+        if cycle:
+            indices[:, 2048 : 2048 + cycle] = torch.arange(
+                args.length - cycle, args.length, device="cuda"
+            )
+        table.copy_(torch.randperm(k.shape[0], device="cuda").reshape_as(table))
+        expected = oracle(*case)
+        for name, call, graph in zip(names, calls, graphs):
+            eager = call().clone()
+            graph.replay()
+            torch.cuda.synchronize()
+            # Another call is not used to inspect replay output.
+            replay = (
+                out
+                if name == "current_triton"
+                else candidates[
+                    args.splits.index(int(name.removeprefix("flashinfer_s")))
+                ].output
+            )
+            torch.testing.assert_close(replay, eager, atol=0, rtol=0)
+            torch.testing.assert_close(replay.float(), expected, atol=2e-3, rtol=1e-2)
+            relative = (
+                (replay.float() - expected).norm() / expected.norm().clamp_min(1e-20)
+            ).item()
+            if relative > 5e-3:
+                raise AssertionError(f"{name}: relative L2 {relative}")
+            checks.append(
+                {
+                    "cycle": cycle,
+                    "route": name,
+                    "max_abs": (replay.float() - expected).abs().max().item(),
+                    "relative_l2": relative,
+                }
+            )
+    # Restore ordinary full-context tail for timing; all arms see same data.
+    indices[:, 2048:] = -1
+    timings = {name: [] for name in names}
+    check_exclusive()
+    for iteration in range(args.samples):
+        order = list(range(len(names)))
+        if iteration % 2:
+            order.reverse()
+        for index in order:
+            timings[names[index]].append(elapsed_us(graphs[index], args.calls))
+    check_exclusive()
+    return {
+        "rows": rows,
+        "length": args.length,
+        "selection_width": 2051,
+        "q_shape": list(q.shape),
+        "page_size": k.shape[1],
+        "flashinfer_sha": UPSTREAM_SHA,
+        "triton_source_sha256": reference_sha,
+        "checks": checks,
+        "microseconds_samples": timings,
+        "median_us": {name: statistics.median(t) for name, t in timings.items()},
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", nargs="+", type=int, default=[1, 4, 8, 16])
+    parser.add_argument("--splits", nargs="+", type=int, default=[16, 32, 64])
+    parser.add_argument("--length", type=int, default=8192)
+    parser.add_argument("--samples", type=int, default=9)
+    parser.add_argument("--calls", type=int, default=30)
+    parser.add_argument("--compare-triton", action="store_true")
+    args = parser.parse_args()
+    torch.manual_seed(7)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    check_exclusive()
+    build()
+    for rows in args.rows:
+        print(json.dumps(screen(rows, args)), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_qsa.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_qsa.py
@@ -194,6 +194,12 @@ def screen(rows, args):
     indices[:, 2048:] = -1
     timings = {name: [] for name in names}
     check_exclusive()
+    # Warm GPU clocks as well as JIT/graphs before paired sampling. Do not
+    # change clock policy or compare against timings from another process.
+    for _ in range(30):
+        for graph in graphs:
+            graph.replay()
+    torch.cuda.synchronize()
     for iteration in range(args.samples):
         order = list(range(len(names)))
         if iteration % 2:
@@ -201,6 +207,16 @@ def screen(rows, args):
         for index in order:
             timings[names[index]].append(elapsed_us(graphs[index], args.calls))
     check_exclusive()
+    hardware = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "-i",
+            os.environ["CUDA_VISIBLE_DEVICES"],
+            "--query-gpu=name,driver_version,clocks.current.sm,clocks.current.memory,temperature.gpu",
+            "--format=csv,noheader",
+        ],
+        text=True,
+    ).strip()
     return {
         "rows": rows,
         "length": args.length,
@@ -212,6 +228,7 @@ def screen(rows, args):
         "checks": checks,
         "microseconds_samples": timings,
         "median_us": {name: statistics.median(t) for name, t in timings.items()},
+        "hardware_after_sampling": hardware,
     }
 
 

--- a/benchmarks/kernels/flashinfer_sm70_qsa.py
+++ b/benchmarks/kernels/flashinfer_sm70_qsa.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark-only instantiation of pinned FlashInfer CUDA QSA decode.
+
+There is no model dispatch change. All mutable buffers belong to each instance;
+construct/warm before CUDA Graph capture. The upstream Python SM75+ gate is not
+disabled, and the previous Flash-V100 or Triton attention is never called here.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import torch
+
+UPSTREAM_SHA = "6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f"
+CCCL_SHA = "16bd510c9b712e82b0ab6cbb630d8e29ba1f7116"
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def build():
+    from torch.utils.cpp_extension import load
+
+    source = Path(
+        os.environ.get(
+            "FLASHINFER_SM70_QSA_SOURCE", ROOT / ".deps/flashinfer-6c14bbd5ff34"
+        )
+    ).resolve()
+    sha = subprocess.check_output(
+        ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+    ).strip()
+    if sha != UPSTREAM_SHA:
+        raise RuntimeError(f"Expected FlashInfer {UPSTREAM_SHA}, got {sha}")
+    if subprocess.check_output(
+        ["git", "-C", str(source), "diff", "HEAD", "--", "include"], text=True
+    ).strip():
+        raise RuntimeError("Upstream CUDA headers must be unmodified")
+    cccl = source / "3rdparty/cccl"
+    if (
+        subprocess.check_output(
+            ["git", "-C", str(cccl), "rev-parse", "HEAD"], text=True
+        ).strip()
+        != CCCL_SHA
+        or subprocess.check_output(
+            ["git", "-C", str(cccl), "diff", "HEAD"], text=True
+        ).strip()
+    ):
+        raise RuntimeError("Expected unmodified pinned CCCL submodule")
+    if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
+        raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0 explicitly")
+    return load(
+        name="flashinfer_qsa_sm70_v1",
+        sources=[str(ROOT / "benchmarks/csrc/sm70_flashinfer_qsa_decode.cu")],
+        extra_include_paths=[
+            str(ROOT / "flashinfer-sm70/include"),
+            str(source / "include"),
+            str(source / "3rdparty/cccl/cub"),
+            str(source / "3rdparty/cccl/thrust"),
+            str(source / "3rdparty/cccl/libcudacxx/include"),
+        ],
+        extra_cuda_cflags=[
+            "-O3",
+            "-lineinfo",
+            "--expt-relaxed-constexpr",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+        ],
+        is_python_module=False,
+        verbose=True,
+    )
+
+
+class FlashInferQSA:
+    """Persistent single-stream workspace; use distinct instances per stream."""
+
+    def __init__(self, q, selection_width, splits):
+        if q.ndim != 3 or q.shape[2] != 256 or q.dtype != torch.float16:
+            raise ValueError("QSA prototype needs FP16 [rows, heads, 256] queries")
+        if not 1 <= splits <= 64 or selection_width <= 0:
+            raise ValueError("Require positive selection width and 1..64 splits")
+        rows, heads, dim = q.shape
+        if rows <= 0 or not 1 <= heads <= 32:
+            raise ValueError("Require positive rows and 1..32 heads")
+        width = ((selection_width + splits - 1) // splits) * splits
+        self.splits = splits
+        self.offsets = torch.empty((rows, width), device=q.device, dtype=torch.int64)
+        self.metadata = torch.empty(
+            rows + 2 + 2 * rows * splits, device=q.device, dtype=torch.int32
+        )
+        self.zero = torch.zeros(256, device=q.device, dtype=torch.float16)
+        self.partial = torch.empty(
+            (rows, splits, heads, dim), device=q.device, dtype=torch.float32
+        )
+        self.lse = torch.empty(
+            (rows, splits, heads), device=q.device, dtype=torch.float32
+        )
+        self.output = torch.empty_like(q, memory_format=torch.contiguous_format)
+
+    def __call__(self, q, k, v, indices, table, requests):
+        torch.ops._C_flashinfer_qsa_sm70.run(
+            q,
+            k,
+            v,
+            indices,
+            table,
+            requests,
+            self.offsets,
+            self.metadata,
+            self.zero,
+            self.partial,
+            self.lse,
+            self.output,
+            self.splits,
+        )
+        return self.output
+
+
+if __name__ == "__main__":
+    print(build())

--- a/docs/design/sm70_flashinfer_qsa_port.md
+++ b/docs/design/sm70_flashinfer_qsa_port.md
@@ -10,6 +10,8 @@ it does not select a new serving backend or change release defaults.
 - Integration: `1CatAI/1Cat-vLLM`, `onecat/main`.
 - Base: `755baae1d075ee04fa9096b23fc0225b23589a86`.
 - Branch: `codex/v100-flashinfer-qsa-sm70-20260905-164136`.
+- Draft PR: [#513](https://github.com/1CatAI/1Cat-vLLM/pull/513), initial
+  implementation commit `6b2f4ad8e9c1ddebf375bb1ea163dc2b5891ced4`.
 - FlashInfer source: [6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f](https://github.com/flashinfer-ai/flashinfer/tree/6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f).
 - Its CCCL submodule: `16bd510c9b712e82b0ab6cbb630d8e29ba1f7116`.
 - The previous WMMA primitive probe has its own older source pin; it is not
@@ -117,17 +119,76 @@ FlashInfer-only tests require neither vLLM's native extension nor Flash-V100.
 - `cuobjdump` confirms native `sm_70`; GQA6 decode uses 72 registers/thread
   and reports zero stack/local memory (not a measured occupancy or speed gain).
 - CPU tests: **5 passed, 9 GPU tests skipped** (not counted as GPU passes).
+- Subsequently acquired an idle, locked V100: **14 tests passed**, including
+  all 9 GPU cases. Runtime: 2.82 seconds; graph replay equals eager.
 - Python Ruff check/format and targeted C++/CUDA formatting: passed.
-- GPU correctness, graph, sanitizer and speed: pending GPU ownership; another
-  task currently holds the shared lock even when its model memory is released.
+- All applicable staged pre-commit hooks: passed, including mypy, shellcheck
+  and project-specific checks.
+- Compute Sanitizer 12.8.93 memcheck: 2 selected GQA6 cases passed, **0 errors**.
+  Racecheck of the same cases: **0 errors, 0 warnings**. Both include mutated
+  metadata, graph replay and empty rows. This is targeted, not whole-model
+  sanitizer coverage.
 - Serving dispatch/defaults/quality or model speed: unchanged, not validated
   by this prototype. Do not advertise a throughput increase yet.
 
 Build and test outputs are stored in this task's unversioned `.artifacts/` directory
 (`flashinfer-qsa-build-v4.log`, `flashinfer-qsa-cpu-tests-v1.log`,
-`flashinfer-qsa-resources-v1.txt`). The initial
+`flashinfer-qsa-resources-v1.txt`, `flashinfer-qsa-tests-v1.log`,
+`flashinfer-qsa-memcheck-v3.log`, `flashinfer-qsa-racecheck-v1.log`). The initial
 build failures from mixed CCCL headers and disabled half conversions were
 localized and fixed; do not rerun those variants as performance experiments.
+
+The system's 2022.4.1 sanitizer could not instrument this runtime (missing
+injection-library lookup, then application-exit failure). Neither failure is
+counted as a pass. The successful run uses NVIDIA's CUDA 12.8.1 redistribution,
+`cuda_sanitizer_api` 12.8.93, archive SHA256
+`ae3574f052c0e06c95305962668eb1fe6ab571dfbb58b305fdb14d523bb1b240`, unpacked
+only in task `.deps/`. It does not replace system tools. Command:
+
+```bash
+compute-sanitizer --tool memcheck --kernel-name kns=flashinfer \
+  --error-exitcode 99 .venv/bin/python -m pytest -q \
+  --confcutdir=flashinfer-sm70/tests flashinfer-sm70/tests/test_qsa_decode.py \
+  -k '16-2051 or 4-33'
+# Repeat with --tool racecheck, using the same pinned tool.
+```
+
+### First paired component screen
+
+After graph and GPU-clock warmup, 11 alternating-order paired samples of 100
+calls per graph, independent 8192-token requests, 2051 selection slots, page
+size 784, FP16 Q/K/V, local Hq=6/Hkv=1/D256. GPU: V100-SXM2-32GB; driver
+580.173.02; post-sampling SM/memory clocks 1530/877 MHz for each row count,
+automatic boost (not clock-locked); temperature 36..40 C. This is a component
+test on one TP4-shaped shard, not a TP4 model timing or a 1200 MHz comparison.
+
+| Query rows | Current two-warp Triton, us | Best FlashInfer, us | Splits | Latency change |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 27.228 | 30.556 | 32 | **+12.22% regression** |
+| 4 | 54.641 | 45.066 | 32 | -17.52% |
+| 8 | 100.055 | 60.611 | 32 | -39.42% |
+| 16 | 167.311 | 87.491 | 16 | -47.71% |
+
+Every FlashInfer timing includes preparation, actual upstream decode and merge.
+The split counts are selected from an explicitly exploratory 16/32/64 sweep,
+not a validated production policy. First-run cold-clock numbers are retained
+in `flashinfer-qsa-screen-v1.log`, but the warmed screen above is
+`flashinfer-qsa-screen-v2.log`. Do not compare unrelated historical absolute
+microseconds. The reference QSA source SHA256 is
+`01e9e97d49fe750e5e0d2ee61961e53349ba631a67be0df22e007a715c625543`.
+
+All four query-scale/tail/mapping cycles passed in every timed shape and split
+choice; maximum FlashInfer relative L2 error against FP32 was 0.00021144.
+This does not establish token equality or model-quality non-inferiority.
+
+Decision: the real FlashInfer SM70 path has a promising concurrent QSA
+component result, but do **not** enable it globally. B1 regresses, QSA indexer
+and projection costs are not included, and no E2E/quality gate is complete.
+Next: local B1/merge optimization, graph-safe serving workspace/metadata
+integration behind opt-in capability detection, then matched quality/latency
+validation. Global server settings must not become shortcut routing gates.
+The benchmark process exited and GPU 0 returned to desktop-only memory;
+no owned worker/API remains resident.
 
 ## Subsequent source-port targets
 

--- a/docs/design/sm70_flashinfer_qsa_port.md
+++ b/docs/design/sm70_flashinfer_qsa_port.md
@@ -1,0 +1,146 @@
+# FlashInfer CUDA QSA port to Volta
+
+## Purpose and frozen baseline
+
+Port actual FlashInfer computation to SM70, starting with sparse QSA decode.
+Changing a backend name or forwarding to the existing Triton/Flash-V100 kernel
+does not meet this objective. This first PR is an isolated benchmark prototype;
+it does not select a new serving backend or change release defaults.
+
+- Integration: `1CatAI/1Cat-vLLM`, `onecat/main`.
+- Base: `755baae1d075ee04fa9096b23fc0225b23589a86`.
+- Branch: `codex/v100-flashinfer-qsa-sm70-20260905-164136`.
+- FlashInfer source: [6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f](https://github.com/flashinfer-ai/flashinfer/tree/6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f).
+- Its CCCL submodule: `16bd510c9b712e82b0ab6cbb630d8e29ba1f7116`.
+- The previous WMMA primitive probe has its own older source pin; it is not
+  silently upgraded or used as evidence for this new attention path.
+
+Scope is different from the HC/QSA follow-up #504 and M1 QSA #507: this
+instantiates FlashInfer's CUDA kernels, not another existing native-FA variant.
+No MoE/HC changes from those worktrees are copied here.
+
+The fixed no-MTP concurrency goals remain 238/420/728 aggregate decode tok/s at
+C4/C8/C16, respectively (85/75/65% of C times 70 tok/s). The previously recorded
+C16 model step was 27.125 ms; meeting 728 tok/s requires 21.978 ms. Component
+microseconds must not be presented as a new model result.
+
+## Actual implementation
+
+`flashinfer-sm70/include/flashinfer/attention/sm70/qsa_decode.cuh` provides a
+virtual page-size-one sparse cache adapter. It directly instantiates the pinned
+upstream `BatchDecodeWithPagedKVCacheKernel` and `MergeStatesKernel` from
+`include/flashinfer/attention/decode.cuh` and `cascade.cuh`. The upstream header
+tree is unmodified. QK, online softmax, PV, split-state normalization and merge
+therefore execute FlashInfer's actual CUDA implementation.
+
+Three GPU operations are measured together:
+
+1. Expand raw logical QSA selections into physical 64-bit offsets and prepare
+   persistent split metadata. Preserve order and duplicate weighting.
+2. Execute FlashInfer paged decode using these sparse virtual pages.
+3. Merge FP32 partial outputs/LSE with FlashInfer's cascade kernel; cast once
+   to FP16 at the final output.
+
+SM70 compatibility is obtained by instantiating the upstream SIMT/GQA kernel.
+Its `cp_async.cuh` already has ordinary vector-load/store fallback below SM80,
+and the decode body retains block barriers. This first candidate does not use
+Tensor Cores and does not claim to replace tensor-core instructions by equally
+fast software emulation. If SIMT loses, optimize tile reuse and evaluate native
+Volta WMMA with the same softmax/masking contract before considering dispatch.
+
+The Torch extension needs a consistent CCCL include set (Thrust, CUB and
+libcudacxx) and undefines Torch's disabled CUDA half-conversion/operator macros.
+These are build integration fixes, not a global relaxation of FlashInfer's
+supported-GPU checks. No FlashInfer Python package is installed or shadowed.
+
+The prototype covers FP16 Q/K/V, D256, 1..32 query heads, GQA groups 1/2/4/6/8,
+1..64 splits, variable batch, selection width, page size and request mapping.
+It accepts vector-aligned strided tensors and rejects misalignment. This is a
+component contract, not a global max-seqs/TP/chunk/prefix-cache restriction.
+Other dtypes, fused output gate, indexer, prefill and serving integration are
+not implemented by this PR's first iteration.
+
+QSA causality is already encoded by the existing selector/expander. Do not
+reinterpret a query row as dense causal attention or physically sort pages.
+Negative/out-of-range requests, indices, pages and split padding are masked.
+Invalid cache loads use a persistent zero vector, not an arbitrary cache page:
+zero probability multiplied by a cached NaN would still produce NaN.
+
+## Test plan
+
+No parameter change, routing-policy change, quantization or model approximation
+is allowed as a substitute for a correct faster operator.
+
+- Compare against an independent FP32 oracle that preserves repeated indices.
+- Test empty/invalid rows and pages, tail and split padding, GQA layouts,
+  non-contiguous tensors, and input/output pointer alignment.
+- Poison output/partial/metadata buffers, mutate indices and physical mappings,
+  then replay a captured graph. Require replay to equal this implementation's
+  eager result and both to match the FP32 oracle (`atol=2e-3, rtol=1e-2`).
+- For timed model-shaped cases require relative L2 error <= 5e-3. This is an
+  operator screen, not a substitute for task-level quality tests.
+- Time current two-warp Triton and FlashInfer with identical inputs, including
+  preparation/merge. Record source SHA256, raw paired samples, B1/4/8/16,
+  CUDA Graph and SM70. Reject results if another process uses the GPU.
+- Only after a stable component gain: sanitizer, runtime metadata integration,
+  representative C1/4/8/16 E2E and output-quality regression. No default change
+  before these gates; no GPU-serving process left resident after testing.
+
+## Reproduction
+
+Use the task virtual environment backed by Torch 2.10.0+cu128, Python 3.12 and
+CUDA 12.8, not system Python. Do not use CUDA 13 to compile SM70.
+
+```bash
+bash tools/prepare-flashinfer-sm70-qsa.sh
+export CUDA_HOME=/path/to/cuda-12.8
+export TORCH_CUDA_ARCH_LIST=7.0
+export TORCH_EXTENSIONS_DIR="$PWD/.artifacts/torch-extensions"
+export MAX_JOBS=2
+# CPU-only compilation; no GPU or model loaded.
+CUDA_VISIBLE_DEVICES='' .venv/bin/python -m benchmarks.kernels.flashinfer_sm70_qsa
+CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q \
+  --confcutdir=flashinfer-sm70/tests flashinfer-sm70/tests/test_qsa_decode.py
+# Acquire the shared GPU ownership locks and confirm an idle physical GPU first.
+CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest -q \
+  --confcutdir=flashinfer-sm70/tests flashinfer-sm70/tests/test_qsa_decode.py
+CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m \
+  benchmarks.kernels.benchmark_sm70_flashinfer_qsa --compare-triton
+```
+
+The comparison needs the source tree's usual working vLLM environment; the
+FlashInfer-only tests require neither vLLM's native extension nor Flash-V100.
+
+## Test result / status
+
+- CPU compilation and shared-library loading: passed for native `sm_70`.
+- `cuobjdump` confirms native `sm_70`; GQA6 decode uses 72 registers/thread
+  and reports zero stack/local memory (not a measured occupancy or speed gain).
+- CPU tests: **5 passed, 9 GPU tests skipped** (not counted as GPU passes).
+- Python Ruff check/format and targeted C++/CUDA formatting: passed.
+- GPU correctness, graph, sanitizer and speed: pending GPU ownership; another
+  task currently holds the shared lock even when its model memory is released.
+- Serving dispatch/defaults/quality or model speed: unchanged, not validated
+  by this prototype. Do not advertise a throughput increase yet.
+
+Build and test outputs are stored in this task's unversioned `.artifacts/` directory
+(`flashinfer-qsa-build-v4.log`, `flashinfer-qsa-cpu-tests-v1.log`,
+`flashinfer-qsa-resources-v1.txt`). The initial
+build failures from mixed CCCL headers and disabled half conversions were
+localized and fixed; do not rerun those variants as performance experiments.
+
+## Subsequent source-port targets
+
+The same pinned source already exposes useful next candidates, but backend
+names alone do not determine implementation or speed:
+
+| Area | Source evidence | Required work before a V100 claim |
+| --- | --- | --- |
+| GDN state update | `flashinfer/gdn_kernels/gdn_decode_pretranspose.py` uses CuTe DSL and cpasync, FP32 recurrent state | Port load pipeline/state layout to SM70, preserve gate math, state-pool read/write indices and graph lifetime |
+| Fused convolution/GDN | `flashinfer/gdn_kernels/experimental/kernel/gdn_fused_decode_sm120.cu` is SM120-specific | Extract reusable fusion/dataflow; native SM70 instruction and reduction implementation, not just a capability bypass |
+| TP communication | `include/flashinfer/comm/vllm_custom_all_reduce.cuh` explicitly derives from vLLM/SGLang; TRT-LLM fusion variants are separate | Diff actual algorithms, NVLink/P2P graph buffer ownership and barriers; measure message-size crossover and useful fusion, not duplicated old allreduce |
+| Projections/HC | FlashInfer has GEMM/communication implementations, not a generic faster replacement for every pointwise Triton kernel | Select by measured operator shape, precision and collective placement; preserve model arithmetic and current native MoE path |
+
+This work is AI-assisted. Keep implementation and unsuccessful paths in the
+owned Draft PR; production admission requires independent correctness and
+performance evidence, not compilation alone.

--- a/flashinfer-sm70/README.md
+++ b/flashinfer-sm70/README.md
@@ -41,3 +41,12 @@ reference, requires zero PTXAS spills and zero SASS `LDL`/`STL`, checks for
 256 emitted `HMMA.884` instructions per kernel, and reports paired timings.
 Timing is observational only and is not an attention promotion or speedup
 gate.
+
+## Sparse QSA decode port (experimental)
+
+The separate [QSA source-port worklog](../docs/design/sm70_flashinfer_qsa_port.md)
+documents an SM70 instantiation of pinned FlashInfer CUDA decode and cascade
+kernels with an ordered sparse-cache adapter. It uses a newer independent
+source pin, not the WMMA probe above. It is benchmark-only, has no serving
+dispatch/default change, and must pass GPU correctness and measured speed
+gates before runtime integration.

--- a/flashinfer-sm70/include/flashinfer/attention/sm70/qsa_decode.cuh
+++ b/flashinfer-sm70/include/flashinfer/attention/sm70/qsa_decode.cuh
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#pragma once
+
+// This adapter instantiates the actual upstream CUDA decode and cascade
+// kernels. Upstream:
+// flashinfer-ai/flashinfer@6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f. No
+// Triton/Flash-V100 fallback is hidden behind this interface.
+#include <flashinfer/attention/decode.cuh>
+
+namespace flashinfer::attention::sm70 {
+
+// QSA's ordered selection is a virtual page-size-one cache. Keeping raw
+// selection order and duplicates is essential: physical-page sorting changed
+// numerical behavior in the previous grouped-page4 implementation.
+struct UnitPage {
+  __host__ __device__ operator unsigned int() const { return 1; }
+  __device__ void divmod(uint32_t n, uint32_t& q, uint32_t& r) const {
+    q = n;
+    r = 0;
+  }
+};
+
+struct SafeCachePointer {
+  const half* data;
+  const half* zero;
+  __device__ const half* operator+(size_t offset) const {
+    // Invalid selections must not read arbitrary cache values: 0 * NaN in
+    // the PV loop is still NaN. Use a persistent zero page, including padding.
+    return (offset >> 63) ? zero + (offset & 255) : data + offset;
+  }
+};
+
+struct SparsePagedKV {
+  UnitPage page_size;
+  uint32_t batch_size, num_heads, width;
+  int64_t head_stride;
+  SafeCachePointer k_data, v_data;
+  const int32_t* indptr;
+  const int32_t* rope_pos_offset = nullptr;
+  const int64_t* offsets;
+
+  __device__ uint32_t get_length(uint32_t) const { return width; }
+  __device__ size_t protective_get_kv_offset(uint32_t index, uint32_t head,
+                                             uint32_t, uint32_t d,
+                                             int32_t end) const {
+    const int64_t offset = index < end ? offsets[index] : -1;
+    return offset < 0 ? (size_t{1} << 63)
+                      : size_t(offset + head * head_stride + d);
+  }
+};
+
+struct QSAParams {
+  using DTypeQ = half;
+  using DTypeKV = half;
+  using DTypeO = float;
+  using IdType = int32_t;
+  const half* q;
+  float* o;
+  float* lse;
+  SparsePagedKV paged_kv;
+  const bool* block_valid_mask = nullptr;
+  uint32_t padded_batch_size, num_qo_heads;
+  bool partition_kv = true;
+  const int32_t* request_indices;
+  const int32_t* kv_tile_indices;
+  const int32_t* kv_chunk_size_ptr;
+  uint32_t q_stride_n, q_stride_h;
+};
+
+struct QSAVariant {
+  static constexpr bool use_softmax = true;
+  float sm_scale_log2 = math::log2e / 16.f;
+  __device__ QSAVariant(const QSAParams&, uint32_t, uint8_t*) {}
+  __device__ float LogitsTransform(const QSAParams&, float value, uint32_t,
+                                   uint32_t, uint32_t, uint32_t,
+                                   uint32_t) const {
+    return value;
+  }
+  __device__ bool LogitsMask(const QSAParams& p, uint32_t row, uint32_t,
+                             uint32_t index, uint32_t, uint32_t) const {
+    return index < p.paged_kv.width &&
+           p.paged_kv.offsets[size_t(row) * p.paged_kv.width + index] >= 0;
+  }
+  __device__ float OutputTransform(const QSAParams&, float value, uint32_t,
+                                   uint32_t, uint32_t, float, float denominator,
+                                   float) const {
+    return denominator > 0.f ? value / denominator : 0.f;
+  }
+};
+
+// Same visible-index contract as qsa_sparse_paged_attention. Causality is
+// applied by the QSA selector/expander before this operator, not reinterpreted
+// as dense causal attention. Invalid rows/pages/indices produce empty states.
+__global__ void PrepareQSA(const int32_t* indices, const int32_t* table,
+                           const int32_t* requests, int64_t* offsets,
+                           int32_t* metadata, int rows, int selected, int width,
+                           int splits, int page, int table_width, int nrequests,
+                           int nblocks, int64_t index_stride,
+                           int64_t table_stride, int64_t block_stride,
+                           int64_t token_stride) {
+  const int row = blockIdx.x;
+  const int request = requests[row];
+  for (int col = threadIdx.x; col < width; col += blockDim.x) {
+    int64_t offset = -1;
+    const int logical = col < selected ? indices[row * index_stride + col] : -1;
+    if (request >= 0 && request < nrequests && logical >= 0 &&
+        logical / page < table_width) {
+      const int physical = table[request * table_stride + logical / page];
+      if (physical >= 0 && physical < nblocks)
+        offset = physical * block_stride + (logical % page) * token_stride;
+    }
+    offsets[size_t(row) * width + col] = offset;
+  }
+  if (threadIdx.x == 0) {
+    metadata[row] = row * width;
+    if (row == 0) {
+      metadata[rows] = rows * width;
+      metadata[rows + 1 + 2 * rows * splits] = width / splits;
+    }
+  }
+  for (int split = threadIdx.x; split < splits; split += blockDim.x) {
+    metadata[rows + 1 + row * splits + split] = row;
+    metadata[rows + 1 + rows * splits + row * splits + split] = split;
+  }
+}
+
+template <int Group>
+void LaunchQSADecode(QSAParams p, half* output, int rows, int splits,
+                     cudaStream_t stream) {
+  // First port: upstream SIMT/GQA kernel, no tensor-core emulation. On SM70
+  // upstream cp_async.cuh uses synchronous vector loads + block barriers.
+  constexpr int stages = 2, tile = 1, vec = 8, bdx = 32, bdz = 1;
+  constexpr int smem = 2 * stages * tile * Group * 256 * sizeof(half) +
+                       tile * Group * bdx * sizeof(size_t);
+  BatchDecodeWithPagedKVCacheKernel<PosEncodingMode::kNone, stages, tile, vec,
+                                    bdx, Group, bdz, QSAVariant>
+      <<<dim3(rows * splits, p.paged_kv.num_heads), dim3(bdx, Group, bdz), smem,
+         stream>>>(p);
+  // Keep FP32 partials until the final output cast. This is upstream's actual
+  // cascade implementation, not the previous Triton merge under a new name.
+  MergeStatesKernel<8, float, half>
+      <<<rows, dim3(32, p.num_qo_heads), 0, stream>>>(
+          p.o, p.lse, output, nullptr, splits, p.num_qo_heads, 256);
+}
+
+}  // namespace flashinfer::attention::sm70

--- a/flashinfer-sm70/tests/test_qsa_decode.py
+++ b/flashinfer-sm70/tests/test_qsa_decode.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Isolated upstream FlashInfer SM70 adapter tests, no vLLM binary required."""
+
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_sm70_flashinfer_qsa import (
+    capture,
+    check_exclusive,
+    make_case,
+    oracle,
+)
+from benchmarks.kernels.flashinfer_sm70_qsa import FlashInferQSA, build
+
+
+@pytest.mark.parametrize("width,splits", [(0, 1), (2, 0), (2, 65), (-1, 4)])
+def test_invalid_plan(width, splits):
+    with pytest.raises(ValueError):
+        FlashInferQSA(torch.empty((1, 6, 256), dtype=torch.float16), width, splits)
+
+
+def test_oracle_keeps_repeats_and_masks_empty_rows():
+    q = torch.zeros(2, 1, 256)
+    k = torch.zeros(1, 4, 1, 256)
+    v = torch.zeros_like(k)
+    v[0, 1] = 3
+    indices = torch.tensor([[0, 1, 1, -1], [0, 1, 2, 3]], dtype=torch.int32)
+    result = oracle(q, k, v, indices, torch.tensor([[0]]), torch.tensor([0, -1]))
+    torch.testing.assert_close(result[0], torch.full_like(result[0], 2))
+    assert result[1].count_nonzero() == 0
+
+
+@pytest.fixture(scope="module")
+def cuda_build():
+    if not torch.cuda.is_available():
+        pytest.skip("SM70 GPU required")
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("Prototype deliberately restricted to SM70")
+    check_exclusive()
+    torch.manual_seed(42)
+    build()
+
+
+@pytest.mark.parametrize(
+    "rows,selected,page,kv_heads,group,splits",
+    [
+        (1, 1, 16, 1, 1, 1),
+        (1, 5, 16, 1, 2, 8),
+        (2, 31, 64, 2, 4, 4),
+        (4, 33, 16, 1, 6, 32),
+        (8, 257, 784, 1, 6, 16),
+        (16, 2051, 784, 1, 6, 32),
+        (3, 2051, 64, 2, 6, 64),
+        (2, 37, 16, 2, 8, 4),
+    ],
+)
+def test_sparse_eager_and_graph(
+    cuda_build, rows, selected, page, kv_heads, group, splits
+):
+    case = list(make_case(rows, selected, page, kv_heads, group))
+    q, k, v, indices, table, requests = case
+    # Strided queries/cache and table, while maintaining vector alignment.
+    q_storage = torch.empty(rows, q.shape[1] * 2, 256, device="cuda", dtype=q.dtype)
+    case[0] = q_storage[:, ::2].copy_(q)
+    case[1] = k.transpose(1, 2).contiguous().transpose(1, 2)
+    case[2] = v.transpose(1, 2).contiguous().transpose(1, 2)
+    q, k, v = case[:3]
+    candidate = FlashInferQSA(q, selected, splits)
+    call = lambda: candidate(*case)
+    graph = capture(call, 1)
+    for cycle in range(5):
+        q.normal_().mul_((0.25, 1.0, 3.0, 1.0, 1.0)[cycle])
+        requests.copy_(torch.randperm(rows, device="cuda"))
+        table.copy_(torch.randperm(k.shape[0], device="cuda").reshape_as(table))
+        indices.random_(0, 8192)
+        if selected > 1:
+            indices[:, 1] = indices[:, 0]  # preserve duplicate weighting
+        if cycle == 1:
+            indices[:, ::3] = -1
+        elif cycle == 2:
+            indices[:, ::3] = table.shape[1] * page + 5
+            table[:, 0] = k.shape[0]  # invalid physical page
+        elif cycle == 3:
+            requests[0] = rows + 1
+        elif cycle == 4:
+            indices.fill_(-1)
+            k.fill_(float("nan"))
+            v.fill_(float("nan"))  # invalid slots must load zero, not page 0
+        expected = oracle(*case)
+        eager = call().clone()
+        for workspace in (candidate.partial, candidate.lse, candidate.output):
+            workspace.fill_(float("nan"))
+        candidate.offsets.fill_(-7)
+        candidate.metadata.fill_(-9)
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(candidate.output, eager, atol=0, rtol=0)
+        torch.testing.assert_close(
+            candidate.output.float(), expected, atol=2e-3, rtol=1e-2
+        )
+
+
+def test_reject_unaligned_inputs(cuda_build):
+    case = list(make_case(1, selected=5))
+    q = case[0]
+    storage = torch.empty(q.numel() + 1, dtype=q.dtype, device=q.device)
+    case[0] = storage[1:].view_as(q).copy_(q)
+    candidate = FlashInferQSA(case[0], 5, 1)
+    with pytest.raises(RuntimeError, match="aligned"):
+        candidate(*case)

--- a/tools/prepare-flashinfer-sm70-qsa.sh
+++ b/tools/prepare-flashinfer-sm70-qsa.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+set -euo pipefail
+
+# Separate pin from the older WMMA primitive probe. No wheel/package install.
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+sha=6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f
+cccl=16bd510c9b712e82b0ab6cbb630d8e29ba1f7116
+source_dir=${FLASHINFER_SM70_QSA_SOURCE:-"$root/.deps/flashinfer-6c14bbd5ff34"}
+if [[ ! -e "$source_dir" ]]; then
+  git clone --filter=blob:none --no-checkout \
+    https://github.com/flashinfer-ai/flashinfer.git "$source_dir"
+  git -C "$source_dir" checkout --detach "$sha"
+fi
+[[ $(git -C "$source_dir" rev-parse HEAD) == "$sha" ]] || {
+  echo "FlashInfer source has a different revision; refusing to overwrite" >&2
+  exit 1
+}
+[[ -z $(git -C "$source_dir" status --porcelain --untracked-files=no) ]] || {
+  echo "FlashInfer source has local edits; refusing to overwrite" >&2
+  exit 1
+}
+git -C "$source_dir" submodule update --init --depth 1 3rdparty/cccl
+[[ $(git -C "$source_dir/3rdparty/cccl" rev-parse HEAD) == "$cccl" ]]
+echo "Prepared FlashInfer $sha with CCCL $cccl at $source_dir"


### PR DESCRIPTION
## Purpose

Begin a real FlashInfer CUDA source port to Volta, starting with sparse QSA.
Instantiate the actual upstream paged-decode and cascade kernels through an
ordered virtual-page adapter; no forwarding to Triton or Flash-V100. This is
an experimental benchmark entry, **not** a serving/default change.

- Base SHA: `755baae1d075ee04fa9096b23fc0225b23589a86` (`main`).
- Initial head: `6b2f4ad8e9c1ddebf375bb1ea163dc2b5891ced4`.
- FlashInfer: `6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f`, unmodified headers.
- CCCL: `16bd510c9b712e82b0ab6cbb630d8e29ba1f7116`.
- No duplicate open FlashInfer PR found. Unlike #504/#507, this uses the
  upstream FlashInfer CUDA computation, not another existing native-FA route
  or a changed Triton launch heuristic. Issue #441's older prefill dispatch
  fix is already on main and is not repeated here.

Implementation: FP16 D256, variable batch/page/selection width, GQA 1/2/4/6/8,
ordered selections including duplicates, 64-bit KV offsets, invalid-slot zero
loads, FP32 partials/LSE, persistent per-instance buffers and graph-compatible
GPU preparation. Upstream's existing pre-SM80 synchronous-load fallback is
used. The global FlashInfer hardware gate remains unchanged.

## Test Plan

- CPU-only native `sm_70` compilation and library loading.
- Independent FP32 oracle, repeated indices, invalid rows/pages, empty states,
  strided tensors, alignment guards and poisoned-buffer CUDA Graph replay.
- Paired component timing against the current two-warp Triton route at
  B1/4/8/16, with index preparation and merge included.
- Sanitizer, serving metadata integration and E2E/task-level quality before
  runtime admission. No model speed claim from component or compile results.
- Targets remain C4/C8/C16 = 238/420/728 aggregate no-MTP decode tok/s against
  the fixed 70 tok/s single-request denominator.

## Test Result

- Native CUDA 12.8 SM70 compile and load: passed.
- `cuobjdump`: native `sm_70`, GQA6 72 registers/thread, zero stack/local.
- CPU pytest: `5 passed, 9 skipped`; GPU skips are not GPU passes.
- All applicable staged pre-commit hooks passed (Ruff, CUDA/C++ formatting,
  mypy, shellcheck, Markdown and repository-specific checks).
- GPU pytest: **14 passed**, including graph replay and poisoned-buffer cases.
- Compute Sanitizer 12.8.93: 2 targeted cases, memcheck **0 errors**;
  racecheck **0 errors / 0 warnings**. Older system sanitizer failures were
  not counted as passes; see worklog.
- Paired warmed CUDA Graph microbenchmark, V100-SXM2, local Hq6/Hkv1/D256,
  8192 context / 2051 sparse slots / page784, 11 samples x 100 calls:

| Rows | Current Triton us | FlashInfer us | Splits | Latency change |
| --- | ---: | ---: | ---: | ---: |
| 1 | 27.228 | 30.556 | 32 | +12.22% regression |
| 4 | 54.641 | 45.066 | 32 | -17.52% |
| 8 | 100.055 | 60.611 | 32 | -39.42% |
| 16 | 167.311 | 87.491 | 16 | -47.71% |

The FlashInfer arm includes preparation + decode + merge; best splits are
from an exploratory 16/32/64 sweep. Auto boost, post-sample 1530/877 MHz,
driver 580.173.02. Maximum observed relative L2 versus FP32 = 0.00021144.
No E2E/model-quality acceptance or default change; B1 regression explicitly
prevents global admission. GPU processes exited and memory released.

Commands and contract: `docs/design/sm70_flashinfer_qsa_port.md`.
The benchmark-only test is run with `--confcutdir=flashinfer-sm70/tests`; no
new wheel is required. Generated build/test artifacts remain unversioned.

Risks: SIMT may be slower than the existing tensor-core route; numerical
reduction order differs and task quality is not proven by an FP32 unit oracle.
FP8 KV, prefill, fused gate, GDN/conv and TP integration are later stages, not
claimed supported by this prototype. Keep Draft until GPU gates and human
review are complete.

This work is AI-assisted (Codex); human maintainer review is required before
promotion or merge. All commits carry DCO sign-off and AI attribution.
