### PR TITLE
[Bugfix][PLE] Integrate split placement with padding and loading repairs (#528)

### DIFF
--- a/docs/design/ple_split_mainline_audit.md
+++ b/docs/design/ple_split_mainline_audit.md
@@ -1,0 +1,45 @@
+# PLE split-placement integration audit (2026-09-07)
+
+## Scope
+
+Integrate PR #528, based on public main
+`53199eb8b996831718330c23144c60ed9952f690`. Preserve automatic FP8 PLE
+placement between VRAM and pinned host storage on pre-Ampere workers,
+explicit placement overrides and stable UVA pointers. The memory estimate
+is a placement heuristic, not a guarantee that any requested context fits;
+hybrid allocator padding and the actual activation peak still matter.
+
+## Repairs
+
+- Separate physical vocabulary padding from the logical checkpoint TP range.
+  A CPU regression reproduced the original all-device placement rejecting
+  a valid padded table. Both halves now copy only their logical overlap,
+  while insufficient combined capacity remains an error.
+- Dummy loading sees a zero-row placeholder, not the private backing tables.
+  Initialize those tables to finite zero bytes before their first post-load
+  preparation when no checkpoint shard was loaded. Normal checkpoint copies
+  and all decode arithmetic remain unchanged.
+- Reject negative or non-finite explicit host/device budgets and reserves.
+- Publish table state only after both allocations succeed, permitting a
+  clean retry after a pinned-host allocation failure.
+
+## Focused validation
+
+Python 3.12, Torch 2.10.0+cu128, NVIDIA V100-SXM2-32GB (SM70), one reserved
+physical GPU 3. Tests use tiny synthetic FP8 tables, no checkpoint or model
+server, and task-owned fresh Triton caches. The existing native extension
+is used for import support; no new C++ execution is claimed by this change.
+
+```bash
+.venv/bin/python -m pytest -q tests/models/qwen4_exp/test_ple.py
+```
+
+The first focused run passed 59 cases, including all-device, mixed and
+all-host gathers, scale decoding, four changing-ID graph replays per split,
+in-place checkpoint reload, stable pointers, poisoned dummy storage and
+budget validation. The allocation-failure retry test was added afterward;
+the final test result and CI head are recorded on the integration PR.
+
+No new full-model throughput or maximum-context claim is made. The original
+PR's heterogeneous-device capacity evidence is retained separately; it must
+not be interpreted as a fresh same-criterion V100 speed measurement.

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -164,6 +164,83 @@ def test_pinned_host_ple_fp8_rows_are_gatherable_across_the_split_on_sm70(
     expected = checkpoint.float() * 0.25
     torch.testing.assert_close(output.float().cpu(), expected[ids.cpu()])
 
+    pointers = (layer._device_table_ptr, dict(layer._accelerator_weight_ptrs))
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            layer(ids)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        graph_output = layer(ids)
+    for offset in range(4):
+        # Reload both halves in-place; captured pointers must stay live.
+        reloaded = raw.roll(offset, dims=0).view(torch.float8_e4m3fn)
+        layer.load_shard(reloaded, checkpoint_start=0, tp_start=0, tp_end=8)
+        layer.prepare_accelerator_weight()
+        ids.copy_((ids + 1) % 8)
+        graph.replay()
+        expected = reloaded.float() * 0.25
+        torch.testing.assert_close(graph_output.float().cpu(), expected[ids.cpu()])
+        assert pointers == (layer._device_table_ptr, layer._accelerator_weight_ptrs)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires pinned memory")
+@pytest.mark.parametrize("host_rows", [0, 4, 8])
+def test_dummy_ple_tables_do_not_retain_uninitialized_bytes(monkeypatch, host_rows):
+    _patch_tp(monkeypatch, rank=0, world_size=1)
+    monkeypatch.setattr(ple_module, "_ple_host_budget_bytes", lambda: host_rows * 8)
+    layer = _pinned_layer(num_embeddings=8)
+    empty = torch.empty
+
+    def poisoned_empty(*args, **kwargs):
+        result = empty(*args, **kwargs)
+        if result.dtype == torch.float8_e4m3fn:
+            result.view(torch.uint8).fill_(0x7F)  # E4M3 NaN, not valid dummy data.
+        return result
+
+    monkeypatch.setattr(ple_module.torch, "empty", poisoned_empty)
+    layer.prepare_accelerator_weight()
+    for table in (layer.ple_device_table, layer.ple_host_storage):
+        assert torch.all(table.view(torch.uint8) == 0)
+
+
+@pytest.mark.parametrize("value", [-1.0, float("nan"), float("inf")])
+@pytest.mark.parametrize("kind", ["HOST", "HOST_RESERVE", "VRAM_RESERVE"])
+def test_ple_budget_rejects_invalid_values(monkeypatch, kind, value):
+    monkeypatch.setattr(ple_module.envs, f"VLLM_QWEN4EXP_PLE_{kind}_GIB", value)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        if kind == "HOST":
+            ple_module._ple_host_budget_bytes()
+        elif kind == "HOST_RESERVE":
+            ple_module._ple_host_reserve_bytes(32 * 1024**3)
+        else:
+            ple_module._ple_vram_reserve_bytes(32 * 1024**3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_ple_host_allocation_failure_keeps_materialization_retryable(monkeypatch):
+    _patch_tp(monkeypatch, rank=0, world_size=1)
+    monkeypatch.setattr(ple_module, "_ple_host_budget_bytes", lambda: 4 * 8)
+    layer = _pinned_layer(num_embeddings=8)
+    empty = torch.empty
+
+    def failing_empty(*args, **kwargs):
+        if kwargs.get("pin_memory"):
+            raise RuntimeError("injected pinned allocation failure")
+        return empty(*args, **kwargs)
+
+    monkeypatch.setattr(ple_module.torch, "empty", failing_empty)
+    with pytest.raises(RuntimeError, match="injected pinned allocation failure"):
+        layer.materialize_tables()
+    assert layer.ple_device_table is None
+    assert layer.ple_host_storage is None
+    assert layer._device_table_ptr == 0
+    monkeypatch.setattr(ple_module.torch, "empty", empty)
+    layer.materialize_tables()
+    assert (layer._device_rows, layer._host_rows) == (4, 4)
+
 
 @pytest.mark.parametrize(
     ("capability", "expected"),
@@ -228,15 +305,29 @@ def test_copy_ple_embedding_shard_split_matches_the_single_copy() -> None:
             vram, host, shard, checkpoint_start=start, tp_start=5, tp_end=15
         )
     torch.testing.assert_close(torch.cat([vram, host]), reference)
-    with pytest.raises(ValueError, match="exceeds the TP range"):
+    with pytest.raises(ValueError, match="do not cover"):
         copy_ple_embedding_shard_split_(
-            torch.zeros(11, 4, dtype=torch.int8),
+            torch.zeros(5, 4, dtype=torch.int8),
             host,
             checkpoint[:6],
             checkpoint_start=0,
             tp_start=5,
             tp_end=15,
         )
+
+
+@pytest.mark.parametrize("host_rows", [0, 4, 8, 12])
+def test_split_copy_accepts_tp_padding(host_rows: int) -> None:
+    checkpoint = torch.arange(20 * 4, dtype=torch.int8).view(20, 4)
+    device = torch.full((12 - host_rows, 4), -1, dtype=torch.int8)
+    host = torch.full((host_rows, 4), -1, dtype=torch.int8)
+    count = copy_ple_embedding_shard_split_(
+        device, host, checkpoint, checkpoint_start=0, tp_start=7, tp_end=17
+    )
+    result = torch.cat([device, host])
+    assert count == 10
+    torch.testing.assert_close(result[:10], checkpoint[7:17])
+    assert torch.all(result[10:] == -1)
 
 
 def test_auto_ple_host_budget_spills_only_the_shortfall() -> None:

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -17,8 +17,12 @@ from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.model_loader.utils import device_loading_context
 from vllm.models.qwen4_exp.common.ple import (
     PLEShardOverlap,
+    auto_ple_host_budget_bytes,
+    available_host_bytes,
     compute_ple_shard_overlap,
     copy_ple_embedding_shard_,
+    copy_ple_embedding_shard_split_,
+    plan_ple_placement,
 )
 from vllm.models.qwen4_exp.nvidia.ple_layer import (
     Qwen4ExpNGramEmbedding,
@@ -29,85 +33,218 @@ from vllm.models.qwen4_exp.nvidia.ple_layer import (
 )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA pinned memory")
-def test_pinned_host_ple_allocates_tp_shard_without_device_table(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _patch_tp(monkeypatch: pytest.MonkeyPatch, rank: int, world_size: int) -> None:
     monkeypatch.setattr(ple_module, "is_pin_memory_available", lambda: True)
-    monkeypatch.setattr(embedding_module, "get_tensor_model_parallel_rank", lambda: 2)
     monkeypatch.setattr(
-        embedding_module, "get_tensor_model_parallel_world_size", lambda: 4
+        embedding_module, "get_tensor_model_parallel_rank", lambda: rank
     )
-    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 2)
     monkeypatch.setattr(
-        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
+        embedding_module, "get_tensor_model_parallel_world_size", lambda: world_size
+    )
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_rank", lambda: rank
+    )
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: world_size
     )
 
-    layer = Qwen4ExpPinnedHostEmbedding(
-        num_embeddings=32,
-        embedding_dim=8,
+
+def _pinned_layer(num_embeddings: int = 32, embedding_dim: int = 8):
+    return Qwen4ExpPinnedHostEmbedding(
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
         params_dtype=torch.float16,
         padding_size=8,
         prefix="model.layers.2.ple.ngram_embedding",
         quant_method=Qwen4ExpPLEFp8EmbeddingMethod(),
     )
 
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA pinned memory")
+def test_pinned_host_ple_allocates_nothing_before_the_first_shard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_tp(monkeypatch, rank=2, world_size=4)
+
+    layer = _pinned_layer()
+
     assert layer.tp_size == 4
-    assert layer.weight.shape == (8, 8)
+    # The loader contract is kept by a row-less CPU placeholder; the TP shard
+    # of 8 rows is only placed once the budget can see the real headroom.
+    assert layer.weight.shape == (0, 8)
     assert layer.weight.dtype == torch.float8_e4m3fn
     assert layer.weight.device.type == "cpu"
-    assert layer.weight.is_pinned()
     assert layer.weight._vllm_keep_on_cpu
-    assert not layer.weight.is_meta
+    assert layer.ple_device_table is None and layer.ple_host_storage is None
     assert not layer.weight_scale.is_meta
     assert layer.weight_scale.dtype == torch.float16
     assert layer._accelerator_weight_views == {}
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA pinned memory")
+def test_pinned_host_ple_splits_the_shard_by_host_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_tp(monkeypatch, rank=2, world_size=4)
+    # 3 rows x 8 bytes fit the host budget, the other 5 rows stay on device.
+    monkeypatch.setattr(ple_module, "_ple_host_budget_bytes", lambda: 3 * 8)
+
+    layer = _pinned_layer()
+    layer.materialize_tables()
+
+    assert layer.ple_device_table is not None and layer.ple_host_storage is not None
+    assert layer.ple_device_table.shape == (5, 8)
+    assert layer.ple_device_table.device.type == "cuda"
+    assert layer.ple_host_storage.shape == (3, 8)
+    assert layer.ple_host_storage.is_pinned()
+    assert (layer._device_rows, layer._host_rows) == (5, 3)
+    # Idempotent: a second call keeps the tables.
+    device_table = layer.ple_device_table
+    layer.materialize_tables()
+    assert layer.ple_device_table is device_table
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA pinned memory")
+def test_pinned_host_ple_without_budget_keeps_everything_on_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_tp(monkeypatch, rank=0, world_size=1)
+    monkeypatch.setattr(ple_module, "_ple_host_budget_bytes", lambda: 0)
+
+    layer = _pinned_layer(num_embeddings=8)
+    # Preparing the accelerator view (process_weights_after_loading) must not
+    # depend on a shard having been loaded, e.g. with dummy weights.
+    layer.prepare_accelerator_weight()
+
+    assert layer.ple_device_table is not None
+    assert layer.ple_device_table.shape == (8, 8)
+    assert layer.ple_host_storage is not None
+    assert layer.ple_host_storage.shape == (0, 8)
+    assert layer._host_rows == 0
 
 
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
     reason="requires an exact SM70 CUDA device",
 )
-def test_pinned_host_ple_fp8_rows_are_gatherable_on_sm70(
+@pytest.mark.parametrize("host_rows", [0, 4, 8])
+def test_pinned_host_ple_fp8_rows_are_gatherable_across_the_split_on_sm70(
     monkeypatch: pytest.MonkeyPatch,
+    host_rows: int,
 ) -> None:
-    monkeypatch.setattr(ple_module, "is_pin_memory_available", lambda: True)
-    monkeypatch.setattr(embedding_module, "get_tensor_model_parallel_rank", lambda: 0)
-    monkeypatch.setattr(
-        embedding_module, "get_tensor_model_parallel_world_size", lambda: 1
-    )
-    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
-    monkeypatch.setattr(
-        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
-    )
+    _patch_tp(monkeypatch, rank=0, world_size=1)
     monkeypatch.setattr(
         embedding_module, "tensor_model_parallel_all_reduce", lambda tensor: tensor
     )
-    layer = Qwen4ExpPinnedHostEmbedding(
-        num_embeddings=8,
-        embedding_dim=8,
-        params_dtype=torch.float16,
-        padding_size=8,
-        prefix="model.layers.2.ple.ngram_embedding",
-        quant_method=Qwen4ExpPLEFp8EmbeddingMethod(),
-    )
+    monkeypatch.setattr(ple_module, "_ple_host_budget_bytes", lambda: host_rows * 8)
+    layer = _pinned_layer(num_embeddings=8)
     raw = torch.tensor(
         [0x00, 0x01, 0x08, 0x38, 0x7E, 0x80, 0xB8, 0xFE],
         dtype=torch.uint8,
     ).repeat(8, 1)
-    layer.weight.data.copy_(raw.view(torch.float8_e4m3fn))
+    # Distinct rows: row i carries the pattern rotated by i.
+    raw = torch.stack([raw[i].roll(i) for i in range(8)])
+    checkpoint = raw.view(torch.float8_e4m3fn)
+    copied = layer.load_shard(checkpoint, checkpoint_start=0, tp_start=0, tp_end=8)
+    assert copied == 8
+    assert (layer._device_rows, layer._host_rows) == (8 - host_rows, host_rows)
     layer.weight_scale = nn.Parameter(
         torch.tensor([0.25], dtype=torch.float16, device="cuda"),
         requires_grad=False,
     )
     layer.prepare_accelerator_weight()
 
-    output = layer(torch.tensor([0, 7], dtype=torch.int64, device="cuda"))
+    ids = torch.tensor([0, 3, 4, 7, 2], dtype=torch.int64, device="cuda")
+    output = layer(ids)
     torch.accelerator.synchronize()
 
     assert output.dtype == torch.float16
-    expected = raw.view(torch.float8_e4m3fn).float() * 0.25
-    torch.testing.assert_close(output.float().cpu(), expected[[0, 7]])
+    expected = checkpoint.float() * 0.25
+    torch.testing.assert_close(output.float().cpu(), expected[ids.cpu()])
+
+
+def test_plan_ple_placement_spills_only_what_the_budget_holds() -> None:
+    assert plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=0) == (
+        plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=7)
+    )
+    placement = plan_ple_placement(
+        total_rows=10, row_bytes=8, host_budget_bytes=3 * 8 + 7
+    )
+    assert (placement.vram_rows, placement.host_rows) == (7, 3)
+    # A budget beyond the table never inflates the host part.
+    big = plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=10**9)
+    assert (big.vram_rows, big.host_rows) == (0, 10)
+    with pytest.raises(ValueError):
+        plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=-1)
+
+
+def test_copy_ple_embedding_shard_split_matches_the_single_copy() -> None:
+    checkpoint = torch.arange(20 * 4, dtype=torch.int8).view(20, 4)
+    # TP range [5, 15) of a 20-row table, checkpoint shards of 6 rows.
+    reference = torch.zeros(10, 4, dtype=torch.int8)
+    vram = torch.zeros(6, 4, dtype=torch.int8)
+    host = torch.zeros(4, 4, dtype=torch.int8)
+    for shard_index in range(4):
+        start = shard_index * 6
+        shard = checkpoint[start : start + 6]
+        copy_ple_embedding_shard_(
+            reference, shard, checkpoint_start=start, tp_start=5, tp_end=15
+        )
+        copy_ple_embedding_shard_split_(
+            vram, host, shard, checkpoint_start=start, tp_start=5, tp_end=15
+        )
+    torch.testing.assert_close(torch.cat([vram, host]), reference)
+    with pytest.raises(ValueError, match="exceeds the TP range"):
+        copy_ple_embedding_shard_split_(
+            torch.zeros(11, 4, dtype=torch.int8),
+            host,
+            checkpoint[:6],
+            checkpoint_start=0,
+            tp_start=5,
+            tp_end=15,
+        )
+
+
+def test_auto_ple_host_budget_spills_only_the_shortfall() -> None:
+    gib = 1024**3
+    common = dict(
+        device_total_bytes=48 * gib,
+        gpu_memory_utilization=0.95,
+        reserve_bytes=2 * gib,
+    )
+    # 45.6 usable - 20 weights - 10 KV - 2 reserve = 13.6 GiB room: a 10 GiB
+    # table fits entirely, a 20 GiB table spills 6.4 GiB.
+    assert (
+        auto_ple_host_budget_bytes(
+            table_bytes=10 * gib,
+            device_allocated_bytes=20 * gib,
+            kv_cache_bytes=10 * gib,
+            **common,
+        )
+        == 0
+    )
+    spill = auto_ple_host_budget_bytes(
+        table_bytes=20 * gib,
+        device_allocated_bytes=20 * gib,
+        kv_cache_bytes=10 * gib,
+        **common,
+    )
+    assert spill == 20 * gib - (int(48 * gib * 0.95) - 32 * gib)
+    # No room at all: the whole table goes to the host, never more.
+    assert (
+        auto_ple_host_budget_bytes(
+            table_bytes=20 * gib,
+            device_allocated_bytes=46 * gib,
+            kv_cache_bytes=10 * gib,
+            **common,
+        )
+        == 20 * gib
+    )
+
+
+def test_available_host_bytes_reads_meminfo() -> None:
+    available = available_host_bytes()
+    assert available is None or available > 0
 
 
 def test_post_load_context_keeps_marked_parameter_on_cpu() -> None:

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -163,6 +163,38 @@ def test_pinned_host_ple_fp8_rows_are_gatherable_across_the_split_on_sm70(
     torch.testing.assert_close(output.float().cpu(), expected[ids.cpu()])
 
 
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [((7, 0), True), ((7, 5), True), ((8, 0), False), ((8, 9), False)],
+)
+def test_pinned_host_ple_decides_on_the_worker_device(
+    monkeypatch: pytest.MonkeyPatch, capability: tuple[int, int], expected: bool
+) -> None:
+    from vllm.platforms.interface import DeviceCapability
+
+    seen: list[int] = []
+
+    def fake_capability(device_id: int = 0) -> DeviceCapability:
+        seen.append(device_id)
+        return DeviceCapability(*capability)
+
+    monkeypatch.setattr(ple_module, "is_offload_process", lambda: False)
+    monkeypatch.setattr(ple_module.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        ple_module.current_platform, "get_device_capability", fake_capability
+    )
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 3)
+
+    config = SimpleNamespace(ple_offload_embedding=None)
+    assert ple_module._should_use_pinned_host_ple(config) is expected
+    # The worker's own device, not device 0 of the visible list.
+    assert seen == [3]
+    # An explicit config choice wins over the capability.
+    assert ple_module._should_use_pinned_host_ple(
+        SimpleNamespace(ple_offload_embedding=not expected)
+    ) is (not expected)
+
+
 def test_plan_ple_placement_spills_only_what_the_budget_holds() -> None:
     assert plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=0) == (
         plan_ple_placement(total_rows=10, row_bytes=8, host_budget_bytes=7)

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -19,10 +19,12 @@ from vllm.models.qwen4_exp.common.ple import (
     PLEShardOverlap,
     auto_ple_host_budget_bytes,
     available_host_bytes,
+    cap_host_budget_bytes,
     compute_ple_shard_overlap,
     copy_ple_embedding_shard_,
     copy_ple_embedding_shard_split_,
     plan_ple_placement,
+    total_host_bytes,
 )
 from vllm.models.qwen4_exp.nvidia.ple_layer import (
     Qwen4ExpNGramEmbedding,
@@ -277,6 +279,59 @@ def test_auto_ple_host_budget_spills_only_the_shortfall() -> None:
 def test_available_host_bytes_reads_meminfo() -> None:
     available = available_host_bytes()
     assert available is None or available > 0
+    total = total_host_bytes()
+    assert total is None or total >= (available or 0)
+
+
+def test_cap_host_budget_shares_the_host_between_ranks() -> None:
+    gib = 1024**3
+    # 30 GB host, 20 GiB available, 7.5 GiB reserve, two ranks: 6.25 GiB each.
+    # The 7.09 GiB that double-booked the host on 2026-09-06 is cut to that.
+    share = cap_host_budget_bytes(
+        budget_bytes=int(7.09 * gib),
+        available_bytes=20 * gib,
+        reserve_bytes=int(7.5 * gib),
+        ranks_sharing_host=2,
+    )
+    assert share == int(12.5 * gib) // 2
+    # A budget below the share passes untouched.
+    assert (
+        cap_host_budget_bytes(
+            budget_bytes=2 * gib,
+            available_bytes=20 * gib,
+            reserve_bytes=int(7.5 * gib),
+            ranks_sharing_host=2,
+        )
+        == 2 * gib
+    )
+    # Reserve swallows everything: nothing may be pinned.
+    assert (
+        cap_host_budget_bytes(
+            budget_bytes=2 * gib,
+            available_bytes=6 * gib,
+            reserve_bytes=8 * gib,
+            ranks_sharing_host=2,
+        )
+        == 0
+    )
+    with pytest.raises(ValueError):
+        cap_host_budget_bytes(
+            budget_bytes=gib, available_bytes=gib, reserve_bytes=0, ranks_sharing_host=0
+        )
+
+
+def test_ple_host_reserve_defaults_to_a_quarter_of_the_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.models.qwen4_exp.nvidia import ple_layer
+
+    monkeypatch.setattr(ple_layer.envs, "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB", None)
+    assert ple_layer._ple_host_reserve_bytes(30 * 1024**3) == int(7.5 * 1024**3)
+    monkeypatch.setattr(ple_layer.envs, "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB", 4.0)
+    assert ple_layer._ple_host_reserve_bytes(30 * 1024**3) == 4 * 1024**3
+    monkeypatch.setattr(ple_layer.envs, "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB", -1.0)
+    with pytest.raises(ValueError):
+        ple_layer._ple_host_reserve_bytes(30 * 1024**3)
 
 
 def test_post_load_context_keeps_marked_parameter_on_cpu() -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -772,6 +772,7 @@ if TYPE_CHECKING:
     VLLM_PLE_OFFLOAD_READY_TIMEOUT: float = 600.0
     VLLM_QWEN4EXP_PLE_HOST_GIB: float | None = None
     VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB: float | None = None
+    VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB: float | None = None
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
@@ -4568,6 +4569,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
         None
         if os.getenv("VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB", "").strip() == ""
         else float(os.getenv("VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB", "0"))
+    ),
+    # Host memory in GiB the automatic PLE placement leaves untouched for the
+    # engine processes, checkpoint loading and other tenants; the rest is
+    # shared equally by the tensor-parallel ranks that pin the table.
+    # Unset: 25 % of the physical host memory.
+    "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB": lambda: (
+        None
+        if os.getenv("VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB", "").strip() == ""
+        else float(os.getenv("VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB", "0"))
     ),
     # Log model inspection after loading.
     # If enabled, logs a transformers-style hierarchical view of the model

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -770,6 +770,8 @@ if TYPE_CHECKING:
     VLLM_PLE_OFFLOAD_AUTO_NUMA: bool = True
     VLLM_PLE_OFFLOAD_PREFAULT: bool = True
     VLLM_PLE_OFFLOAD_READY_TIMEOUT: float = 600.0
+    VLLM_QWEN4EXP_PLE_HOST_GIB: float | None = None
+    VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB: float | None = None
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
@@ -4548,6 +4550,24 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout for PLE weight loading and TP worker registration.
     "VLLM_PLE_OFFLOAD_READY_TIMEOUT": lambda: float(
         os.getenv("VLLM_PLE_OFFLOAD_READY_TIMEOUT", "600")
+    ),
+    # Qwen4Exp pinned-host PLE: host memory in GiB, per tensor-parallel rank,
+    # for the part of the FP8 n-gram table that does not stay in device
+    # memory. Unset or "auto": derived from the device headroom left beside
+    # the weights and the KV cache of the requested context.
+    "VLLM_QWEN4EXP_PLE_HOST_GIB": lambda: (
+        None
+        if os.getenv("VLLM_QWEN4EXP_PLE_HOST_GIB", "auto").strip().lower()
+        in ("", "auto")
+        else float(os.getenv("VLLM_QWEN4EXP_PLE_HOST_GIB", "0"))
+    ),
+    # Device memory in GiB the automatic PLE placement keeps free for the
+    # activation peak and the CUDA graph pool. Unset: 8 % of the device,
+    # at most 4 GiB.
+    "VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB": lambda: (
+        None
+        if os.getenv("VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB", "").strip() == ""
+        else float(os.getenv("VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB", "0"))
     ),
     # Log model inspection after loading.
     # If enabled, logs a transformers-style hierarchical view of the model

--- a/vllm/models/qwen4_exp/common/ple.py
+++ b/vllm/models/qwen4_exp/common/ple.py
@@ -3,11 +3,13 @@
 """Common Qwen4Exp PLE helpers."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 
 from vllm.distributed.utils import get_layers_outside_first_pp_rank
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 
 
 def check_ple_layers_on_first_pp_rank(text_config: Any, pp_size: int) -> None:
@@ -101,3 +103,140 @@ def copy_ple_embedding_shard_(
     with torch.no_grad():
         target.copy_(source.to(device=target.device, dtype=target.dtype))
     return overlap.row_count
+
+
+@dataclass(frozen=True)
+class PLEPlacement:
+    """How many PLE table rows live in device memory and how many on the host."""
+
+    vram_rows: int
+    host_rows: int
+
+    @property
+    def total_rows(self) -> int:
+        return self.vram_rows + self.host_rows
+
+
+def plan_ple_placement(
+    *,
+    total_rows: int,
+    row_bytes: int,
+    host_budget_bytes: int,
+) -> PLEPlacement:
+    """Place as many PLE rows as possible in device memory.
+
+    The table is addressed by hashes, so every row is equally likely to be read
+    and the split point carries no meaning beyond capacity: whatever does not
+    fit in device memory goes to the host. Rows are never dropped, so the
+    caller must provide a host budget large enough for the remainder.
+    """
+
+    if total_rows < 0 or row_bytes <= 0:
+        raise ValueError("total_rows must be non-negative and row_bytes positive")
+    if host_budget_bytes < 0:
+        raise ValueError("host budget must be non-negative")
+    host_rows = min(total_rows, host_budget_bytes // row_bytes)
+    return PLEPlacement(vram_rows=total_rows - host_rows, host_rows=host_rows)
+
+
+def copy_ple_embedding_shard_split_(
+    vram_table: torch.Tensor,
+    host_table: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    checkpoint_start: int,
+    tp_start: int,
+    tp_end: int,
+) -> int:
+    """Copy one checkpoint shard into a table split across device and host.
+
+    The split point is a row index in the TP-local range, so both halves are
+    plain sub-ranges of the same vocabulary interval and the single-target
+    copy above handles each of them unchanged.
+    """
+
+    boundary = tp_start + vram_table.shape[0]
+    if boundary > tp_end:
+        raise ValueError(
+            f"device part ({vram_table.shape[0]} rows) exceeds the TP range "
+            f"({tp_end - tp_start} rows)"
+        )
+    copied = 0
+    if vram_table.shape[0]:
+        copied += copy_ple_embedding_shard_(
+            vram_table,
+            loaded_weight,
+            checkpoint_start=checkpoint_start,
+            tp_start=tp_start,
+            tp_end=boundary,
+        )
+    if host_table.shape[0]:
+        copied += copy_ple_embedding_shard_(
+            host_table,
+            loaded_weight,
+            checkpoint_start=checkpoint_start,
+            tp_start=boundary,
+            tp_end=tp_end,
+        )
+    return copied
+
+
+def kv_cache_bytes_for_max_model_len(vllm_config: "VllmConfig") -> int:
+    """Bytes this rank's KV cache needs to serve ``max_model_len``.
+
+    Sums what every KV-owning layer of this pipeline stage declares. The specs
+    are the engine's own source of truth for that number -- the same ones the
+    allocator consults later -- so the estimate cannot drift from what is
+    actually reserved.
+    """
+
+    from vllm.config import get_layers_from_vllm_config
+    from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+
+    layers = get_layers_from_vllm_config(vllm_config, AttentionLayerBase)  # type: ignore[type-abstract]
+    total = 0
+    for layer in layers.values():
+        spec = layer.get_kv_cache_spec(vllm_config)
+        if spec is not None:
+            total += spec.max_memory_usage_bytes(vllm_config)
+    return total
+
+
+def auto_ple_host_budget_bytes(
+    *,
+    table_bytes: int,
+    device_total_bytes: int,
+    device_allocated_bytes: int,
+    gpu_memory_utilization: float,
+    kv_cache_bytes: int,
+    reserve_bytes: int,
+) -> int:
+    """Host bytes needed so the requested context still fits beside the table.
+
+    The table stays in device memory and only what the context claims is
+    spilled -- never more. Spilling beyond that would be wasted: with pipeline
+    parallelism the weakest stage caps the block count for all of them, so
+    surplus room on this rank buys nothing while pinned host memory is the
+    scarcer resource.
+    """
+
+    if table_bytes < 0 or device_total_bytes <= 0:
+        raise ValueError("table and device sizes must be non-negative")
+    usable = int(device_total_bytes * gpu_memory_utilization)
+    room_for_table = usable - device_allocated_bytes - kv_cache_bytes - reserve_bytes
+    if room_for_table >= table_bytes:
+        return 0
+    return table_bytes - max(0, room_for_table)
+
+
+def available_host_bytes() -> int | None:
+    """Host memory the kernel currently reports as available, or None."""
+
+    try:
+        with open("/proc/meminfo") as meminfo:
+            for line in meminfo:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        return None
+    return None

--- a/vllm/models/qwen4_exp/common/ple.py
+++ b/vllm/models/qwen4_exp/common/ple.py
@@ -156,12 +156,13 @@ def copy_ple_embedding_shard_split_(
     copy above handles each of them unchanged.
     """
 
-    boundary = tp_start + vram_table.shape[0]
-    if boundary > tp_end:
-        raise ValueError(
-            f"device part ({vram_table.shape[0]} rows) exceeds the TP range "
-            f"({tp_end - tp_start} rows)"
-        )
+    if tp_start < 0 or tp_end < tp_start:
+        raise ValueError("invalid TP vocabulary range")
+    if vram_table.shape[0] + host_table.shape[0] < tp_end - tp_start:
+        raise ValueError("split tables do not cover the requested TP range")
+    # Storage includes vocabulary padding, while checkpoint TP bounds do not.
+    # Padding can lie in either half and must not reject a valid checkpoint.
+    boundary = min(tp_end, tp_start + vram_table.shape[0])
     copied = 0
     if vram_table.shape[0]:
         copied += copy_ple_embedding_shard_(
@@ -171,7 +172,7 @@ def copy_ple_embedding_shard_split_(
             tp_start=tp_start,
             tp_end=boundary,
         )
-    if host_table.shape[0]:
+    if boundary < tp_end:
         copied += copy_ple_embedding_shard_(
             host_table,
             loaded_weight,
@@ -187,8 +188,8 @@ def kv_cache_bytes_for_max_model_len(vllm_config: "VllmConfig") -> int:
 
     Sums what every KV-owning layer of this pipeline stage declares. The specs
     are the engine's own source of truth for that number -- the same ones the
-    allocator consults later -- so the estimate cannot drift from what is
-    actually reserved.
+    allocator consults later. This is a per-layer estimate: hybrid cache
+    grouping and allocator padding can require additional capacity.
     """
 
     from vllm.config import get_layers_from_vllm_config

--- a/vllm/models/qwen4_exp/common/ple.py
+++ b/vllm/models/qwen4_exp/common/ple.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from vllm.distributed.utils import get_layers_outside_first_pp_rank
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 

--- a/vllm/models/qwen4_exp/common/ple.py
+++ b/vllm/models/qwen4_exp/common/ple.py
@@ -230,14 +230,51 @@ def auto_ple_host_budget_bytes(
     return table_bytes - max(0, room_for_table)
 
 
-def available_host_bytes() -> int | None:
-    """Host memory the kernel currently reports as available, or None."""
-
+def _meminfo_bytes(key: str) -> int | None:
     try:
         with open("/proc/meminfo") as meminfo:
             for line in meminfo:
-                if line.startswith("MemAvailable:"):
+                if line.startswith(key + ":"):
                     return int(line.split()[1]) * 1024
     except OSError:
         return None
     return None
+
+
+def available_host_bytes() -> int | None:
+    """Host memory the kernel currently reports as available, or None."""
+
+    return _meminfo_bytes("MemAvailable")
+
+
+def total_host_bytes() -> int | None:
+    """Physical host memory as the kernel reports it, or None."""
+
+    return _meminfo_bytes("MemTotal")
+
+
+def cap_host_budget_bytes(
+    *,
+    budget_bytes: int,
+    available_bytes: int,
+    reserve_bytes: int,
+    ranks_sharing_host: int,
+) -> int:
+    """Bound a rank's pinned-host budget by its fair share of the host.
+
+    Every tensor-parallel rank of the stage that owns the table pins its own
+    share, and all of them draw on the same host memory. Reading MemAvailable
+    per rank therefore double-books it: on a 30 GB host with 20 GB available,
+    two ranks each saw room for 7 GiB, pinned 14 GiB together and pushed the
+    engine processes, the checkpoint loading and everything else into swap
+    (2026-09-06). The share is what remains after the reserve, divided by the
+    ranks; a budget above it is cut to the share. What no longer spills stays
+    on the device, and if the context then does not fit, the KV allocator
+    reports the reachable max_model_len -- host memory is the hard limit,
+    context the negotiable one.
+    """
+
+    if ranks_sharing_host <= 0:
+        raise ValueError("ranks_sharing_host must be positive")
+    share = max(0, available_bytes - reserve_bytes) // ranks_sharing_host
+    return min(budget_bytes, share)

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -73,10 +73,12 @@ from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from ..common.ple import (
     auto_ple_host_budget_bytes,
     available_host_bytes,
+    cap_host_budget_bytes,
     copy_ple_embedding_shard_,
     copy_ple_embedding_shard_split_,
     kv_cache_bytes_for_max_model_len,
     plan_ple_placement,
+    total_host_bytes,
 )
 
 _MASK64 = (1 << 64) - 1
@@ -533,6 +535,25 @@ def _ple_host_budget_bytes() -> int | None:
     return int(budget_gib * 1024**3)
 
 
+def _ple_host_reserve_bytes(host_total_bytes: int) -> int:
+    """Host memory the automatic placement leaves to everything else.
+
+    The engine processes, the checkpoint loading and other tenants of the
+    host need room that no single rank can measure; on a 30 GB host the
+    default keeps 7.5 GiB.
+    """
+
+    reserve_gib = envs.VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB
+    if reserve_gib is not None:
+        if reserve_gib < 0:
+            raise ValueError(
+                "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB must not be negative, "
+                f"got {reserve_gib}"
+            )
+        return int(reserve_gib * 1024**3)
+    return host_total_bytes // 4
+
+
 def _ple_vram_reserve_bytes(device_total_bytes: int) -> int:
     """Device memory the automatic placement keeps free.
 
@@ -660,6 +681,33 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
             format_gib(reserve_bytes),
             format_gib(budget),
         )
+        # The table lives on the first pipeline stage only, so its
+        # tensor-parallel ranks are the ones sharing this host's memory.
+        host_available = available_host_bytes()
+        host_total = total_host_bytes()
+        if budget and host_available is not None and host_total is not None:
+            ranks = vllm_config.parallel_config.tensor_parallel_size
+            host_reserve = _ple_host_reserve_bytes(host_total)
+            capped = cap_host_budget_bytes(
+                budget_bytes=budget,
+                available_bytes=host_available,
+                reserve_bytes=host_reserve,
+                ranks_sharing_host=ranks,
+            )
+            if capped < budget:
+                logger.warning(
+                    "Qwen4Exp PLE host budget cut from %s to %s: %s host "
+                    "memory available, %s kept in reserve, shared by %d "
+                    "tensor-parallel ranks. The rest of the table stays on the "
+                    "device; if the requested context no longer fits, the KV "
+                    "allocator reports the reachable max_model_len.",
+                    format_gib(budget),
+                    format_gib(capped),
+                    format_gib(host_available),
+                    format_gib(host_reserve),
+                    ranks,
+                )
+                budget = capped
         return budget
 
     def materialize_tables(self) -> None:

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -70,7 +70,14 @@ from vllm.v1.attention.backends.short_conv_attn import (
 )
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
-from ..common.ple import copy_ple_embedding_shard_
+from ..common.ple import (
+    auto_ple_host_budget_bytes,
+    available_host_bytes,
+    copy_ple_embedding_shard_,
+    copy_ple_embedding_shard_split_,
+    kv_cache_bytes_for_max_model_len,
+    plan_ple_placement,
+)
 
 _MASK64 = (1 << 64) - 1
 _SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
@@ -503,13 +510,50 @@ def _should_use_pinned_host_ple(config: Qwen4ExpTextConfig) -> bool:
     return capability is not None and capability.to_int() == 70
 
 
-class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
-    """TP-sharded FP8 PLE table backed directly by pinned host memory.
+def _ple_host_budget_bytes() -> int | None:
+    """Configured host bytes per rank for the PLE table, or None to derive them."""
 
-    The base embedding is constructed on the meta device, so the full shard is
-    never allocated on a GPU. Checkpoint shards copy directly into the pinned
-    CPU parameter. A stable UVA view is created after loading and used only for
-    embedding gathers.
+    budget_gib = envs.VLLM_QWEN4EXP_PLE_HOST_GIB
+    if budget_gib is None:
+        return None
+    if budget_gib < 0:
+        raise ValueError(
+            f"VLLM_QWEN4EXP_PLE_HOST_GIB must not be negative, got {budget_gib}"
+        )
+    return int(budget_gib * 1024**3)
+
+
+def _ple_vram_reserve_bytes(device_total_bytes: int) -> int:
+    """Device memory the automatic placement keeps free.
+
+    It covers the activation peak and the graph pool, which the engine only
+    measures after the weights are placed -- so they cannot be read here. On
+    a 48 GB card the gap between (weights + KV) and the utilization budget
+    stayed between 1.8 and 2.3 GiB; the default leaves a slightly wider
+    margin. Overshooting costs host memory, undershooting makes the KV
+    allocator fail late.
+    """
+
+    reserve_gib = envs.VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB
+    if reserve_gib is not None:
+        return int(reserve_gib * 1024**3)
+    return min(int(device_total_bytes * 0.08), 4 * 1024**3)
+
+
+class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+    """TP-sharded FP8 PLE table split between device memory and pinned host.
+
+    The base embedding is constructed on the meta device, so nothing is
+    allocated up front. The real tables are built lazily on the first
+    checkpoint shard (or when the accelerator view is prepared), when every
+    other weight of this pipeline stage is already placed and the automatic
+    budget can measure the real headroom: rows that fit beside the weights,
+    the KV cache of the requested context and a reserve stay in device
+    memory, only the remainder goes to pinned host memory and is gathered
+    through a stable UVA view. ``VLLM_QWEN4EXP_PLE_HOST_GIB`` fixes the host
+    share instead. Gathers always read both halves (an unused half reads row
+    0), because branching on the ids would need a device-to-host sync on
+    every decode step.
     """
 
     def __init__(
@@ -541,19 +585,23 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         meta_weight = self._parameters.get("weight")
         if not isinstance(meta_weight, torch.Tensor):
             raise RuntimeError("Qwen4Exp PLE meta weight was not initialized")
-        host_weight = ModelWeightParameter(
+        self._meta_weight_shape = tuple(meta_weight.shape)
+        self._meta_weight_dtype = meta_weight.dtype
+        # Placeholder parameter: keeps the loader contract (a CPU-resident
+        # ``weight`` that must not be moved to the device) without holding
+        # rows; the tables live in ple_device_table / ple_host_storage.
+        placeholder = ModelWeightParameter(
             data=torch.empty(
-                tuple(meta_weight.shape),
+                (0, self.embedding_dim),
                 dtype=meta_weight.dtype,
                 device="cpu",
-                pin_memory=True,
             ),
             input_dim=1,
             output_dim=0,
             weight_loader=self.weight_loader,
         )
-        host_weight._vllm_keep_on_cpu = True
-        self.weight = host_weight
+        placeholder._vllm_keep_on_cpu = True
+        self.weight = placeholder
         self.weight_scale = create_fp8_scale_parameter(
             PerTensorScaleParameter,
             [self.num_embeddings_per_partition],
@@ -565,9 +613,111 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         self._accelerator_weight_views: dict[int, torch.Tensor] = {}
         self._accelerator_weight_ptrs: dict[int, int] = {}
         self._output_dtype = self.weight_scale.dtype
+        self._device_rows = 0
+        self._host_rows = 0
+        self._device_table_ptr = 0
+        self.ple_device_table: torch.Tensor | None = None
+        self.ple_host_storage: torch.Tensor | None = None
+
+    def _resolve_host_budget(self, device: torch.device) -> int:
+        """Host bytes for the table: as configured, or derived from headroom."""
+        explicit = _ple_host_budget_bytes()
+        if explicit is not None:
+            return explicit
+        vllm_config = get_current_vllm_config()
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        kv_bytes = kv_cache_bytes_for_max_model_len(vllm_config)
+        reserve_bytes = _ple_vram_reserve_bytes(total_bytes)
+        gmu = vllm_config.cache_config.gpu_memory_utilization
+        table_bytes = self._meta_weight_shape[0] * self.embedding_dim
+        budget = auto_ple_host_budget_bytes(
+            table_bytes=table_bytes,
+            device_total_bytes=total_bytes,
+            device_allocated_bytes=total_bytes - free_bytes,
+            gpu_memory_utilization=gmu,
+            kv_cache_bytes=kv_bytes,
+            reserve_bytes=reserve_bytes,
+        )
         logger.info(
-            "Qwen4Exp PLE shard allocated in pinned host memory: %s",
-            format_gib(self.weight.numel() * self.weight.element_size()),
+            "Qwen4Exp PLE auto placement: %s usable at gmu=%.2f, %s already "
+            "allocated, %s KV for %d tokens, %s reserve -> %s of the table go "
+            "to host memory",
+            format_gib(int(total_bytes * gmu)),
+            gmu,
+            format_gib(total_bytes - free_bytes),
+            format_gib(kv_bytes),
+            vllm_config.model_config.max_model_len,
+            format_gib(reserve_bytes),
+            format_gib(budget),
+        )
+        return budget
+
+    def materialize_tables(self) -> None:
+        """Allocate the device and host parts of the FP8 table (idempotent)."""
+        if self.ple_device_table is not None:
+            return
+        device = torch.device("cuda", torch.accelerator.current_device_index())
+        total_rows = self._meta_weight_shape[0]
+        host_budget = self._resolve_host_budget(device)
+        placement = plan_ple_placement(
+            total_rows=total_rows,
+            row_bytes=self.embedding_dim,
+            host_budget_bytes=host_budget,
+        )
+        needed = placement.host_rows * self.embedding_dim
+        available = available_host_bytes()
+        if needed and available is not None and needed > available:
+            raise RuntimeError(
+                f"Qwen4Exp PLE placement needs {format_gib(needed)} of pinned "
+                f"host memory but only {format_gib(available)} is available, "
+                "and every tensor-parallel rank pins its own share. Lower the "
+                "requested context or VLLM_QWEN4EXP_PLE_HOST_GIB."
+            )
+        self.ple_device_table = torch.empty(
+            (placement.vram_rows, self.embedding_dim),
+            dtype=self._meta_weight_dtype,
+            device=device,
+        )
+        self.ple_host_storage = torch.empty(
+            (placement.host_rows, self.embedding_dim),
+            dtype=self._meta_weight_dtype,
+            device="cpu",
+            pin_memory=placement.host_rows > 0,
+        )
+        self._device_rows = placement.vram_rows
+        self._host_rows = placement.host_rows
+        # Cached as a plain int: torch.compile cannot trace data_ptr() inside
+        # the forward, the same reason the host pointer is cached below.
+        self._device_table_ptr = self.ple_device_table.data_ptr()
+        logger.info(
+            "Qwen4Exp PLE table placement: %d of %d rows in device memory "
+            "(%s), %d rows in pinned host memory (%s)",
+            placement.vram_rows,
+            placement.total_rows,
+            format_gib(placement.vram_rows * self.embedding_dim),
+            placement.host_rows,
+            format_gib(placement.host_rows * self.embedding_dim),
+        )
+
+    def load_shard(
+        self,
+        loaded_weight: torch.Tensor,
+        *,
+        checkpoint_start: int,
+        tp_start: int,
+        tp_end: int,
+    ) -> int:
+        """Copy one checkpoint shard into whichever part owns its rows."""
+        self.materialize_tables()
+        assert self.ple_device_table is not None
+        assert self.ple_host_storage is not None
+        return copy_ple_embedding_shard_split_(
+            self.ple_device_table,
+            self.ple_host_storage,
+            loaded_weight,
+            checkpoint_start=checkpoint_start,
+            tp_start=tp_start,
+            tp_end=tp_end,
         )
 
     def get_accelerator_weight(self, device: torch.device) -> torch.Tensor:
@@ -586,8 +736,13 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 raise RuntimeError(
                     "Qwen4Exp PLE UVA view must be prepared before CUDA graph capture"
                 )
-            with torch.accelerator.device_index(device_index):
-                view = get_accelerator_view_from_cpu_tensor(self.weight)
+            self.materialize_tables()
+            assert self.ple_host_storage is not None
+            if self.ple_host_storage.numel():
+                with torch.accelerator.device_index(device_index):
+                    view = get_accelerator_view_from_cpu_tensor(self.ple_host_storage)
+            else:
+                view = self.ple_host_storage
             self._accelerator_weight_views[device_index] = view
             self._accelerator_weight_ptrs[device_index] = view.data_ptr()
         return view
@@ -598,29 +753,55 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         )
 
     def embedding_lookup(self, input_: torch.Tensor) -> torch.Tensor:
-        """Gather FP8 UVA rows and emit scaled model-dtype values."""
+        """Gather FP8 rows from the device/host split, emit scaled values."""
 
         device_index = (
             torch.accelerator.current_device_index()
             if input_.device.index is None
             else input_.device.index
         )
-        weight_ptr = self._accelerator_weight_ptrs.get(device_index)
-        if weight_ptr is None:
+        host_ptr = self._accelerator_weight_ptrs.get(device_index)
+        if host_ptr is None:
             self.get_accelerator_weight(input_.device)
-            weight_ptr = self._accelerator_weight_ptrs[device_index]
+            host_ptr = self._accelerator_weight_ptrs[device_index]
+        flat_ids = input_.reshape(-1)
         output = torch.empty(
             (*input_.shape, self.embedding_dim),
             dtype=self._output_dtype,
             device=input_.device,
         )
+        out_flat = output.reshape(-1, self.embedding_dim)
+        if self._host_rows == 0 or self._device_rows == 0:
+            table_ptr = self._device_table_ptr if self._host_rows == 0 else host_ptr
+            torch.ops.vllm.qwen4_exp_ple_pinned_gather(
+                flat_ids,
+                out_flat,
+                self.weight_scale,
+                table_ptr,
+                self.embedding_dim,
+            )
+            return output
+        boundary = self._device_rows
+        on_host = flat_ids >= boundary
+        zero = flat_ids.new_zeros(())
+        device_ids = torch.where(on_host, zero, flat_ids)
+        host_ids = torch.where(on_host, flat_ids - boundary, zero)
+        host_out = torch.empty_like(out_flat)
         torch.ops.vllm.qwen4_exp_ple_pinned_gather(
-            input_.reshape(-1),
-            output.reshape(-1, self.embedding_dim),
+            device_ids,
+            out_flat,
             self.weight_scale,
-            weight_ptr,
+            self._device_table_ptr,
             self.embedding_dim,
         )
+        torch.ops.vllm.qwen4_exp_ple_pinned_gather(
+            host_ids,
+            host_out,
+            self.weight_scale,
+            host_ptr,
+            self.embedding_dim,
+        )
+        out_flat.copy_(torch.where(on_host.unsqueeze(-1), host_out, out_flat))
         return output
 
 
@@ -1177,13 +1358,23 @@ class Qwen4ExpNGramEmbedding(PleOffloadLayer):
                     self._disk_mapped_paths.add(mapped_path)
                     loaded.add("ngram_embedding.weight")
                     continue
-                copy_ple_embedding_shard_(
-                    embedding.weight.data,
-                    loaded_weight,
-                    checkpoint_start=checkpoint_start,
-                    tp_start=embedding.shard_indices.org_vocab_start_index,
-                    tp_end=embedding.shard_indices.org_vocab_end_index,
-                )
+                if isinstance(embedding, Qwen4ExpPinnedHostEmbedding):
+                    # Split placement: the embedding routes each shard into
+                    # its device or host part (tables built on first shard).
+                    embedding.load_shard(
+                        loaded_weight,
+                        checkpoint_start=checkpoint_start,
+                        tp_start=embedding.shard_indices.org_vocab_start_index,
+                        tp_end=embedding.shard_indices.org_vocab_end_index,
+                    )
+                else:
+                    copy_ple_embedding_shard_(
+                        embedding.weight.data,
+                        loaded_weight,
+                        checkpoint_start=checkpoint_start,
+                        tp_start=embedding.shard_indices.org_vocab_start_index,
+                        tp_end=embedding.shard_indices.org_vocab_end_index,
+                    )
                 loaded.add("ngram_embedding.weight")
                 continue
             if disk_offload and name == "ngram_embedding.weight_scale":

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -528,9 +528,10 @@ def _ple_host_budget_bytes() -> int | None:
     budget_gib = envs.VLLM_QWEN4EXP_PLE_HOST_GIB
     if budget_gib is None:
         return None
-    if budget_gib < 0:
+    if not math.isfinite(budget_gib) or budget_gib < 0:
         raise ValueError(
-            f"VLLM_QWEN4EXP_PLE_HOST_GIB must not be negative, got {budget_gib}"
+            f"VLLM_QWEN4EXP_PLE_HOST_GIB must be finite and non-negative, "
+            f"got {budget_gib}"
         )
     return int(budget_gib * 1024**3)
 
@@ -545,9 +546,9 @@ def _ple_host_reserve_bytes(host_total_bytes: int) -> int:
 
     reserve_gib = envs.VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB
     if reserve_gib is not None:
-        if reserve_gib < 0:
+        if not math.isfinite(reserve_gib) or reserve_gib < 0:
             raise ValueError(
-                "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB must not be negative, "
+                "VLLM_QWEN4EXP_PLE_HOST_RESERVE_GIB must be finite and non-negative, "
                 f"got {reserve_gib}"
             )
         return int(reserve_gib * 1024**3)
@@ -567,6 +568,11 @@ def _ple_vram_reserve_bytes(device_total_bytes: int) -> int:
 
     reserve_gib = envs.VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB
     if reserve_gib is not None:
+        if not math.isfinite(reserve_gib) or reserve_gib < 0:
+            raise ValueError(
+                "VLLM_QWEN4EXP_PLE_VRAM_RESERVE_GIB must be finite and non-negative, "
+                f"got {reserve_gib}"
+            )
         return int(reserve_gib * 1024**3)
     return min(int(device_total_bytes * 0.08), 4 * 1024**3)
 
@@ -649,6 +655,7 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         self._device_table_ptr = 0
         self.ple_device_table: torch.Tensor | None = None
         self.ple_host_storage: torch.Tensor | None = None
+        self._checkpoint_shard_loaded = False
 
     def _resolve_host_budget(self, device: torch.device) -> int:
         """Host bytes for the table: as configured, or derived from headroom."""
@@ -731,17 +738,21 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 "and every tensor-parallel rank pins its own share. Lower the "
                 "requested context or VLLM_QWEN4EXP_PLE_HOST_GIB."
             )
-        self.ple_device_table = torch.empty(
+        device_table = torch.empty(
             (placement.vram_rows, self.embedding_dim),
             dtype=self._meta_weight_dtype,
             device=device,
         )
-        self.ple_host_storage = torch.empty(
+        host_storage = torch.empty(
             (placement.host_rows, self.embedding_dim),
             dtype=self._meta_weight_dtype,
             device="cpu",
             pin_memory=placement.host_rows > 0,
         )
+        # Publish only a complete allocation so a host allocation failure
+        # cannot leave the idempotent path pointing at a half-built table.
+        self.ple_device_table = device_table
+        self.ple_host_storage = host_storage
         self._device_rows = placement.vram_rows
         self._host_rows = placement.host_rows
         # Cached as a plain int: torch.compile cannot trace data_ptr() inside
@@ -769,7 +780,7 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         self.materialize_tables()
         assert self.ple_device_table is not None
         assert self.ple_host_storage is not None
-        return copy_ple_embedding_shard_split_(
+        copied = copy_ple_embedding_shard_split_(
             self.ple_device_table,
             self.ple_host_storage,
             loaded_weight,
@@ -777,6 +788,8 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
             tp_start=tp_start,
             tp_end=tp_end,
         )
+        self._checkpoint_shard_loaded = True
+        return copied
 
     def get_accelerator_weight(self, device: torch.device) -> torch.Tensor:
         if device.type != "cuda":
@@ -806,6 +819,15 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
         return view
 
     def prepare_accelerator_weight(self) -> None:
+        self.materialize_tables()
+        if not self._checkpoint_shard_loaded and not self._accelerator_weight_views:
+            # Dummy loading initializes only the zero-row parameter, not these
+            # private tables. Ensure finite profiling data before graph capture.
+            # Real checkpoints load in-place before this post-load callback.
+            assert self.ple_device_table is not None
+            assert self.ple_host_storage is not None
+            self.ple_device_table.view(torch.uint8).zero_()
+            self.ple_host_storage.view(torch.uint8).zero_()
         self.get_accelerator_weight(
             torch.device("cuda", torch.accelerator.current_device_index())
         )

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -506,8 +506,18 @@ def _should_use_pinned_host_ple(config: Qwen4ExpTextConfig) -> bool:
     explicit = getattr(config, "ple_offload_embedding", None)
     if explicit is not None:
         return bool(explicit)
-    capability = current_platform.get_device_capability()
-    return capability is not None and capability.to_int() == 70
+    if not current_platform.is_cuda():
+        return False
+    # Decide on THIS worker's device: on a heterogeneous pipeline the PLE
+    # stage is not necessarily device 0 of the visible list. Every
+    # pre-Ampere card takes the split placement, not only exact Volta: the
+    # generic path dequantizes the whole FP8 table to fp16 inside the
+    # compiled graph (47.7 GiB for Qwen3.8 Flash Next), which none of them
+    # can hold.
+    capability = current_platform.get_device_capability(
+        device_id=torch.accelerator.current_device_index()
+    )
+    return capability is not None and capability.major < 8
 
 
 def _ple_host_budget_bytes() -> int | None:


### PR DESCRIPTION
## Purpose
Integrate #528 on current public main `53199eb8b996831718330c23144c60ed9952f690`, preserving its commits and automatic split PLE placement. Fix audit findings without adding decode-time branches or changing gather arithmetic.

## Repairs
- Logical TP bounds may exclude physical vocabulary padding. Original all-device copy rejected a valid padded table (reproduced: 1 failed / 3 passed); preserve padding and reject only insufficient total storage.
- Dummy loader initializes only the zero-row placeholder, leaving the private tables uninitialized. Initialize finite zero bytes before first post-load preparation if no checkpoint shard was loaded; real checkpoint path remains in-place.
- Validate finite non-negative host budgets and host/device reserves.
- Publish allocation state only after both device and pinned-host allocation succeed.

## Test Plan / Result
- Focused V100 suite: 59 passed, including all-device/mixed/all-host gather, FP8 decoding, changing-ID CUDA Graph replay, in-place reload and pointer stability, poisoned dummy data and budget guards.
- Additional allocation-failure/retry regression passed separately (60 PLE cases covered in total).
- 101 config/environment/fingerprint regressions passed.
- Scoped pre-commit including mypy passed. Awaiting fresh GitHub integration checks before merge.
- No model server or full E2E rerun. Physical V100 GPU 3 was reserved with existing group and per-GPU locks; task-owned Triton caches used. No new C++ kernel build is claimed.

## Performance / limitations
Preserve #528 capacity/default placement logic. These repairs are load-time; no new decode arithmetic or additional runtime copy is introduced. No fresh model-level speed or maximum-context claim. Memory planning is an estimate; hybrid allocator padding, actual graph/activation peaks and host limits can still cap the reachable context. See `docs/design/ple_split_mainline_audit.md`.

## Ownership
Owned worktree `/home/ymzx/桌面/1cat-vllm/worktrees/v100-sep07-ple-review-20260907-030709`. Logs `/tmp/1cat-sep07-ple-gpu.log`, `/tmp/1cat-sep07-ple-retry.log`, `/tmp/1cat-sep07-ple-config.log`. Canonical dirty checkout untouched.