### PR TITLE
[Kernel][WIP] Port FlashInfer GDN and HC layer fusion to SM70

### DIFF
--- a/benchmarks/csrc/sm70_flashinfer_gdn_conv.cu
+++ b/benchmarks/csrc/sm70_flashinfer_gdn_conv.cu
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+#include <torch/types.h>
+#include <flashinfer/gdn/sm70/gdn_fused_decode.cuh>
+
+namespace {
+using namespace flashinfer::sm70::gdn;
+
+void run(torch::Tensor hidden, torch::Tensor weights, torch::Tensor qkv,
+         torch::Tensor conv_w, torch::Tensor conv_bias, torch::Tensor conv,
+         torch::Tensor A_log, torch::Tensor dt_bias, torch::Tensor state,
+         torch::Tensor indices, torch::Tensor output, torch::Tensor conv_out,
+         torch::Tensor partial) {
+  const c10::cuda::CUDAGuard guard(hidden.device());
+  for (const auto& t : {hidden, weights, qkv, conv_w, conv_bias, conv, A_log,
+                        dt_bias, state, indices, output, conv_out, partial})
+    TORCH_CHECK(t.is_cuda() && t.device() == hidden.device());
+  const auto* props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0, "SM70 prototype only");
+  const int B = hidden.size(0);
+  TORCH_CHECK(B > 0 && B <= 64 && hidden.dim() == 2 &&
+              hidden.size(1) == HIDDEN);
+  TORCH_CHECK(weights.sizes() == torch::IntArrayRef({HIDDEN, N_BA}));
+  TORCH_CHECK(qkv.sizes() == torch::IntArrayRef({B, QKV_DIM}) &&
+              qkv.stride(1) == 1);
+  TORCH_CHECK(conv_w.sizes() == torch::IntArrayRef({QKV_DIM, CONV_WIDTH}));
+  TORCH_CHECK(conv_bias.numel() == 0 || conv_bias.numel() == QKV_DIM);
+  TORCH_CHECK(conv.dim() == 3 && conv.size(1) == QKV_DIM && conv.size(2) == 3);
+  TORCH_CHECK(state.dim() == 4 && state.size(0) == conv.size(0) &&
+              state.size(1) == HV && state.size(2) == D && state.size(3) == D &&
+              state.stride(1) == D * D && state.stride(2) == D &&
+              state.stride(3) == 1);
+  TORCH_CHECK(A_log.numel() == HV && dt_bias.numel() == HV &&
+              indices.numel() == B);
+  TORCH_CHECK(output.numel() == B * HV * D && conv_out.numel() == B * QKV_DIM);
+  TORCH_CHECK(partial.numel() == B * N_BA * GEMV_NSPLIT);
+  for (const auto& t : {hidden, weights, conv_w, conv_bias, A_log, dt_bias,
+                        indices, output, conv_out, partial})
+    TORCH_CHECK(t.is_contiguous());
+  for (const auto& t : {hidden, weights, qkv, conv_w, conv_bias, conv, dt_bias,
+                        output, conv_out})
+    TORCH_CHECK(t.scalar_type() == at::kHalf);
+  for (const auto& t : {state, A_log, partial})
+    TORCH_CHECK(t.scalar_type() == at::kFloat);
+  TORCH_CHECK(indices.scalar_type() == at::kInt);
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(state.data_ptr()) % 16 == 0 &&
+              state.stride(0) % 4 == 0);
+  const int block = 256;
+  int occupancy = 0;
+  if (B == 1) {
+    C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &occupancy, gdn_fused_decode_kernel<true>, block, 0));
+  } else {
+    C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &occupancy, gdn_fused_decode_kernel<false>, block, 0));
+  }
+  TORCH_CHECK(occupancy > 0);
+  const int needed = (B * HV * D + ROWS_PER_WARP * 8 - 1) / (ROWS_PER_WARP * 8);
+  const int grid = std::min(needed, occupancy * props->multiProcessorCount);
+  auto stream = at::cuda::getCurrentCUDAStream();
+  TORCH_CHECK(props->cooperativeLaunch,
+              "GDN grid sync needs cooperative launch");
+  cudaLaunchConfig_t config{};
+  config.gridDim = grid;
+  config.blockDim = block;
+  config.stream = stream;
+  cudaLaunchAttribute attribute{};
+  attribute.id = cudaLaunchAttributeCooperative;
+  attribute.val.cooperative = 1;
+  config.attrs = &attribute;
+  config.numAttrs = 1;
+#define LAUNCH(B1)                                                          \
+  C10_CUDA_CHECK(cudaLaunchKernelEx(                                        \
+      &config, gdn_fused_decode_kernel<B1>, (const half*)hidden.data_ptr(), \
+      (const half*)weights.data_ptr(), (const half*)qkv.data_ptr(),         \
+      (const half*)conv_w.data_ptr(),                                       \
+      conv_bias.numel() ? (const half*)conv_bias.data_ptr() : nullptr,      \
+      (const half*)conv.data_ptr(), A_log.data_ptr<float>(),                \
+      (const half*)dt_bias.data_ptr(), state.data_ptr<float>(),             \
+      indices.data_ptr<int>(), 1.f / sqrtf(float(D)), state.stride(0),      \
+      qkv.stride(0), conv.stride(0), conv.stride(1), conv.stride(2),        \
+      (half*)output.data_ptr(), (half*)conv.data_ptr(),                     \
+      state.data_ptr<float>(), partial.data_ptr<float>(),                   \
+      (half*)conv_out.data_ptr(), B))
+  if (B == 1) {
+    LAUNCH(true);
+  } else {
+    LAUNCH(false);
+  }
+#undef LAUNCH
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+}  // namespace
+
+TORCH_LIBRARY_FRAGMENT(_C_flashinfer_gdn_sm70, m) {
+  m.def(
+      "run(Tensor hidden, Tensor weights, Tensor qkv, Tensor conv_w, "
+      "Tensor conv_bias, Tensor(a!) conv, Tensor A_log, Tensor dt_bias, "
+      "Tensor(b!) state, Tensor indices, Tensor(c!) output, Tensor(d!) "
+      "conv_out, "
+      "Tensor(e!) partial) -> ()");
+}
+TORCH_LIBRARY_IMPL(_C_flashinfer_gdn_sm70, CUDA, m) { m.impl("run", &run); }

--- a/benchmarks/csrc/sm70_flashinfer_gdn_conv.cu
+++ b/benchmarks/csrc/sm70_flashinfer_gdn_conv.cu
@@ -96,7 +96,7 @@ void run(torch::Tensor hidden, torch::Tensor weights, torch::Tensor qkv,
 }
 }  // namespace
 
-TORCH_LIBRARY_FRAGMENT(_C_flashinfer_gdn_sm70, m) {
+TORCH_LIBRARY_FRAGMENT(FI_GDN_TORCH_NAMESPACE, m) {
   m.def(
       "run(Tensor hidden, Tensor weights, Tensor qkv, Tensor conv_w, "
       "Tensor conv_bias, Tensor(a!) conv, Tensor A_log, Tensor dt_bias, "
@@ -104,4 +104,4 @@ TORCH_LIBRARY_FRAGMENT(_C_flashinfer_gdn_sm70, m) {
       "conv_out, "
       "Tensor(e!) partial) -> ()");
 }
-TORCH_LIBRARY_IMPL(_C_flashinfer_gdn_sm70, CUDA, m) { m.impl("run", &run); }
+TORCH_LIBRARY_IMPL(FI_GDN_TORCH_NAMESPACE, CUDA, m) { m.impl("run", &run); }

--- a/benchmarks/csrc/sm70_flashinfer_hc_norm.cu
+++ b/benchmarks/csrc/sm70_flashinfer_hc_norm.cu
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+#include <torch/types.h>
+#include <flashinfer/hc/sm70/hc_combine_norm.cuh>
+
+namespace {
+template <class T, class B, class W>
+void launch(torch::Tensor residual, torch::Tensor block,
+            torch::Tensor injection, torch::Tensor weight,
+            torch::Tensor combined, torch::Tensor output, float eps,
+            int warps) {
+  const int groups = injection.size(1), d = block.size(1);
+  const int rounds = (d + 8 * 32 * warps - 1) / (8 * 32 * warps);
+  const int shared =
+      ((warps + 3) / 4 * 4 + rounds * 8 * 32 * warps) * sizeof(float);
+  flashinfer::sm70::hc::HCCombineNormKernel<8, T, B, W>
+      <<<dim3(residual.size(0), groups), dim3(32, warps), shared,
+         at::cuda::getCurrentCUDAStream()>>>(
+          (const B*)block.data_ptr(), (const T*)residual.data_ptr(),
+          (const W*)weight.data_ptr(), (const W*)injection.data_ptr(),
+          (T*)combined.data_ptr(), (T*)output.data_ptr(), groups, d,
+          block.stride(0), residual.stride(0), injection.stride(0),
+          weight.numel() == d, eps);
+}
+
+template <class T, class B>
+void weight_dispatch(torch::Tensor r, torch::Tensor b, torch::Tensor i,
+                     torch::Tensor w, torch::Tensor c, torch::Tensor o,
+                     float eps, int warps) {
+  if (w.scalar_type() == at::kHalf)
+    launch<T, B, half>(r, b, i, w, c, o, eps, warps);
+  else
+    launch<T, B, float>(r, b, i, w, c, o, eps, warps);
+}
+
+void run(torch::Tensor r, torch::Tensor b, torch::Tensor i, torch::Tensor w,
+         torch::Tensor c, torch::Tensor o, double eps, int64_t warps) {
+  const c10::cuda::CUDAGuard guard(r.device());
+  for (const auto& t : {r, b, i, w, c, o}) {
+    TORCH_CHECK(t.is_cuda() && t.device() == r.device() && t.is_contiguous());
+    TORCH_CHECK(t.scalar_type() == at::kHalf || t.scalar_type() == at::kFloat);
+    TORCH_CHECK(reinterpret_cast<uintptr_t>(t.data_ptr()) % 16 == 0);
+  }
+  const auto* props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0);
+  TORCH_CHECK(r.dim() == 2 && b.dim() == 2 && i.dim() == 2 && w.dim() == 1);
+  TORCH_CHECK(r.size(0) == b.size(0) && r.size(0) == i.size(0));
+  TORCH_CHECK(i.size(1) > 0 && b.size(1) > 0 && b.size(1) <= 4096 &&
+              b.size(1) % 8 == 0);
+  TORCH_CHECK(r.size(1) == i.size(1) * b.size(1));
+  TORCH_CHECK(w.numel() == b.size(1) || w.numel() == r.size(1));
+  TORCH_CHECK(i.scalar_type() == w.scalar_type());
+  TORCH_CHECK(c.sizes() == r.sizes() && o.sizes() == r.sizes() &&
+              c.scalar_type() == r.scalar_type() &&
+              o.scalar_type() == r.scalar_type());
+  TORCH_CHECK(warps == 1 || warps == 2 || warps == 4 || warps == 8);
+  TORCH_CHECK(eps > 0 && r.size(0) > 0);
+  if (r.scalar_type() == at::kHalf) {
+    if (b.scalar_type() == at::kHalf)
+      weight_dispatch<half, half>(r, b, i, w, c, o, eps, warps);
+    else
+      weight_dispatch<half, float>(r, b, i, w, c, o, eps, warps);
+  } else {
+    if (b.scalar_type() == at::kHalf)
+      weight_dispatch<float, half>(r, b, i, w, c, o, eps, warps);
+    else
+      weight_dispatch<float, float>(r, b, i, w, c, o, eps, warps);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+}  // namespace
+TORCH_LIBRARY_FRAGMENT(_C_flashinfer_hc_sm70, m) {
+  m.def(
+      "run(Tensor residual, Tensor block, Tensor injection, Tensor weight, "
+      "Tensor(a!) combined, Tensor(b!) output, float eps, int warps) -> ()");
+}
+TORCH_LIBRARY_IMPL(_C_flashinfer_hc_sm70, CUDA, m) { m.impl("run", &run); }

--- a/benchmarks/csrc/sm70_flashinfer_hc_norm.cu
+++ b/benchmarks/csrc/sm70_flashinfer_hc_norm.cu
@@ -11,9 +11,26 @@ namespace {
 template <class T, class B, class W>
 void launch(torch::Tensor residual, torch::Tensor block,
             torch::Tensor injection, torch::Tensor weight,
-            torch::Tensor combined, torch::Tensor output, float eps,
-            int warps) {
+            torch::Tensor combined, torch::Tensor output, float eps, int warps,
+            bool registers) {
   const int groups = injection.size(1), d = block.size(1);
+  if (registers) {
+#define REG_LAUNCH(NW)                                                    \
+  flashinfer::sm70::hc::HCCombineNormRegisterKernel<8, 2560, NW, T, B, W> \
+      <<<dim3(residual.size(0), groups), 32 * NW, 0,                      \
+         at::cuda::getCurrentCUDAStream()>>>(                             \
+          (const B*)block.data_ptr(), (const T*)residual.data_ptr(),      \
+          (const W*)weight.data_ptr(), (const W*)injection.data_ptr(),    \
+          (T*)combined.data_ptr(), (T*)output.data_ptr(), groups,         \
+          weight.numel() == d, eps)
+    if (warps == 4) {
+      REG_LAUNCH(4);
+    } else {
+      REG_LAUNCH(8);
+    }
+#undef REG_LAUNCH
+    return;
+  }
   const int rounds = (d + 8 * 32 * warps - 1) / (8 * 32 * warps);
   const int shared =
       ((warps + 3) / 4 * 4 + rounds * 8 * 32 * warps) * sizeof(float);
@@ -30,15 +47,16 @@ void launch(torch::Tensor residual, torch::Tensor block,
 template <class T, class B>
 void weight_dispatch(torch::Tensor r, torch::Tensor b, torch::Tensor i,
                      torch::Tensor w, torch::Tensor c, torch::Tensor o,
-                     float eps, int warps) {
+                     float eps, int warps, bool registers) {
   if (w.scalar_type() == at::kHalf)
-    launch<T, B, half>(r, b, i, w, c, o, eps, warps);
+    launch<T, B, half>(r, b, i, w, c, o, eps, warps, registers);
   else
-    launch<T, B, float>(r, b, i, w, c, o, eps, warps);
+    launch<T, B, float>(r, b, i, w, c, o, eps, warps, registers);
 }
 
 void run(torch::Tensor r, torch::Tensor b, torch::Tensor i, torch::Tensor w,
-         torch::Tensor c, torch::Tensor o, double eps, int64_t warps) {
+         torch::Tensor c, torch::Tensor o, double eps, int64_t warps,
+         bool registers) {
   const c10::cuda::CUDAGuard guard(r.device());
   for (const auto& t : {r, b, i, w, c, o}) {
     TORCH_CHECK(t.is_cuda() && t.device() == r.device() && t.is_contiguous());
@@ -58,17 +76,18 @@ void run(torch::Tensor r, torch::Tensor b, torch::Tensor i, torch::Tensor w,
               c.scalar_type() == r.scalar_type() &&
               o.scalar_type() == r.scalar_type());
   TORCH_CHECK(warps == 1 || warps == 2 || warps == 4 || warps == 8);
+  TORCH_CHECK(!registers || (b.size(1) == 2560 && (warps == 4 || warps == 8)));
   TORCH_CHECK(eps > 0 && r.size(0) > 0);
   if (r.scalar_type() == at::kHalf) {
     if (b.scalar_type() == at::kHalf)
-      weight_dispatch<half, half>(r, b, i, w, c, o, eps, warps);
+      weight_dispatch<half, half>(r, b, i, w, c, o, eps, warps, registers);
     else
-      weight_dispatch<half, float>(r, b, i, w, c, o, eps, warps);
+      weight_dispatch<half, float>(r, b, i, w, c, o, eps, warps, registers);
   } else {
     if (b.scalar_type() == at::kHalf)
-      weight_dispatch<float, half>(r, b, i, w, c, o, eps, warps);
+      weight_dispatch<float, half>(r, b, i, w, c, o, eps, warps, registers);
     else
-      weight_dispatch<float, float>(r, b, i, w, c, o, eps, warps);
+      weight_dispatch<float, float>(r, b, i, w, c, o, eps, warps, registers);
   }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -76,6 +95,7 @@ void run(torch::Tensor r, torch::Tensor b, torch::Tensor i, torch::Tensor w,
 TORCH_LIBRARY_FRAGMENT(_C_flashinfer_hc_sm70, m) {
   m.def(
       "run(Tensor residual, Tensor block, Tensor injection, Tensor weight, "
-      "Tensor(a!) combined, Tensor(b!) output, float eps, int warps) -> ()");
+      "Tensor(a!) combined, Tensor(b!) output, float eps, int warps, bool "
+      "registers) -> ()");
 }
 TORCH_LIBRARY_IMPL(_C_flashinfer_hc_sm70, CUDA, m) { m.impl("run", &run); }

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired gate-projection/conv/recurrent component screen, no engine launch.
+
+Uses real checkpoint weights with synthetic changing hidden states. Both arms
+include an identical input-refresh copy because production conv mutates QKV.
+This is not a model-quality test or complete GDN layer timing.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from benchmarks.kernels.flashinfer_sm70_gdn_conv import FusedGDN, build
+
+
+def check_exclusive():
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if not visible or "," in visible:
+        raise RuntimeError("Reserve exactly one GPU")
+    info = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "-i",
+            visible,
+            "--query-compute-apps=pid,process_name",
+            "--format=csv,noheader",
+        ],
+        text=True,
+    )
+    for row in info.splitlines():
+        pid, _, name = row.partition(",")
+        if pid.strip().isdigit() and int(pid) != os.getpid() and "snapd" not in name:
+            raise RuntimeError(f"Foreign GPU owner: {row}")
+
+
+def load_weights(model, layer=0, rank=0, tp=4):
+    mapping = json.loads((model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    config = json.loads((model / "config.json").read_text())["text_config"]
+    prefix = f"model.language_model.layers.{layer}.linear_attn."
+
+    def get(name, dtype=torch.float16):
+        name = prefix + name
+        with safe_open(model / mapping[name], framework="pt", device="cpu") as f:
+            return f.get_tensor(name).to(dtype)
+
+    qfull = config["linear_num_key_heads"] * 128
+    vfull = config["linear_num_value_heads"] * 128
+    hq, hv = (
+        config["linear_num_key_heads"] // tp,
+        config["linear_num_value_heads"] // tp,
+    )
+    selection = torch.cat(
+        [
+            torch.arange(rank * hq * 128, (rank + 1) * hq * 128),
+            torch.arange(qfull + rank * hq * 128, qfull + (rank + 1) * hq * 128),
+            torch.arange(
+                2 * qfull + rank * hv * 128, 2 * qfull + (rank + 1) * hv * 128
+            ),
+        ]
+    )
+    assert qfull * 2 + vfull == get("conv1d.weight").shape[0]
+    wqkv = get("in_proj_qkv.weight")[selection].contiguous().cuda()
+    ba = (
+        torch.cat(
+            [
+                get("in_proj_b.weight")[rank * hv : (rank + 1) * hv],
+                get("in_proj_a.weight")[rank * hv : (rank + 1) * hv],
+            ]
+        )
+        .contiguous()
+        .cuda()
+    )
+    conv = get("conv1d.weight").reshape(-1, 4)[selection].contiguous().cuda()
+    A = get("A_log", torch.float32)[rank * hv : (rank + 1) * hv].contiguous().cuda()
+    dt = get("dt_bias")[rank * hv : (rank + 1) * hv].contiguous().cuda()
+    return config["hidden_size"], hq, hv, wqkv, ba, conv, A, dt
+
+
+def capture(fn, repeats=1):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        for _ in range(repeats):
+            fn()
+    return graph
+
+
+def error(actual, reference):
+    a, b = actual.float(), reference.float()
+    if not a.numel():
+        return {"max_abs": 0.0, "relative_l2": 0.0, "finite": True, "exact": True}
+    return {
+        "max_abs": (a - b).abs().max().item(),
+        "relative_l2": ((a - b).norm() / b.norm().clamp_min(1e-20)).item(),
+        "finite": bool(torch.isfinite(a).all()),
+        "exact": bool(torch.equal(actual, reference)),
+    }
+
+
+@torch.inference_mode()
+def screen(rows, weights, args):
+    from flash_qla.ops.gated_delta_rule.chunk.sm70 import fused_fwd as qla
+    from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
+
+    hidden, hq, hv, wqkv, ba_weight, cw, A, dt = weights
+    pool = rows + 3
+    width = (2 * hq + hv) * 128
+    x = torch.randn(rows, hidden, device="cuda", dtype=torch.float16)
+    raw = torch.empty(rows, width, device="cuda", dtype=torch.float16)
+    raw.copy_(x @ wqkv.t())
+    base_in, candidate_in = torch.empty_like(raw), torch.empty_like(raw)
+    c0 = torch.randn(pool, 3, width, device="cuda", dtype=torch.float16).transpose(1, 2)
+    s0 = torch.randn(pool, hv, 128, 128, device="cuda", dtype=torch.float32) * 0.01
+    cb, cc, sb, sc = c0.clone(), c0.clone(), s0.clone(), s0.clone()
+    indices = torch.arange(rows, device="cuda", dtype=torch.int32)
+    bias = torch.empty(0, device="cuda", dtype=torch.float16)
+    packed = ba_weight.t().contiguous()
+    ba = torch.empty(rows, 2 * hv, device="cuda", dtype=torch.float16)
+    b, a = (
+        torch.empty(rows, hv, device="cuda", dtype=torch.float16),
+        torch.empty(rows, hv, device="cuda", dtype=torch.float16),
+    )
+    out = torch.empty(rows, hv, 128, device="cuda", dtype=torch.float16)
+    candidate = FusedGDN(rows, hq, hv)
+
+    def baseline():
+        base_in.copy_(raw)
+        torch.mm(x, ba_weight.t(), out=ba)
+        b.copy_(ba[:, :hv])
+        a.copy_(ba[:, hv:])
+        causal_conv1d_update(
+            base_in,
+            cb,
+            cw,
+            None,
+            "silu",
+            conv_state_indices=indices,
+            validate_data=False,
+        )
+        return qla.gdn_decode_mixed_qkv_global_state_sm70(
+            base_in, a, b, A, dt, sb, indices, out
+        )
+
+    def fused():
+        candidate_in.copy_(raw)
+        return candidate(x, packed, candidate_in, cw, bias, cc, A, dt, sc, indices)
+
+    baseline()
+    candidate_graph = capture(fused)
+    checks = []
+    for cycle in range(args.steps):
+        x.normal_().mul_((0.25, 1.0, 3.0)[cycle % 3])
+        raw.copy_(x @ wqkv.t())
+        indices.copy_(torch.randperm(pool, device="cuda")[:rows])
+        if cycle % 8 == 7:
+            indices[-1] = -1
+        cb.copy_(c0)
+        cc.copy_(c0)
+        sb.copy_(s0)
+        sc.copy_(s0)
+        baseline()
+        fused()
+        live = indices >= 0
+        checks.append(
+            {
+                "cycle": cycle,
+                "out": error(candidate.output[live], out[live]),
+                "state": error(sc, sb),
+                "conv_state": error(cc, cb),
+                "conv_out": error(candidate.conv_out[live], base_in[live]),
+            }
+        )
+        eager_out, eager_state, eager_conv = (
+            candidate.output.clone(),
+            sc.clone(),
+            cc.clone(),
+        )
+        cc.copy_(c0)
+        sc.copy_(s0)
+        candidate.output.fill_(float("nan"))
+        candidate.partial.fill_(float("nan"))
+        candidate_graph.replay()
+        torch.cuda.synchronize()
+        for actual, ref in (
+            (candidate.output, eager_out),
+            (sc, eager_state),
+            (cc, eager_conv),
+        ):
+            torch.testing.assert_close(actual, ref, atol=0, rtol=0)
+        # Advance a real recurrent history rather than always testing zero state.
+        c0.copy_(cb)
+        s0.copy_(sb)
+    maxima = {
+        part: {
+            metric: max(c[part][metric] for c in checks)
+            for metric in ("max_abs", "relative_l2")
+        }
+        for part in ("out", "state", "conv_out")
+    }
+    gate = (
+        all(c[part]["finite"] for c in checks for part in ("out", "state", "conv_out"))
+        and all(c["conv_state"]["exact"] for c in checks)
+        and maxima["out"]["relative_l2"] < 5e-3
+        and maxima["state"]["relative_l2"] < 5e-3
+    )
+    record = {
+        "rows": rows,
+        "q_heads": hq,
+        "v_heads": hv,
+        "checks": checks,
+        "maxima": maxima,
+        "operator_gate": gate,
+    }
+    if gate:
+        indices.copy_(torch.arange(rows, device="cuda"))
+        graphs = [capture(baseline, args.calls), capture(fused, args.calls)]
+        for _ in range(20):
+            for graph in graphs:
+                graph.replay()
+        torch.cuda.synchronize()
+        samples = [[], []]
+        check_exclusive()
+        for repeat in range(args.samples):
+            for i in [0, 1] if repeat % 2 == 0 else [1, 0]:
+                start, end = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+                start.record()
+                graphs[i].replay()
+                end.record()
+                end.synchronize()
+                samples[i].append(start.elapsed_time(end) * 1000 / args.calls)
+        check_exclusive()
+        record.update(
+            samples_us=samples, median_us=[statistics.median(s) for s in samples]
+        )
+    record["reference_qla_binary_sha256"] = hashlib.sha256(
+        Path(qla._load_ext().__file__).read_bytes()
+    ).hexdigest()
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--rows", type=int, nargs="+", default=[1, 4, 8, 16])
+    parser.add_argument("--steps", type=int, default=32)
+    parser.add_argument("--samples", type=int, default=9)
+    parser.add_argument("--calls", type=int, default=30)
+    args = parser.parse_args()
+    torch.manual_seed(20260906)
+    check_exclusive()
+    weights = load_weights(args.model)
+    build(*weights[:3])
+    for rows in args.rows:
+        print(json.dumps(screen(rows, weights, args)), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
@@ -46,6 +46,15 @@ def load_weights(model, layer=0, rank=0, tp=4):
         "weight_map"
     ]
     config = json.loads((model / "config.json").read_text())["text_config"]
+    if (
+        tp < 1
+        or not 0 <= rank < tp
+        or config["linear_num_key_heads"] % tp
+        or config["linear_num_value_heads"] % tp
+        or config["linear_key_head_dim"] != 128
+        or config["linear_value_head_dim"] != 128
+    ):
+        raise ValueError("Require D128 and a valid evenly sharded TP geometry")
     prefix = f"model.language_model.layers.{layer}.linear_attn."
 
     def get(name, dtype=torch.float16):
@@ -136,7 +145,7 @@ def screen(rows, weights, args):
         torch.empty(rows, hv, device="cuda", dtype=torch.float16),
     )
     out = torch.empty(rows, hv, 128, device="cuda", dtype=torch.float16)
-    candidate = FusedGDN(rows, hq, hv)
+    candidate = FusedGDN(rows, hq, hv, hidden=hidden)
 
     def baseline():
         base_in.copy_(raw)
@@ -218,12 +227,68 @@ def screen(rows, weights, args):
         and maxima["out"]["relative_l2"] < 5e-3
         and maxima["state"]["relative_l2"] < 5e-3
     )
+    # Unlike the local comparisons above, neither arm is reset from the other
+    # arm in this phase. This screens accumulation through independent FP32
+    # recurrent histories, including graph replays and recycled request slots.
+    cb.copy_(c0)
+    cc.copy_(c0)
+    sb.copy_(s0)
+    sc.copy_(s0)
+    history_maxima = {
+        part: {"max_abs": 0.0, "relative_l2": 0.0}
+        for part in ("out", "state", "conv_out")
+    }
+    history_gate, history_first_failure = True, None
+    for cycle in range(args.history_steps):
+        x.normal_().mul_((0.25, 1.0, 3.0)[cycle % 3])
+        raw.copy_(x @ wqkv.t())
+        indices.copy_(torch.randperm(pool, device="cuda")[:rows])
+        if cycle % 8 == 7:
+            indices[-1] = -1
+        if cycle % 31 == 30:
+            # A retired slot is cleared identically before being reused. Do
+            # not synchronize either arm's other, independently evolved slots.
+            slot = (cycle // 31) % pool
+            cb[slot].zero_()
+            cc[slot].zero_()
+            sb[slot].zero_()
+            sc[slot].zero_()
+        baseline()
+        candidate.output.fill_(float("nan"))
+        candidate.partial.fill_(float("nan"))
+        candidate_graph.replay()
+        live = indices >= 0
+        current = {
+            "out": error(candidate.output[live], out[live]),
+            "state": error(sc, sb),
+            "conv_out": error(candidate.conv_out[live], base_in[live]),
+        }
+        for part, metrics in history_maxima.items():
+            for metric in metrics:
+                metrics[metric] = max(metrics[metric], current[part][metric])
+        current_gate = (
+            all(check["finite"] for check in current.values())
+            and torch.equal(cc, cb)
+            and bool((candidate.output[~live] == 0).all())
+            and current["out"]["relative_l2"] < 5e-3
+            and current["state"]["relative_l2"] < 5e-3
+        )
+        if not current_gate and history_first_failure is None:
+            history_first_failure = {"cycle": cycle, "errors": current}
+        history_gate = history_gate and current_gate
+    gate = gate and history_gate
     record = {
         "rows": rows,
         "q_heads": hq,
         "v_heads": hv,
         "checks": checks,
         "maxima": maxima,
+        "independent_history": {
+            "steps": args.history_steps,
+            "maxima": history_maxima,
+            "gate": history_gate,
+            "first_failure": history_first_failure,
+        },
         "operator_gate": gate,
     }
     if gate:
@@ -256,14 +321,20 @@ def screen(rows, weights, args):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--tp", type=int, default=4)
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--layer", type=int, default=0)
     parser.add_argument("--rows", type=int, nargs="+", default=[1, 4, 8, 16])
     parser.add_argument("--steps", type=int, default=32)
+    parser.add_argument("--history-steps", type=int, default=256)
     parser.add_argument("--samples", type=int, default=9)
     parser.add_argument("--calls", type=int, default=30)
     args = parser.parse_args()
+    if min(args.steps, args.history_steps, args.samples, args.calls) <= 0:
+        parser.error("Step, sample and call counts must be positive")
     torch.manual_seed(20260906)
     check_exclusive()
-    weights = load_weights(args.model)
+    weights = load_weights(args.model, args.layer, args.rank, args.tp)
     build(*weights[:3])
     for rows in args.rows:
         print(json.dumps(screen(rows, weights, args)), flush=True)

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_gdn_conv.py
@@ -145,7 +145,7 @@ def screen(rows, weights, args):
         torch.empty(rows, hv, device="cuda", dtype=torch.float16),
     )
     out = torch.empty(rows, hv, 128, device="cuda", dtype=torch.float16)
-    candidate = FusedGDN(rows, hq, hv, hidden=hidden)
+    candidate = FusedGDN(rows, hq, hv, hidden=hidden, rows_per_warp=args.rows_per_warp)
 
     def baseline():
         base_in.copy_(raw)
@@ -281,6 +281,7 @@ def screen(rows, weights, args):
         "rows": rows,
         "q_heads": hq,
         "v_heads": hv,
+        "rows_per_warp": args.rows_per_warp,
         "checks": checks,
         "maxima": maxima,
         "independent_history": {
@@ -324,6 +325,7 @@ def main():
     parser.add_argument("--tp", type=int, default=4)
     parser.add_argument("--rank", type=int, default=0)
     parser.add_argument("--layer", type=int, default=0)
+    parser.add_argument("--rows-per-warp", type=int, choices=(4, 8), default=8)
     parser.add_argument("--rows", type=int, nargs="+", default=[1, 4, 8, 16])
     parser.add_argument("--steps", type=int, default=32)
     parser.add_argument("--history-steps", type=int, default=256)
@@ -335,7 +337,7 @@ def main():
     torch.manual_seed(20260906)
     check_exclusive()
     weights = load_weights(args.model, args.layer, args.rank, args.tp)
-    build(*weights[:3])
+    build(*weights[:3], rows_per_warp=args.rows_per_warp)
     for rows in args.rows:
         print(json.dumps(screen(rows, weights, args)), flush=True)
 

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_hc_norm.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_hc_norm.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Complete HC combine + Gemma-norm micro, not projection or model timing."""
+
+import argparse
+import json
+import statistics
+
+import torch
+
+from benchmarks.kernels.benchmark_sm70_flashinfer_gdn_conv import (
+    capture,
+    check_exclusive,
+    error,
+)
+from benchmarks.kernels.flashinfer_sm70_hc_norm import HCNorm, build
+
+
+@torch.inference_mode()
+def screen(rows, dtype, args):
+    from vllm.models.qwen4_exp.nvidia.ops.hc import hc_combine_norm
+
+    r = torch.randn(rows, 4 * 2560, device="cuda", dtype=dtype)
+    b = torch.randn(rows, 2560, device="cuda", dtype=torch.float16)
+    inj = torch.randn(rows, 4, device="cuda", dtype=torch.float16)
+    weight = torch.randn(4 * 2560, device="cuda", dtype=torch.float16) * 0.05
+    calls = [lambda: hc_combine_norm(r, b, inj, weight, 1e-6, 4)]
+    candidates = [HCNorm(r, warps) for warps in (1, 2, 4, 8)]
+    calls += [lambda candidate=c: candidate(r, b, inj, weight) for c in candidates]
+    graphs = [capture(fn, args.calls) for fn in calls]
+    checks = []
+    for cycle, scale in enumerate((0.25, 1.0, 3.0, 1.0)):
+        r.normal_().mul_(scale)
+        b.normal_().mul_(scale)
+        inj.normal_()
+        expected = calls[0]()
+        for index, candidate in enumerate(candidates):
+            eager = [x.clone() for x in calls[index + 1]()]
+            candidate.combined.fill_(float("nan"))
+            candidate.normalized.fill_(float("nan"))
+            graphs[index + 1].replay()
+            torch.cuda.synchronize()
+            for x, y in zip((candidate.combined, candidate.normalized), eager):
+                torch.testing.assert_close(x, y, atol=0, rtol=0)
+            diffs = [error(x, y) for x, y in zip(eager, expected)]
+            checks.append({"cycle": cycle, "warps": candidate.warps, "errors": diffs})
+    gate = all(
+        d["finite"] and d["relative_l2"] < 1e-3 for c in checks for d in c["errors"]
+    )
+    result = {
+        "rows": rows,
+        "residual_dtype": str(dtype),
+        "operator_gate": gate,
+        "checks": checks,
+    }
+    if gate:
+        for _ in range(20):
+            for graph in graphs:
+                graph.replay()
+        torch.cuda.synchronize()
+        samples = [[] for _ in calls]
+        for repeat in range(args.samples):
+            order = (
+                range(len(calls)) if repeat % 2 == 0 else reversed(range(len(calls)))
+            )
+            for index in order:
+                s, e = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+                s.record()
+                graphs[index].replay()
+                e.record()
+                e.synchronize()
+                samples[index].append(s.elapsed_time(e) * 1000 / args.calls)
+        check_exclusive()
+        result.update(
+            median_us=[statistics.median(s) for s in samples], samples_us=samples
+        )
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", nargs="+", type=int, default=[1, 4, 8, 16])
+    parser.add_argument("--calls", type=int, default=100)
+    parser.add_argument("--samples", type=int, default=9)
+    args = parser.parse_args()
+    check_exclusive()
+    torch.manual_seed(20260906)
+    build()
+    for dtype in (torch.float16, torch.float32):
+        for rows in args.rows:
+            print(json.dumps(screen(rows, dtype, args)), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_flashinfer_hc_norm.py
+++ b/benchmarks/kernels/benchmark_sm70_flashinfer_hc_norm.py
@@ -26,6 +26,7 @@ def screen(rows, dtype, args):
     weight = torch.randn(4 * 2560, device="cuda", dtype=torch.float16) * 0.05
     calls = [lambda: hc_combine_norm(r, b, inj, weight, 1e-6, 4)]
     candidates = [HCNorm(r, warps) for warps in (1, 2, 4, 8)]
+    candidates += [HCNorm(r, warps, registers=True) for warps in (4, 8)]
     calls += [lambda candidate=c: candidate(r, b, inj, weight) for c in candidates]
     graphs = [capture(fn, args.calls) for fn in calls]
     checks = []
@@ -43,7 +44,14 @@ def screen(rows, dtype, args):
             for x, y in zip((candidate.combined, candidate.normalized), eager):
                 torch.testing.assert_close(x, y, atol=0, rtol=0)
             diffs = [error(x, y) for x, y in zip(eager, expected)]
-            checks.append({"cycle": cycle, "warps": candidate.warps, "errors": diffs})
+            checks.append(
+                {
+                    "cycle": cycle,
+                    "warps": candidate.warps,
+                    "registers": candidate.registers,
+                    "errors": diffs,
+                }
+            )
     gate = all(
         d["finite"] and d["relative_l2"] < 1e-3 for c in checks for d in c["errors"]
     )
@@ -52,6 +60,7 @@ def screen(rows, dtype, args):
         "residual_dtype": str(dtype),
         "operator_gate": gate,
         "checks": checks,
+        "variants": [{"warps": c.warps, "registers": c.registers} for c in candidates],
     }
     if gate:
         for _ in range(20):

--- a/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
+++ b/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer-derived FP16 gate projection + conv + FP32 delta-rule prototype.
+
+No production dispatch. A workspace is single-stream, state indices must be
+unique live pool entries or negative padding. Geometry is specialized at JIT
+time; no checkpoint name, max-seqs, KV dtype or TP degree is used as a gate.
+"""
+
+import os
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_SHA = "6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f"
+
+
+def build(hidden=2560, q_heads=4, v_heads=12):
+    from torch.utils.cpp_extension import load
+
+    if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
+        raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0")
+    return load(
+        name=f"flashinfer_gdn_sm70_h{hidden}_q{q_heads}_v{v_heads}",
+        sources=[str(ROOT / "benchmarks/csrc/sm70_flashinfer_gdn_conv.cu")],
+        extra_include_paths=[str(ROOT / "flashinfer-sm70/include")],
+        extra_cuda_cflags=[
+            "-O3",
+            "-lineinfo",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+            f"-DFI_GDN_HIDDEN={hidden}",
+            f"-DFI_GDN_N_BA={2 * v_heads}",
+            f"-DFI_GDN_QKV_DIM={(2 * q_heads + v_heads) * 128}",
+            f"-DFI_GDN_H_Q={q_heads}",
+            f"-DFI_GDN_HV={v_heads}",
+            "-DFI_GDN_D=128",
+            "-DFI_GDN_CONV_WIDTH=4",
+            "-DFI_GDN_CONV_STATE_LEN=3",
+        ],
+        is_python_module=False,
+        verbose=True,
+    )
+
+
+class FusedGDN:
+    def __init__(self, rows, q_heads=4, v_heads=12, device="cuda"):
+        if not 1 <= rows <= 64 or q_heads <= 0 or v_heads % q_heads:
+            raise ValueError("Require 1..64 rows and integral GQA grouping")
+        self.output = torch.empty(
+            rows, v_heads, 128, device=device, dtype=torch.float16
+        )
+        self.conv_out = torch.empty(
+            rows, (2 * q_heads + v_heads) * 128, device=device, dtype=torch.float16
+        )
+        self.partial = torch.empty(
+            rows * 2 * v_heads * 160, device=device, dtype=torch.float32
+        )
+
+    def __call__(
+        self,
+        hidden,
+        weights,
+        qkv,
+        conv_w,
+        conv_bias,
+        conv,
+        A_log,
+        dt_bias,
+        state,
+        indices,
+    ):
+        torch.ops._C_flashinfer_gdn_sm70.run(
+            hidden,
+            weights,
+            qkv,
+            conv_w,
+            conv_bias,
+            conv,
+            A_log,
+            dt_bias,
+            state,
+            indices,
+            self.output,
+            self.conv_out,
+            self.partial,
+        )
+        return self.output
+
+
+if __name__ == "__main__":
+    print(build())

--- a/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
+++ b/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
@@ -16,9 +16,15 @@ ROOT = Path(__file__).resolve().parents[2]
 SOURCE_SHA = "6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f"
 
 
+def namespace(hidden, q_heads, v_heads):
+    return f"_C_flashinfer_gdn_sm70_h{hidden}_q{q_heads}_v{v_heads}"
+
+
 def build(hidden=2560, q_heads=4, v_heads=12):
     from torch.utils.cpp_extension import load
 
+    if min(hidden, q_heads, v_heads) <= 0 or v_heads % q_heads:
+        raise ValueError("Require positive geometry and integral GQA grouping")
     if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
         raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0")
     return load(
@@ -31,6 +37,7 @@ def build(hidden=2560, q_heads=4, v_heads=12):
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",
+            f"-DFI_GDN_TORCH_NAMESPACE={namespace(hidden, q_heads, v_heads)}",
             f"-DFI_GDN_HIDDEN={hidden}",
             f"-DFI_GDN_N_BA={2 * v_heads}",
             f"-DFI_GDN_QKV_DIM={(2 * q_heads + v_heads) * 128}",
@@ -46,9 +53,14 @@ def build(hidden=2560, q_heads=4, v_heads=12):
 
 
 class FusedGDN:
-    def __init__(self, rows, q_heads=4, v_heads=12, device="cuda"):
-        if not 1 <= rows <= 64 or q_heads <= 0 or v_heads % q_heads:
-            raise ValueError("Require 1..64 rows and integral GQA grouping")
+    def __init__(self, rows, q_heads=4, v_heads=12, device="cuda", hidden=2560):
+        if (
+            not 1 <= rows <= 64
+            or min(hidden, q_heads, v_heads) <= 0
+            or v_heads % q_heads
+        ):
+            raise ValueError("Require 1..64 rows, positive geometry and integral GQA")
+        self.run = getattr(torch.ops, namespace(hidden, q_heads, v_heads)).run
         self.output = torch.empty(
             rows, v_heads, 128, device=device, dtype=torch.float16
         )
@@ -72,7 +84,7 @@ class FusedGDN:
         state,
         indices,
     ):
-        torch.ops._C_flashinfer_gdn_sm70.run(
+        self.run(
             hidden,
             weights,
             qkv,

--- a/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
+++ b/benchmarks/kernels/flashinfer_sm70_gdn_conv.py
@@ -16,19 +16,23 @@ ROOT = Path(__file__).resolve().parents[2]
 SOURCE_SHA = "6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f"
 
 
-def namespace(hidden, q_heads, v_heads):
-    return f"_C_flashinfer_gdn_sm70_h{hidden}_q{q_heads}_v{v_heads}"
+def namespace(hidden, q_heads, v_heads, rows_per_warp=8):
+    suffix = "" if rows_per_warp == 8 else f"_r{rows_per_warp}"
+    return f"_C_flashinfer_gdn_sm70_h{hidden}_q{q_heads}_v{v_heads}{suffix}"
 
 
-def build(hidden=2560, q_heads=4, v_heads=12):
+def build(hidden=2560, q_heads=4, v_heads=12, rows_per_warp=8):
     from torch.utils.cpp_extension import load
 
     if min(hidden, q_heads, v_heads) <= 0 or v_heads % q_heads:
         raise ValueError("Require positive geometry and integral GQA grouping")
+    if rows_per_warp not in (4, 8):
+        raise ValueError("Screened row tiles are 4 or 8")
     if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
         raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0")
+    op_namespace = namespace(hidden, q_heads, v_heads, rows_per_warp)
     return load(
-        name=f"flashinfer_gdn_sm70_h{hidden}_q{q_heads}_v{v_heads}",
+        name=op_namespace[3:],
         sources=[str(ROOT / "benchmarks/csrc/sm70_flashinfer_gdn_conv.cu")],
         extra_include_paths=[str(ROOT / "flashinfer-sm70/include")],
         extra_cuda_cflags=[
@@ -37,7 +41,7 @@ def build(hidden=2560, q_heads=4, v_heads=12):
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",
-            f"-DFI_GDN_TORCH_NAMESPACE={namespace(hidden, q_heads, v_heads)}",
+            f"-DFI_GDN_TORCH_NAMESPACE={op_namespace}",
             f"-DFI_GDN_HIDDEN={hidden}",
             f"-DFI_GDN_N_BA={2 * v_heads}",
             f"-DFI_GDN_QKV_DIM={(2 * q_heads + v_heads) * 128}",
@@ -46,21 +50,26 @@ def build(hidden=2560, q_heads=4, v_heads=12):
             "-DFI_GDN_D=128",
             "-DFI_GDN_CONV_WIDTH=4",
             "-DFI_GDN_CONV_STATE_LEN=3",
-        ],
+        ]
+        + ([f"-DFI_GDN_ROWS_PER_WARP={rows_per_warp}"] if rows_per_warp != 8 else []),
         is_python_module=False,
         verbose=True,
     )
 
 
 class FusedGDN:
-    def __init__(self, rows, q_heads=4, v_heads=12, device="cuda", hidden=2560):
+    def __init__(
+        self, rows, q_heads=4, v_heads=12, device="cuda", hidden=2560, rows_per_warp=8
+    ):
         if (
             not 1 <= rows <= 64
             or min(hidden, q_heads, v_heads) <= 0
             or v_heads % q_heads
         ):
             raise ValueError("Require 1..64 rows, positive geometry and integral GQA")
-        self.run = getattr(torch.ops, namespace(hidden, q_heads, v_heads)).run
+        self.run = getattr(
+            torch.ops, namespace(hidden, q_heads, v_heads, rows_per_warp)
+        ).run
         self.output = torch.empty(
             rows, v_heads, 128, device=device, dtype=torch.float16
         )

--- a/benchmarks/kernels/flashinfer_sm70_hc_norm.py
+++ b/benchmarks/kernels/flashinfer_sm70_hc_norm.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer-derived fused HC combine/Gemma-norm component, not dispatch."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import torch
+
+from benchmarks.kernels.flashinfer_sm70_gdn_conv import ROOT, SOURCE_SHA
+
+
+def build():
+    from torch.utils.cpp_extension import load
+
+    source = Path(os.environ["FLASHINFER_SOURCE"])
+    if (
+        subprocess.check_output(
+            ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+        ).strip()
+        != SOURCE_SHA
+    ):
+        raise RuntimeError("Unrecognized FlashInfer revision")
+    if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
+        raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0")
+    return load(
+        name="flashinfer_hc_norm_sm70_v1",
+        sources=[str(ROOT / "benchmarks/csrc/sm70_flashinfer_hc_norm.cu")],
+        extra_include_paths=[
+            str(ROOT / "flashinfer-sm70/include"),
+            str(source / "include"),
+            str(source / "3rdparty/cccl/thrust"),
+            str(source / "3rdparty/cccl/cub"),
+            str(source / "3rdparty/cccl/libcudacxx/include"),
+        ],
+        extra_cuda_cflags=[
+            "-O3",
+            "-lineinfo",
+            "--expt-relaxed-constexpr",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        ],
+        is_python_module=False,
+        verbose=True,
+    )
+
+
+class HCNorm:
+    def __init__(self, residual, warps=4):
+        self.combined = torch.empty_like(residual)
+        self.normalized = torch.empty_like(residual)
+        self.warps = warps
+
+    def __call__(self, residual, block, injection, weight, eps=1e-6):
+        torch.ops._C_flashinfer_hc_sm70.run(
+            residual,
+            block,
+            injection,
+            weight,
+            self.combined,
+            self.normalized,
+            eps,
+            self.warps,
+        )
+        return self.combined, self.normalized
+
+
+if __name__ == "__main__":
+    print(build())

--- a/benchmarks/kernels/flashinfer_sm70_hc_norm.py
+++ b/benchmarks/kernels/flashinfer_sm70_hc_norm.py
@@ -25,7 +25,7 @@ def build():
     if os.environ.get("TORCH_CUDA_ARCH_LIST") != "7.0":
         raise RuntimeError("Set TORCH_CUDA_ARCH_LIST=7.0")
     return load(
-        name="flashinfer_hc_norm_sm70_v1",
+        name="flashinfer_hc_norm_sm70_v2",
         sources=[str(ROOT / "benchmarks/csrc/sm70_flashinfer_hc_norm.cu")],
         extra_include_paths=[
             str(ROOT / "flashinfer-sm70/include"),
@@ -49,10 +49,11 @@ def build():
 
 
 class HCNorm:
-    def __init__(self, residual, warps=4):
+    def __init__(self, residual, warps=4, registers=False):
         self.combined = torch.empty_like(residual)
         self.normalized = torch.empty_like(residual)
         self.warps = warps
+        self.registers = registers
 
     def __call__(self, residual, block, injection, weight, eps=1e-6):
         torch.ops._C_flashinfer_hc_sm70.run(
@@ -64,6 +65,7 @@ class HCNorm:
             self.normalized,
             eps,
             self.warps,
+            self.registers,
         )
         return self.combined, self.normalized
 

--- a/docs/design/sm70_flashinfer_layer_fusion.md
+++ b/docs/design/sm70_flashinfer_layer_fusion.md
@@ -1,0 +1,108 @@
+# FlashInfer-derived GDN / HC layer-fusion campaign
+
+## Purpose
+
+Finish operator adaptation and evidence first, then run one consolidated
+end-to-end comparison. Do not launch another full model per operator. Maintain
+the same no-MTP FlashNext workload, output-quality gates and fixed-70
+concurrency targets (C4/C8/C16 aggregate 238/420/728 tok/s).
+
+Integration base: `onecat/main` at `755baae1d075ee04fa9096b23fc0225b23589a86`.
+Owned branch/worktree: `codex/v100-flashinfer-gdn-conv-20260905-173007` /
+`worktrees/v100-flashinfer-gdn-conv-20260905-173007`.
+Related QSA prototype is Draft #513; prior batch HC work is Draft #504.
+This change does not duplicate their QSA or TP-sharding implementations.
+The M1-only #506/#510 work remains separate and is not overwritten.
+
+Source pin: FlashInfer `6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f`.
+The CUDA code is genuinely derived from its kernels, not a FlashInfer API
+redirect to Triton. The adapters are benchmark-only until gates pass.
+
+## GDN adaptation
+
+Derived from `gdn_kernels/experimental/kernel/gdn_fused_decode_sm120.cu`:
+gate B/A projection, width-4 causal convolution, Q/K normalization, gating,
+FP32 delta-rule state update and attention output in one kernel. FP16
+activations/weights and FP32 recurrent state remain unchanged. Geometry is
+JIT-specialized, not identified by checkpoint name or global server settings.
+
+The actual FlashNext TP4 shard is hidden=2560, Hq=4, Hv=12, D=128,
+QKV-width=2560 and BA-width=24. Do not reuse an old Hq4/Hv8 GDN result as this
+model's baseline. Reference QLA source SHA256:
+`fd6389cef9f1b38df7e122e582221d74d9ae1fba377ac3bec0da047fd3d30af8`.
+
+Load-bearing integration changes:
+
+- Production conv PTX emits `mul.f16`, then `cvt.f32.f16`. Preserve the FP16
+  product boundary and ordered FP32 accumulation, not upstream BF16/FP32
+  widened multiplication. Keep the SiLU-to-FP16 materialization.
+- Preserve B/A projection's FP16 materialization before FP32 sigmoid/softplus.
+- Preserve in-place state aliasing and V-major `[pool,Hv,V,K]` layout,
+  explicit pool strides, DS/SD conv layouts and strided QKV projection views.
+- Negative padding owns no state and emits zero. Valid slots must be unique
+  within a call, in range, and owned by the scheduler; this prototype is not
+  a replacement for prefix-cache copy-on-write / metadata validation.
+- Use cooperative launch and CUDA grid synchronization instead of relying on
+  a software spin barrier's regular-launch residency assumption in a runtime
+  with auxiliary streams. Cooperative graphs/stream capture are supported
+  by CUDA; see [NVIDIA's CUDA 11 description](https://developer.nvidia.com/blog/cuda-11-features-revealed/).
+  Runtime capability and exact occupancy are still checked before launch.
+
+## HC adaptation
+
+The fused combine/Gemma-norm adapter derives from FlashInfer's
+`FusedAddRMSNormKernel` vector IO, shared staging and warp/block reduction.
+It adds HC's injection gate and per-branch/shared affine addressing. The
+materialized residual is rounded before RMS statistics, and Gemma affine is
+`fma(y, w, y)`, not an unqualified ordinary RMSNorm replacement. Single-lane
+shared reduction writes avoid redundant same-address writes.
+
+FP16/FP32 residual and block types are distinct template parameters. Weight
+and injection dtypes match; no FP8/int8/QPN approximation is introduced.
+The initial component accepts vector-aligned contiguous matrices with
+group width a multiple of 8, <=4096, and 1/2/4/8 warps for screening. No
+production settings or server max-seqs/TP/prefill limits are changed.
+
+## Existing negative evidence not to repeat
+
+- Previous v0.6.13 standalone GDN-input GEMV replacement reached parity,
+  and M1 HC down/up replacement regressed. A route hit is not a gain.
+- Batch GDN projection concatenation/overlap and generic cuBLASLt retuning
+  already failed their integration thresholds.
+- FP16 recurrent-state compression caused large state/output error in the
+  prior batch audit and is not included.
+- HC projections plus communication already have an isolated #504 candidate;
+  reuse its validated pieces instead of reimplementing or counting them twice.
+
+## Test plan and progress
+
+Environment: Python 3.12.13, Torch 2.10.0+cu128, CUDA 12.8, native SM70,
+private Torch/Triton caches. No service/model engine is launched at this stage.
+
+1. Native CPU compilation and load, current-library/geometry provenance.
+2. Independent GDN oracle; dynamic state slots, live slot zero, padding,
+   poisoned outputs, strided input/state layout and graph/eager equality.
+3. Checkpoint-weight GDN component against actual production conv+FlashQLA;
+   separate conv/state/output errors and preserve reference trajectories.
+   An identical input-refresh copy is timed in both arms because production
+   conv mutates its input; QKV/Z projection itself is excluded.
+4. HC full combine/norm versus current Triton, FP16/FP32 residuals, B1/4/8/16.
+5. Memcheck/racecheck/synccheck and longer independent recurrent histories
+   before runtime admission. Micro error thresholds are screening gates,
+   not proof of task-level quality non-inferiority.
+6. Integrate only winners together with QSA, preserve fallback routes and
+   baseline precision. Then one consolidated E2E C1/4/8/16 comparison plus
+   coding/tool/schema quality checks, reporting actual routes and pure decode
+   separately from prefill/TTFT. Failed operators stay off.
+
+Current result: initial GDN and HC native SM70 builds passed. Updated
+cooperative GDN build, GPU correctness, speed and sanitizer results must be
+recorded before any performance claim. GPU 0--3 are reserved by another task;
+honor the paper and 1Cat shared locks, even between its GPU launches.
+
+Local artifacts: `.artifacts/gdn-build-v1.log`, `gdn-build-v2.log`,
+`gdn-build-cooperative.log`, `hc-norm-build-v1.log`. GPU test logs may exist
+but be empty when lock acquisition timed out; file presence is not a result.
+No model speed or output-quality result is claimed yet. No owned service.
+
+AI-assisted work (Codex); human review and DCO sign-off required before merge.

--- a/docs/design/sm70_flashinfer_layer_fusion.md
+++ b/docs/design/sm70_flashinfer_layer_fusion.md
@@ -95,13 +95,23 @@ private Torch/Triton caches. No service/model engine is launched at this stage.
    coding/tool/schema quality checks, reporting actual routes and pure decode
    separately from prefill/TTFT. Failed operators stay off.
 
-Current result: initial GDN and HC native SM70 builds passed. Updated
-cooperative GDN build, GPU correctness, speed and sanitizer results must be
-recorded before any performance claim. GPU 0--3 are reserved by another task;
+Current result: initial GDN and HC native SM70 builds passed. Cooperative
+GDN builds also passed, including Hq4/Hv12 and Hq8/Hv24 modules loaded in the
+same process; per-geometry Torch namespaces prevent duplicate registration.
+CPU tests: 8 passed, 8 GPU cases skipped (not GPU validation). The component
+benchmark now additionally retains independent reference/candidate state for
+256 steps with dynamic slots, padding and slot recycling; this screen is
+implemented but has not run on GPU yet.
+HC GPU tests include shared/per-branch weights, mixed FP16/FP32 inputs,
+non-power-of-two widths, an independent wider-precision oracle, poisoned
+outputs and graph replay. These are also pending GPU execution.
+GPU correctness, speed and sanitizer results must be recorded before any
+performance claim. GPU 0--3 are reserved by another task;
 honor the paper and 1Cat shared locks, even between its GPU launches.
 
 Local artifacts: `.artifacts/gdn-build-v1.log`, `gdn-build-v2.log`,
-`gdn-build-cooperative.log`, `hc-norm-build-v1.log`. GPU test logs may exist
+`gdn-build-cooperative.log`, `gdn-build-multi-geometry.log`,
+`hc-norm-build-v1.log`. GPU test logs may exist
 but be empty when lock acquisition timed out; file presence is not a result.
 No model speed or output-quality result is claimed yet. No owned service.
 

--- a/docs/design/sm70_flashinfer_layer_fusion.md
+++ b/docs/design/sm70_flashinfer_layer_fusion.md
@@ -95,19 +95,98 @@ private Torch/Triton caches. No service/model engine is launched at this stage.
    coding/tool/schema quality checks, reporting actual routes and pure decode
    separately from prefill/TTFT. Failed operators stay off.
 
-Current result: initial GDN and HC native SM70 builds passed. Cooperative
-GDN builds also passed, including Hq4/Hv12 and Hq8/Hv24 modules loaded in the
-same process; per-geometry Torch namespaces prevent duplicate registration.
-CPU tests: 8 passed, 8 GPU cases skipped (not GPU validation). The component
-benchmark now additionally retains independent reference/candidate state for
-256 steps with dynamic slots, padding and slot recycling; this screen is
-implemented but has not run on GPU yet.
-HC GPU tests include shared/per-branch weights, mixed FP16/FP32 inputs,
-non-power-of-two widths, an independent wider-precision oracle, poisoned
-outputs and graph replay. These are also pending GPU execution.
-GPU correctness, speed and sanitizer results must be recorded before any
-performance claim. GPU 0--3 are reserved by another task;
-honor the paper and 1Cat shared locks, even between its GPU launches.
+Native GDN and HC SM70 builds passed. Cooperative GDN builds also passed,
+including Hq4/Hv12 and Hq8/Hv24 modules loaded in the same process;
+per-geometry Torch namespaces prevent duplicate registration.
+
+### GPU results, 2026-09-06
+
+After the prior lease released GPU 0--3, the `72af224161` tests ran on locked
+GPU 0: **16 passed**, including all 8 GPU cases (33.39 s, including HC build).
+This covers independent GDN histories, DS/SD conv layouts, strided QKV,
+padding/live slot zero, and HC shared/per-branch weights, mixed FP16/FP32,
+non-power-of-two widths, poisoned outputs and graph replay.
+Artifact: `.artifacts/gdn-hc-unit-gpu-v4.log`.
+
+Checkpoint component screen: RadixArk Qwen3.8-Flash-Next-NVFP4, layer 0,
+TP4 rank-0-shaped **FP16** GDN weights, FP32 state, Hq4/Hv12/D128,
+synthetic changing hidden states. The target MoE quantization is not being
+retested here. CUDA Graph, 9 alternating paired samples, 30 calls per graph,
+identical raw-QKV refresh in both arms; no full model launch. GPU clocks use
+automatic boost and were not locked, so use paired deltas, not cross-run
+absolute comparisons. First screen uses 16 local steps and then 256 fully
+independent state-history steps with padding and slot recycling.
+
+| Rows | Existing BA + conv + FlashQLA, us | Fused chain, us | Latency reduction |
+| --- | ---: | ---: | ---: |
+| 1 | 17.237 | 11.674 | 32.28% |
+| 4 | 28.604 | 15.087 | 47.26% |
+| 8 | 33.041 | 22.801 | 30.99% |
+| 16 | 57.344 | 47.343 | 17.44% |
+
+All four independent-history screens pass the unchanged operator gates.
+Worst output relative L2 across those histories is 2.458e-4 and worst FP32
+state relative L2 is 2.636e-5; conv state updates remain exact. These errors
+are not zero and this is not a task-quality admission. The M1 reference
+includes separate BA projection whereas production M1 can fuse QKVZ/BA;
+**do not count the M1 component delta as a production gain**.
+Artifact: `.artifacts/gdn-screen-v1.log`.
+
+Commands inside the owned GPU-lock/environment launcher (the wrapper sets
+the pinned QLA binary, FlashInfer headers and task-private caches):
+
+```bash
+.venv/bin/python -m pytest -q -x --confcutdir=flashinfer-sm70/tests \
+  flashinfer-sm70/tests/test_layer_fusion.py
+.venv/bin/python -m benchmarks.kernels.benchmark_sm70_flashinfer_gdn_conv \
+  --model /path/to/Qwen3.8-Flash-Next-NVFP4 --steps 16
+.venv/bin/python -m benchmarks.kernels.benchmark_sm70_flashinfer_hc_norm
+```
+
+Reference QLA binary SHA256:
+`3982305151798be22a1dabd0140feb085f787e1e76da01f58d8256de66050975`.
+GDN candidate binary SHA256:
+`45cfe0090f43792ac8f4a5a21b9475e988c0f6872c874faf2e5da967db978d66`.
+The 8-row-warp cooperative kernel has 122 registers/thread (M1: 110),
+zero stack/local memory. These are static resources, not measured occupancy.
+
+HC shared-staging version passed all numerical screens but **lost every
+timed shape**. FP16 residual results (best of 1/2/4/8 warps):
+
+| Rows | Existing Triton, us | Best FlashInfer-derived HC, us |
+| --- | ---: | ---: |
+| 1 | 3.164 | 4.321 |
+| 4 | 3.052 | 3.942 |
+| 8 | 2.918 | 3.717 |
+| 16 | 3.144 | 3.953 |
+
+The FP32-residual arm also regressed. Retain the existing production HC;
+do not promote this version on the basis of a FlashInfer label.
+Artifact: `.artifacts/hc-norm-screen-v1.log`. HC v1 binary SHA256:
+`ef905abb8feb41a5887fc64dc45f11dbea97039c60095a1e17b93fbe143d079b`.
+
+### Follow-up candidates and remaining gate
+
+- GDN four-row-per-warp variant: B8/16 independent-history screens pass;
+  paired baseline/candidate medians 36.420/25.054 and 57.344/46.353 us.
+  Registers fall to 89 (M1: 78), still no spills. This is not a same-run
+  eight-versus-four comparison; do not change the default based on the small
+  cross-run difference. Artifact: `.artifacts/gdn-screen-r4-v1.log`.
+- HC register-staging variant: retain materialized FP16/FP32 residuals in
+  registers over the reduction, avoiding the shared-value write/reload.
+  Local D2560, 4/8-warp specialization; all other geometries retain the
+  general component. Native build passes, but GPU correctness/speed is pending.
+  Artifact: `.artifacts/hc-norm-build-v2.log`; binary SHA256:
+  `6087639c2f615ce04775000d556325589f391993c88653a5e3baad04bff347ff`.
+- Updated CPU suite: **8 passed, 12 GPU cases skipped** with GPU hidden.
+  The four additional register-HC cases have not run on GPU. Previous v1 GPU
+  results must not be relabeled as v2 validation.
+- The targeted GDN memcheck attempt did **not** launch: the new QUASAR E4M3
+  task acquired the paper GPU 0--3 lease between component jobs. Exit 75 and
+  an empty sanitizer log are not a pass. Wait for release; never preempt it.
+- No runtime integration, new E2E throughput, or model-quality pass yet.
+  Preserve existing projection/M1 and HC paths until complete-chain gates
+  pass; avoid recomputing BA if using the new fused-input GDN boundary.
 
 Local artifacts: `.artifacts/gdn-build-v1.log`, `gdn-build-v2.log`,
 `gdn-build-cooperative.log`, `gdn-build-multi-geometry.log`,

--- a/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
+++ b/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 FlashInfer team
+// SM70 adaptation by 1Cat-vLLM contributors. Source: FlashInfer
+// 6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f, gdn_fused_decode_sm120.cu.
+#pragma once
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_fp16.h>
+#include <cooperative_groups.h>
+#include <cuda_runtime.h>
+#include <math.h>
+
+namespace flashinfer::sm70::gdn {
+
+// Fused GDN decode step for one layer geometry: a single persistent kernel
+// covering the in_proj_ba GEMV, the depthwise causal conv1d update (width 4,
+// silu), the q/k/v head split, and the gated delta-rule state update with
+// qk-L2-norm, replacing the multi-launch serving chain.
+//
+// The layer geometry is a compile-time parameter of this translation unit,
+// supplied by benchmarks/kernels/flashinfer_sm70_gdn_conv.py (one JIT
+// module per geometry; a serving process runs one model, hence one module).
+// Only the sizes change: the block shape, warp->row mapping and reduction
+// trees below are geometry-independent, and the static_asserts state exactly
+// which divisibility relations the code relies on.
+#if !defined(FI_GDN_HIDDEN) || !defined(FI_GDN_N_BA) ||                        \
+    !defined(FI_GDN_QKV_DIM) || !defined(FI_GDN_H_Q) || !defined(FI_GDN_HV) || \
+    !defined(FI_GDN_D) || !defined(FI_GDN_CONV_WIDTH) ||                       \
+    !defined(FI_GDN_CONV_STATE_LEN)
+  #error "gdn_fused_decode.cuh requires the FI_GDN_* geometry defines"
+#endif
+constexpr int HIDDEN = FI_GDN_HIDDEN;
+constexpr int N_BA = FI_GDN_N_BA;
+constexpr int QKV_DIM = FI_GDN_QKV_DIM;
+constexpr int H_Q = FI_GDN_H_Q;
+constexpr int HV = FI_GDN_HV;
+constexpr int D = FI_GDN_D;
+constexpr int CONV_WIDTH = FI_GDN_CONV_WIDTH;
+constexpr int CONV_STATE_LEN = FI_GDN_CONV_STATE_LEN;
+// v-heads per qk-head: the delta phase maps v-head h to qk-head h/HEADS_PER_QK.
+constexpr int HEADS_PER_QK = HV / H_Q;
+constexpr int ROWS_PER_WARP = 8;
+constexpr int GEMV_NSPLIT = 160;
+// The gate reduction below unrolls the GEMV partials as 5 warp-wide loads.
+static_assert(GEMV_NSPLIT == 5 * 32,
+              "gate reduction assumes 5 warp-strided loads");
+// The b/a projection produces HV gate values and HV decay values, stored as
+// the low and high halves of the N_BA columns (see the delta phase's
+// base_b/base_a offsets).
+static_assert(N_BA == 2 * HV, "w_ba columns are [b gates | a decays], HV each");
+static_assert(HV % H_Q == 0,
+              "each qk-head must serve a whole number of v-heads");
+// The delta phase gives each lane 4 consecutive channels of a D-wide row and
+// reduces across the warp; the B=1 fast path indexes rows with shifts/masks.
+static_assert(D == 4 * 32,
+              "delta phase maps one D-wide row onto a warp, 4 per lane");
+static_assert((D & (D - 1)) == 0,
+              "B=1 row index math uses D as a power of two");
+static_assert(D % ROWS_PER_WARP == 0, "warps own whole groups of state rows");
+// mixed_qkv is [q | k | v] with H_Q q-heads, H_Q k-heads and HV v-heads.
+static_assert(QKV_DIM == (2 * H_Q + HV) * D,
+              "qkv_dim must match the head split");
+// The conv phase is unrolled over the width-4 / 3-step shift register below.
+static_assert(CONV_WIDTH == 4 && CONV_STATE_LEN == 3,
+              "conv taps are unrolled as width 4");
+
+// log2(D), for the B=1 fast path's shift/mask row indexing.
+constexpr int ilog2_ce(int v) { return v <= 1 ? 0 : 1 + ilog2_ce(v >> 1); }
+constexpr int D_LOG2 = ilog2_ce(D);
+
+typedef half f16;
+
+__device__ __forceinline__ float siluf(float x) {
+  return x / (1.0f + __expf(-x));
+}
+__device__ __forceinline__ float sigmoidf(float x) {
+  return 1.0f / (1.0f + __expf(-x));
+}
+__device__ __forceinline__ float softplusf(float x) {
+  return x > 20.0f ? x : log1pf(__expf(x));
+}
+__device__ __forceinline__ float warp_reduce(float v) {
+#pragma unroll
+  for (int o = 16; o > 0; o >>= 1) v += __shfl_down_sync(0xffffffff, v, o);
+  return v;
+}
+
+// Cooperative launch guarantees grid residency even when vLLM has auxiliary
+// streams. Use CUDA's specified grid synchronization instead of an occupancy-
+// capped regular launch with a software spin barrier.
+__device__ __forceinline__ void grid_barrier() {
+  cooperative_groups::this_grid().sync();
+}
+
+// Single persistent kernel: gemv+conv -> [barrier] -> delta. Cooperative
+// launch. The kB1 instantiation specializes the serving-hot B=1 case:
+// batch/split index math collapses to compile-time constants and the fp32 state
+// rows for the (single) delta task of each warp are prefetched before the
+// barrier so their long-scoreboard latency overlaps the gemv/conv phases (the
+// state pool is only written after the barrier, each row by the warp that
+// prefetched it).
+//
+// Padded batch rows: a NEGATIVE state index (vLLM's PAD_SLOT_ID = -1) marks a
+// batch row that owns no pool slot -- what a CUDA-graph replay carries in the
+// rows between the live request count and the captured batch size. Such a row
+// is skipped in every phase that touches a pool (no read and no write of
+// conv_state / ssm_state) and its output rows are written as zero, matching
+// the fp32 path of gated_delta_rule_decode_pretranspose. The check has to be
+// here rather than on the host: reading index VALUES host-side costs a
+// device-to-host sync per layer per decode step and is impossible under graph
+// capture. Each guard is uniform over the threads that share a batch row
+// (warp-uniform in the delta phase, where the warp-wide shuffles below make
+// divergence unacceptable), so it costs one predicated branch, not divergence.
+// Indices >= P are NOT padding and are not checked -- see the note on
+// state_indices in the FFI entry point below.
+//
+// Aliasing: the op updates both state pools IN PLACE, so the launcher passes
+// the same pointer for (conv_state, updated_conv) and for (ssm_state,
+// ssm_out).  Those four parameters therefore carry no __restrict__ -- the
+// pools are read and written through two different parameters, which is
+// exactly what restrict promises does not happen, and promising it would let
+// the compiler reorder a pool load across a pool store.  The remaining
+// pointers are genuinely disjoint buffers and keep the qualifier.  The read
+// path pays for this: loads from the pools can no longer be promoted to
+// ld.global.nc.  Only this impl is affected -- the registry prefers the
+// CuTe-DSL kernel for every shipped row -- and correctness is not a thing to
+// trade for a read-only-cache hint.
+template <bool kB1>
+__global__ void gdn_fused_decode_kernel(
+    const f16* __restrict__ hidden, const f16* __restrict__ w_ba,
+    const f16* __restrict__ mixed_qkv, const f16* __restrict__ conv_weight,
+    const f16* __restrict__ conv_bias, const f16* conv_state,
+    const float* __restrict__ A_log, const f16* __restrict__ dt_bias,
+    const float* ssm_state, const int* __restrict__ state_indices, float scale,
+    long state_stride_0, long qkv_stride, long conv_stride_p,
+    long conv_stride_c, long conv_stride_t, f16* __restrict__ output,
+    f16* updated_conv, float* ssm_out, float* __restrict__ ba_part,
+    f16* __restrict__ conv_out, int B) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int nthreads = gridDim.x * blockDim.x;
+  const int Beff = kB1 ? 1 : B;
+
+  // ---- Phase A1: GEMV partials ----
+  // tasks: (split in 0..GEMV_NSPLIT-1) x (b) x (col in 0..N_BA-1). Partials
+  // are stored split-major per (col, b) so the gate reduction reads them with
+  // warp-coalesced loads.
+  long gemv_tasks = (long)GEMV_NSPLIT * Beff * N_BA;
+  for (long t = tid; t < gemv_tasks; t += nthreads) {
+    int col = t % N_BA;
+    long r = t / N_BA;
+    int b;
+    int split;
+    if constexpr (kB1) {
+      b = 0;
+      split = (int)r;
+    } else {
+      b = r % B;
+      split = r / B;
+    }
+    const f16* hrow = hidden + (long)b * HIDDEN;
+    float a0 = 0, a1 = 0, a2 = 0, a3 = 0;
+    int k = split;
+    for (; k + 3 * GEMV_NSPLIT < HIDDEN; k += 4 * GEMV_NSPLIT) {
+      a0 += __half2float(hrow[k]) * __half2float(w_ba[(long)k * N_BA + col]);
+      a1 += __half2float(hrow[k + GEMV_NSPLIT]) *
+            __half2float(w_ba[(long)(k + GEMV_NSPLIT) * N_BA + col]);
+      a2 += __half2float(hrow[k + 2 * GEMV_NSPLIT]) *
+            __half2float(w_ba[(long)(k + 2 * GEMV_NSPLIT) * N_BA + col]);
+      a3 += __half2float(hrow[k + 3 * GEMV_NSPLIT]) *
+            __half2float(w_ba[(long)(k + 3 * GEMV_NSPLIT) * N_BA + col]);
+    }
+    for (; k < HIDDEN; k += GEMV_NSPLIT)
+      a0 += __half2float(hrow[k]) * __half2float(w_ba[(long)k * N_BA + col]);
+    ba_part[((long)col * Beff + b) * GEMV_NSPLIT + split] =
+        (a0 + a1) + (a2 + a3);
+  }
+
+  // ---- Phase A2: conv (independent of gemv) ----
+  long conv_tasks = (long)Beff * QKV_DIM;
+  for (long t = tid; t < conv_tasks; t += nthreads) {
+    int b;
+    int c;
+    if constexpr (kB1) {
+      b = 0;
+      c = (int)t;
+    } else {
+      b = t / QKV_DIM;
+      c = t % QKV_DIM;
+    }
+    int idx = state_indices[b];
+    // Padded row: owns no conv-state slot, so neither shift it nor append to
+    // it. conv_out for this row stays whatever the scratch held -- the delta
+    // phase skips the same row, so nothing reads it.
+    if (idx < 0) continue;
+    // conv_state addressing is stride-parameterized: the pool arrives as a
+    // logical [P, QKV_DIM, CONV_STATE_LEN] view of either a DS-dense pool
+    // (strides p,3,1 -> per-thread 3-element rows) or a transposed SD pool
+    // (strides p,1,QKV_DIM -> fully coalesced across channels, the vLLM
+    // default). Pure index arithmetic; the update math is identical.
+    const f16* st =
+        conv_state + (long)idx * conv_stride_p + (long)c * conv_stride_c;
+    f16 s0 = st[0], s1 = st[conv_stride_t], s2 = st[2 * conv_stride_t];
+    // mixed_qkv rows may be strided (e.g. a view into a wider projection).
+    f16 xr = mixed_qkv[(long)b * qkv_stride + c];
+    const f16* w = conv_weight + (long)c * CONV_WIDTH;
+    // vLLM's FP16 conv actually emits mul.f16 then cvt.f32.f16, with
+    // FP32 accumulation. Preserve those load-bearing product roundings;
+    // widening before the multiply changes this model's recurrent inputs.
+    float y = conv_bias ? __half2float(conv_bias[c]) : 0.f;
+    y += __half2float(__hmul(s0, w[0]));
+    y += __half2float(__hmul(s1, w[1]));
+    y += __half2float(__hmul(s2, w[2]));
+    y += __half2float(__hmul(xr, w[3]));
+    conv_out[(long)b * QKV_DIM + c] = __float2half_rn(siluf(y));
+    f16* uc =
+        updated_conv + (long)idx * conv_stride_p + (long)c * conv_stride_c;
+    uc[0] = s1;
+    uc[conv_stride_t] = s2;
+    uc[2 * conv_stride_t] = xr;
+  }
+
+  // ---- Pre-barrier prefetch of this warp's first delta task's state rows.
+  // The state pool is read-only until phase C, and each row is written only
+  // by the warp that owns (and prefetched) it, so this is race-free.
+  int gwarp = tid >> 5;
+  int lane = threadIdx.x & 31;
+  int nwarps = nthreads >> 5;
+  long total_rows = (long)Beff * HV * D;
+  long warps_needed = (total_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
+
+  float4 s_pre[ROWS_PER_WARP];
+  long pre_row_base = -1;
+  if (gwarp < warps_needed) {
+    long first_row = (long)gwarp * ROWS_PER_WARP;
+    int v0;
+    int h;
+    int b;
+    if constexpr (kB1) {
+      v0 = (int)(first_row & (D - 1));
+      h = (int)(first_row >> D_LOG2);
+      b = 0;
+    } else {
+      v0 = first_row % D;
+      long tmp = first_row / D;
+      h = tmp % HV;
+      b = tmp / HV;
+    }
+    int idx = state_indices[b];
+    // A padded row has no state row to prefetch. pre_row_base stays -1, which
+    // no live row_base can equal, so the delta phase never mistakes the
+    // (unwritten) s_pre registers for this warp's prefetched rows.
+    if (idx >= 0) {
+      pre_row_base = (long)idx * state_stride_0 + (long)h * (D * D);
+      const float4* base_srow =
+          (const float4*)(ssm_state + pre_row_base + (long)v0 * D);
+#pragma unroll
+      for (int r = 0; r < ROWS_PER_WARP; ++r)
+        s_pre[r] = base_srow[r * (D / 4) + lane];
+    }
+  }
+
+  grid_barrier();
+
+  // ---- Phase C: delta (gate reduced inline from ba_part) ----
+  for (long w = gwarp; w < warps_needed; w += nwarps) {
+    long first_row = w * ROWS_PER_WARP;
+    int v0;
+    int h;
+    int b;
+    if constexpr (kB1) {
+      v0 = (int)(first_row & (D - 1));
+      h = (int)(first_row >> D_LOG2);
+      b = 0;
+    } else {
+      v0 = first_row % D;
+      long tmp = first_row / D;
+      h = tmp % HV;
+      b = tmp / HV;
+    }
+    int j = h / HEADS_PER_QK;
+    const f16* co = conv_out + (long)b * QKV_DIM;
+    const f16* qb = co + j * D;
+    const f16* kb = co + H_Q * D + j * D;
+    int k0 = lane * 4;
+    int idx = state_indices[b];
+    if (idx < 0) {
+      // Padded row: no state row to read or write; its output rows are zero.
+      // b (hence idx) is warp-uniform -- first_row is a multiple of
+      // ROWS_PER_WARP and the whole warp shares w -- so the whole warp takes
+      // this branch together and the warp-wide shuffles below are never
+      // reached with a partial mask.
+      if (lane == 0) {
+#pragma unroll
+        for (int r = 0; r < ROWS_PER_WARP; ++r)
+          output[((long)b * HV + h) * D + v0 + r] = __float2half_rn(0.0f);
+      }
+      continue;
+    }
+    long row_base = (long)idx * state_stride_0 + (long)h * (D * D);
+    float4 s4[ROWS_PER_WARP];
+    if (w == gwarp && row_base == pre_row_base) {
+      // First iteration (the only one for B=1): use the prefetched rows.
+#pragma unroll
+      for (int r = 0; r < ROWS_PER_WARP; ++r) s4[r] = s_pre[r];
+    } else {
+      const float4* base_srow =
+          (const float4*)(ssm_state + row_base + (long)v0 * D);
+#pragma unroll
+      for (int r = 0; r < ROWS_PER_WARP; ++r)
+        s4[r] = base_srow[r * (D / 4) + lane];
+    }
+    // Issue the gate-partial loads early (10 concurrent warp-wide loads) so
+    // they overlap the qk-norm compute below.
+    const float* base_b = ba_part + ((long)h * Beff + b) * GEMV_NSPLIT;
+    const float* base_a = ba_part + ((long)(HV + h) * Beff + b) * GEMV_NSPLIT;
+    float b0 = base_b[lane + 0];
+    float a0v = base_a[lane + 0];
+    float b1 = base_b[lane + 32];
+    float a1v = base_a[lane + 32];
+    float b2 = base_b[lane + 64];
+    float a2v = base_a[lane + 64];
+    float b3 = base_b[lane + 96];
+    float a3v = base_a[lane + 96];
+    float b4 = base_b[lane + 128];
+    float a4v = base_a[lane + 128];
+    float qraw[4], kraw[4];
+    float qss = 0.f, kss = 0.f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      qraw[i] = __half2float(qb[k0 + i]);
+      kraw[i] = __half2float(kb[k0 + i]);
+      qss += qraw[i] * qraw[i];
+      kss += kraw[i] * kraw[i];
+    }
+    qss = warp_reduce(qss);
+    kss = warp_reduce(kss);
+    qss = __shfl_sync(0xffffffff, qss, 0);
+    kss = __shfl_sync(0xffffffff, kss, 0);
+    float qn = rsqrtf(qss + 1e-6f), kn = rsqrtf(kss + 1e-6f);
+    float qh[4], kh[4], QKp = 0.f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      qh[i] = qraw[i] * qn;
+      kh[i] = kraw[i] * kn;
+      QKp += qh[i] * kh[i];
+    }
+    QKp = warp_reduce(QKp);
+    float QK = __shfl_sync(0xffffffff, QKp, 0);
+    // gate g,beta reduced from the split-major partials (values now arrived)
+    float accb = ((b0 + b1) + (b2 + b3)) + b4;
+    float acca = ((a0v + a1v) + (a2v + a3v)) + a4v;
+    accb = warp_reduce(accb);
+    acca = warp_reduce(acca);
+    accb = __shfl_sync(0xffffffff, accb, 0);
+    acca = __shfl_sync(0xffffffff, acca, 0);
+    // The f16 round-trip of the two gate sums is load-bearing, not a leftover:
+    // the composable path materializes `ba = (hidden @ w_ba)` as a f16 tensor
+    // and only then widens it for the gates, so the values it feeds
+    // sigmoid/softplus are f16-rounded. Keeping the fp32 accumulator here
+    // would make this kernel *more* precise than the operation it implements
+    // and move the gates off the reference by up to one f16 ulp -- amplified
+    // by exp() in the decay gate. Track the composable path's `ba` dtype, not
+    // the accumulator's.
+    float beta = sigmoidf(__half2float(__float2half_rn(accb)));
+    float xg = __half2float(__float2half_rn(acca)) + __half2float(dt_bias[h]);
+    float g = __expf(-__expf(A_log[h]) * softplusf(xg));
+#pragma unroll
+    for (int r = 0; r < ROWS_PER_WARP; ++r) {
+      int v = v0 + r;
+      float s[4] = {s4[r].x, s4[r].y, s4[r].z, s4[r].w};
+      float vv = __half2float(co[2 * H_Q * D + h * D + v]);
+      float kSp = 0.f, qSp = 0.f;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        kSp += kh[i] * s[i];
+        qSp += qh[i] * s[i];
+      }
+#pragma unroll
+      for (int o = 16; o > 0; o >>= 1) {
+        kSp += __shfl_down_sync(0xffffffff, kSp, o);
+        qSp += __shfl_down_sync(0xffffffff, qSp, o);
+      }
+      float kS = __shfl_sync(0xffffffff, kSp, 0);
+      float qS = __shfl_sync(0xffffffff, qSp, 0);
+      float old_v = g * kS;
+      float delta = beta * (vv - old_v);
+      float out_v = scale * (g * qS + delta * QK);
+      float4* Sorow = (float4*)(ssm_out + row_base + (long)v * D);
+      float4 o4;
+      o4.x = g * s[0] + kh[0] * delta;
+      o4.y = g * s[1] + kh[1] * delta;
+      o4.z = g * s[2] + kh[2] * delta;
+      o4.w = g * s[3] + kh[3] * delta;
+      Sorow[lane] = o4;
+      if (lane == 0)
+        output[((long)b * HV + h) * D + v] = __float2half_rn(out_v);
+    }
+  }
+}
+
+}  // namespace flashinfer::sm70::gdn

--- a/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
+++ b/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
@@ -54,7 +54,10 @@ constexpr int CONV_WIDTH = FI_GDN_CONV_WIDTH;
 constexpr int CONV_STATE_LEN = FI_GDN_CONV_STATE_LEN;
 // v-heads per qk-head: the delta phase maps v-head h to qk-head h/HEADS_PER_QK.
 constexpr int HEADS_PER_QK = HV / H_Q;
-constexpr int ROWS_PER_WARP = 8;
+#ifndef FI_GDN_ROWS_PER_WARP
+  #define FI_GDN_ROWS_PER_WARP 8
+#endif
+constexpr int ROWS_PER_WARP = FI_GDN_ROWS_PER_WARP;
 constexpr int GEMV_NSPLIT = 160;
 // The gate reduction below unrolls the GEMV partials as 5 warp-wide loads.
 static_assert(GEMV_NSPLIT == 5 * 32,

--- a/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
+++ b/flashinfer-sm70/include/flashinfer/gdn/sm70/gdn_fused_decode.cuh
@@ -33,7 +33,8 @@ namespace flashinfer::sm70::gdn {
 //
 // The layer geometry is a compile-time parameter of this translation unit,
 // supplied by benchmarks/kernels/flashinfer_sm70_gdn_conv.py (one JIT
-// module per geometry; a serving process runs one model, hence one module).
+// module and Torch operator namespace per geometry, so multiple TP geometries
+// may coexist in the same process).
 // Only the sizes change: the block shape, warp->row mapping and reduction
 // trees below are geometry-independent, and the static_asserts state exactly
 // which divisibility relations the code relies on.
@@ -136,9 +137,7 @@ __device__ __forceinline__ void grid_barrier() {
 // the compiler reorder a pool load across a pool store.  The remaining
 // pointers are genuinely disjoint buffers and keep the qualifier.  The read
 // path pays for this: loads from the pools can no longer be promoted to
-// ld.global.nc.  Only this impl is affected -- the registry prefers the
-// CuTe-DSL kernel for every shipped row -- and correctness is not a thing to
-// trade for a read-only-cache hint.
+// ld.global.nc. There is no production dispatch for this prototype yet.
 template <bool kB1>
 __global__ void gdn_fused_decode_kernel(
     const f16* __restrict__ hidden, const f16* __restrict__ w_ba,

--- a/flashinfer-sm70/include/flashinfer/hc/sm70/hc_combine_norm.cuh
+++ b/flashinfer-sm70/include/flashinfer/hc/sm70/hc_combine_norm.cuh
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 FlashInfer team
+// Adapted by 1Cat-vLLM contributors from FlashInfer norm.cuh at
+// 6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f. HC injection and materialized
+// residual rounding are model semantics absent from upstream fused-add norm.
+#pragma once
+#include <flashinfer/norm.cuh>
+namespace flashinfer::sm70::hc {
+template <uint32_t VEC_SIZE, typename T, typename B, typename W>
+__global__ void HCCombineNormKernel(
+    const B* __restrict__ input, const T* __restrict__ residual,
+    const W* __restrict__ weight, const W* __restrict__ injection,
+    T* __restrict__ combined, T* __restrict__ output, uint32_t groups,
+    uint32_t d, uint32_t stride_input, uint32_t stride_residual,
+    uint32_t stride_injection, bool shared_weight, float eps) {
+  const uint32_t bx = blockIdx.x, group = blockIdx.y;
+  const float gate =
+      2.f /
+      (1.f + __expf(-float(injection[bx * stride_injection + group]) / groups));
+  const uint32_t weight_offset = shared_weight ? 0 : group * d;
+  const uint32_t tx = threadIdx.x, ty = threadIdx.y;
+  constexpr uint32_t warp_size = 32;
+  const uint32_t num_warps = blockDim.y;
+  const uint32_t thread_id = tx + ty * warp_size;
+  const uint32_t num_threads = num_warps * warp_size;
+  const uint32_t rounds = ceil_div(d, VEC_SIZE * num_threads);
+  extern __shared__ float smem[];
+  float* smem_x = smem + ceil_div(num_warps, 4) * 4;
+
+  float sum_sq = 0.f;
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && \
+     (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<B, VEC_SIZE> input_vec;
+    input_vec.fill(0.f);
+    vec_t<T, VEC_SIZE> residual_vec;
+    residual_vec.fill(0.f);
+    vec_t<float, VEC_SIZE> x_vec;
+    x_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.load(input + bx * stride_input + i * num_threads * VEC_SIZE +
+                     thread_id * VEC_SIZE);
+      residual_vec.load(residual + bx * stride_residual + group * d +
+                        i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      // Match HC combine -> materialized residual -> Gemma norm rounding.
+      float x =
+          float(T(fmaf(float(input_vec[j]), gate, float(residual_vec[j]))));
+      sum_sq += x * x;
+      residual_vec[j] = (T)x;
+      x_vec[j] = x;
+    }
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      residual_vec.store(combined + bx * stride_residual + group * d +
+                         i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+      x_vec.store(smem_x + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+  }
+
+  // first, warp reduce sum
+#pragma unroll
+  for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+    sum_sq += math::shfl_xor_sync(sum_sq, offset);
+  }
+
+  if (tx == 0) smem[ty] = sum_sq;
+  __syncthreads();
+  // then, cross warp reduce sum using only the first warp
+  if (ty == 0) {
+    sum_sq = (tx < num_warps) ? smem[tx] : 0.f;
+#pragma unroll
+    for (uint32_t offset = warp_size / 2; offset > 0; offset /= 2) {
+      sum_sq += math::shfl_xor_sync(sum_sq, offset);
+    }
+    if (tx == 0) smem[0] = sum_sq;
+  }
+  __syncthreads();
+
+  float rms_rcp = math::rsqrt(smem[0] / float(d) + eps);
+
+  for (uint32_t i = 0; i < rounds; i++) {
+    vec_t<T, VEC_SIZE> input_vec;
+    vec_t<W, VEC_SIZE> weight_vec;
+    vec_t<float, VEC_SIZE> x_vec;
+    input_vec.fill(0.f);
+    weight_vec.fill(0.f);
+    x_vec.fill(0.f);
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      weight_vec.load(weight + weight_offset + i * num_threads * VEC_SIZE +
+                      thread_id * VEC_SIZE);
+      x_vec.load(smem_x + i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; j++) {
+      const float y = x_vec[j] * rms_rcp;
+      input_vec[j] = fmaf(y, float(weight_vec[j]), y);
+    }
+    if ((i * num_threads + thread_id) * VEC_SIZE < d) {
+      input_vec.store(output + bx * stride_residual + group * d +
+                      i * num_threads * VEC_SIZE + thread_id * VEC_SIZE);
+    }
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && \
+     (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+}  // namespace flashinfer::sm70::hc

--- a/flashinfer-sm70/include/flashinfer/hc/sm70/hc_combine_norm.cuh
+++ b/flashinfer-sm70/include/flashinfer/hc/sm70/hc_combine_norm.cuh
@@ -6,6 +6,77 @@
 #pragma once
 #include <flashinfer/norm.cuh>
 namespace flashinfer::sm70::hc {
+// Same fused-add norm algorithm, but a small fixed-width decode row can
+// retain its rounded residual in registers instead of staging/reloading it
+// through shared memory. Geometry specialization is local to this operator.
+template <uint32_t VEC_SIZE, uint32_t D, uint32_t WARPS, typename T, typename B,
+          typename W>
+__global__ void HCCombineNormRegisterKernel(
+    const B* __restrict__ input, const T* __restrict__ residual,
+    const W* __restrict__ weight, const W* __restrict__ injection,
+    T* __restrict__ combined, T* __restrict__ output, uint32_t groups,
+    bool shared_weight, float eps) {
+  constexpr uint32_t THREADS = 32 * WARPS;
+  constexpr uint32_t ROUNDS = ceil_div(D, VEC_SIZE * THREADS);
+  const uint32_t row = blockIdx.x, group = blockIdx.y;
+  const uint32_t tid = threadIdx.x, lane = tid % 32, warp = tid / 32;
+  const uint32_t offset = (row * groups + group) * D;
+  const float gate =
+      2.f / (1.f + __expf(-float(injection[row * groups + group]) / groups));
+  vec_t<float, VEC_SIZE> values[ROUNDS];
+  float sum_sq = 0.f;
+#pragma unroll
+  for (uint32_t round = 0; round < ROUNDS; ++round) {
+    const uint32_t col = (round * THREADS + tid) * VEC_SIZE;
+    vec_t<B, VEC_SIZE> bv;
+    vec_t<T, VEC_SIZE> rv;
+    bv.fill(0.f);
+    rv.fill(0.f);
+    if (col < D) {
+      bv.load(input + row * D + col);
+      rv.load(residual + offset + col);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      const float x = float(T(fmaf(float(bv[j]), gate, float(rv[j]))));
+      values[round][j] = x;
+      rv[j] = T(x);
+      sum_sq += x * x;
+    }
+    if (col < D) rv.store(combined + offset + col);
+  }
+#pragma unroll
+  for (uint32_t delta = 16; delta > 0; delta /= 2)
+    sum_sq += math::shfl_xor_sync(sum_sq, delta);
+  __shared__ float sums[WARPS];
+  if (lane == 0) sums[warp] = sum_sq;
+  __syncthreads();
+  if (warp == 0) {
+    sum_sq = lane < WARPS ? sums[lane] : 0.f;
+#pragma unroll
+    for (uint32_t delta = 16; delta > 0; delta /= 2)
+      sum_sq += math::shfl_xor_sync(sum_sq, delta);
+    if (lane == 0) sums[0] = sum_sq;
+  }
+  __syncthreads();
+  const float inv_rms = math::rsqrt(sums[0] / D + eps);
+#pragma unroll
+  for (uint32_t round = 0; round < ROUNDS; ++round) {
+    const uint32_t col = (round * THREADS + tid) * VEC_SIZE;
+    vec_t<W, VEC_SIZE> wv;
+    vec_t<T, VEC_SIZE> result;
+    if (col < D) {
+      wv.load(weight + (shared_weight ? 0 : group * D) + col);
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        const float y = values[round][j] * inv_rms;
+        result[j] = T(fmaf(y, float(wv[j]), y));
+      }
+      result.store(output + offset + col);
+    }
+  }
+}
+
 template <uint32_t VEC_SIZE, typename T, typename B, typename W>
 __global__ void HCCombineNormKernel(
     const B* __restrict__ input, const T* __restrict__ residual,

--- a/flashinfer-sm70/tests/test_layer_fusion.py
+++ b/flashinfer-sm70/tests/test_layer_fusion.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from benchmarks.kernels.benchmark_sm70_flashinfer_gdn_conv import (
+    capture,
+    check_exclusive,
+)
+from benchmarks.kernels.flashinfer_sm70_gdn_conv import FusedGDN, build
+
+
+def test_conv_product_rounding_is_not_fp32_multiply():
+    x = torch.tensor([1.0009765625], dtype=torch.float16)
+    assert (x * x).float().item() != (x.float() * x.float()).item()
+
+
+@pytest.mark.parametrize("rows", [0, -1, 65])
+def test_invalid_rows_fail_before_gpu_allocation(rows):
+    with pytest.raises(ValueError):
+        FusedGDN(rows, device="cpu")
+
+
+@pytest.fixture(scope="module")
+def cuda_build():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 required")
+    check_exclusive()
+    torch.manual_seed(7)
+    build()
+
+
+def oracle(x, weights, qkv, cw, conv, A, dt, state, indices):
+    ba = (x @ weights).half().float()
+    output = torch.zeros(x.shape[0], 12, 128, device=x.device, dtype=torch.float32)
+    for row in range(x.shape[0]):
+        slot = int(indices[row])
+        if slot < 0:
+            continue
+        # Explicit FP16 product boundary observed in production conv PTX.
+        y = (conv[slot, :, 0] * cw[:, 0]).float()
+        y += (conv[slot, :, 1] * cw[:, 1]).float()
+        y += (conv[slot, :, 2] * cw[:, 2]).float()
+        y += (qkv[row] * cw[:, 3]).float()
+        mixed = (y / (1 + (-y).exp())).half().float()
+        conv[slot, :, :2] = conv[slot, :, 1:].clone()
+        conv[slot, :, 2] = qkv[row]
+        q = mixed[:512].reshape(4, 128).repeat_interleave(3, 0)
+        k = mixed[512:1024].reshape(4, 128).repeat_interleave(3, 0)
+        v = mixed[1024:].reshape(12, 128)
+        q *= (q.square().sum(-1, keepdim=True) + 1e-6).rsqrt()
+        k *= (k.square().sum(-1, keepdim=True) + 1e-6).rsqrt()
+        decay = (
+            -A.exp() * torch.nn.functional.softplus(ba[row, 12:] + dt.float())
+        ).exp()
+        beta = ba[row, :12].sigmoid()
+        old = state[slot] * decay[:, None, None]
+        delta = (v - (old * k[:, None, :]).sum(-1)) * beta[:, None]
+        state[slot] = old + delta[:, :, None] * k[:, None, :]
+        output[row] = (state[slot] * q[:, None, :]).sum(-1) / (128**0.5)
+    return output
+
+
+@pytest.mark.parametrize(
+    "rows,sd_layout", [(1, True), (4, False), (8, True), (16, True)]
+)
+def test_gdn_graph_dynamic_slots_and_history(cuda_build, rows, sd_layout):
+    pool, width = rows + 2, 2560
+    x = torch.randn(rows, 2560, device="cuda", dtype=torch.float16)
+    weights = torch.randn(2560, 24, device="cuda", dtype=torch.float16) * 0.01
+    qkv_storage = torch.randn(rows, 4096, device="cuda", dtype=torch.float16)
+    qkv = qkv_storage[:, :width]
+    cw = torch.randn(width, 4, device="cuda", dtype=torch.float16) * 0.2
+    bias = torch.empty(0, device="cuda", dtype=torch.float16)
+    conv = torch.randn(pool, width, 3, device="cuda", dtype=torch.float16) * 0.2
+    if sd_layout:
+        conv = conv.transpose(1, 2).contiguous().transpose(1, 2)
+    state = torch.randn(pool, 12, 128, 128, device="cuda", dtype=torch.float32) * 0.02
+    A = torch.randn(12, device="cuda", dtype=torch.float32)
+    dt = torch.randn(12, device="cuda", dtype=torch.float16)
+    indices = torch.arange(rows, device="cuda", dtype=torch.int32)
+    candidate = FusedGDN(rows)
+    call = lambda: candidate(x, weights, qkv, cw, bias, conv, A, dt, state, indices)
+    graph = capture(call)
+    for cycle in range(8):
+        x.normal_()
+        qkv.normal_()
+        indices.copy_(torch.randperm(pool, device="cuda")[:rows])
+        if cycle % 3 == 2:
+            indices[-1] = -1
+        c0, s0 = conv.clone(), state.clone()
+        expected_c, expected_s = c0.clone(), s0.clone()
+        expected_o = oracle(x, weights, qkv, cw, expected_c, A, dt, expected_s, indices)
+        eager = call().clone()
+        eager_state, eager_conv = state.clone(), conv.clone()
+        conv.copy_(c0)
+        state.copy_(s0)
+        candidate.partial.fill_(float("nan"))
+        candidate.output.fill_(float("nan"))
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(candidate.output, eager, atol=0, rtol=0)
+        torch.testing.assert_close(state, eager_state, atol=0, rtol=0)
+        torch.testing.assert_close(conv, eager_conv, atol=0, rtol=0)
+        torch.testing.assert_close(conv, expected_c, atol=0, rtol=0)
+        torch.testing.assert_close(state, expected_s, atol=1e-4, rtol=2e-3)
+        torch.testing.assert_close(
+            candidate.output.float(), expected_o, atol=1e-4, rtol=2e-3
+        )

--- a/flashinfer-sm70/tests/test_layer_fusion.py
+++ b/flashinfer-sm70/tests/test_layer_fusion.py
@@ -139,12 +139,26 @@ def test_gdn_graph_dynamic_slots_and_history(cuda_build, rows, sd_layout):
 def test_hc_graph_rounding_and_shared_weights(
     cuda_hc_build, rows, groups, width, r_dtype, b_dtype, w_dtype, shared, warps
 ):
+    check_hc_graph(rows, groups, width, r_dtype, b_dtype, w_dtype, shared, warps)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("warps", [4, 8])
+def test_hc_register_graph(cuda_hc_build, dtype, warps):
+    check_hc_graph(
+        16, 4, 2560, dtype, torch.float16, torch.float16, True, warps, registers=True
+    )
+
+
+def check_hc_graph(
+    rows, groups, width, r_dtype, b_dtype, w_dtype, shared, warps, registers=False
+):
     torch.manual_seed(19)
     r = torch.randn(rows, groups * width, device="cuda", dtype=r_dtype)
     b = torch.randn(rows, width, device="cuda", dtype=b_dtype)
     inj = torch.randn(rows, groups, device="cuda", dtype=w_dtype)
     w = torch.randn(width if shared else groups * width, device="cuda", dtype=w_dtype)
-    candidate = HCNorm(r, warps)
+    candidate = HCNorm(r, warps, registers=registers)
     call = lambda: candidate(r, b, inj, w)
     graph = capture(call)
     for scale in (0.25, 1.0, 3.0):

--- a/flashinfer-sm70/tests/test_layer_fusion.py
+++ b/flashinfer-sm70/tests/test_layer_fusion.py
@@ -8,6 +8,8 @@ from benchmarks.kernels.benchmark_sm70_flashinfer_gdn_conv import (
     check_exclusive,
 )
 from benchmarks.kernels.flashinfer_sm70_gdn_conv import FusedGDN, build
+from benchmarks.kernels.flashinfer_sm70_hc_norm import HCNorm
+from benchmarks.kernels.flashinfer_sm70_hc_norm import build as build_hc
 
 
 def test_conv_product_rounding_is_not_fp32_multiply():
@@ -21,6 +23,12 @@ def test_invalid_rows_fail_before_gpu_allocation(rows):
         FusedGDN(rows, device="cpu")
 
 
+@pytest.mark.parametrize("hq,hv", [(0, 12), (4, 0), (4, 7), (-1, 12)])
+def test_invalid_heads_fail_before_gpu_allocation(hq, hv):
+    with pytest.raises(ValueError):
+        FusedGDN(4, hq, hv, device="cpu")
+
+
 @pytest.fixture(scope="module")
 def cuda_build():
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
@@ -28,6 +36,14 @@ def cuda_build():
     check_exclusive()
     torch.manual_seed(7)
     build()
+
+
+@pytest.fixture(scope="module")
+def cuda_hc_build():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 required")
+    check_exclusive()
+    build_hc()
 
 
 def oracle(x, weights, qkv, cw, conv, A, dt, state, indices):
@@ -82,6 +98,7 @@ def test_gdn_graph_dynamic_slots_and_history(cuda_build, rows, sd_layout):
     candidate = FusedGDN(rows)
     call = lambda: candidate(x, weights, qkv, cw, bias, conv, A, dt, state, indices)
     graph = capture(call)
+    expected_c, expected_s = conv.clone(), state.clone()
     for cycle in range(8):
         x.normal_()
         qkv.normal_()
@@ -89,7 +106,8 @@ def test_gdn_graph_dynamic_slots_and_history(cuda_build, rows, sd_layout):
         if cycle % 3 == 2:
             indices[-1] = -1
         c0, s0 = conv.clone(), state.clone()
-        expected_c, expected_s = c0.clone(), s0.clone()
+        # The oracle retains its own history: copying candidate state into it
+        # each cycle would hide accumulated recurrent drift.
         expected_o = oracle(x, weights, qkv, cw, expected_c, A, dt, expected_s, indices)
         eager = call().clone()
         eager_state, eager_conv = state.clone(), conv.clone()
@@ -107,3 +125,51 @@ def test_gdn_graph_dynamic_slots_and_history(cuda_build, rows, sd_layout):
         torch.testing.assert_close(
             candidate.output.float(), expected_o, atol=1e-4, rtol=2e-3
         )
+
+
+@pytest.mark.parametrize(
+    "rows,groups,width,r_dtype,b_dtype,w_dtype,shared,warps",
+    [
+        (4, 4, 2560, torch.float16, torch.float16, torch.float16, False, 2),
+        (8, 4, 320, torch.float32, torch.float16, torch.float16, True, 1),
+        (16, 2, 520, torch.float16, torch.float32, torch.float32, False, 4),
+        (1, 3, 4096, torch.float32, torch.float32, torch.float32, True, 8),
+    ],
+)
+def test_hc_graph_rounding_and_shared_weights(
+    cuda_hc_build, rows, groups, width, r_dtype, b_dtype, w_dtype, shared, warps
+):
+    torch.manual_seed(19)
+    r = torch.randn(rows, groups * width, device="cuda", dtype=r_dtype)
+    b = torch.randn(rows, width, device="cuda", dtype=b_dtype)
+    inj = torch.randn(rows, groups, device="cuda", dtype=w_dtype)
+    w = torch.randn(width if shared else groups * width, device="cuda", dtype=w_dtype)
+    candidate = HCNorm(r, warps)
+    call = lambda: candidate(r, b, inj, w)
+    graph = capture(call)
+    for scale in (0.25, 1.0, 3.0):
+        r.normal_().mul_(scale)
+        b.normal_().mul_(scale)
+        inj.normal_()
+        # Independent wider-precision oracle, with the same explicit
+        # materialized residual boundary; never normalize the unrounded sum.
+        gate = 2 * (inj.double() / groups).sigmoid()
+        combined = (
+            r.double().reshape(rows, groups, width)
+            + b.double()[:, None, :] * gate[:, :, None]
+        ).to(r_dtype)
+        y = combined.double()
+        y *= (y.square().mean(-1, keepdim=True) + 1e-6).rsqrt()
+        y *= 1 + w.double().reshape(1, 1 if shared else groups, width)
+        eager = [t.clone() for t in call()]
+        candidate.combined.fill_(float("nan"))
+        candidate.normalized.fill_(float("nan"))
+        graph.replay()
+        torch.accelerator.synchronize()
+        for actual, ref in zip((candidate.combined, candidate.normalized), eager):
+            torch.testing.assert_close(actual, ref, atol=0, rtol=0)
+        atol = 2e-3 if r_dtype == torch.float16 else 2e-5
+        for actual, ref in zip(eager, (combined, y.to(r_dtype))):
+            torch.testing.assert_close(
+                actual.reshape(rows, groups, width), ref, atol=atol, rtol=2e-3
+            )


### PR DESCRIPTION
## Purpose

Port real FlashInfer layer-fusion computation to SM70 and finish operator
screening before a consolidated model E2E/quality run. No serving defaults
are changed by this benchmark prototype.

- Base: `755baae1d075ee04fa9096b23fc0225b23589a86` (`main`).
- Initial implementation: `e2061d5049`.
- First GPU correctness/component screen head: `72af224161`.
- Upstream FlashInfer pin: `6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f`.
- GDN: port gate projection + width-4 convolution + FP32 recurrent update,
  FP16 activations, graph-safe cooperative grid synchronization.
- HC: port fused-add norm vector/staging/reduction algorithm, adapt HC gate,
  materialized-residual rounding and Gemma affine semantics.
- Preserve actual production `mul.f16 -> cvt.f32.f16` convolution boundary
  confirmed in captured Triton PTX; do not silently use widened products.

Duplicate audit: this is not #513's QSA kernel nor #504's batch HC TP sharding.
M1 #506/#510 work and previous v0.6.13 negative probes are left untouched.
The existing TurboMind quantization and native/FA paths are not replaced.

## Test Plan

1. Native SM70 build, independent oracle, dynamic pool indices and padding,
   poisoned-buffer eager/graph replay.
2. Paired B1/4/8/16 production-conv/FlashQLA and HC-Triton component screens,
   real checkpoint GDN weights, FP32 state, unchanged numerical gates.
3. Targeted sanitizer, independent long recurrent histories, multistream
   lifetime/synchronization checks; only integrate operator winners.
4. Then one consolidated same-contract E2E C1/4/8/16 and coding/tool/schema
   quality validation. Micro timings do not establish model quality or TPS.

## Test Result

- GDN (including cooperative launch) and HC native SM70 builds/load passed,
  Python 3.12.13 / Torch 2.10.0+cu128 / CUDA 12.8.
- TP4 Hq4/Hv12 and TP2 Hq8/Hv24 specializations compile and load together;
  distinct Torch operator namespaces avoid geometry registration collisions.
- Initial complete GPU pytest: **16 passed**, including 8 GPU cases, in
  33.39 s. Independent GDN histories, HC oracle and graph replay pass.
- Real checkpoint FP16 GDN/FP32-state chain, paired CUDA Graph medians:
  B4 28.604 → 15.087 us, B8 33.041 → 22.801 us,
  B16 57.344 → 47.343 us. All 256-step independent-history screens pass.
  These are component timings, not model throughput or quality admission.
- Both HC variants are numerically correct but slower than current Triton.
  Updated GPU suite: **20 passed**, including the new register variant.
  FP16 B16: current 3.164 us vs register HC 3.779 us. Neither is enabled.
- Targeted CUDA 12.8 GDN memcheck: 0 errors (B16); racecheck: 0 errors / 0 warnings (B4).
- Applicable staged pre-commit hooks passed, including Ruff, mypy,
  clang-format, Markdown and repository-specific checks.
- The earlier GPU-lease rejection (75) remains a pre-launch negative result.
  The user subsequently freed GPU 4–7; component checks above completed there.
  Runtime integration and E2E evidence are tracked separately in #523.
- Serving dispatch remains unchanged. No model-quality pass or E2E speedup
  is claimed. Retain existing M1 projection and HC paths.

Worklog: `docs/design/sm70_flashinfer_layer_fusion.md`.
All build/test caches are task-private and generated files are unversioned.
Reference QLA source matches the retained current baseline; hash in worklog.

Keep Draft. FP16-state compression and failed prior GEMV/HC substitutions
are deliberately not retried or promoted. No deployed API is touched.
This work is AI-assisted (Codex). Human review is required before admission;
commits have DCO sign-off and AI attribution.


September 6 integration note: #523 exposed and corrected a prefill-trace specialization that initially bypassed fused GDN. Its first model result is therefore QSA-only, not a GDN speedup; it also has a negative small-sample tool-quality signal. The corrected combined run completed in #523: C4/8/16 throughput +6.98% / +7.00% / +7.35%, with both native paths selected, but offline BFCL is 49/64 vs 52/64 control. All throughput targets remain unmet and quality is unadmitted. Keep default-off/Draft; all owned GPU workers exited.

