### PR TITLE
[Bench][SM70] Make the Qwen3.8 no-MTP baseline reproducible from source

### DIFF
--- a/benchmarks/benchmark_sm70_qwen38_baseline.py
+++ b/benchmarks/benchmark_sm70_qwen38_baseline.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reproduce the quality-repaired no-MTP TP4 baseline with freshly built overlays.
+
+Obtain exclusive GPU ownership before running. Normal output checks use the
+checkpoint's sampling configuration; forced-length greedy timing is separate.
+All model workers shut down after the bounded test. No API service is started.
+"""
+
+import argparse
+import json
+import os
+import signal
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import regex as re
+
+# Support both direct script execution and `python -m benchmarks...`.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from benchmarks.sm70_qwen38_baseline import (  # noqa: E402
+    FIXED_PROMPT,
+    ROOT,
+    configure_environment,
+    engine_args,
+    validate_bundle,
+)
+
+
+def run(args):
+    from transformers import AutoTokenizer
+
+    from benchmarks.benchmark_sm70_decode import _hash_ids, _run_once, _summarize
+    from vllm import LLM, SamplingParams
+
+    bundle = validate_bundle(args.runtime_dir)
+    tokenizer = AutoTokenizer.from_pretrained(args.model, local_files_only=True)
+    config = json.loads((Path(args.model) / "generation_config.json").read_text())
+    natural = SamplingParams(
+        max_tokens=513,
+        temperature=config["temperature"],
+        top_p=config["top_p"],
+        top_k=config["top_k"],
+        seed=0,
+        ignore_eos=False,
+        skip_special_tokens=False,
+    )
+    fixed = SamplingParams(
+        max_tokens=513,
+        temperature=0,
+        seed=0,
+        ignore_eos=True,
+        skip_special_tokens=False,
+    )
+    piece = tokenizer.encode(FIXED_PROMPT, add_special_tokens=False)
+    lengths = [8192, 261631] if args.long_context else [8192]
+    reference = {}
+    if args.reference_json:
+        previous = json.loads(args.reference_json.read_text())
+        reference = {c["name"]: c["runs"][0]["token_ids"] for c in previous["cases"]}
+        if not {f"fixed_{n}" for n in lengths}.issubset(reference):
+            raise ValueError("Reference is missing a requested fixed-prompt case")
+    report = {
+        "source_sha": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        "bundle": bundle,
+        "contract": engine_args(args.model),
+        "gpu_group": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "started_unix": time.time(),
+        "health": [],
+        "cases": [],
+        "complete": False,
+        "scope": (
+            "Warm single-request fixed-prompt benchmark; forced post-EOS timing "
+            "is not quality evidence. Natural health/boundary checks are separate."
+        ),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        temporary = args.output.with_suffix(".tmp.json")
+        temporary.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+        temporary.replace(args.output)
+
+    def health(llm, name, ids, pattern):
+        result = _run_once(llm, {"prompt_token_ids": ids}, natural)
+        passed = result["finish_reason"] == "stop" and bool(
+            re.search(pattern, result["text"].rsplit("</think>", 1)[-1])
+        )
+        report["health"].append(
+            {"name": name, "input_tokens": len(ids), "passed": passed, "result": result}
+        )
+        save()
+        print(json.dumps({"health": name, "passed": passed}), flush=True)
+        if not passed:
+            raise RuntimeError(f"Natural output health failed: {name}")
+
+    llm = None
+    try:
+        save()
+        llm = LLM(**engine_args(args.model))
+        for name, prompt, pattern in (
+            (
+                "arithmetic",
+                "请计算 19 × 23。请在最后一行写 RESULT=计算结果。",
+                r"RESULT\s*=\s*437\b",
+            ),
+            (
+                "record_copy",
+                "项目代号 CEDAR-47，编号 8261。最后一行准确输出 CEDAR-47|8261。",
+                r"CEDAR-47\s*\|\s*8261",
+            ),
+        ):
+            ids = tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                tokenize=True,
+                return_dict=False,
+                add_generation_prompt=True,
+                enable_thinking=True,
+            )
+            health(llm, name, ids, pattern)
+        for length in lengths:
+            ids = (piece * ((length + len(piece) - 1) // len(piece)))[:length]
+            case = {
+                "name": f"fixed_{length}",
+                "input_tokens": length,
+                "prompt_hash": _hash_ids(ids),
+                "runs": [],
+            }
+            report["cases"].append(case)
+            case["warmup"] = _run_once(llm, {"prompt_token_ids": ids}, fixed)
+            if "workers" not in report:
+                workers = llm.collective_rpc("baseline_manifest", timeout=90)
+                report["workers"] = workers
+                if len(workers) != 4 or sorted(w["rank"] for w in workers) != list(
+                    range(4)
+                ):
+                    raise RuntimeError("Missing or duplicate TP worker manifests")
+                for worker in workers:
+                    if (
+                        worker["ssm_dtype"] != "float32"
+                        or worker["mtp"]
+                        or worker["prefix_cache"]
+                    ):
+                        raise RuntimeError(
+                            f"Worker precision/state contract mismatch: {worker}"
+                        )
+                    if (
+                        worker["max_model_len"] != 262144
+                        or "FULL" not in worker["graph_mode"]
+                        or worker["qsa_specialization_version"] != 1
+                        or set(worker["binaries"])
+                        != {"hc", "qpn", "qsa", "flashqla", "flashv100"}
+                        or not worker["native_dependencies"]
+                    ):
+                        raise RuntimeError(
+                            "Worker route or dependency contract mismatch"
+                        )
+                    if Path(worker["vllm_file"]).resolve() != ROOT / "vllm/__init__.py":
+                        raise RuntimeError("Worker imported another source checkout")
+                    for component, binary in worker["binaries"].items():
+                        if (
+                            not binary["mapped"]
+                            or binary["sha256"]
+                            != bundle["libraries"][component]["sha256"]
+                        ):
+                            raise RuntimeError(
+                                f"Worker did not map the freshly built {component}"
+                            )
+            for _ in range(args.repeats):
+                result = _run_once(llm, {"prompt_token_ids": ids}, fixed)
+                metrics = result["request_metrics"]
+                if (
+                    result["output_tokens"] != 513
+                    or not metrics
+                    or metrics["raw"]["is_corrupted"]
+                ):
+                    raise RuntimeError("Missing/corrupted separated request metrics")
+                case["runs"].append(result)
+                save()
+                if result["token_ids"] != case["warmup"]["token_ids"]:
+                    raise RuntimeError(f"Token repeatability failed: {case['name']}")
+                if (
+                    case["name"] in reference
+                    and result["token_ids"] != reference[case["name"]]
+                ):
+                    raise RuntimeError(
+                        f"Output differs from frozen reference: {case['name']}"
+                    )
+            case["summary"] = _summarize(case["runs"])
+            case["prefill_tps_mean"] = statistics.mean(
+                length / r["request_metrics"]["prefill_time"] for r in case["runs"]
+            )
+            case["same_token_hash"] = True
+            case["matches_reference"] = True if case["name"] in reference else None
+            print(
+                json.dumps(
+                    {
+                        "case": case["name"],
+                        "summary": case["summary"],
+                        "prefill_tps": case["prefill_tps_mean"],
+                    }
+                ),
+                flush=True,
+            )
+            save()
+        if args.long_context:
+            marker = "ONECAT_LONG_ARCHIVE_MARKER"
+            rendered = tokenizer.apply_chat_template(
+                [
+                    {
+                        "role": "user",
+                        "content": marker
+                        + "\nFind the archive code and finish with RESULT=<code>.",
+                    }
+                ],
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=True,
+            )
+            before, after = rendered.split(marker)
+            lead = tokenizer.encode(before, add_special_tokens=False)
+            tail = tokenizer.encode(after, add_special_tokens=False)
+            filler = tokenizer.encode(
+                "A routine archive entry, without task instructions.\n",
+                add_special_tokens=False,
+            )
+            record = tokenizer.encode(
+                "\nArchive code: MAPLE-8261.\n", add_special_tokens=False
+            )
+            count = 261631 - len(lead) - len(tail) - len(record)
+            padding = (filler * ((count + len(filler) - 1) // len(filler)))[:count]
+            ids = lead + padding[: count // 2] + record + padding[count // 2 :] + tail
+            health(llm, "long_middle_record", ids, r"RESULT\s*=\s*MAPLE-8261")
+            ids = (piece * ((262143 + len(piece) - 1) // len(piece)))[:262143]
+            report["exact_context_boundary"] = _run_once(
+                llm,
+                {"prompt_token_ids": ids},
+                SamplingParams(max_tokens=1, temperature=0, seed=0, ignore_eos=True),
+            )
+            if report["exact_context_boundary"]["output_tokens"] != 1:
+                raise RuntimeError("262143+1 context boundary failed")
+        report["complete"] = True
+    except BaseException as error:
+        report["error"] = f"{type(error).__name__}: {error}"
+        raise
+    finally:
+        if llm is not None:
+            llm.llm_engine.engine_core.shutdown(timeout=30.0)
+        report["ended_unix"] = time.time()
+        save()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--runtime-dir", type=Path, required=True)
+    parser.add_argument("--native-extension-dir", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--reference-json", type=Path)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--long-context", action="store_true")
+    parser.add_argument("--configured", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.repeats < 2:
+        parser.error("At least two repeats are required")
+    if not args.configured:
+        configure_environment(
+            args.runtime_dir, args.output.parent / "cache", args.native_extension_dir
+        )
+        # The fresh interpreter installs the same import path in spawned workers.
+        os.execv(
+            sys.executable,
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                *sys.argv[1:],
+                "--configured",
+            ],
+        )
+
+    def stop(signum, _frame):
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGTERM, stop)
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/build_sm70_qwen38_runtime.py
+++ b/benchmarks/kernels/build_sm70_qwen38_runtime.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Build the admitted Qwen3.8 single-request overlays from this checkout.
+
+Requires the project's CUDA-enabled Torch/build environment and a compatible
+native vLLM installation. This is an explicit source-overlay build, not a full
+vLLM wheel build. No model or GPU context is initialized by this script.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+from benchmarks.sm70_qwen38_baseline import production_fingerprint  # noqa: E402
+
+
+def digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def build(output: Path) -> dict:
+    import torch
+    from torch.utils.cpp_extension import load
+
+    output.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "source_sha": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        "source_root": str(ROOT),
+        "production_fingerprint": production_fingerprint(),
+        "torch": str(torch.__version__),
+        "cuda_runtime": torch.version.cuda,
+        "nvcc": subprocess.check_output(
+            [str(Path(os.environ["CUDA_HOME"]) / "bin/nvcc"), "--version"],
+            text=True,
+        ),
+        "libraries": {},
+    }
+    specifications = {
+        "hc": (
+            "vllm_qwen38_hc_sm70",
+            ["benchmarks/kernels/sm70_qwen38_custom_ar_sidecar.cu"],
+            ["-O3", "-DNDEBUG", "-std=c++17"],
+            ["csrc/custom_all_reduce.cu", "csrc/custom_all_reduce.cuh"],
+        ),
+        "qpn": (
+            "vllm_qwen38_nvfp4_sm70",
+            [
+                "csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu",
+                "benchmarks/kernels/sm70_qwen38_nvfp4_sidecar.cpp",
+            ],
+            ["-O3", "-lineinfo"],
+            ["csrc/ops.h"],
+        ),
+        "qsa": (
+            "vllm_qsa_decode_topk_sm70",
+            ["benchmarks/kernels/sm70_qsa_topk_sidecar.cu"],
+            ["-O3", "-lineinfo"],
+            ["csrc/qsa_lexicographic_topk.cuh"],
+        ),
+        "flashqla": (
+            "flash_qla_sm70_gdn_strided",
+            ["flash_qla/ops/gated_delta_rule/chunk/sm70/csrc/gdn_forward.cu"],
+            ["-O3"],
+            [],
+        ),
+    }
+    for component, (name, sources, flags, headers) in specifications.items():
+        destination = output / component
+        destination.mkdir(exist_ok=True)
+        print(f"Building {component} from {ROOT}", flush=True)
+        library = load(
+            name=name,
+            sources=[str(ROOT / s) for s in sources],
+            extra_cflags=["-O3", "-DNDEBUG"] if component == "hc" else ["-O3"],
+            extra_cuda_cflags=flags,
+            extra_include_paths=[str(ROOT / "csrc")] if component == "hc" else [],
+            extra_ldflags=["-lcuda"] if component == "hc" else [],
+            build_directory=str(destination),
+            is_python_module=component == "flashqla",
+            verbose=True,
+        )
+        path = Path(library.__file__ if component == "flashqla" else library)
+        manifest["libraries"][component] = {
+            "path": str(path),
+            "sha256": digest(path),
+            "sources": {s: digest(ROOT / s) for s in sources + headers},
+        }
+        (output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    destination = output / "flashv100"
+    subprocess.run(
+        [
+            sys.executable,
+            "setup.py",
+            "build_ext",
+            "--build-lib",
+            str(destination),
+            "--build-temp",
+            str(output / "flashv100_build"),
+            "-j1",
+        ],
+        cwd=ROOT / "flash-attention-v100",
+        check=True,
+    )
+    for component, pattern in (
+        ("flashv100", "flash_attn_v100_cuda*.so"),
+        ("paged_kv", "paged_kv_utils*.so"),
+    ):
+        libraries = list(destination.glob(pattern))
+        if len(libraries) != 1:
+            raise RuntimeError(f"Expected one {pattern} in {destination}")
+        path = libraries[0]
+        manifest["libraries"][component] = {"path": str(path), "sha256": digest(path)}
+    manifest["flashv100_sources"] = {
+        str(p.relative_to(ROOT)): digest(p)
+        for folder in ("kernel", "include")
+        for p in sorted((ROOT / "flash-attention-v100" / folder).rglob("*"))
+        if p.suffix in (".h", ".cuh", ".cu", ".cpp")
+    }
+    if manifest["production_fingerprint"] != production_fingerprint():
+        raise RuntimeError("Production sources changed during compilation")
+    manifest["complete"] = True
+    (output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    if not os.environ.get("CUDA_HOME"):
+        parser.error("Set CUDA_HOME to the compatible CUDA toolkit")
+    os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0"
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    os.environ.setdefault("MAX_JOBS", "2")
+    build(args.output_dir.expanduser().resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/sm70_qwen38_custom_ar_sidecar.cu
+++ b/benchmarks/kernels/sm70_qwen38_custom_ar_sidecar.cu
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+// The communicator lifecycle and every operation taking its opaque pointer
+// must belong to the same DSO. Compile the production implementation directly.
+#include "../../csrc/custom_all_reduce.cu"
+
+TORCH_LIBRARY(_C_custom_ar_flashnext, ops) {
+  ops.def("init_custom_ar", &init_custom_ar);
+  ops.def("all_reduce", &all_reduce);
+  ops.def("all_reduce_sum2", &all_reduce_sum2);
+  ops.def(
+      "sm70_qwen38_hc_down_allgather(int fa, Tensor inp, Tensor! out) -> ()",
+      &sm70_qwen38_hc_down_allgather);
+  ops.def(
+      "sm70_qwen38_hc_gate_mix(int fa, Tensor local_gate, Tensor branches, "
+      "Tensor! out) -> ()",
+      &sm70_qwen38_hc_gate_mix);
+  ops.def(
+      "sm70_qwen38_hc_output_allgather(int fa, Tensor local_block, "
+      "Tensor! out) -> ()",
+      &sm70_qwen38_hc_output_allgather);
+  ops.def(
+      "sm70_qwen38_hc_up_mix_allgather(int fa, Tensor lora, Tensor weight, "
+      "Tensor branches, Tensor! out) -> ()",
+      &sm70_qwen38_hc_up_mix_allgather);
+  ops.def("dispose", &dispose);
+  ops.def("meta_size", &meta_size);
+  ops.def("sm70_tp4_push_allreduce_buffer_size",
+          &sm70_tp4_push_allreduce_buffer_size);
+  ops.def("register_buffer", &register_buffer);
+  ops.def("register_sm70_tp4_push_allreduce_buffer",
+          &register_sm70_tp4_push_allreduce_buffer);
+  ops.def("get_graph_buffer_ipc_meta", &get_graph_buffer_ipc_meta);
+  ops.def("register_graph_buffers", &register_graph_buffers);
+  ops.def("allocate_shared_buffer_and_handle",
+          &allocate_shared_buffer_and_handle);
+  ops.def("open_mem_handle", &open_mem_handle);
+  ops.def("free_shared_buffer", &free_shared_buffer);
+}

--- a/benchmarks/kernels/sm70_qwen38_nvfp4_sidecar.cpp
+++ b/benchmarks/kernels/sm70_qwen38_nvfp4_sidecar.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/all.h>
+#include <torch/library.h>
+#define ENABLE_SM70_TURBOMIND
+#include "../../csrc/ops.h"
+
+// Match the admitted single-request sidecar surface. This does not register
+// experimental batch/QPN8 kernels or change the production implementation.
+TORCH_LIBRARY_FRAGMENT(_C_qwen38, ops) {
+  ops.def(
+      "nvfp4_moe_qpn_m1_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor weights, Tensor scales, Tensor expert_ids, "
+      "bool broadcast_input, int split_k) -> ()");
+  ops.impl("nvfp4_moe_qpn_m1_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_m1_sm70_out);
+  ops.def(
+      "nvfp4_moe_qpn_mtp5_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor weights, Tensor scales, Tensor expert_ids, "
+      "bool broadcast_input, int split_k) -> ()");
+  ops.impl("nvfp4_moe_qpn_mtp5_sm70_out", torch::kCUDA,
+           &nvfp4_moe_qpn_mtp5_sm70_out);
+  ops.def(
+      "nvfp4_qwen38_w2_direct_reduce_out(Tensor(a!) out, Tensor input, "
+      "Tensor weights, Tensor scales, Tensor expert_ids, "
+      "Tensor topk_weights) -> ()");
+  ops.impl("nvfp4_qwen38_w2_direct_reduce_out", torch::kCUDA,
+           &nvfp4_qwen38_w2_direct_reduce_out);
+  ops.def(
+      "nvfp4_qwen38_w13_fused_swiglu_out(Tensor(a!) out, Tensor input, "
+      "Tensor weights, Tensor scales, Tensor expert_ids) -> ()");
+  ops.impl("nvfp4_qwen38_w13_fused_swiglu_out", torch::kCUDA,
+           &nvfp4_qwen38_w13_fused_swiglu_out);
+  ops.def(
+      "qwen38_shared_gate_exact_out(Tensor(a!) out, Tensor input, "
+      "Tensor weight) -> ()");
+  ops.impl("qwen38_shared_gate_exact_out", torch::kCUDA,
+           &qwen38_shared_gate_exact_out);
+}

--- a/benchmarks/sm70_qwen38_baseline.py
+++ b/benchmarks/sm70_qwen38_baseline.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Explicit, opt-in reproduction contract for the quality-repaired M1 baseline."""
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXED_PROMPT = (
+    "This fixed benchmark prompt is used to create a deterministic tokenized "
+    "input for single-request decode measurement. "
+)
+LIBRARY_ENVS = {
+    "hc": "VLLM_SM70_CUSTOM_AR_LIBRARY",
+    "qpn": "VLLM_SM70_NVFP4_QPN_M1_LIBRARY",
+    "qsa": "VLLM_SM70_QSA_TOPK_LIBRARY",
+    "flashqla": "FLASH_QLA_SM70_PREBUILT_EXTENSION_PATH",
+}
+BASELINE_ENV = {
+    name: "1"
+    for name in (
+        "VLLM_DISABLE_COMPILE_CACHE",
+        "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE",
+        "VLLM_FLASH_V100_ROUTE_SUMMARY",
+        "VLLM_PLE_CPU_OFFLOAD",
+        "VLLM_PLE_DISK_OFFLOAD",
+        "VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP",
+        "VLLM_SM70_FLASH_ATTN_V100",
+        "VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH",
+        "VLLM_SM70_FLA_RECURRENT_SCHEDULE",
+        "VLLM_SM70_FUSED_SIGMOID_GATING_SCHED",
+        "VLLM_SM70_GDN_CHUNK_O_SCHEDULE",
+        "VLLM_SM70_GDN_DECODE_FLASHQLA",
+        "VLLM_SM70_GDN_DELTA_H_SCHEDULE",
+        "VLLM_SM70_GDN_KKT_SCHEDULE",
+        "VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE",
+        "VLLM_SM70_GREEDY_TOKEN_FASTPATH",
+        "VLLM_SM70_MOE_ADD_ALLREDUCE",
+        "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_INDEXED_PREFILL",
+        "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE",
+        "VLLM_SM70_NVFP4_TURBOMIND",
+        "VLLM_SM70_QSA_GROUPED_PAGE4",
+        "VLLM_SM70_QSA_INDEXER_CUBLAS",
+        "VLLM_SM70_QSA_XQA_PAGE4",
+        "VLLM_SM70_QWEN38_DUAL_COMPILE",
+        "VLLM_SM70_QWEN38_FP16_GEMV",
+        "VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16",
+        "VLLM_SM70_QWEN38_FUSED_HC_FP16",
+        "VLLM_SM70_QWEN38_HYBRID_PLE",
+        "VLLM_SM70_QWEN38_ROUTER_TOPK",
+        "VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION",
+        "VLLM_SM70_TP4_PUSH_ALLREDUCE",
+        "VLLM_SM70_TP4_PUSH_ALLREDUCE_SUM2_M1",
+        "VLLM_USE_AOT_COMPILE",
+        "VLLM_USE_V2_MODEL_RUNNER",
+    )
+}
+BASELINE_ENV.update(
+    {
+        name: "0"
+        for name in (
+            "VLLM_PLE_DISK_OFFLOAD_PROFILE",
+            "VLLM_SM70_FP8_QPN8",
+            "VLLM_SM70_GDN_QPN8_BA_SPLIT",
+            "VLLM_SM70_GDN_RMSNORM_ONEPASS",
+            "VLLM_SM70_LM_HEAD_TOP1",
+            "VLLM_SM70_MTP_PROFILE",
+            "VLLM_SM70_NVFP4_QPN2",
+            "VLLM_SM70_NVFP4_QPN2_PREFILL",
+            "VLLM_SM70_PROFILE_TRACE",
+            "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8",
+            "VLLM_SM70_QWEN_GDN_INPUT_PROJECTION_OP",
+            "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE",
+        )
+    }
+)
+BASELINE_ENV.update(
+    {
+        "VLLM_ENGINE_READY_TIMEOUT_S": "1200",
+        "VLLM_LOGGING_LEVEL": "INFO",
+        "VLLM_MQ_BROADCASTER_MAX_CHUNKS": "64",
+        "VLLM_PLE_DISK_OFFLOAD_NUM_THREADS": "32",
+        "VLLM_PLE_OFFLOAD_READY_TIMEOUT": "600",
+        "VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS": "128",
+        "VLLM_SM70_QSA_INDEXER_CUBLAS_MIN_ROWS": "512",
+        "VLLM_SM70_QSA_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS": "1048576",
+        "VLLM_SM70_QSA_XQA_PAGE4_MIN_ROWS": "4096",
+        "VLLM_SM70_QUANT_BACKEND": "turbomind",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+    }
+)
+
+
+def digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def production_fingerprint() -> str:
+    """Cover tracked Python and transitive local CUDA headers, including edits."""
+    paths = (
+        subprocess.check_output(
+            [
+                "git",
+                "ls-files",
+                "-z",
+                "--",
+                "vllm",
+                "csrc",
+                "flash_qla",
+                "flash-attention-v100",
+            ],
+            cwd=ROOT,
+        )
+        .decode()
+        .split("\0")
+    )
+    fingerprint = hashlib.sha256()
+    for name in sorted(filter(None, paths)):
+        path = ROOT / name
+        if not path.is_file():
+            raise ValueError(f"Missing tracked production source: {name}")
+        fingerprint.update(name.encode() + b"\0" + digest(path).encode() + b"\0")
+    return fingerprint.hexdigest()
+
+
+def validate_bundle(bundle: Path) -> dict:
+    bundle = bundle.resolve()
+    manifest = json.loads((bundle / "manifest.json").read_text())
+    expected = {*LIBRARY_ENVS, "flashv100", "paged_kv"}
+    if not manifest.get("complete") or set(manifest["libraries"]) != expected:
+        raise ValueError("Runtime bundle is incomplete")
+    sources = dict(manifest["flashv100_sources"])
+    for entry in manifest["libraries"].values():
+        path = Path(entry["path"]).resolve()
+        if not path.is_relative_to(bundle) or digest(path) != entry["sha256"]:
+            raise ValueError(f"Runtime binary is outside the bundle or changed: {path}")
+        sources.update(entry.get("sources", {}))
+    for name, expected_hash in sources.items():
+        path = (ROOT / name).resolve()
+        if not path.is_relative_to(ROOT) or digest(path) != expected_hash:
+            raise ValueError(f"Source changed since the runtime build: {name}")
+    if manifest.get("production_fingerprint") != production_fingerprint():
+        raise ValueError("Production source tree changed since the runtime build")
+    return manifest
+
+
+def configure_environment(bundle: Path, cache: Path, native_dir: Path | None) -> dict:
+    manifest = validate_bundle(bundle)
+    # Do not inherit another experiment's optional VLLM route switches.
+    for name in list(os.environ):
+        if name.startswith("VLLM_"):
+            del os.environ[name]
+    os.environ.update(BASELINE_ENV)
+    for component, name in LIBRARY_ENVS.items():
+        os.environ[name] = manifest["libraries"][component]["path"]
+    if native_dir is not None:
+        native_dir = native_dir.resolve()
+        if not (native_dir / "_C.abi3.so").is_file():
+            raise ValueError(f"Missing native vLLM extension: {native_dir}")
+        os.environ["ONECAT_VLLM_EXTENSION_DIR"] = str(native_dir)
+    else:
+        os.environ.pop("ONECAT_VLLM_EXTENSION_DIR", None)
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        map(
+            str,
+            (
+                ROOT / "benchmarks/sm70_source_overlay",
+                ROOT,
+                Path(manifest["libraries"]["flashv100"]["path"]).parent,
+                ROOT / "flash-attention-v100",
+            ),
+        )
+    )
+    for name, suffix in (
+        ("TORCHINDUCTOR_CACHE_DIR", "inductor"),
+        ("TRITON_CACHE_DIR", "triton"),
+        ("TORCH_EXTENSIONS_DIR", "extensions"),
+        ("VLLM_CACHE_ROOT", "vllm"),
+        ("XDG_CACHE_HOME", "xdg"),
+    ):
+        os.environ[name] = str(cache.resolve() / suffix)
+    os.environ.update(
+        {
+            "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+            "CUDA_MODULE_LOADING": "LAZY",
+            "TORCH_CUDA_ARCH_LIST": "7.0",
+            "TORCHINDUCTOR_COMPILE_THREADS": "1",
+            "TRITON_CACHE_AUTOTUNING": "1",
+            "OMP_NUM_THREADS": "1",
+            "MALLOC_ARENA_MAX": "2",
+            "TOKENIZERS_PARALLELISM": "false",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+    )
+    return manifest
+
+
+def engine_args(model: str) -> dict:
+    return {
+        "model": model,
+        "tensor_parallel_size": 4,
+        "dtype": "half",
+        "quantization": "modelopt",
+        "kv_cache_dtype": "float16",
+        "max_model_len": 262144,
+        "max_num_batched_tokens": 8192,
+        "max_num_seqs": 1,
+        "gpu_memory_utilization": 0.90,
+        "seed": 0,
+        "attention_backend": "FLASH_ATTN_V100",
+        "language_model_only": True,
+        "enable_prefix_caching": False,
+        "enable_chunked_prefill": True,
+        "disable_log_stats": False,
+        "distributed_executor_backend": "mp",
+        "mamba_cache_mode": "align",
+        "mamba_cache_dtype": "float16",
+        "mamba_ssm_cache_dtype": "auto",
+        "kernel_config": {
+            "ir_op_priority": {
+                "rms_norm": ["vllm_c", "native"],
+                "fused_add_rms_norm": ["vllm_c", "native"],
+            }
+        },
+        "compilation_config": {
+            "mode": "VLLM_COMPILE",
+            "cudagraph_mode": "PIECEWISE",
+            "use_inductor_graph_partition": False,
+            "inductor_compile_config": {
+                "combo_kernels": True,
+                "benchmark_combo_kernel": True,
+            },
+            "pass_config": {
+                "fuse_norm_quant": True,
+                "fuse_act_quant": True,
+                "fuse_attn_quant": False,
+                "fuse_allreduce_rms": False,
+                "enable_sp": False,
+                "fuse_gemm_comms": False,
+                "fuse_rope_kvcache_cat_mla": False,
+                "fuse_act_padding": False,
+            },
+        },
+        "worker_extension_cls": "benchmarks.sm70_qwen38_baseline_worker.BaselineWorker",
+    }

--- a/benchmarks/sm70_qwen38_baseline_worker.py
+++ b/benchmarks/sm70_qwen38_baseline_worker.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Read-only runtime provenance for the single-request reproduction driver."""
+
+import os
+import sys
+from pathlib import Path
+
+from benchmarks.sm70_qwen38_baseline import LIBRARY_ENVS, ROOT, digest
+
+
+class BaselineWorker:
+    def baseline_manifest(self):
+        import torch
+        from flash_attn_v100 import flash_attn_interface
+
+        import vllm
+
+        paths = {key: os.environ[name] for key, name in LIBRARY_ENVS.items()}
+        paths["flashv100"] = flash_attn_interface.flash_attn_v100_cuda.__file__
+        mapped = Path("/proc/self/maps").read_text()
+        binaries = {
+            key: {
+                "path": str(Path(path).resolve()),
+                "sha256": digest(Path(path)),
+                "mapped": str(Path(path).resolve()) in mapped,
+            }
+            for key, path in paths.items()
+        }
+        native = {
+            name: {"path": module.__file__, "sha256": digest(Path(module.__file__))}
+            for name, module in list(sys.modules.items())
+            if name.startswith("vllm.")
+            and str(getattr(module, "__file__", "")).endswith(".so")
+        }
+        cfg = self.vllm_config
+        return {
+            "rank": int(self.rank),
+            "pid": os.getpid(),
+            "torch": str(torch.__version__),
+            "cuda_runtime": str(torch.version.cuda),
+            "source_root": str(ROOT),
+            "vllm_file": vllm.__file__,
+            "ssm_dtype": str(cfg.cache_config.mamba_ssm_cache_dtype),
+            "kv_dtype": str(cfg.cache_config.cache_dtype),
+            "prefix_cache": bool(cfg.cache_config.enable_prefix_caching),
+            "mtp": cfg.speculative_config is not None,
+            "max_model_len": int(cfg.model_config.max_model_len),
+            "graph_mode": str(cfg.compilation_config.cudagraph_mode),
+            "mamba_cache_mode": str(cfg.cache_config.mamba_cache_mode),
+            "binaries": binaries,
+            "native_dependencies": native,
+            "qsa_specialization_version": (
+                torch.ops._C_qsa_sm70.decode_specialization_version()
+            ),
+        }

--- a/benchmarks/sm70_source_overlay/sitecustomize.py
+++ b/benchmarks/sm70_source_overlay/sitecustomize.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Optional native-wheel attachment for the explicit benchmark overlay mode.
+
+Activated only when this directory is explicitly added to PYTHONPATH. It does
+not change kernels, dispatch, precision, or an installed environment.
+"""
+
+import os
+from pathlib import Path
+
+if directory := os.environ.get("ONECAT_VLLM_EXTENSION_DIR"):
+    import vllm
+
+    extension_dir = Path(directory).expanduser().resolve()
+    if not (extension_dir / "_C.abi3.so").is_file():
+        raise RuntimeError(f"Missing native SM70 extension in {extension_dir}")
+    if str(extension_dir) not in vllm.__path__:
+        vllm.__path__.append(str(extension_dir))

--- a/docs/design/sm70_qwen38_reproducible_baseline.md
+++ b/docs/design/sm70_qwen38_reproducible_baseline.md
@@ -1,0 +1,128 @@
+# Reproduce the Qwen3.8 NVFP4 single-request baseline from source
+
+This is the quality-repaired **no-MTP** lane, not the experimental FlashInfer,
+E4M3-KV, batched, or projection/W13 candidates. The production kernels were
+integrated by [PR #525](https://github.com/1CatAI/1Cat-vLLM/pull/525), including
+the HC and QSA/router commits from #506/#507. A stacked PR remaining open is
+not proof that its commits are absent from `main`.
+
+## What this entry point fixes
+
+Previous local launchers selected HC, NVFP4 W13/W2, QSA top-k, FlashQLA and
+Flash-V100 binaries from old experiment directories. Source being merged did
+not by itself make those launchers reproducible from a clean checkout.
+
+The new builder compiles the production sources in the selected checkout and
+records source/binary hashes. Public sidecar bindings replace the formerly
+local HC/NVFP4 wrappers; they do not copy or modify kernel algorithms. The HC
+communicator lifecycle and every operation using its opaque pointer stay in
+the same DSO. The benchmark rejects changed sources, changed libraries, or a
+library pointing outside its runtime bundle, and verifies worker mappings.
+
+This is a **source-overlay** reproduction route. A compatible native SM70
+vLLM installation is still required for the remaining standard operators;
+this command is not a full wheel rebuild. The worker report records those
+native dependency paths and hashes instead of concealing that dependency.
+An ordinary editable/source build with native extensions in `vllm/` can omit
+`--native-extension-dir`. The optional public bootstrap only attaches the
+specified native extension directory; it does not patch model execution.
+
+## Fixed contract
+
+| Item | Value |
+|---|---|
+| Model | RadixArk/Qwen3.8-Flash-Next-NVFP4 |
+| Hardware | Four peer-connected V100-SXM2-32GB; TP4/PP1, one request |
+| Precision | FP16 activations/KV, checkpoint NVFP4 experts via TurboMind W4A16 |
+| Recurrent state | `mamba_ssm_cache_dtype=auto`, resolves to native FP32 |
+| Runner | V2, dynamic prefill and full static decode CUDA Graph |
+| Context/chunk | 262144 total tokens; prefill chunk8192 |
+| PLE | Disk mmap prefill, rank-local pinned-UVA decode |
+| MTP/prefix cache | Both off |
+| Short speed workload | Fixed8192-token prompt,513 generated tokens,512 decode intervals |
+| Sampling | Greedy/ignore-EOS for timing only; official sampling/natural EOS for health |
+| Excluded routes | Online QPN8, approximate LM-head, experimental batch sidecars |
+
+The validated environment uses Torch2.10.0+cu128, CUDA compiler12.0.140,
+Triton3.6 and NVIDIA driver580.173.02. The compiler/runtime minor versions are
+different in this recorded environment; no toolkit or dependency upgrade is
+implied by the reproduction recipe. Preserve this environment when comparing
+against the recorded baseline. Compiler flags retain the existing production
+build recipe; this change introduces no lower-precision kernel route.
+
+## Build and run
+
+Run from the source checkout, with the project Python environment. Replace
+the example paths. The build needs no GPUs and does not install into or change
+the shared Python environment.
+
+```bash
+CUDA_HOME=/usr TORCH_CUDA_ARCH_LIST=7.0 MAX_JOBS=2 \
+  .venv/bin/python benchmarks/kernels/build_sm70_qwen38_runtime.py \
+  --output-dir /path/to/task/runtime
+```
+
+Reserve four idle GPUs before running; do not preempt other jobs. The tested
+hybrid PLE setup needs at least90GiB of available host RAM at admission. This
+is not the model's total host-memory footprint. Keep the output/cache directory
+private to this run.
+
+```bash
+CUDA_HOME=/usr CUDA_VISIBLE_DEVICES=0,1,2,3 \
+  .venv/bin/python benchmarks/benchmark_sm70_qwen38_baseline.py \
+  --model /path/to/Qwen3.8-Flash-Next-NVFP4 \
+  --runtime-dir /path/to/task/runtime \
+  --native-extension-dir /path/to/compatible/site-packages/vllm \
+  --output /path/to/task/results/result.json \
+  --repeats 3 --long-context
+```
+
+Without `--long-context`, only the short health and8192-token baseline run.
+With it, the same instance also measures261631+513, checks retrieval of a
+middle-position record with natural EOS, and exercises262143+1 at the exact
+context boundary. This is a focused regression, not broad quality certification.
+All workers shut down in `finally`; no API is kept resident. A caller may apply
+an outer timeout, for example `timeout --kill-after=35s 1800s ...`.
+
+`--reference-json /path/to/previous/result.json` accepts the retained length
+sweep's `cases[].runs[]` format and requires identical complete output tokens
+for every requested fixed-prompt case (missing cases are rejected). The warmup
+and timed repeats must also agree.
+The driver does not change sampling to conceal early EOS or numerical drift.
+
+## Accepted historical evidence and fresh-build acceptance
+
+The unprofiled `main` source95205a2d9952 sweep used physical GPUs4-7 with the
+fixed contract above. Two warmed repeats per case measured:
+
+| Input | Prefill tok/s | Decode tok/s | TPOT ms |
+|---:|---:|---:|---:|
+|8192|6936.60|97.826|10.222|
+|65536|6245.95|90.729|11.022|
+|131072|5830.36|83.814|11.931|
+|261631|5137.10|73.977|13.518|
+
+These are the previous frozen-library results, **not yet fresh-builder results**.
+The source-only reproduction review must attach fresh build manifests, worker
+route evidence, natural quality results, repeatability/reference comparisons,
+and unprofiled timings before claiming the new entry point reproduces them.
+Do not substitute an Nsight graph interval for endpoint TPOT, or call a
+configured256K maximum a tested256K input.
+
+The follow-up length trace attributed98.989% of the increase in graph kernel
+service to QSA Top-K and compressed-key scoring. It did not implement a new
+long-context optimization. The current Top-K still has its single-CTA long-row
+fallback; these reproduction changes do not claim reduced context decay.
+
+## Focused checks
+
+Pure configuration/provenance tests do not require the GPU test conftest:
+
+```bash
+CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q \
+  --confcutdir=tests/benchmarks tests/benchmarks/test_sm70_qwen38_baseline.py
+```
+
+Use the freshly built runtime paths when running existing HC raw-bit,
+QSA/router, and page4 relocation tests. Keep numerical admission separate from
+speed: a startup or nonempty response is not an output-quality gate.

--- a/docs/design/sm70_qwen38_reproducible_baseline.md
+++ b/docs/design/sm70_qwen38_reproducible_baseline.md
@@ -6,6 +6,22 @@ integrated by [PR #525](https://github.com/1CatAI/1Cat-vLLM/pull/525), including
 the HC and QSA/router commits from #506/#507. A stacked PR remaining open is
 not proof that its commits are absent from `main`.
 
+The integration audit found these accepted components already in the base
+`95205a2d9952813aa7469f63ff65b8f2813c027a`; this PR adds their reproducible
+build/launch packaging, not a second copy of the optimizations:
+
+| Component | Main-source implementation |
+|---|---|
+| HC projection/mix and TP4 communication | `vllm/models/qwen4_exp/nvidia/sm70_fp16_hc.py`, `csrc/custom_all_reduce.cu` |
+| NVFP4 M1 experts, fused W13 and direct W2 reduction | `csrc/sm70_turbomind/ops/mxfp4_qpn_m1_sm70.cu`, `vllm/_sm70_ops.py` |
+| Exact QSA top-k and router | `csrc/qsa_lexicographic_topk.cuh`, `vllm/models/qwen4_exp/nvidia/ops/qsa.py`, `vllm/model_executor/layers/fused_moe/fused_topk_router.py` |
+| Flash-V100 logical-page-order quality repair | `flash-attention-v100/kernel/fused_mha_forward_paged.cu` and its public planner regression |
+| GDN and fused FP16 projections | `flash_qla/`, `vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py` |
+| Hybrid PLE and unified prefill/decode configuration | `vllm/v1/ple_offload/`, `vllm/config/vllm.py` |
+
+PR #507 was closed as already incorporated through #525. Open #510 and the
+FlashInfer/E4M3 experiments are not part of this accepted single-request lane.
+
 ## What this entry point fixes
 
 Previous local launchers selected HC, NVFP4 W13/W2, QSA top-k, FlashQLA and
@@ -102,10 +118,9 @@ fixed contract above. Two warmed repeats per case measured:
 |131072|5830.36|83.814|11.931|
 |261631|5137.10|73.977|13.518|
 
-These are the previous frozen-library results, **not yet fresh-builder results**.
-The source-only reproduction review must attach fresh build manifests, worker
-route evidence, natural quality results, repeatability/reference comparisons,
-and unprofiled timings before claiming the new entry point reproduces them.
+These are the previous frozen-library results, not measurements of the new
+builder. The fresh short-context reproduction follows below; keep the two
+sets of evidence distinct.
 Do not substitute an Nsight graph interval for endpoint TPOT, or call a
 configured256K maximum a tested256K input.
 
@@ -113,6 +128,54 @@ The follow-up length trace attributed98.989% of the increase in graph kernel
 service to QSA Top-K and compressed-key scoring. It did not implement a new
 long-context optimization. The current Top-K still has its single-CTA long-row
 fallback; these reproduction changes do not claim reduced context decay.
+
+### Fresh-source baseline, 2026-09-06
+
+Source `b2042fb24b78bba131ec9aa0b1a05cdf3f54df60`, physical GPUs4-7, with all
+six overlay libraries rebuilt by the public script and independent compilation
+caches. This is one model initialization, with two warmed timing repeats:
+
+8192-token input:
+
+| Measurement | Run1 | Run2 | Mean |
+|---|---:|---:|---:|
+| Decode tok/s |97.71679|97.73243|**97.72461**|
+| TPOT ms |10.23366|10.23202|**10.23284**|
+| Prefill tok/s |6890.26|7010.06|**6950.16**|
+
+The complete513-token outputs of both repeats and their warmup match the
+accepted frozen-library sweep exactly, not just the first token or a text
+prefix. The arithmetic and record-copy checks both stop naturally and pass.
+All four workers verify this checkout, native FP32 SSM, FP16 KV, no MTP/prefix
+cache, `FULL_AND_PIECEWISE`, QSA specialization version1, and the five loaded
+optimized DSO hashes. The sixth built library is the paged-KV utility.
+
+The same instance's261631+513 case measures **73.98534 decode tok/s**, **5169.99
+prefill tok/s**, and **13.51619ms TPOT** (two warmed repeats). Both complete
+513-token outputs and the warmup match the corresponding frozen-sweep output
+exactly. This reproduces the existing length-dependent baseline; it is not a
+new long-context speed optimization.
+
+Model-free checks of these new builds also pass: HC256 graph replays with zero
+bit mismatches on every rank; router1280 bitwise rows; QSA72 exact cases and
+128 changing-length graph replays/1536 row comparisons. Eleven CPU helper tests
+and the scoped pre-commit suite pass. Long-context completion, detailed runtime
+manifests and the final integration audit are recorded in
+[PR #532](https://github.com/1CatAI/1Cat-vLLM/pull/532).
+
+The compatible native-base dependency hashes observed on every worker are:
+
+| Native library | SHA256 |
+|---|---|
+| `_C.abi3.so` | `c35b76ca723ec1a6907e31b2f0fe4f96c2e1b212603e04b976f9a48b85d0916a` |
+| `_C_stable_libtorch.abi3.so` | `8c866c3612bbbe2323ff4cc912f5fe3924d6f0517ee675f3f40230c151854890` |
+| `_moe_C.abi3.so` | `80d92f26cbed180bf538ce3254534f32581d89741953ee6ee45e4e9e63ece85e` |
+
+This reproduces approximately98 decode/7K prefill tok/s under the stated
+contract; it is not a100 tok/s claim or a universal speed/quality guarantee.
+The bounded output agreement does not close the broader GDN/W13
+actual-input numerical-reference work described in the
+[quality repair report](sm70_qwen38_nvfp4_quality_repair.md).
 
 ## Focused checks
 

--- a/tests/benchmarks/test_sm70_qwen38_baseline.py
+++ b/tests/benchmarks/test_sm70_qwen38_baseline.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks import sm70_qwen38_baseline as baseline
+
+
+@pytest.fixture
+def bundle(tmp_path, monkeypatch):
+    root = tmp_path / "source"
+    root.mkdir()
+    source = root / "kernel.cu"
+    source.write_text("source fixture")
+    monkeypatch.setattr(baseline, "ROOT", root)
+    monkeypatch.setattr(baseline, "production_fingerprint", lambda: "test-source-tree")
+    output = tmp_path / "bundle"
+    output.mkdir()
+    libraries = {}
+    for name in (*baseline.LIBRARY_ENVS, "flashv100", "paged_kv"):
+        path = output / f"{name}.so"
+        path.write_bytes(name.encode())
+        libraries[name] = {
+            "path": str(path),
+            "sha256": baseline.digest(path),
+            "sources": {"kernel.cu": baseline.digest(source)},
+        }
+    manifest = {
+        "complete": True,
+        "libraries": libraries,
+        "flashv100_sources": {},
+        "production_fingerprint": "test-source-tree",
+    }
+    (output / "manifest.json").write_text(json.dumps(manifest))
+    return output, root, manifest
+
+
+def test_native_state_contract():
+    args = baseline.engine_args("model")
+    assert args["mamba_ssm_cache_dtype"] == "auto"
+    assert args["dtype"] == "half" and args["kv_cache_dtype"] == "float16"
+    assert args["tensor_parallel_size"] == 4 and args["max_num_seqs"] == 1
+    assert args["max_model_len"] == 262144 and args["max_num_batched_tokens"] == 8192
+    assert args["enable_prefix_caching"] is False
+    assert args["disable_log_stats"] is False
+    assert "speculative_config" not in args
+    assert baseline.BASELINE_ENV["VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE"] == "0"
+    assert baseline.BASELINE_ENV["VLLM_SM70_QWEN4_EXP_ONLINE_QPN8"] == "0"
+    assert baseline.BASELINE_ENV["VLLM_SM70_LM_HEAD_TOP1"] == "0"
+
+
+def test_bundle_validation(bundle):
+    output, _, expected = bundle
+    assert baseline.validate_bundle(output) == expected
+
+
+def test_reject_modified_binary(bundle):
+    output, _, _ = bundle
+    (output / "hc.so").write_bytes(b"changed")
+    with pytest.raises(ValueError, match="binary"):
+        baseline.validate_bundle(output)
+
+
+def test_reject_modified_source(bundle):
+    output, root, _ = bundle
+    (root / "kernel.cu").write_text("changed")
+    with pytest.raises(ValueError, match="Source changed"):
+        baseline.validate_bundle(output)
+
+
+def test_reject_modified_production_tree(bundle, monkeypatch):
+    output, _, _ = bundle
+    monkeypatch.setattr(baseline, "production_fingerprint", lambda: "changed-tree")
+    with pytest.raises(ValueError, match="Production source tree"):
+        baseline.validate_bundle(output)
+
+
+def test_reject_incomplete_bundle(bundle):
+    output, _, manifest = bundle
+    manifest["complete"] = False
+    (output / "manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="incomplete"):
+        baseline.validate_bundle(output)
+
+
+def test_reject_old_artifact_pointer(bundle, tmp_path):
+    output, _, manifest = bundle
+    old = tmp_path / "old.so"
+    old.write_bytes(b"hc")
+    manifest["libraries"]["hc"]["path"] = str(old)
+    (output / "manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="outside"):
+        baseline.validate_bundle(output)
+
+
+def test_environment_is_explicit(bundle, tmp_path, monkeypatch):
+    output, root, _ = bundle
+    original = dict(os.environ)
+    # configure_environment changes only this benchmark process, not user shell
+    # state. Restore the complete mapping at the end of this unit test.
+    monkeypatch.setattr(os, "environ", dict(original))
+    os.environ["VLLM_UNRELATED_EXPERIMENT"] = "1"
+    os.environ["VLLM_SM70_QWEN4_EXP_ONLINE_QPN8"] = "1"
+    os.environ["CUDA_VISIBLE_DEVICES"] = "4,5,6,7"
+    baseline.configure_environment(output, tmp_path / "cache", None)
+    assert "VLLM_UNRELATED_EXPERIMENT" not in os.environ
+    assert os.environ["VLLM_SM70_QWEN4_EXP_ONLINE_QPN8"] == "0"
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "4,5,6,7"
+    assert str(root) in os.environ["PYTHONPATH"]
+    for component, name in baseline.LIBRARY_ENVS.items():
+        assert os.environ[name] == str(output / f"{component}.so")
+
+
+@pytest.mark.parametrize("failure", [None, "health", "reference"])
+def test_driver_records_failure_and_releases_workers(
+    bundle, tmp_path, monkeypatch, failure
+):
+    from benchmarks import benchmark_sm70_qwen38_baseline as driver
+
+    monkeypatch.setattr(driver, "ROOT", Path(__file__).resolve().parents[2])
+    output, _, manifest = bundle
+    shutdown = []
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            self.llm_engine = SimpleNamespace(
+                engine_core=SimpleNamespace(shutdown=lambda **kw: shutdown.append(kw))
+            )
+
+        def collective_rpc(self, *args, **kwargs):
+            return [
+                {
+                    "rank": rank,
+                    "ssm_dtype": "float32",
+                    "mtp": False,
+                    "prefix_cache": False,
+                    "max_model_len": 262144,
+                    "graph_mode": "FULL_DECODE_ONLY",
+                    "qsa_specialization_version": 1,
+                    "native_dependencies": {"vllm._C": {}},
+                    "vllm_file": str(driver.ROOT / "vllm/__init__.py"),
+                    "binaries": {
+                        key: {"mapped": True, "sha256": entry["sha256"]}
+                        for key, entry in manifest["libraries"].items()
+                        if key != "paged_kv"
+                    },
+                }
+                for rank in range(4)
+            ]
+
+    def fake_run(llm, prompt, sampling):
+        return {
+            "finish_reason": "length" if failure == "health" else "stop",
+            "text": "RESULT=437 CEDAR-47|8261",
+            "output_tokens": 513,
+            "token_ids": [1] * 513,
+            "request_metrics": {"prefill_time": 1.0, "raw": {"is_corrupted": False}},
+        }
+
+    tokenizer = SimpleNamespace(
+        encode=lambda *a, **kw: [7, 8],
+        apply_chat_template=lambda *a, **kw: [9],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoTokenizer=SimpleNamespace(from_pretrained=lambda *a, **kw: tokenizer)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm",
+        SimpleNamespace(LLM=FakeLLM, SamplingParams=SimpleNamespace),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "benchmarks.benchmark_sm70_decode",
+        SimpleNamespace(
+            _hash_ids=lambda ids: "hash",
+            _run_once=fake_run,
+            _summarize=lambda runs: {"count": len(runs)},
+        ),
+    )
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "generation_config.json").write_text(
+        json.dumps({"temperature": 1.0, "top_p": 0.95, "top_k": 20})
+    )
+    reference = tmp_path / "reference.json"
+    reference.write_text(
+        json.dumps(
+            {
+                "cases": [
+                    {
+                        "name": "fixed_8192",
+                        "runs": [
+                            {"token_ids": [2 if failure == "reference" else 1] * 513}
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    args = SimpleNamespace(
+        model=str(model),
+        runtime_dir=output,
+        long_context=False,
+        repeats=2,
+        reference_json=reference,
+        output=tmp_path / "result.json",
+    )
+    if failure:
+        with pytest.raises(RuntimeError, match="health failed|differs from frozen"):
+            driver.run(args)
+    else:
+        driver.run(args)
+    result = json.loads(args.output.read_text())
+    assert result["complete"] is (failure is None)
+    assert ("error" in result) is (failure is not None)
+    assert shutdown == [{"timeout": 30.0}]


### PR DESCRIPTION
## Purpose

Deliver the accepted quality-repaired Qwen3.8 NVFP4 single-request TP4 baseline as a reproducible current-source build and bounded benchmark. User-requested integration audit, not a new performance/precision experiment.

Base: `95205a2d9952813aa7469f63ff65b8f2813c027a` (main, #525). Core HC #506 and QSA/router #507 commits are already ancestors of main. Existing open #507 targets the old HC feature branch; re-merging it is unnecessary. #510 and FlashInfer/E4M3 drafts are not accepted baseline dependencies and are intentionally excluded.

This is not duplicate work: the prior kernel PRs contain the production implementations, but the validated launch depended on untracked HC/NVFP4 wrapper DSOs and a local import bootstrap. This PR publishes those build bindings, a source/binary manifest, the explicit baseline contract, and the actual quality/speed reproduction entry point.

## Implementation / numerical scope

- Build HC, NVFP4 W13/W2, QSA, FlashQLA and repaired Flash-V100 from this checkout. No production kernel algorithm changed.
- Keep opaque HC communicator creation and operations in one DSO.
- Verify source hashes, complete tracked production-tree fingerprint, runtime library hashes and worker mappings.
- Publish an opt-in source-overlay bootstrap; **this is not a full native wheel rebuild**. Compatible standard SM70 native extensions remain explicit, fingerprinted dependencies.
- Preserve native FP32 SSM, FP16 activations/KV, checkpoint NVFP4; TP4/PP1, V2, dual prefill/full-decode graph, 262144 context, chunk8192, maxseq1, disk-mmap prefill/pinned-UVA decode, no MTP or prefix cache. Do not enable online QPN8, approximate LM-head or experimental batch sidecars.

## Test plan / current results

- CPU-only source build: all six libraries compiled with Torch2.10.0+cu128, nvcc12.0.140, SM70. No shared environment install.
- `CUDA_VISIBLE_DEVICES= <project-python> -m pytest -q --confcutdir=tests/benchmarks tests/benchmarks/test_sm70_qwen38_baseline.py`: **11 passed**. Includes tampered/incomplete bundle rejection, exact precision contract, successful and failed driver cleanup.
- `pre-commit run` on scoped staged files: **passed**. An initial standard `re` import was corrected to the repository's required `regex`.
- Environment and engine arguments compared with accepted sweep: exact match except read-only worker manifest class; fixed8192 prompt SHA matches `220ffafa68b25b7d632b762d17beb292f8ada1351ae5105954b490749015e997`.
- Fresh operator acceptance passed: HC raw-bit256 graph replays/16 patterns/eight alignments, zero mismatches on every TP rank; router1280 bitwise rows; QSA72 exact cases, dynamic128 graph replays/1536 row comparisons. Built from this checkout, not frozen DSOs.
- **One full-length model initialization**, native FP32 SSM confirmed in all four workers, freshly built overlays mapped and hashed. Two warmed fixed8192 and261631+513 repeats each; all complete513-token outputs and warmups match the corresponding prior native-state sweep exactly. Natural arithmetic, record copy and middle-context retrieval pass (88/110/172 output tokens, natural EOS). The262143+1 boundary passes (50.97670s prefill). All workers exited and released GPUs.

## Fresh unprofiled end-to-end result

Initial tested source `b2042fb24b78bba131ec9aa0b1a05cdf3f54df60`. Physical V100 GPUs4-7, same group as the comparison sweep. TP4/maxseq1, max262144, no MTP/prefix cache, native FP32 SSM/FP16 KV, hybrid PLE and dual graph unchanged. Greedy513-output timing is separated from official-sampling/natural-EOS health checks. Main subsequently advanced; see the separate integration gate below rather than treating the initial numbers as a newer-source measurement.

| Input | Previous decode tok/s | Fresh decode tok/s | Previous prefill tok/s | Fresh prefill tok/s | Fresh TPOT ms |
|---:|---:|---:|---:|---:|---:|
|8192|97.826|97.72461|6936.60|6950.16|10.23284|
|261631|73.977|73.98534|5137.10|5169.99|13.51619|

Two warmed repeats per row. Both new complete output sequences match their old reference and warmup exactly. No approximate/lower-precision path was introduced to recover speed. This reproduces the accepted approximately98tok/s short baseline; it does not claim100tok/s or reduced long-context decay. Fixed repetitive-prompt prefill is not a universal conversational/dataset speed.

Production-tree fingerprint: `110d349cd3be7f30b1cee724567b391598295f5740ab93ef15c0f44fc227aaed`.
All four workers report `FULL_AND_PIECEWISE`, QSA specialization1, matching current-checkout imports, freshly built/mapped HC/QPN/QSA/FlashQLA/FlashV100 libraries and identical compatible native-base hashes (documented publicly).

This bounded source-reproduction gate does not certify arbitrary inputs or close the broader GDN/W13 actual-input numerical-reference audit. No independent human review or complete from-scratch native wheel rebuild is claimed.

## Latest-main integration gate

During the first acceptance, main advanced to `a193c285d4` through #517. We merged it normally into this owned branch: `b6cb3f10896b850de6b3c6655b7e53a1316f1cae`. No manual conflict resolution or runtime patch. The PR diff versus current main is still only the nine public reproduction files.

The incoming changes touch shared sampling and NVFP4 alignment as well as DFlash2-only/gated code. Therefore the initial model result is not relabeled as latest-main evidence. The builder was rerun incrementally; HC/QPN/QSA/FlashQLA/paged utility binaries stayed identical, FlashV100 rebuilt from the updated source. New production fingerprint: `ca473d5f1dbd628597ea4e48c038c63b01415744dbad602958efbb3464f45175`.

The14 focused shared top-k/top-p tie/capture tests pass on V100 in16.11s. A second, short-only model instance **passed** on actual source `b6cb3f10896b850de6b3c6655b7e53a1316f1cae`:

| Latest-main8K metric | Run1 | Run2 | Mean |
|---|---:|---:|---:|
| Pure decode tok/s |97.64778|97.72422|**97.68600**|
| Prefill time s |1.19615|1.17787|1.18701|
| Prefill tok/s |6848.64|6954.92|**6901.78**|
| TPOT ms |10.24089|10.23288|**10.23688**|

Both complete513-token outputs and warmup match the original native-state reference exactly. Natural arithmetic/copy pass; all four worker manifests retain native FP32 SSM/FP16 KV/full-decode graph/new-library mappings. Result `complete=true`; workers and PLE exited and all four test GPUs returned to7MiB. No resident API.

No duplicate full256K/HC/QSA campaign; no DFlash2/FP32-logits/E4M3 route is enabled in our contract. The near256K result remains attributed to initial b2042, not misrepresented as a repeated b6 measurement. Final b6 CI is green (pre-commit4m49s, pre-run-check passed). The latest-main runtime has therefore reproduced the approximately98 decode/7K prefill short baseline without lowering precision.

## Reproduction / artifacts

See `docs/design/sm70_qwen38_reproducible_baseline.md` for public build/run commands and limitations. Generated manifests, build logs and detailed results are retained task-locally, not committed; no model weights, tokens, personal absolute paths or binaries are included.

## Disclosure

AI assistance: OpenAI Codex performed implementation, audit and tests at the repository owner's request. No independent human review is claimed by this report.
