### PR TITLE
[Bugfix][MRv2] Repair six sampling and logprob runtime defects

### DIFF
--- a/docs/design/sm70_mrv2_sampling_contract_repairs.md
+++ b/docs/design/sm70_mrv2_sampling_contract_repairs.md
@@ -1,0 +1,88 @@
+# MRv2 sampling contract repairs
+
+This batch repairs three independently reproduced sampling defects on top of
+`099d9841f542f1b71121b4aff49e3aa29053a489`. They affect the shared MRv2 runner,
+including Qwen3.8-Flash-Next-NVFP4; none changes model weights, attention,
+quantization, or the precision of model kernels.
+
+## Defects and scope
+
+| Request | Defect | Repair |
+| --- | --- | --- |
+| `min_tokens > 0` with stop IDs | EOS remains masked for one extra step. | Compare the input-token position against `prompt_len + min_tokens - 1`. |
+| `logprobs=-1`, when the server allows full-vocabulary logprobs | Public `-1` aliases the internal "no logprobs" marker: a single request loses its logprobs, and a mixed batch can truncate them. | Normalize the public value to vocabulary size when adding the request. |
+| Bad words with speculative rows | The draft-prefix lookup reads the last committed token as draft zero, producing both false bans and missed bans. | Skip expanded input row zero when reading the draft prefix. |
+
+For `L` prompt tokens and `t` already generated tokens, the logits input's
+zero-based position is `L + t - 1`. The stop condition must therefore mask
+exactly while `t < min_tokens`. The regression compares both the mask and the
+actual greedy sampled token against the existing min-token reference.
+
+Expanded speculative inputs are `[last_committed, draft_0, draft_1, ...]`.
+Row `r` must match bad words against committed output followed by the first
+`r` draft tokens. Non-speculative row zero never reads a draft. Tests compare
+the complete output masks exactly with the existing CPU bad-word reference.
+
+Full-vocabulary logprobs still require a server configuration that permits
+them, such as `--max-logprobs -1`. This repair does not bypass server limits.
+The existing internal output layout (sampled token followed by requested top-k)
+is preserved. Full-vocabulary requests thus have `vocab_size + 1` columns, with
+the sampled token appearing again in the vocabulary columns.
+
+The full-output logprob calculation uses FP32 `log_softmax` followed by a gather.
+The small-output Triton calculation is unchanged. This avoids compiling a
+single enormous Triton output program for 248,320 vocabulary entries; the old
+program passed correctness tests but incurred a long first compilation. The
+dense branch uses an additional FP32 vocabulary-sized intermediate, so full
+logprobs remain a memory-intensive, opt-in diagnostic feature. It does not feed
+back into token selection.
+
+## Focused validation
+
+Environment: NVIDIA V100-SXM2-32GB (SM70), driver 580.173.02, Torch
+2.10.0+cu128, Triton 3.6.0, and installed CUDA toolkit 12.0.140. Tests use one
+idle device, the source overlay with the accepted native extension bundle,
+and task-owned compiler caches. No model weights are initialized and no
+environment dependencies or native binaries are rebuilt.
+
+From the checked-out source tree, with its runtime installed or the documented
+source-overlay bootstrap configured:
+
+```bash
+.venv/bin/python -m pytest -q --tb=short --confcutdir=tests/v1/worker \
+  tests/v1/worker/test_gpu_sampler_runtime_contracts.py
+CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q --tb=short \
+  --confcutdir=tests/v1/worker \
+  tests/v1/worker/test_gpu_sampler_runtime_states.py \
+  tests/v1/worker/test_gpu_model_runner_v2_greedy.py
+```
+
+- Original 20 GPU reproductions on the base source: **16 failed, 4 passed**.
+  Nine min-token boundaries, four full-logprob requests, and three speculative
+  bad-word cases fail independently. Default/non-speculative controls pass.
+- Fixed, expanded GPU suite: **28 passed in 6.11 s**. This includes eager and
+  CUDA Graph checks, changing draft prefixes, request-slot reuse, FP16/FP32
+  inputs, vocabularies 257 and 248,320, single/mixed requests, and prompt
+  logprobs across the 1,024-token chunk boundary.
+- CPU metadata and existing greedy-dispatch tests: **17 passed in 7.31 s**.
+- Logprob values match FP32 PyTorch references at `atol=2e-5, rtol=1e-5`;
+  mask/token checks are exact. This is not a claim of bitwise equality of
+  different log-softmax algorithms or a full-model numerical certification.
+
+The GPU test durations include cache-dependent initialization and are not
+model throughput measurements. The initial repaired 20-test suite, before
+the dense logprob branch, also passed (135.66 s including compilation).
+Do not interpret that difference as a steady-state sampling speedup.
+
+## Baseline and remaining scope
+
+The accepted approximately 98 tok/s no-MTP baseline uses `min_tokens=0`, no
+bad words, and no requested logprobs. Its greedy dispatch is unchanged and
+covered by the state tests. It was **not rebenchmarked** for this batch; no
+new prefill/decode performance claim is made. These tests validate the changed
+runtime boundaries without another full-model startup.
+
+The apparent tied-logprob rank issue was rejected: the existing reference
+uses the same `>=` convention. Earlier ngram EOS/padding probes also passed.
+Neither is counted as a repaired bug. Actual-input GDN/W13 numerical auditing
+and a broader end-to-end model quality evaluation remain separate work.

--- a/docs/design/sm70_mrv2_sampling_contract_repairs.md
+++ b/docs/design/sm70_mrv2_sampling_contract_repairs.md
@@ -86,3 +86,53 @@ The apparent tied-logprob rank issue was rejected: the existing reference
 uses the same `>=` convention. Earlier ngram EOS/padding probes also passed.
 Neither is counted as a repaired bug. Actual-input GDN/W13 numerical auditing
 and a broader end-to-end model quality evaluation remain separate work.
+
+## Second batch: prompt and custom-logprob safety
+
+Three more independently reproduced defects were found on the first batch's
+fixed source, `cbfda71b82e6494151a23be20cd3f26252447bc4`:
+
+1. Prompt-logprob token lookup reads one position ahead for every scheduled
+   row, including the final prompt row and unrelated decode requests. Those
+   rows have no known next prompt token. It can read stale slot contents or
+   cross the history row boundary before their logprobs are discarded.
+   The lookup now masks reads at the actual prompt length and substitutes
+   token zero **only for discarded rows**. Real prompt targets are unchanged.
+   The runner supplies existing GPU/UVA prompt-length metadata; no new host
+   synchronization or metadata transfer is introduced.
+2. The MRv2 rejection sampler ignores `logprob_token_ids`. It drops custom-only
+   results or returns unrelated top-k IDs when a count is present, including
+   mixed batches and steps with no scheduled drafts. It now passes the same
+   per-request custom-ID state as the ordinary sampler. Sampling, rejection
+   decisions, raw/processed logprob modes and accepted-token row offsets are
+   preserved.
+3. `SamplingParams` validates custom-ID list length but not vocabulary bounds.
+   SDK/direct-engine requests can therefore forward negative or out-of-vocab
+   IDs to a GPU gather. Model-aware validation now raises `VLLMValidationError`
+   before scheduling. The HTTP generative-scoring endpoint already performs
+   its own bounds check; this is not a claim that that endpoint lacked it.
+
+The before-fix GPU reproductions had **19 failures and 1 passing control**
+(8.78 s): three invalid prompt-target reads and sixteen custom-ID failures.
+CPU validation had **6 failures and 11 passes** (4.31 s). The prompt test keeps
+an allocated guard row and intercepts target IDs before gathering, so the
+defect can be observed without deliberately faulting a CUDA context.
+
+The second batch adds
+`tests/v1/worker/test_gpu_logprob_request_contracts.py` to the GPU command
+above, and extends the existing CPU metadata suite. Coverage includes mixed
+prefill/decode, partial prompt chunks, full/partial draft acceptance, raw and
+processed custom logprobs, and exact/near 64K, 128K and 256K history boundaries
+under CUDA Graph replay. These are small runtime tests, not model-length
+prefill/decode speed measurements.
+
+A test initially required every trailing column of a smaller mixed-batch
+top-k request to be a sentinel. That expectation was corrected: the sampler
+may return the batch-wide top-k, which the frontend truncates per request.
+Only positions beyond batch-wide top-k are sentinels. This is not another
+production defect and does not justify changing the established output layout.
+
+Final combined validation: **62 GPU tests passed in 6.37 s**, **27 CPU tests
+passed in 5.87 s**, and all applicable scoped pre-commit hooks passed. GPU
+leases were released afterwards. Both batches are included in the same PR;
+the approximately 98 tok/s default path remains unmodified, not remeasured.

--- a/tests/v1/worker/test_gpu_logprob_request_contracts.py
+++ b/tests/v1/worker/test_gpu_logprob_request_contracts.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bounded prompt/speculative logprob regressions; no model initialization."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample import prompt_logprob as prompt_module
+from vllm.v1.worker.gpu.sample.prompt_logprob import (
+    PromptLogprobsWorker,
+    get_prompt_logprobs_token_ids,
+)
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
+from vllm.v1.worker.gpu.states import RequestState
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA runtime operators"
+)
+
+
+@pytest.mark.parametrize(
+    "width,start,query_len,mixed",
+    [(8, 0, 4, False), (4, 0, 4, False), (8, 2, 2, True), (8, 0, 2, False)],
+)
+def test_prompt_logprobs_do_not_read_unknown_next_tokens(
+    width, start, query_len, mixed, monkeypatch
+):
+    worker = PromptLogprobsWorker(2)
+    worker.add_request("prompt", 1, SamplingParams(prompt_logprobs=1))
+    worker.add_request("decode", 0, SamplingParams())
+    # The extra storage row makes the old out-of-view read safe to observe.
+    # Never send poisoned IDs to the logprob gather on the unfixed source.
+    storage = torch.full((3, width), -91, dtype=torch.int32, device="cuda")
+    storage[1, :4] = torch.tensor([1, 2, 3, 4], device="cuda")
+    storage[0, :4] = torch.tensor([5, 6, 7, 8], device="cuda")
+    slots = [1, 0] if mixed else [1]
+    lengths = [query_len, 1] if mixed else [query_len]
+    cu = np.array([0, *np.cumsum(lengths)], dtype=np.int32)
+    batch = SimpleNamespace(
+        req_ids=["prompt", "decode"] if mixed else ["prompt"],
+        idx_mapping_np=np.array(slots, dtype=np.int32),
+        idx_mapping=torch.tensor(slots, dtype=torch.int32, device="cuda"),
+        num_tokens=sum(lengths),
+        num_scheduled_tokens=np.array(lengths, dtype=np.int32),
+        query_start_loc=torch.tensor(cu, device="cuda"),
+        query_start_loc_np=cu,
+    )
+    expected_ids = [
+        p + 1 if p < 4 else 0 for p in range(start + 1, start + query_len + 1)
+    ]
+    if mixed:
+        expected_ids.append(0)
+    real_compute = prompt_module.compute_prompt_logprobs_with_chunking
+
+    def checked_compute(token_ids, *args):
+        assert token_ids.tolist() == expected_ids
+        return real_compute(token_ids, *args)
+
+    monkeypatch.setattr(
+        prompt_module, "compute_prompt_logprobs_with_chunking", checked_compute
+    )
+    logits = torch.arange(128, device="cuda", dtype=torch.float32).repeat(
+        sum(lengths), 1
+    )
+    output = worker.compute_prompt_logprobs(
+        lambda x: x,
+        logits,
+        batch,
+        storage[:2],
+        torch.tensor([3, start], dtype=torch.int32, device="cuda"),
+        np.array([2, 4], dtype=np.int32),
+        np.array([4, 4], dtype=np.int32),
+        np.array([3, start], dtype=np.int32),
+        torch.tensor([2, 4], dtype=torch.int32, device="cuda"),
+    )
+    if start + query_len < 4:
+        assert output == {}
+    else:
+        assert list(output) == ["prompt"]
+        result = output["prompt"]
+        assert result.logprob_token_ids[:, 0].tolist() == expected_ids[: query_len - 1]
+        expected = torch.log_softmax(logits[: query_len - 1], dim=-1).gather(
+            1, result.logprob_token_ids.long()
+        )
+        torch.testing.assert_close(result.logprobs, expected, atol=2e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("explicit_count", [False, True])
+@pytest.mark.parametrize("mixed", [False, True])
+@pytest.mark.parametrize("num_drafts,reject_first", [(0, False), (2, False), (2, True)])
+@pytest.mark.parametrize("mode", ["raw_logprobs", "processed_logprobs"])
+def test_rejection_sampler_preserves_custom_logprob_ids(
+    explicit_count, mixed, num_drafts, reject_first, mode
+):
+    device = torch.device("cuda")
+    reqs = RequestState(2, 16, 8, 2, 128, device)
+    sampler = Sampler(2, 128, device, reqs, logprobs_mode=mode)
+    custom_ids = [13, 17, 19]
+    spec_config = SimpleNamespace(
+        num_speculative_tokens=2, rejection_sample_method="standard"
+    )
+    slots = []
+    for i in range(2 if mixed else 1):
+        name = str(i)
+        reqs.add_request(name, 2, [1, 5], 2, 8)
+        slot = reqs.req_id_to_index[name]
+        slots.append(slot)
+        params = (
+            SamplingParams(
+                temperature=0,
+                logprobs=3 if explicit_count else None,
+                logprob_token_ids=custom_ids,
+                allowed_token_ids=[7, 9, 11, *custom_ids],
+            )
+            if i == 0
+            else SamplingParams(temperature=0, logprobs=2)
+        )
+        params._validate_logprobs(
+            SimpleNamespace(max_logprobs=20, get_vocab_size=lambda: 128)
+        )
+        params._validate_spec_decode(spec_config)
+        sampler.add_request(slot, 2, params)
+    reqs.apply_staged_writes()
+    sampler.apply_staged_writes()
+    first_rows = num_drafts + 1
+    inputs = [5, 7, 9][:first_rows] + ([5] if mixed else [])
+    if reject_first:
+        inputs[1] = 9
+    winners = [7, 9, 11][:first_rows] + ([23] if mixed else [])
+    expanded = [slots[0]] * first_rows + ([slots[1]] if mixed else [])
+    cu = np.array(
+        [0, first_rows, first_rows + 1] if mixed else [0, first_rows], dtype=np.int32
+    )
+    batch = SimpleNamespace(
+        idx_mapping_np=np.array(slots, dtype=np.int32),
+        idx_mapping=torch.tensor(slots, dtype=torch.int32, device=device),
+        expanded_idx_mapping=torch.tensor(expanded, dtype=torch.int32, device=device),
+        expanded_local_pos=torch.tensor(
+            list(range(first_rows)) + ([0] if mixed else []),
+            dtype=torch.int32,
+            device=device,
+        ),
+        input_ids=torch.tensor(inputs, dtype=torch.int32, device=device),
+        positions=torch.tensor(
+            list(range(1, first_rows + 1)) + ([1] if mixed else []), device=device
+        ),
+        logits_indices=torch.arange(len(inputs), device=device),
+        cu_num_logits=torch.tensor(cu, device=device),
+        cu_num_logits_np=cu,
+    )
+    logits = torch.linspace(-3, 3, 128, device=device).repeat(len(inputs), 1)
+    logits[
+        torch.arange(len(inputs), device=device), torch.tensor(winners, device=device)
+    ] = 8
+    result = RejectionSampler(sampler, spec_config, device)(logits, batch)
+    emitted = 1 if reject_first else first_rows
+    assert result.num_sampled.tolist() == ([emitted, 1] if mixed else [emitted])
+    assert result.sampled_token_ids[0, :emitted].tolist() == winners[:emitted]
+    output = result.logprobs_tensors
+    assert output is not None
+    assert (
+        output.logprob_token_ids[:first_rows, 1:4].tolist() == [custom_ids] * first_rows
+    )
+    selected = winners.copy()
+    selected[emitted:first_rows] = [0] * (first_rows - emitted)
+    assert output.logprob_token_ids[:, 0].tolist() == selected
+    assert output.cu_num_generated_tokens == (cu.tolist() if num_drafts else None)
+    reference = logits.clone()
+    if mode == "processed_logprobs":
+        keep = torch.zeros(128, dtype=torch.bool, device=device)
+        keep[[7, 9, 11, *custom_ids]] = True
+        reference[:first_rows, ~keep] = -torch.inf
+    expected = torch.log_softmax(reference, dim=-1).gather(
+        1, output.logprob_token_ids.long()
+    )
+    valid = torch.ones_like(expected, dtype=torch.bool)
+    if mixed:
+        # Batch-wide top-k can exceed this request's own count (the frontend
+        # truncates it); only columns beyond batch-wide top-k are sentinels.
+        topk = 3 if explicit_count else 2
+        assert (
+            output.logprob_token_ids[-1, 1 : topk + 1].tolist()
+            == logits[-1].topk(topk).indices.tolist()
+        )
+        valid[-1, topk + 1 :] = False
+        assert torch.isneginf(output.logprobs[-1, topk + 1 :]).all()
+    torch.testing.assert_close(
+        output.logprobs[valid], expected[valid], atol=2e-5, rtol=1e-5
+    )
+
+
+@pytest.mark.parametrize("max_len", [65536, 131072, 262144])
+@pytest.mark.parametrize("spare", [0, 1])
+def test_prompt_token_lookup_long_context_graph_boundary(max_len, spare):
+    prompt_len = max_len - spare
+    storage = torch.full((1, max_len), -91, dtype=torch.int32, device="cuda")
+    storage[0, prompt_len - 4 : prompt_len] = torch.tensor([5, 7, 9, 11], device="cuda")
+    computed = torch.tensor([prompt_len - 4], dtype=torch.int32, device="cuda")
+    prompt_lens = torch.tensor([prompt_len], dtype=torch.int32, device="cuda")
+    mapping = torch.zeros(1, dtype=torch.int32, device="cuda")
+    query_start = torch.tensor([0, 4], dtype=torch.int32, device="cuda")
+    get_prompt_logprobs_token_ids(
+        4, query_start, mapping, computed, storage, prompt_lens
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        ids = get_prompt_logprobs_token_ids(
+            4, query_start, mapping, computed, storage, prompt_lens
+        )
+    for start, expected in [
+        (prompt_len - 4, [7, 9, 11, 0]),
+        (prompt_len - 3, [9, 11, 0, 0]),
+    ]:
+        computed.fill_(start)
+        graph.replay()
+        assert ids.tolist() == expected

--- a/tests/v1/worker/test_gpu_sampler_runtime_contracts.py
+++ b/tests/v1/worker/test_gpu_sampler_runtime_contracts.py
@@ -14,6 +14,9 @@ from vllm.v1.sample.ops.bad_words import _apply_bad_words_single_batch
 from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
+from vllm.v1.worker.gpu.sample.prompt_logprob import (
+    compute_prompt_logprobs_with_chunking,
+)
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.states import RequestState
 
@@ -86,7 +89,8 @@ def _batch(slots):
 
 @pytest.mark.parametrize("vocab_size", [257, 248320])
 @pytest.mark.parametrize("mixed", [False, True])
-def test_full_vocab_logprobs_are_not_the_none_sentinel(vocab_size, mixed):
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_full_vocab_logprobs_are_not_the_none_sentinel(vocab_size, mixed, dtype):
     reqs = _request_state(vocab_size)
     sampler = Sampler(2, vocab_size, torch.device("cuda"), reqs)
     slots = []
@@ -106,7 +110,11 @@ def test_full_vocab_logprobs_are_not_the_none_sentinel(vocab_size, mixed):
     sampler.apply_staged_writes()
     batch = _batch(slots)
     assert not sampler.can_use_sm70_greedy_token_fastpath(batch)
-    logits = torch.linspace(-5, 5, vocab_size, device="cuda").repeat(len(slots), 1)
+    logits = (
+        torch.linspace(-5, 5, vocab_size, device="cuda").to(dtype).repeat(len(slots), 1)
+    )
+    # Keep the winner unique even after casting a large vocabulary to FP16.
+    logits[:, -1] = 6
     result = sampler(logits, batch)
     output = result.logprobs_tensors
     assert output is not None
@@ -117,6 +125,28 @@ def test_full_vocab_logprobs_are_not_the_none_sentinel(vocab_size, mixed):
     )
     torch.testing.assert_close(output.logprobs, expected, atol=2e-5, rtol=1e-5)
     assert result.sampled_token_ids[:, 0].tolist() == [vocab_size - 1] * len(slots)
+
+
+@pytest.mark.parametrize("count", [-1, 2])
+def test_prompt_logprobs_shared_helper_across_chunk_boundary(count):
+    vocab_size = 257
+    logits = torch.linspace(-5, 5, vocab_size, device="cuda").half().repeat(1025, 1)
+    prompt_ids = torch.full((1025,), 77, dtype=torch.int64, device="cuda")
+    ids, values, ranks = compute_prompt_logprobs_with_chunking(
+        prompt_ids, logits, lambda chunk: chunk, count
+    )
+    columns = 1 + (vocab_size if count == -1 else count)
+    assert values.shape == (1025, columns)
+    assert values.dtype == torch.float32
+    torch.testing.assert_close(ids[:, 0], prompt_ids)
+    expected = torch.log_softmax(logits.float(), dim=-1).gather(1, ids.long())
+    torch.testing.assert_close(values, expected, atol=2e-5, rtol=1e-5)
+    expected_ranks = (logits >= logits[:, 77:78]).sum(dim=-1)
+    torch.testing.assert_close(ranks, expected_ranks)
+    if count == -1:
+        assert torch.all(
+            ids[:, 1:].sort(dim=-1).values == torch.arange(vocab_size, device="cuda")
+        )
 
 
 @pytest.mark.parametrize("drafts", [[], [7], [7, 8], [7, 8, 7]])
@@ -144,3 +174,62 @@ def test_bad_words_follow_current_draft_prefix(drafts):
         _apply_bad_words_single_batch(expected[row], words, [5, *drafts[:row]])
     state.apply_bad_words(logits, mapping, np.array([slot]), inputs, local_pos)
     torch.testing.assert_close(logits.cpu(), expected, atol=0, rtol=0)
+
+
+def test_min_tokens_graph_replay_crosses_boundary():
+    state = LogitBiasState(1, torch.device("cuda"))
+    state.add_request(0, 17, SamplingParams(min_tokens=2, stop_token_ids=[44]))
+    state.apply_staged_writes()
+    positions = torch.tensor([17], device="cuda")
+    mapping = torch.zeros(1, dtype=torch.int32, device="cuda")
+    template = torch.zeros(1, 128, device="cuda")
+    template[:, 44] = 10
+    output = template.clone()
+    state.apply_logit_bias(output, mapping, np.array([0]), positions)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output.copy_(template)
+        state.apply_logit_bias(output, mapping, np.array([0]), positions)
+    for generated in (1, 2, 3, 1, 2):
+        positions.fill_(17 + generated - 1)
+        graph.replay()
+        assert torch.isneginf(output[0, 44]).item() == (generated < 2)
+
+
+def test_bad_words_graph_replay_and_request_slot_reuse():
+    reqs = _request_state(128)
+    reqs.add_request("first", 2, [1, 2, 5], 3, 8)
+    slot = reqs.req_id_to_index["first"]
+    state = BadWordsState(reqs)
+    words = [[7, 9], [5, 10], [7, 8, 11], [8, 7, 12]]
+    params = SamplingParams(_bad_words_token_ids=words)
+    state.add_request(slot, params)
+    reqs.apply_staged_writes()
+    state.apply_staged_writes()
+    inputs = torch.tensor([5, 7, 8], dtype=torch.int32, device="cuda")
+    positions = torch.arange(3, dtype=torch.int32, device="cuda")
+    mapping = torch.full_like(positions, slot)
+    template = torch.arange(128, device="cuda", dtype=torch.float32).repeat(3, 1)
+    output = template.clone()
+    state.apply_bad_words(output, mapping, np.array([slot]), inputs, positions)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output.copy_(template)
+        state.apply_bad_words(output, mapping, np.array([slot]), inputs, positions)
+    for drafts in ([7, 8], [8, 7], [7, 8]):
+        inputs.copy_(torch.tensor([5, *drafts], dtype=torch.int32, device="cuda"))
+        graph.replay()
+        expected = template.cpu()
+        for row in range(3):
+            _apply_bad_words_single_batch(expected[row], words, [5, *drafts[:row]])
+        torch.testing.assert_close(output.cpu(), expected, atol=0, rtol=0)
+
+    reqs.remove_request("first")
+    reqs.add_request("second", 2, [1, 2, 5], 3, 8)
+    assert reqs.req_id_to_index["second"] == slot
+    state.add_request(slot, SamplingParams())
+    reqs.apply_staged_writes()
+    state.apply_staged_writes()
+    output.copy_(template)
+    state.apply_bad_words(output, mapping, np.array([slot]), inputs, positions)
+    torch.testing.assert_close(output, template, atol=0, rtol=0)

--- a/tests/v1/worker/test_gpu_sampler_runtime_contracts.py
+++ b/tests/v1/worker/test_gpu_sampler_runtime_contracts.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Small GPU regressions for MRv2 sampling, without loading model weights."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.ops.bad_words import _apply_bad_words_single_batch
+from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.states import RequestState
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA runtime operators"
+)
+
+
+@pytest.mark.parametrize("prompt_len", [1, 17, 8192])
+@pytest.mark.parametrize("minimum", [0, 1, 2, 17])
+def test_min_tokens_uses_generated_count(prompt_len, minimum):
+    state = LogitBiasState(1, torch.device("cuda"))
+    params = SamplingParams(
+        min_tokens=minimum, max_tokens=64, stop_token_ids=[44, 46], temperature=0
+    )
+    state.add_request(0, prompt_len, params)
+    state.apply_staged_writes()
+    counts = sorted({0, max(0, minimum - 1), minimum, minimum + 1})
+    positions = torch.tensor(
+        [prompt_len + count - 1 for count in counts], device="cuda"
+    )
+    mapping = torch.zeros(len(counts), dtype=torch.int32, device="cuda")
+    logits = torch.zeros((len(counts), 128), device="cuda")
+    logits[:, 44], logits[:, 46], logits[:, 42] = 10, 9, 5
+    state.apply_logit_bias(logits, mapping, np.array([0]), positions)
+    expected = [
+        MinTokensLogitsProcessor.add_request(params, None, [42] * count) is not None
+        for count in counts
+    ]
+    assert torch.isneginf(logits[:, 44]).tolist() == expected
+    assert torch.isneginf(logits[:, 46]).tolist() == expected
+    sampled = gumbel_sample(
+        logits,
+        mapping,
+        torch.zeros(1, device="cuda"),
+        torch.zeros(1, dtype=torch.int64, device="cuda"),
+        positions,
+        apply_temperature=False,
+        is_drafting=False,
+    )
+    assert sampled.tolist() == [42 if mask else 44 for mask in expected]
+
+
+def _request_state(vocab_size, num_reqs=2):
+    return RequestState(
+        max_num_reqs=num_reqs,
+        max_model_len=64,
+        max_num_batched_tokens=8,
+        num_speculative_steps=3,
+        vocab_size=vocab_size,
+        device=torch.device("cuda"),
+    )
+
+
+def _batch(slots):
+    n = len(slots)
+    mapping = torch.tensor(slots, dtype=torch.int32, device="cuda")
+    return SimpleNamespace(
+        idx_mapping_np=np.array(slots, dtype=np.int32),
+        expanded_idx_mapping=mapping,
+        expanded_local_pos=torch.zeros(n, dtype=torch.int32, device="cuda"),
+        positions=torch.full((n,), 1, dtype=torch.int64, device="cuda"),
+        input_ids=torch.full((n,), 2, dtype=torch.int32, device="cuda"),
+        logits_indices=torch.arange(n, device="cuda"),
+        cu_num_logits_np=np.arange(n + 1, dtype=np.int32),
+        seq_lens=torch.full((n,), 2, dtype=torch.int32, device="cuda"),
+        num_reqs=n,
+    )
+
+
+@pytest.mark.parametrize("vocab_size", [257, 248320])
+@pytest.mark.parametrize("mixed", [False, True])
+def test_full_vocab_logprobs_are_not_the_none_sentinel(vocab_size, mixed):
+    reqs = _request_state(vocab_size)
+    sampler = Sampler(2, vocab_size, torch.device("cuda"), reqs)
+    slots = []
+    for i, count in enumerate([-1, 2] if mixed else [-1]):
+        name = str(i)
+        reqs.add_request(name, 2, [1, 2], 2, 8)
+        slot = reqs.req_id_to_index[name]
+        slots.append(slot)
+        params = SamplingParams(temperature=0, seed=0, logprobs=count)
+        # A server permitting full vocabulary logprobs accepts this request
+        # without rewriting -1 into an internal count.
+        params._validate_logprobs(
+            SimpleNamespace(max_logprobs=-1, get_vocab_size=lambda: vocab_size)
+        )
+        sampler.add_request(slot, 2, params)
+    reqs.apply_staged_writes()
+    sampler.apply_staged_writes()
+    batch = _batch(slots)
+    assert not sampler.can_use_sm70_greedy_token_fastpath(batch)
+    logits = torch.linspace(-5, 5, vocab_size, device="cuda").repeat(len(slots), 1)
+    result = sampler(logits, batch)
+    output = result.logprobs_tensors
+    assert output is not None
+    assert output.logprobs.shape == (len(slots), vocab_size + 1)
+    assert torch.unique(output.logprob_token_ids[0]).numel() == vocab_size
+    expected = torch.log_softmax(logits.float(), dim=-1).gather(
+        1, output.logprob_token_ids.long()
+    )
+    torch.testing.assert_close(output.logprobs, expected, atol=2e-5, rtol=1e-5)
+    assert result.sampled_token_ids[:, 0].tolist() == [vocab_size - 1] * len(slots)
+
+
+@pytest.mark.parametrize("drafts", [[], [7], [7, 8], [7, 8, 7]])
+def test_bad_words_follow_current_draft_prefix(drafts):
+    reqs = _request_state(128)
+    reqs.add_request("request", 2, [1, 2, 5], 3, 8)
+    slot = reqs.req_id_to_index["request"]
+    state = BadWordsState(reqs)
+    words = [[7, 9], [5, 10], [7, 8, 11], [5, 7, 12], [13]]
+    params = SamplingParams()
+    params._bad_words_token_ids = words
+    state.add_request(slot, params)
+    reqs.apply_staged_writes()
+    state.apply_staged_writes()
+
+    # Expanded row zero is the last committed token, not draft zero.
+    inputs = torch.tensor([5, *drafts], dtype=torch.int32, device="cuda")
+    local_pos = torch.arange(len(inputs), dtype=torch.int32, device="cuda")
+    mapping = torch.full_like(local_pos, slot)
+    logits = torch.arange(128, device="cuda", dtype=torch.float32).repeat(
+        len(inputs), 1
+    )
+    expected = logits.cpu()
+    for row in range(len(inputs)):
+        _apply_bad_words_single_batch(expected[row], words, [5, *drafts[:row]])
+    state.apply_bad_words(logits, mapping, np.array([slot]), inputs, local_pos)
+    torch.testing.assert_close(logits.cpu(), expected, atol=0, rtol=0)

--- a/tests/v1/worker/test_gpu_sampler_runtime_states.py
+++ b/tests/v1/worker/test_gpu_sampler_runtime_states.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu.sample import sampler as sampler_module
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -58,3 +59,21 @@ def test_greedy_dispatch_rejects_full_logprobs_then_recovers(monkeypatch):
     assert not sampler.can_use_sm70_greedy_token_fastpath(batch)
     state.add_request(2, SamplingParams(temperature=0, seed=0))
     assert sampler.can_use_sm70_greedy_token_fastpath(batch)
+
+
+@pytest.mark.parametrize("vocab_size", [257, 248320])
+@pytest.mark.parametrize("invalid", [-1, 0, 1024])
+def test_custom_logprob_token_ids_reject_out_of_vocabulary(vocab_size, invalid):
+    token_id = invalid if invalid < 0 else vocab_size + invalid
+    params = SamplingParams(logprob_token_ids=[0, token_id])
+    config = SimpleNamespace(max_logprobs=20, get_vocab_size=lambda: vocab_size)
+    with pytest.raises(VLLMValidationError, match="logprob_token_ids"):
+        params._validate_logprobs(config)
+
+
+@pytest.mark.parametrize("ids", [[], [0], [256], [0, 256, 0]])
+def test_custom_logprob_valid_boundaries_are_accepted(ids):
+    params = SamplingParams(logprob_token_ids=ids)
+    params._validate_logprobs(
+        SimpleNamespace(max_logprobs=20, get_vocab_size=lambda: 257)
+    )

--- a/tests/v1/worker/test_gpu_sampler_runtime_states.py
+++ b/tests/v1/worker/test_gpu_sampler_runtime_states.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU state/dispatch checks; GPU arithmetic is covered in runtime_contracts."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample import sampler as sampler_module
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS, SamplingStates
+
+
+def _states():
+    state = object.__new__(SamplingStates)
+    state.vocab_size = 248320
+    for name in ("temperature", "top_p", "top_k", "min_p", "seeds"):
+        setattr(state, name, SimpleNamespace(np=np.zeros(3)))
+    state.num_logprobs = np.full(3, NO_LOGPROBS, dtype=np.int32)
+    return state
+
+
+@pytest.mark.parametrize("count", [None, -1, 0, 1, 20])
+def test_sample_logprob_request_is_normalized_and_reusable(count):
+    state = _states()
+    state.add_request(2, SamplingParams(logprobs=count, seed=0))
+    expected = NO_LOGPROBS if count is None else 248320 if count == -1 else count
+    assert state.max_num_logprobs(np.array([2])) == expected
+    assert state.num_logprobs[0] == NO_LOGPROBS
+    state.add_request(2, SamplingParams(logprobs=None, seed=0))
+    assert state.max_num_logprobs(np.array([2])) == NO_LOGPROBS
+
+
+def test_full_vocabulary_dominates_mixed_batch_count():
+    state = _states()
+    for slot, count in enumerate([None, 20, -1]):
+        state.add_request(slot, SamplingParams(logprobs=count, seed=0))
+    assert state.max_num_logprobs(np.array([1, 0])) == 20
+    assert state.max_num_logprobs(np.array([1, 2])) == 248320
+
+
+def test_greedy_dispatch_rejects_full_logprobs_then_recovers(monkeypatch):
+    monkeypatch.setattr(sampler_module.envs, "VLLM_SM70_GREEDY_TOKEN_FASTPATH", True)
+    state = _states()
+    sampler = object.__new__(Sampler)
+    sampler.compute_nans = False
+    sampler.sampling_states = state
+    sampler.logprob_token_ids_state = SimpleNamespace(max_num_token_ids=lambda _: 0)
+    sampler.logit_bias_state = SimpleNamespace(use_logit_bias=np.zeros(3, dtype=bool))
+    sampler.penalties_state = SimpleNamespace(use_penalty=np.zeros(3, dtype=bool))
+    sampler.bad_words_state = SimpleNamespace(
+        num_bad_words=SimpleNamespace(np=np.zeros(3, dtype=np.int32))
+    )
+    batch = SimpleNamespace(idx_mapping_np=np.array([2]))
+    state.add_request(2, SamplingParams(temperature=0, logprobs=-1, seed=0))
+    assert not sampler.can_use_sm70_greedy_token_fastpath(batch)
+    state.add_request(2, SamplingParams(temperature=0, seed=0))
+    assert sampler.can_use_sm70_greedy_token_fastpath(batch)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -737,6 +737,20 @@ class SamplingParams(
                     parameter="logprob_token_ids",
                     value=n,
                 )
+
+            vocab_size = model_config.get_vocab_size()
+            invalid_token_ids = [
+                token_id
+                for token_id in self.logprob_token_ids
+                if token_id < 0 or token_id >= vocab_size
+            ]
+            if invalid_token_ids:
+                raise VLLMValidationError(
+                    f"token_id(s) {invalid_token_ids} in logprob_token_ids contain "
+                    f"out-of-vocab token ids. Vocabulary size: {vocab_size}",
+                    parameter="logprob_token_ids",
+                    value=invalid_token_ids,
+                )
             if self.logprobs is not None and self.logprobs != n:
                 raise VLLMValidationError(
                     f"When both logprobs and logprob_token_ids are set, "

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1751,6 +1751,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.req_states.prompt_len.np,
             self.req_states.prefill_len.np,
             self.req_states.num_computed_prefill_tokens,
+            self.req_states.prompt_len.gpu,
         )
 
         # Prepare the model runner output.

--- a/vllm/v1/worker/gpu/sample/bad_words.py
+++ b/vllm/v1/worker/gpu/sample/bad_words.py
@@ -152,7 +152,8 @@ def _bad_words_kernel(
         from_spec_input = actual_pos >= output_len
         if from_spec_input:
             spec_offset = actual_pos - output_len
-            actual = tl.load(input_ids_ptr + cur_req_first_pos + spec_offset)
+            # Row zero is the last committed token; drafts start at row one.
+            actual = tl.load(input_ids_ptr + cur_req_first_pos + spec_offset + 1)
         else:
             actual = tl.load(output_base + actual_pos)
 

--- a/vllm/v1/worker/gpu/sample/logit_bias.py
+++ b/vllm/v1/worker/gpu/sample/logit_bias.py
@@ -88,7 +88,8 @@ class LogitBiasState:
 
         # Min tokens.
         min_tokens = sampling_params.min_tokens
-        min_len = prompt_len + min_tokens
+        # Sampling uses the zero-based position of the last input token.
+        min_len = prompt_len + min_tokens - 1
         self.min_lens.np[req_idx] = min_len
         stop_token_ids = sampling_params.all_stop_token_ids
         if min_tokens > 0 and stop_token_ids:

--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -78,12 +78,16 @@ def _ranks_kernel(
 def compute_token_logprobs(
     logits: torch.Tensor, token_ids: torch.Tensor
 ) -> torch.Tensor:
-    # NOTE(woosuk): To save GPU memory, we do not materialize the full
+    # For small requested subsets, avoid materializing the full
     # [batch_size, vocab_size] logprobs tensor. The kernel computes
     # max + logsumexp per row and only emits logprobs at `token_ids`.
     batch_size, vocab_size = logits.shape
     token_ids = token_ids.to(torch.int64)
     num_logprobs = token_ids.shape[1]
+    if num_logprobs >= vocab_size:
+        # Full-vocabulary requests already return a dense row. Avoid expanding
+        # all output IDs into one enormous small-top-k Triton program.
+        return torch.log_softmax(logits.float(), dim=-1).gather(1, token_ids)
     logprobs = logits.new_empty((batch_size, num_logprobs), dtype=torch.float32)
     _topk_log_softmax_kernel[(batch_size,)](
         logprobs,

--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -46,6 +46,8 @@ class PromptLogprobsWorker:
         prefill_lens: np.ndarray,
         # [max_num_reqs]
         num_computed_prefill_tokens: np.ndarray,
+        # [max_num_reqs], existing device/UVA metadata (no per-step host copy).
+        prompt_lens_gpu: torch.Tensor,
     ) -> dict[str, LogprobsTensors]:
         idx_mapping_np = input_batch.idx_mapping_np
         needs_prompt_logprobs = self.uses_prompt_logprobs[idx_mapping_np]
@@ -79,6 +81,7 @@ class PromptLogprobsWorker:
             input_batch.idx_mapping,
             num_computed_tokens,
             all_token_ids,
+            prompt_lens_gpu,
         )
         prompt_token_ids, prompt_logprobs, prompt_ranks = (
             compute_prompt_logprobs_with_chunking(
@@ -159,6 +162,7 @@ def _prompt_logprobs_token_ids_kernel(
     num_computed_tokens_ptr,
     all_token_ids_ptr,
     all_token_ids_stride,
+    prompt_lens_ptr,
     BLOCK_SIZE: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
@@ -169,6 +173,7 @@ def _prompt_logprobs_token_ids_kernel(
     query_len = query_end - query_start
 
     num_computed_tokens = tl.load(num_computed_tokens_ptr + req_state_idx)
+    prompt_len = tl.load(prompt_lens_ptr + req_state_idx)
     for i in range(0, query_len, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
         mask = block < query_len
@@ -177,7 +182,10 @@ def _prompt_logprobs_token_ids_kernel(
         target_pos = num_computed_tokens + 1 + block
         token_ids = tl.load(
             all_token_ids_ptr + req_state_idx * all_token_ids_stride + target_pos,
-            mask=mask,
+            # The final prompt row and other requests' decode rows have no
+            # known next prompt token. Their logprobs are discarded later.
+            mask=mask & (target_pos < prompt_len),
+            other=0,
         )
         tl.store(
             prompt_logprobs_token_ids_ptr + query_start + block, token_ids, mask=mask
@@ -190,6 +198,7 @@ def get_prompt_logprobs_token_ids(
     idx_mapping: torch.Tensor,
     num_computed_tokens: torch.Tensor,
     all_token_ids: torch.Tensor,
+    prompt_lens: torch.Tensor,
 ) -> torch.Tensor:
     token_ids = torch.empty(num_tokens, dtype=torch.int64, device=idx_mapping.device)
     num_reqs = idx_mapping.shape[0]
@@ -200,6 +209,7 @@ def get_prompt_logprobs_token_ids(
         num_computed_tokens,
         all_token_ids,
         all_token_ids.stride(0),
+        prompt_lens,
         BLOCK_SIZE=1024,
     )
     return token_ids

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -52,6 +52,9 @@ class SamplingStates:
         num_logprobs = sampling_params.logprobs
         if num_logprobs is None:
             num_logprobs = NO_LOGPROBS
+        elif num_logprobs == -1:
+            # The public full-vocabulary request is not our internal None marker.
+            num_logprobs = self.vocab_size
         self.num_logprobs[req_idx] = num_logprobs
 
     def apply_staged_writes(self) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -68,7 +68,11 @@ class RejectionSampler:
         max_num_logprobs = self.sampler.sampling_states.max_num_logprobs(
             input_batch.idx_mapping_np
         )
-        if max_num_logprobs == NO_LOGPROBS:
+        token_ids_state = self.sampler.logprob_token_ids_state
+        max_per_req_token_ids = token_ids_state.max_num_token_ids(
+            input_batch.idx_mapping_np
+        )
+        if max_num_logprobs == NO_LOGPROBS and max_per_req_token_ids == 0:
             return None
 
         num_reqs = input_batch.cu_num_logits.shape[0] - 1
@@ -87,9 +91,12 @@ class RejectionSampler:
         expanded_logits = num_logits != input_batch.idx_mapping.shape[0]
         return compute_topk_logprobs(
             logits,
-            max_num_logprobs,
+            max_num_logprobs if max_num_logprobs != NO_LOGPROBS else 0,
             flat_sampled,
             input_batch.cu_num_logits_np.tolist() if expanded_logits else None,
+            logprob_token_ids_state=token_ids_state,
+            expanded_idx_mapping=input_batch.expanded_idx_mapping,
+            max_per_req_token_ids=max_per_req_token_ids,
         )
 
     def __call__(


### PR DESCRIPTION
## Purpose

Repair six independently reproduced runtime defects in two batches, as requested by the repository owner. Qwen3.8 NVFP4 uses this runner, but these are shared sampling/logprob defects rather than model quantization changes. The owner requested combining both batches in this PR and merging into main after validation.

- Integration base: public/main `099d9841f542f1b71121b4aff49e3aa29053a489` (unchanged at publication).
- Head: `bb179ac5d53b265a8325b3aae44bef2c73280464`.
- Reproductions committed before implementation: `3999ccfe31af84e5e0b8e15cd19744de4905cee8`.

## Repairs / affected requests

1. `min_tokens > 0` with stop IDs: stop-token masking compared an input-token position with a token count, incorrectly suppressing EOS for one extra step. Use `prompt_len + min_tokens - 1`.
2. `logprobs=-1`: normalize the public full-vocabulary request into vocabulary size instead of storing the same `-1` marker as "no logprobs". Single requests previously lost the result/admitted the greedy shortcut; mixed requests could silently truncate to another request's top-k. Server validation must still permit full logprobs, e.g. `--max-logprobs -1`.
3. Bad words with speculative rows: expanded input row zero is the last committed token, not draft zero. Correct the draft-prefix offset to prevent both false bans and missed bans. Non-speculative row zero is unchanged.
4. Prompt logprobs: never read unknown next tokens from the final prompt row or unrelated decode rows. Bound loads by actual prompt length using existing GPU/UVA metadata, and use a harmless zero ID only for rows whose logprobs are discarded. Real prompt targets are not clamped or changed.
5. Custom logprobs under MRv2 rejection sampling: propagate per-request custom-ID state instead of dropping custom-only requests or silently returning unrelated top-k IDs. Preserve raw/processed modes, acceptance decisions, mixed-batch widths and accepted-token row offsets.
6. Direct SDK/engine validation: reject negative or out-of-vocab `logprob_token_ids` before GPU indexing. The HTTP generative-scoring endpoint already checks its label IDs; this closes the lower-level validation gap rather than claiming that endpoint was exposed.

Full-output logprobs use FP32 log-softmax plus gather to avoid an enormous single Triton output program. Small-output logprobs and token selection are unchanged. The original full-output kernel did pass correctness tests, but its initial compilation dominated a 135.66 s run; this is not reported as a runtime crash or steady-state speedup. The dense path has an additional FP32 vocabulary-sized intermediate and remains an opt-in diagnostic.

## Test plan

With the source runtime installed (or the existing source-overlay bootstrap configured):

```bash
.venv/bin/python -m pytest -q --tb=short --confcutdir=tests/v1/worker \
  tests/v1/worker/test_gpu_sampler_runtime_contracts.py \
  tests/v1/worker/test_gpu_logprob_request_contracts.py
CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q --tb=short \
  --confcutdir=tests/v1/worker \
  tests/v1/worker/test_gpu_sampler_runtime_states.py \
  tests/v1/worker/test_gpu_model_runner_v2_greedy.py
pre-commit run
```

## Test results

- Before batch 1: **16 failed, 4 passed in 10.56 s**, actual production GPU operators. Failures split into nine min-token cases, four full-logprob cases, and three speculative bad-word cases; default/non-speculative controls pass.
- Before batch 2 on `cbfda71b82`: **19 GPU failures, 1 passing control (8.78 s)**, plus **6 CPU validation failures, 11 passes (4.31 s)**. Prompt target IDs are checked using allocated guard storage before a gather, so the test does not deliberately fault CUDA.
- Final combined GPU suite: **62 passed in 6.37 s**, V100 SM70. Includes FP16/FP32, vocabulary 257/248320, single/mixed requests, graph replay, changing draft prefixes, request-slot reuse, full/small prompt logprobs across a chunk boundary, custom raw/processed logprobs with full/partial draft acceptance, and exact/near 64K/128K/256K history lookup boundaries.
- Final CPU request metadata, vocabulary validation and existing greedy dispatch regressions: **27 passed in 5.87 s**.
- Existing frontend truncation/container regressions: **2 passed in 0.02 s** (`CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q --tb=short --confcutdir=tests/v1/engine tests/v1/engine/test_logprobs_processor.py`), retained in `batch2_frontend_cpu.log`.
- All applicable scoped pre-commit hooks passed, including mypy, ruff and markdownlint.
- Exact stop/bad-word masks and greedy token checks; logprobs compared with FP32 PyTorch references at `atol=2e-5, rtol=1e-5`. Not a claim of bitwise log-softmax equivalence or full-model quality certification.

Environment: V100-SXM2-32GB, driver 580.173.02, Torch 2.10.0+cu128, Triton 3.6.0, installed toolkit 12.0.140. Existing native source-overlay bundle reused read-only; separate task compiler caches. No model weights loaded, no native rebuild, no dependency change, no foreign GPU process interrupted. Test processes exited and leases were released.

Public reproduction/worklog: `docs/design/sm70_mrv2_sampling_contract_repairs.md`. Retained raw logs under task-local `.artifacts/`: first-batch `three_bugs_before.log`, `three_bugs_after.log`, `three_bugs_final.log`, `cpu_sampling_states.log`; second-batch `batch2_gpu_before.log`, `batch2_cpu_before.log`, `batch2_gpu_final_run.log`, `batch2_cpu_after.log`, `batch2_precommit.log`. No private absolute paths or build products are committed.

## Performance / quality scope

The accepted approximately 98 tok/s no-MTP baseline uses no requested logprobs, no bad words, and `min_tokens=0`; its greedy dispatch is unchanged and covered by tests. **No new full-model throughput result is claimed.** Model precision, weights, attention, PLE/SSM and quantized projections are untouched. These fixes intentionally change incorrect behavior only for affected request options.

The apparent tied-logprob rank issue was rejected because the existing reference has the same `>=` convention. Previous ngram EOS/padding probes passed and are not counted as bugs. Actual-input GDN/W13 numerical certification remains separate work.

An intermediate test incorrectly demanded sentinel values beyond a small request's own top-k, even when the batch-wide top-k was larger. The fixture was corrected to the existing frontend truncation contract; this is not counted as another production bug. GPU-busy attempts exited without starting a test and did not preempt other tasks.

## Scope / duplication / disclosure

Open-PR searches found no equivalent MRv2 min_tokens/full-logprobs/bad-words or prompt/custom-ID safety fix. This is distinct from FlashInfer, DFlash2 throughput and projection experiments. No dependency PR is required beyond the stated base. Both batches are isolated in this PR for review and rollback; no direct main push.

AI assistance: OpenAI Codex performed the audit, reproductions and implementation at the repository owner's request. No independent human review is claimed. Local implementation gates passed; remote checks must be evaluated at the final head before the requested merge, not an earlier reproduction-only commit.
