### PR TITLE
[Core] Profile the KV budget on a warm forward, not on the cold torch.compile

### DIFF
--- a/tests/v1/worker/test_gpu_worker_memory_profile.py
+++ b/tests/v1/worker/test_gpu_worker_memory_profile.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The KV budget must reflect the steady-state forward, not the first
+(compiling) one: a cold torch.compile allocates scratch that has nothing to
+do with serving, and on a cache miss it shrank the budget by GiBs."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.platforms import current_platform
+from vllm.utils.mem_utils import MemorySnapshot
+from vllm.v1.worker.gpu_worker import Worker
+
+MiB = 1024 * 1024
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="needs a CUDA device for memory stats"
+)
+
+
+class _FakeRunner:
+    """First profile_run behaves like a cold compile: a large transient
+    allocation plus a small one that stays; the second is the plain forward."""
+
+    def __init__(self, device: torch.device, weights_bytes: int) -> None:
+        self.model_memory_usage = weights_bytes
+        self._device = device
+        self.calls = 0
+        self._kept: list[torch.Tensor] = []
+
+    def profile_run(self) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            scratch = torch.empty(1024 * MiB, dtype=torch.uint8, device=self._device)
+            self._kept.append(
+                torch.empty(64 * MiB, dtype=torch.uint8, device=self._device)
+            )
+            del scratch
+        else:
+            activations = torch.empty(256 * MiB, dtype=torch.uint8, device=self._device)
+            del activations
+        torch.accelerator.synchronize(self._device)
+
+    def profile_cudagraph_memory(self) -> int:
+        return 0
+
+
+def test_kv_budget_ignores_cold_compile_scratch() -> None:
+    device = torch.device("cuda:0")
+    torch.accelerator.empty_cache()
+    worker = Worker.__new__(Worker)
+    worker.device = device
+    worker.init_snapshot = MemorySnapshot(device=device)
+    weights_bytes = 512 * MiB
+    weights = torch.empty(weights_bytes, dtype=torch.uint8, device=device)
+    worker.requested_memory = int(worker.init_snapshot.free_memory * 0.9)
+    worker.cache_config = SimpleNamespace(
+        kv_cache_memory_bytes=None, gpu_memory_utilization=0.9
+    )
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE)
+    )
+    runner = _FakeRunner(device, weights_bytes)
+    worker.model_runner = runner
+
+    available = worker.determine_available_memory()
+
+    # Peak activation is the second (steady-state) forward, not the 1 GiB scratch.
+    assert abs(worker.peak_activation_memory - 256 * MiB) <= 16 * MiB
+    # What the warm-up left allocated is still charged to the budget. Other
+    # processes on the device show up in non_torch_memory, so account for it.
+    charged = (
+        worker.requested_memory
+        - available
+        - worker.non_torch_memory
+        - worker.peak_activation_memory
+        - weights_bytes
+    )
+    assert abs(charged - 64 * MiB) <= 32 * MiB
+    assert runner.calls == 2
+    del weights

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -527,6 +527,17 @@ class Worker(WorkerBase):
             logger.info(msg)
             return kv_cache_memory_bytes
 
+        # The first forward triggers torch.compile, and a cold compile (cache
+        # miss) is not steady-state serving: on a 27B NVFP4 model on a 48 GB
+        # card it added 1.85 GiB of torch peak (inductor autotuning, AOT
+        # export) and 0.64 GiB of non-torch memory on top of the forward
+        # itself, so the KV budget came out at 3.5 instead of 6.0 GiB and
+        # depended on the state of the compile cache. Warm the compiled
+        # graphs up first and measure the second forward. Memory the warm-up
+        # keeps allocated still counts: non-torch is measured against the
+        # init snapshot, and torch memory the warm-up left behind beyond the
+        # weights is added below as warmup_torch_residual.
+        self.model_runner.profile_run()
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -555,10 +566,17 @@ class Worker(WorkerBase):
         profile_result.torch_peak_increase = (
             profile_torch_peak - profile_result.before_profile.torch_peak
         )
+        warmup_torch_residual = max(
+            0,
+            profile_result.before_profile.torch_memory
+            - self.init_snapshot.torch_memory
+            - profile_result.weights_memory,
+        )
         profile_result.non_kv_cache_memory = (
             profile_result.non_torch_increase
             + profile_result.torch_peak_increase
             + profile_result.weights_memory
+            + warmup_torch_residual
         )
 
         # On ROCm, cudagraph_memory_estimate is always 0 so this is a no-op.


### PR DESCRIPTION
## Purpose

`Worker.determine_available_memory()` derives the KV budget from the torch
peak and the non-torch increase observed across `profile_run()`. That first
forward is also where torch.compile happens, and a cold compile (compile
cache miss) is not steady-state serving: inductor autotuning and the AOT
export allocate scratch, and the compile leaves memory behind that a warm
boot never touches. The measurement therefore depends on the state of the
compile cache.

Measured on our rig (Qwen3.8-27B-NVFP4, TP=1 on a Quadro RTX 8000 48 GB,
`--gpu-memory-utilization 0.98`, DEBUG log of the profiling result):

    cold compile (cache miss, 74 s):  torch peak +2.59 GiB, non-torch +0.86 GiB -> KV 3.53 GiB
    warm compile (cache hit,  2.8 s): torch peak +0.74 GiB, non-torch +0.22 GiB -> KV 6.03 GiB

Every new `--max-model-len` is a new compile-cache key, so a boot sequence
that follows vLLM's own "max seq len larger than KV cache" hints walks
into a cold compile and caps far too low: 262144 -> 94080 (warm) -> 93296
(warm) -> 52528 (cold, 3.53 GiB) although a warm boot at 52528 then
reports room for 90,664 tokens. On Tesla V100 the effect does not show
(7.61 GiB cold and warm), which is why it went unnoticed on the SM70 path.

This PR runs `profile_run()` once before the measured pass, so the compiled
graphs are in place when the peak is taken, and charges what the warm-up
left allocated:

- non-torch memory is already measured against the init snapshot, so
  anything the compile keeps (worker contexts, handles) still counts;
- torch memory the warm-up kept beyond the weights is added explicitly as
  `warmup_torch_residual`. On the RTX that term is 0.43 GiB, which the old
  code silently handed to the KV cache.

The budget can only shrink from the residual term, never grow. The cost is
one extra dummy forward (seconds), and only the compile is no longer part
of the measurement.

After the change, same card, same model, new compile-cache key:

    cold compile: torch peak +0.73 GiB, non-torch +0.86 GiB, residual 0.5 GiB -> KV 4.96 GiB
    warm compile: torch peak +0.73 GiB, non-torch +0.22 GiB, residual 0.43 GiB -> KV 5.60 GiB

The remaining cold/warm difference is the non-torch memory a cold compile
keeps allocated for the lifetime of the process; it is real and stays
charged.

Duplicate check (per AGENTS.md): `gh pr list --state open --search
"determine_available_memory"`, `--search "memory profiling"`,
`--search "profile_run"`: the hits are #511 (mentions the function in its
description) and #470 (bounds an AWQ kernel scratch), neither touches the
profiling measurement. Verified against origin/main 755baae today.

## Test Plan

Environment: 1Cat-vLLM 1.5.0 wheel venv (Python 3.12), checkout at
origin/main 755baae with the compiled extensions linked in, single Tesla
V100 (`CUDA_VISIBLE_DEVICES=4`) for the unit test; the end-to-end numbers
above from our 1.5.0 deployment with the same two hunks applied.

    python -m pytest tests/v1/worker/test_gpu_worker_memory_profile.py tests/v1/worker/test_gpu_worker_static_pp.py -q
    # new test with vllm/v1/worker/gpu_worker.py reverted to origin/main (git stash)
    python -m pytest tests/v1/worker/test_gpu_worker_memory_profile.py -q
    pre-commit run --files vllm/v1/worker/gpu_worker.py tests/v1/worker/test_gpu_worker_memory_profile.py
    pre-commit run mypy-3.10 --hook-stage manual --files <same two files>
    mypy --python-version 3.10 vllm/v1/worker/gpu_worker.py   # local, with the wheel's site-packages

## Test Result

With the fix (new test plus the existing worker tests in the same process):

    5 passed

New test with `gpu_worker.py` reverted to origin/main:

    1 failed: peak_activation_memory == 1088 MiB (the 1 GiB scratch of the
    first forward), expected 256 MiB

pre-commit: ruff-check, ruff-format, typos, SPDX headers, forbidden
imports, torch.cuda-call check, mypy-local and mypy-3.10 (manual stage)
all Passed. Local mypy on `gpu_worker.py`: 9 errors before and after,
identical set (pre-existing, none in the touched lines).

AI assistance: this change was developed with Claude (Anthropic) as a
coding assistant. Every changed line was reviewed by me and the test runs
above were executed on my hardware; I can defend the change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
