### PR TITLE
[Bugfix][SM70] Gate SM70 config defaults on any visible device (#412)

### DIFF
--- a/tests/config/test_prefix_anchored_swa.py
+++ b/tests/config/test_prefix_anchored_swa.py
@@ -42,7 +42,8 @@ def sm70_platform(monkeypatch: pytest.MonkeyPatch) -> None:
         "current_platform",
         SimpleNamespace(
             is_cuda=lambda: True,
-            is_device_capability=lambda capability: capability == (7, 0),
+            device_count=lambda: 1,
+            is_device_capability=lambda capability, device_id=0: capability == (7, 0),
         ),
     )
 
@@ -113,7 +114,8 @@ def test_engine_contract_rejects_non_sm70(monkeypatch: pytest.MonkeyPatch):
         "current_platform",
         SimpleNamespace(
             is_cuda=lambda: True,
-            is_device_capability=lambda capability: False,
+            device_count=lambda: 1,
+            is_device_capability=lambda capability, device_id=0: False,
         ),
     )
 

--- a/tests/config/test_sm70_gates_any_visible_device.py
+++ b/tests/config/test_sm70_gates_any_visible_device.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for #412: the SM70 gates in ``VllmConfig`` must consider
+every visible device, not only device 0."""
+
+import os
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+from vllm import platforms
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
+from vllm.config.vllm import apply_prefix_anchored_swa_constraints
+
+SM70 = (7, 0)
+SM75 = (7, 5)
+
+# The unconditional part of the SM70 Flash-V100 baseline defaults.
+BASELINE_ENV = (
+    "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE",
+    "VLLM_SM70_GDN_KKT_SCHEDULE",
+    "VLLM_SM70_GDN_DELTA_H_SCHEDULE",
+    "VLLM_SM70_GDN_CHUNK_O_SCHEDULE",
+    "VLLM_SM70_FLA_RECURRENT_SCHEDULE",
+    "VLLM_SM70_FUSED_SIGMOID_GATING_SCHED",
+    "VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE",
+    "VLLM_SM70_GDN_DECODE_FLASHQLA",
+)
+
+
+def _fake_platform(capabilities: list[tuple[int, int]], is_cuda: bool = True):
+    return SimpleNamespace(
+        is_cuda=lambda: is_cuda,
+        device_count=lambda: len(capabilities),
+        is_device_capability=lambda capability, device_id=0: (
+            capabilities[device_id] == capability
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        pytest.param([SM70], True, id="single-sm70"),
+        pytest.param([SM75, SM70], True, id="sm75-first"),
+        pytest.param([SM70, SM75], True, id="sm70-first"),
+        pytest.param([SM75, SM75], False, id="homogeneous-sm75"),
+        pytest.param([], False, id="no-devices"),
+    ],
+)
+def test_any_visible_device_is_capability(monkeypatch, capabilities, expected):
+    from vllm.config.vllm import _any_visible_device_is_capability
+
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform(capabilities))
+    assert _any_visible_device_is_capability(SM70) is expected
+
+
+def test_any_visible_device_is_capability_requires_cuda(monkeypatch):
+    from vllm.config.vllm import _any_visible_device_is_capability
+
+    monkeypatch.setattr(
+        platforms, "current_platform", _fake_platform([SM70], is_cuda=False)
+    )
+    assert _any_visible_device_is_capability(SM70) is False
+
+
+def test_prefix_anchored_swa_accepts_sm70_behind_sm75(monkeypatch):
+    """The engine contract only needs an SM70 device somewhere in the grid."""
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform([SM75, SM70]))
+    cfg = SimpleNamespace(
+        attention_config=SimpleNamespace(prefix_anchored_decode_window=64),
+    )
+    # Passing the capability gate means reaching the model-config check.
+    with pytest.raises(ValueError, match="requires a model config"):
+        cfg.model_config = None
+        apply_prefix_anchored_swa_constraints(cfg)
+
+
+@pytest.fixture
+def isolated_baseline_env() -> Iterator[None]:
+    saved = {name: os.environ.get(name) for name in BASELINE_ENV}
+    for name in BASELINE_ENV:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _patch_visible_devices(monkeypatch, capabilities: list[tuple[int, int]]):
+    # Patch the platform instance, not its class: other tests leave
+    # instance-level attributes behind that would shadow a class patch.
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "device_count", lambda: len(capabilities))
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        lambda capability, device_id=0: capabilities[device_id] == capability,
+    )
+    assert current_platform.device_count() == len(capabilities)
+    assert current_platform.is_device_capability((7, 0)) is (capabilities[0] == (7, 0))
+
+
+def _build_vllm_config() -> VllmConfig:
+    model_config = ModelConfig(model="facebook/opt-125m", dtype="float16", seed=42)
+    return VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=16, gpu_memory_utilization=0.9, cache_dtype="auto"
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=10,
+            max_num_batched_tokens=512,
+            max_model_len=512,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        parallel_config=ParallelConfig(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        pytest.param([SM75, SM70], True, id="sm70-stage-behind-sm75"),
+        pytest.param([SM75, SM75], False, id="homogeneous-sm75"),
+    ],
+)
+def test_sm70_baseline_defaults_follow_any_visible_device(
+    monkeypatch, isolated_baseline_env, capabilities, expected
+):
+    """PP stage 0 on an sm75 card, stage 1 on sm70: the Flash-V100 baseline
+    defaults must still be applied; a homogeneous sm75 box must stay clean."""
+    _patch_visible_devices(monkeypatch, capabilities)
+
+    _build_vllm_config()
+
+    applied = {name for name in BASELINE_ENV if os.environ.get(name) == "1"}
+    assert (applied == set(BASELINE_ENV)) is expected
+    if not expected:
+        assert not applied

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -218,6 +218,25 @@ def _is_sm70_qwen38_nomtp_dual_compile_contract(
     )
 
 
+def _any_visible_device_is_capability(capability: tuple[int, int]) -> bool:
+    """True if any visible CUDA device has exactly this compute capability.
+
+    ``current_platform.is_device_capability`` inspects device 0 only. On a
+    heterogeneous pipeline-parallel deployment the stage that needs the SM70
+    defaults is not necessarily the one on device 0; the defaults are gated
+    again per worker at their point of use, so applying them whenever an SM70
+    device is visible is safe for the other stages.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_cuda():
+        return False
+    return any(
+        current_platform.is_device_capability(capability, device_id=device_id)
+        for device_id in range(current_platform.device_count())
+    )
+
+
 def _apply_sm70_dflash2_verifier_defaults() -> tuple[str, ...]:
     """Set quality-audited defaults while preserving every explicit override."""
     applied = []
@@ -572,9 +591,7 @@ def apply_prefix_anchored_swa_constraints(cfg: "VllmConfig") -> None:
     from vllm.platforms import current_platform
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-    if not (
-        current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
-    ):
+    if not (current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))):
         raise ValueError("prefix_anchored_decode_window requires an NVIDIA SM70 GPU")
 
     model_config = cfg.model_config
@@ -1620,8 +1637,7 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
             ),
         )
         sm70_glm5_dflash_tp8_pp1_verifier = (
@@ -1631,7 +1647,7 @@ class VllmConfig:
                 self.parallel_config,
                 is_sm70=(
                     current_platform.is_cuda()
-                    and current_platform.is_device_capability((7, 0))
+                    and _any_visible_device_is_capability((7, 0))
                 ),
             )
         )
@@ -1640,8 +1656,7 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
             ),
         )
 
@@ -1658,9 +1673,7 @@ class VllmConfig:
             )
 
         if envs.VLLM_SM70_USE_BREAKABLE_CUDAGRAPH:
-            if current_platform.is_cuda() and current_platform.is_device_capability(
-                (7, 0)
-            ):
+            if current_platform.is_cuda() and _any_visible_device_is_capability((7, 0)):
                 if "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ:
                     os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
                     logger.info_once(
@@ -1737,7 +1750,7 @@ class VllmConfig:
             and self.parallel_config.tensor_parallel_size <= 2
             and sm70_fp8_kv_requested
             and current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             and "VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK" not in os.environ
@@ -1756,7 +1769,7 @@ class VllmConfig:
             and self.model_config.quantization == "fp8"
             and self.model_config.is_moe
             and current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK
             and not envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
@@ -1778,7 +1791,7 @@ class VllmConfig:
         )
         sm70_flash_v100_baseline = (
             current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FLASH_ATTN_V100
             and sm70_flash_v100_backend
         )
@@ -1949,7 +1962,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 self.compilation_config.mode = CompilationMode.VLLM_COMPILE
@@ -2126,7 +2139,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 capture_size = max(
@@ -2181,7 +2194,7 @@ class VllmConfig:
                 self.model_config is not None
                 and self.model_config.quantization == "fp8"
                 and current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             )
 


### PR DESCRIPTION
## Purpose

Fixes #412 (capability gates probe device 0 only), first item.

`VllmConfig.__post_init__` applies the SM70 environment defaults -- the
Flash-V100 baseline (`VLLM_SM70_GDN_*`, `VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE`,
...), the FP8 MoE lanes, breakable cudagraph, the GLM DFlash2 paths -- behind
`current_platform.is_device_capability((7, 0))`, which only inspects device 0.
On a heterogeneous pipeline-parallel deployment that is the wrong question:

- Turing card first (`CUDA_VISIBLE_DEVICES=0,2,1,3`, stage 0 = sm75): the whole
  block is skipped, the Volta stage runs without its tuning. On our rig
  (1.3.0 at the time of the issue) that showed up as 0 instead of 9
  "Auto-setting" lines and as MTP acceptance dropping from ~21 % to 2-9 %
  with incoherent output.
- Volta card first: applied for everyone, which is fine because every
  default is gated again per worker at its point of use.

The same gate makes `apply_prefix_anchored_swa_constraints` reject a grid
that has an SM70 device behind an SM75 one.

This PR adds `_any_visible_device_is_capability()` (module helper next to the
other SM70 default helpers; iterates `current_platform.device_count()` with
`is_device_capability(..., device_id=...)`) and gates the eleven
`is_device_capability((7, 0))` sites in `vllm/config/vllm.py` on it.
Homogeneous setups behave exactly as before. Sites that ask a different
question are left alone: the int-form fusion check, the Turing fp32
warning, the dense-cudagraph `cap.major == 7` check and the quantization
minimum-capability check (`get_device_capability()`), see below.

Not in this PR: item 3 of the issue (`ModelOptNvFp4Config.get_min_capability`
hard-coded to 75) was addressed in #403 (70 when a TurboMind/Marlin/emulation
backend is selected). With that, item 2 (the quantization gate reading device
0) no longer blocks a boot in practice, and widening it to "any visible
device" would weaken the check, so it stays as is.

`tests/config/test_prefix_anchored_swa.py` fakes `current_platform` with a
`SimpleNamespace`; the fake gains `device_count` and the `device_id`
parameter the helper uses. The assertions are unchanged.

Duplicate check (per AGENTS.md): `gh issue view 412 --comments` (no
follow-up), `gh pr list --state open --search "412 in:body"` (none),
`--search "is_device_capability"` and `--search "heterogeneous"` (no PR
touches these gates). Verified against origin/main 755baae today.

## Test Plan

Environment: 1Cat-vLLM 1.5.0 wheel venv (Python 3.12), checkout at
origin/main 755baae with the compiled extensions linked in, single Tesla
V100 (`CUDA_VISIBLE_DEVICES=4`), facebook/opt-125m from the HF cache.

    # every test file that exercises these gates, plus the new file
    python -m pytest tests/config/test_prefix_anchored_swa.py tests/compile/test_sm70_decode_graph.py \
        tests/engine/test_arg_utils.py tests/v1/spec_decode/test_dflash2.py \
        tests/config/test_sm70_gates_any_visible_device.py -q
    python -m pytest tests/v1/spec_decode/test_mtp.py -q

    # new file + prefix-anchored file with vllm/config/vllm.py reverted to origin/main (git stash), tests kept
    python -m pytest tests/config/test_sm70_gates_any_visible_device.py tests/config/test_prefix_anchored_swa.py -q

    # pre-commit hooks as configured in the repo (ruff, typos, mypy-local) plus the CI-only mypy stage
    pre-commit run --files <3 files>
    pre-commit run mypy-3.10 --hook-stage manual --files <3 files>
    mypy --python-version 3.10 --follow-imports skip tests/config/test_sm70_gates_any_visible_device.py tests/config/test_prefix_anchored_swa.py

## Test Result

Four affected test files on origin/main 755baae, before the change:

    264 passed, 9 skipped in 101.58s

Same four files plus the new file, with the fix (9 new cases):

    273 passed, 9 skipped in 101.33s

`tests/v1/spec_decode/test_mtp.py` (patches `is_device_capability` and builds a
VllmConfig): 8 passed before and after.

New file + prefix-anchored file, `vllm/config/vllm.py` reverted to origin/main:

    8 failed, 15 passed
    test_sm70_baseline_defaults_follow_any_visible_device[sm70-stage-behind-sm75]
        assert (set() == {'VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE', ...})   -> no defaults applied
    test_prefix_anchored_swa_accepts_sm70_behind_sm75
        ValueError: prefix_anchored_decode_window requires an NVIDIA SM70 GPU  -> grid rejected
    test_any_visible_device_is_capability[*] (6 cases)   ImportError (helper does not exist)
    [homogeneous-sm75] passes before and after: no behaviour change for homogeneous boxes.

pre-commit (`pre-commit run --files <3 files>` and `pre-commit run mypy-3.10
--hook-stage manual --files <3 files>`): ruff-check, ruff-format, typos, SPDX
headers, forbidden-imports, torch.cuda-call check, mypy-local and mypy-3.10
all Passed.
mypy on `vllm/config/vllm.py`: no issues before and after.
mypy on both test files: no issues.

On our rig (2x RTX 8000 sm75 + 3x V100 sm70) the same change has been in
production in our fork since the 1.3.0 days; with the RTX pair as PP stage 0
the Volta stage boots with all 14 SM70 defaults, and TP2xPP2 with MTP runs
coherently at the same throughput as before.

AI assistance: this change was developed with Claude (Anthropic) as a
coding assistant. Every changed line was reviewed by me and the test runs
above were executed on my hardware; I can defend the change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
