### PR TITLE
[Core][Qwen4Exp] Gate PLE under pipeline parallelism on the partition, not the PP size (#479)

### DIFF
--- a/tests/distributed/test_pipeline_partition.py
+++ b/tests/distributed/test_pipeline_partition.py
@@ -65,3 +65,36 @@ def test_uneven_auto_partition(
     indices: tuple[int, int],
 ):
     assert indices == get_pp_indices(num_hidden_layers, pp_rank, pp_size)
+
+
+@pytest.mark.parametrize(
+    ("layer_indices", "num_layers", "pp_size", "partition", "expected"),
+    [
+        # Flash-Next shape: 48 layers, PLE on decoder layer 1, even split.
+        pytest.param([1], 48, 2, None, ([], 24), id="even-split-on-rank0"),
+        pytest.param([1, 30], 48, 2, None, ([30], 24), id="even-split-misplaced"),
+        pytest.param([1], 48, 1, None, ([], 48), id="pp1-never-misplaced"),
+        # VLLM_PP_LAYER_PARTITION decides, not the even split.
+        pytest.param([1], 48, 2, "2,46", ([], 2), id="custom-split-keeps-rank0"),
+        pytest.param([1], 48, 2, "1,47", ([1], 1), id="custom-split-misplaces"),
+        pytest.param([0, 5, 9], 12, 3, "4,4,4", ([5, 9], 4), id="pp3-sorted"),
+    ],
+)
+def test_get_layers_outside_first_pp_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    layer_indices,
+    num_layers,
+    pp_size,
+    partition,
+    expected,
+):
+    from vllm.distributed.utils import get_layers_outside_first_pp_rank
+
+    if partition is None:
+        monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", partition)
+
+    assert (
+        get_layers_outside_first_pp_rank(layer_indices, num_layers, pp_size) == expected
+    )

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
+import regex as re
 import torch
 from torch import nn
 from torch.nn import functional as F
@@ -771,3 +772,60 @@ def test_ple_state_shape_reserves_speculative_tokens() -> None:
     module.num_spec_tokens = 3
 
     assert module.get_state_shape()[0] in ((32, 12), (12, 32))
+
+
+# ---------------------------------------------------------------------------
+# PP gate: the pipeline partition decides, not the pipeline size (#479)
+# ---------------------------------------------------------------------------
+
+
+def _text_config(ple_layer_ids, num_hidden_layers=48):
+    return SimpleNamespace(
+        ple_layer_ids=ple_layer_ids, num_hidden_layers=num_hidden_layers
+    )
+
+
+@pytest.mark.parametrize(
+    ("ple_layer_ids", "pp_size", "partition"),
+    [
+        pytest.param([2], 1, None, id="pp1"),
+        pytest.param([2], 2, None, id="pp2-even-split"),
+        pytest.param([2], 2, "2,46", id="pp2-custom-split-rank0-holds-layer1"),
+        pytest.param([2, 24], 2, None, id="pp2-two-ple-layers-on-rank0"),
+    ],
+)
+def test_ple_pp_gate_accepts_ple_layers_on_first_rank(
+    monkeypatch: pytest.MonkeyPatch, ple_layer_ids, pp_size, partition
+):
+    from vllm.models.qwen4_exp.common.ple import check_ple_layers_on_first_pp_rank
+
+    if partition is None:
+        monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", partition)
+
+    check_ple_layers_on_first_pp_rank(_text_config(ple_layer_ids), pp_size)
+
+
+@pytest.mark.parametrize(
+    ("ple_layer_ids", "pp_size", "partition", "misplaced"),
+    [
+        pytest.param([2, 30], 2, None, "[29]", id="pp2-even-split"),
+        # ple_layer_ids are 1-based: id 2 is decoder layer 1, which a 1,47
+        # split puts on the second stage.
+        pytest.param([2], 2, "1,47", "[1]", id="pp2-custom-split-off-by-one"),
+        pytest.param([2, 20, 40], 4, None, "[19, 39]", id="pp4-two-misplaced"),
+    ],
+)
+def test_ple_pp_gate_rejects_ple_layers_beyond_first_rank(
+    monkeypatch: pytest.MonkeyPatch, ple_layer_ids, pp_size, partition, misplaced
+):
+    from vllm.models.qwen4_exp.common.ple import check_ple_layers_on_first_pp_rank
+
+    if partition is None:
+        monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", partition)
+
+    with pytest.raises(RuntimeError, match=re.escape(f"decoder layers {misplaced}")):
+        check_ple_layers_on_first_pp_rank(_text_config(ple_layer_ids), pp_size)

--- a/tests/v1/worker/test_gpu_model_runner_pp.py
+++ b/tests/v1/worker/test_gpu_model_runner_pp.py
@@ -136,3 +136,82 @@ def test_mamba_neutral_pp_update_accepts_int32_slot_indices(monkeypatch) -> None
     state.postprocess_state(idx_mapping, 0)
 
     assert launches == [(idx_mapping, 1)]
+
+
+# ---------------------------------------------------------------------------
+# PLE under PP: the runner gate follows the partition, not the PP size (#479)
+# ---------------------------------------------------------------------------
+
+
+def _pp2_vllm_config_with_ple(ple_layer_ids: list[int]):
+    from vllm.config import (
+        CacheConfig,
+        ModelConfig,
+        ParallelConfig,
+        SchedulerConfig,
+        VllmConfig,
+    )
+
+    model_config = ModelConfig(model="facebook/opt-125m", dtype="float16", seed=42)
+    # Give the text config the PLE shape of a Qwen4Exp checkpoint.
+    model_config.hf_text_config.ple_layer_ids = ple_layer_ids
+    model_config.hf_text_config.ngram_size = 3
+    # A world of two ranks in a single-GPU test process: set after
+    # construction, the validator would otherwise count the local GPUs.
+    parallel_config = ParallelConfig()
+    parallel_config.pipeline_parallel_size = 2
+    return VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=16, gpu_memory_utilization=0.9, cache_dtype="auto"
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=10,
+            max_num_batched_tokens=512,
+            max_model_len=512,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        parallel_config=parallel_config,
+    )
+
+
+def _patch_pp_group(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_model_runner.get_pp_group",
+        lambda: SimpleNamespace(
+            world_size=2,
+            rank=0,
+            rank_in_group=0,
+            ranks=[0, 1],
+            is_first_rank=True,
+            is_last_rank=False,
+        ),
+    )
+
+
+def test_runner_accepts_pp2_with_ple_layers_on_first_rank(monkeypatch) -> None:
+    from vllm.config import set_current_vllm_config
+    from vllm.platforms import current_platform
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    _patch_pp_group(monkeypatch)
+    monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+    vllm_config = _pp2_vllm_config_with_ple([2])  # decoder layer 1 of 12
+    with set_current_vllm_config(vllm_config):
+        runner = GPUModelRunner(vllm_config, current_platform.device_type)
+    assert runner.uses_ngram_embedding
+
+
+def test_runner_rejects_pp2_with_ple_layer_on_second_rank(monkeypatch) -> None:
+    from vllm.config import set_current_vllm_config
+    from vllm.platforms import current_platform
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    _patch_pp_group(monkeypatch)
+    monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+    vllm_config = _pp2_vllm_config_with_ple([10])  # decoder layer 9 of 12
+    with (
+        set_current_vllm_config(vllm_config),
+        pytest.raises(RuntimeError, match="first pipeline rank"),
+    ):
+        GPUModelRunner(vllm_config, current_platform.device_type)

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -14,7 +14,7 @@ import sys
 import time
 import uuid
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import timedelta
 from typing import Any
 
@@ -138,6 +138,21 @@ def get_pp_indices(
     end_layer = start_layer + partitions[pp_rank]
 
     return (start_layer, end_layer)
+
+
+def get_layers_outside_first_pp_rank(
+    layer_indices: Iterable[int], num_hidden_layers: int, pp_size: int
+) -> tuple[list[int], int]:
+    """Return the given layer indices the pipeline partition places beyond the
+    first rank, together with the exclusive end of the first rank's range.
+
+    Honours ``VLLM_PP_LAYER_PARTITION`` through :func:`get_pp_indices`, so a
+    caller that needs certain layers on the first rank can check the actual
+    split instead of refusing ``pp_size > 1`` outright.
+    """
+    _, first_rank_end = get_pp_indices(num_hidden_layers, 0, pp_size)
+    misplaced = sorted(index for index in layer_indices if index >= first_rank_end)
+    return misplaced, first_rank_end
 
 
 def create_tcp_store(

--- a/vllm/models/qwen4_exp/amd/model_state.py
+++ b/vllm/models/qwen4_exp/amd/model_state.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
+from vllm.models.qwen4_exp.common.ple import check_ple_layers_on_first_pp_rank
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
@@ -32,13 +33,9 @@ class Qwen4ExpModelState(MambaHybridModelState):
             self.ngram_eos_token_id = 0
             return
 
-        if vllm_config.parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1 because non-first pipeline ranks do "
-                "not receive the raw input_ids required by PLE. Please run "
-                "with PP=1."
-            )
+        check_ple_layers_on_first_pp_rank(
+            config, vllm_config.parallel_config.pipeline_parallel_size
+        )
 
         self.ngram_context_len = int(config.ngram_size) - 1
         if self.ngram_context_len <= 0:

--- a/vllm/models/qwen4_exp/common/ple.py
+++ b/vllm/models/qwen4_exp/common/ple.py
@@ -3,8 +3,36 @@
 """Common Qwen4Exp PLE helpers."""
 
 from dataclasses import dataclass
+from typing import Any
 
 import torch
+
+from vllm.distributed.utils import get_layers_outside_first_pp_rank
+
+
+def check_ple_layers_on_first_pp_rank(text_config: Any, pp_size: int) -> None:
+    """Refuse a pipeline split that puts a PLE layer beyond the first rank.
+
+    The n-gram context and ``query_start_loc`` a PLE layer consumes are only
+    prepared on the first pipeline rank, and later ranks receive no input ids
+    at all. ``ple_layer_ids`` are 1-based: id ``L`` attaches the PLE module to
+    decoder layer ``L - 1`` (see ``Qwen4ExpDecoderLayer``), so that is the
+    index the partition has to keep on rank 0.
+    """
+    if pp_size <= 1:
+        return
+    ple_decoder_layers = [int(layer_id) - 1 for layer_id in text_config.ple_layer_ids]
+    misplaced, first_rank_end = get_layers_outside_first_pp_rank(
+        ple_decoder_layers, int(text_config.num_hidden_layers), pp_size
+    )
+    if misplaced:
+        raise RuntimeError(
+            "N-gram PLE embedding requires every PLE layer on the first pipeline "
+            f"rank, which holds decoder layers 0..{first_rank_end - 1}, but the "
+            f"PLE modules of decoder layers {misplaced} fall on a later stage. "
+            "Either run with pipeline_parallel_size=1 or move the split with "
+            "VLLM_PP_LAYER_PARTITION so those layers stay on rank 0."
+        )
 
 
 @dataclass(frozen=True)

--- a/vllm/models/qwen4_exp/nvidia/model_state.py
+++ b/vllm/models/qwen4_exp/nvidia/model_state.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
+from vllm.models.qwen4_exp.common.ple import check_ple_layers_on_first_pp_rank
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
@@ -32,13 +33,9 @@ class Qwen4ExpModelState(MambaHybridModelState):
             self.ngram_eos_token_id = 0
             return
 
-        if vllm_config.parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1 because non-first pipeline ranks do "
-                "not receive the raw input_ids required by PLE. Please run "
-                "with PP=1."
-            )
+        check_ple_layers_on_first_pp_rank(
+            config, vllm_config.parallel_config.pipeline_parallel_size
+        )
 
         self.ngram_context_len = int(config.ngram_size) - 1
         if self.ngram_context_len <= 0:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1405,8 +1405,14 @@ class GPUModelRunner(
             self.ngram_eos_token_id = 0
         if self.uses_ngram_embedding and self.ngram_context_len <= 0:
             raise ValueError("N-gram embedding requires context length >= 1")
-        if self.uses_ngram_embedding and parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError("N-gram PLE embedding requires pipeline_parallel_size=1")
+        if self.uses_ngram_embedding:
+            from vllm.models.qwen4_exp.common.ple import (
+                check_ple_layers_on_first_pp_rank,
+            )
+
+            check_ple_layers_on_first_pp_rank(
+                model_config.hf_text_config, parallel_config.pipeline_parallel_size
+            )
         self._ple_offload_connector: Any | None = None
 
         self.cascade_attn_enabled = not self.model_config.disable_cascade_attn


### PR DESCRIPTION
## Purpose

Second slice of the PP enablement offered in #479 (the loader fix was #485).

The n-gram PLE embedding currently refuses `pipeline_parallel_size > 1`
outright, at three places: `GPUModelRunner.__init__` and both
`Qwen4ExpModelState` trees (nvidia, amd). The stated reason is right --
`ngram_context`, `query_start_loc` and the raw `input_ids` are only prepared
on the first pipeline rank (`gpu_model_runner.py`, `not is_first_rank` guard
in the PLE input preparation) -- but the conclusion is wider than needed. The
model forward passes those inputs down the layer loop and only a decoder
layer that owns a PLE module consumes them (`Qwen4ExpDecoderLayer.forward`:
`if self.ple is not None`). So PP works as long as every decoder layer with a
PLE module sits on the first rank, and that is decided by the pipeline
partition, not by the pipeline size.

This PR

- adds `get_layers_outside_first_pp_rank()` in `vllm/distributed/utils.py`
  next to `get_pp_indices()`, so the check honours `VLLM_PP_LAYER_PARTITION`
  exactly like the model does,
- adds `check_ple_layers_on_first_pp_rank()` in
  `vllm/models/qwen4_exp/common/ple.py` and uses it at all three gates
  (one rule, one message),
- maps `ple_layer_ids` correctly: they are 1-based -- id `L` attaches the PLE
  module to decoder layer `L - 1` (`if (self.layer_idx + 1) in ple_layer_ids`
  in `Qwen4ExpDecoderLayer.__init__`) -- so the check compares `L - 1`
  against the first rank's layer range. A `1,47` split of a 48-layer model
  with `ple_layer_ids=[2]` is therefore rejected (decoder layer 1 is on the
  second stage), while `2,46` passes.

With `ple_layer_ids=[2]` (Qwen3.8-Flash-Next) the default even split keeps
the PLE layer on rank 0 for any `pipeline_parallel_size`, so the common case
needs no `VLLM_PP_LAYER_PARTITION` at all.

Not in this PR: gate 1 of #479 (`VLLM_PLE_CPU_OFFLOAD` refuses PP in
`Worker._validate_ple_offload_config`). Lifting it needs the offload child
process to inherit the partition as well; that is a separate, reviewable
step. `PP=N` therefore still shows up as unsupported for the offload path.

Duplicate check (per AGENTS.md): `gh issue view 479 --comments` (no reply
since 2026-09-03), `gh pr list --state open --search "479 in:body"` (none),
`--search "PLE pipeline"` and `--search "ple_layer_ids"` (none). Verified
against origin/main 755baae today.

## Test Plan

Environment: 1Cat-vLLM 1.5.0 wheel venv (Python 3.12), checkout at
origin/main 755baae with the compiled extensions linked in, single Tesla
V100 (`CUDA_VISIBLE_DEVICES=4`), facebook/opt-125m from the HF cache for the
runner construction.

    # the three touched test files plus the PLE offload worker tests
    python -m pytest tests/distributed/test_pipeline_partition.py tests/models/qwen4_exp/test_ple.py \
        tests/v1/worker/test_gpu_model_runner_pp.py tests/v1/worker/test_ple_offload_worker.py -q

    # same, with the five source files reverted to origin/main (git stash), tests kept
    python -m pytest <same four files> -q

    # pre-commit hooks as configured (ruff, typos, forbidden imports, mypy-local) plus the CI-only mypy stage
    pre-commit run --files <8 files>
    pre-commit run mypy-3.10 --hook-stage manual --files <8 files>
    mypy --python-version 3.10 <5 source files>   # local, with the wheel's site-packages

## Test Result

Four test files with the fix (15 new cases):

    86 passed, 1 skipped in 29.59s

Same four files, source files reverted to origin/main, tests kept:

    15 failed, 71 passed, 1 skipped
    all 71 pre-existing tests pass on origin/main; the 15 failures are the new cases:
      helper / check: ImportError (functions do not exist)
      test_runner_accepts_pp2_with_ple_layers_on_first_rank:
        RuntimeError: N-gram PLE embedding requires pipeline_parallel_size=1   <- the old gate
      test_runner_rejects_pp2_with_ple_layer_on_second_rank:
        message mismatch (old gate refuses without naming the stage)

pre-commit: ruff-check, ruff-format, typos, SPDX headers, forbidden imports,
torch.cuda-call check, mypy-local and mypy-3.10 (manual stage) all Passed.
Local mypy on the five source files: 69 errors before and after, identical
set (all pre-existing in gpu_model_runner.py / parallel utils, none in the
touched lines); the three new/changed test files: no issues.

Production context: our fork has run this rule (first-rank check instead of
the PP ban) for Qwen3.8-Flash-Next at TP2/PP2 with MTP since 1.3.0, on
2x RTX 8000 + 2x V100. The fork variant compared the 1-based ids directly,
i.e. was one layer stricter; this PR uses the exact mapping.

AI assistance: this change was developed with Claude (Anthropic) as a
coding assistant. Every changed line was reviewed by me and the test runs
above were executed on my hardware; I can defend the change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
