### PR TITLE
[Bugfix][MTP] Integrate safe YaRN context inheritance (#410)

### DIFF
--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -228,6 +228,38 @@ def test_native_mtp_rejects_missing_yarn_parameters(key: str) -> None:
         SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
 
 
+@pytest.mark.parametrize("rope_type", ["linear", "yarn"])
+def test_native_mtp_preserves_existing_matching_scaled_context(rope_type: str) -> None:
+    from vllm.config.model import _get_and_verify_max_len
+
+    config, draft_hf_config = _native_mtp_yarn_config()
+    rope = {
+        "rope_type": rope_type,
+        "factor": 4.0,
+        "original_max_position_embeddings": 262_144,
+    }
+    config.target_model_config.hf_config.rope_parameters = copy.deepcopy(rope)
+    draft_hf_config.rope_parameters = copy.deepcopy(rope)
+    original_rope = draft_hf_config.rope_parameters
+
+    def derive_limit(requested: int) -> int:
+        return _get_and_verify_max_len(
+            hf_config=draft_hf_config,
+            model_arch_config=SimpleNamespace(
+                derived_max_model_len_and_key=(262_144, "max_position_embeddings")
+            ),
+            tokenizer_config=None,
+            max_model_len=requested,
+            disable_sliding_window=False,
+            sliding_window=None,
+        )
+
+    config.draft_model_config.get_and_verify_max_len = derive_limit
+    assert derive_limit(-1) == 1_048_576
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+    assert draft_hf_config.rope_parameters is original_rope
+
+
 @pytest.mark.parametrize("field,value", [("method", "eagle"), ("model", "other/draft")])
 def test_native_mtp_leaves_unrelated_drafters_unchanged(field: str, value: str) -> None:
     config, draft_hf_config = _native_mtp_yarn_config()

--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -116,7 +116,10 @@ def _native_mtp_yarn_config(
             "factor": 4.0,
             "original_max_position_embeddings": 262_144,
         }
-    target_hf_config = PretrainedConfig(rope_parameters=rope_parameters)
+    target_hf_config = PretrainedConfig(max_position_embeddings=262_144)
+    # Keep deliberately invalid fixtures out of Transformers' constructor
+    # validation so these cases exercise vLLM's own inheritance checks.
+    target_hf_config.rope_parameters = copy.deepcopy(rope_parameters)
     draft_hf_config = PretrainedConfig(max_position_embeddings=262_144)
     target_model_config = SimpleNamespace(
         model="test/native-mtp",
@@ -199,4 +202,36 @@ def test_native_mtp_does_not_modify_unextended_drafter() -> None:
 
     SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
 
+    assert draft_hf_config.to_dict() == original
+
+
+@pytest.mark.parametrize("factor", [0.0, 1.0, float("nan"), float("inf"), 1e308])
+def test_native_mtp_rejects_invalid_or_overflowing_yarn_factor(factor: float) -> None:
+    config, _ = _native_mtp_yarn_config()
+    config.target_model_config.hf_config.rope_parameters["factor"] = factor
+    with pytest.raises(ValueError):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+def test_native_mtp_respects_target_limit_below_yarn_limit() -> None:
+    config, _ = _native_mtp_yarn_config(max_model_len=800_001)
+    config.target_model_config.max_model_len = 800_000
+    with pytest.raises(ValueError, match="validated target YaRN limit=800000"):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+@pytest.mark.parametrize("key", ["factor", "original_max_position_embeddings"])
+def test_native_mtp_rejects_missing_yarn_parameters(key: str) -> None:
+    config, _ = _native_mtp_yarn_config()
+    config.target_model_config.hf_config.rope_parameters.pop(key)
+    with pytest.raises(ValueError, match="requires numeric"):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+@pytest.mark.parametrize("field,value", [("method", "eagle"), ("model", "other/draft")])
+def test_native_mtp_leaves_unrelated_drafters_unchanged(field: str, value: str) -> None:
+    config, draft_hf_config = _native_mtp_yarn_config()
+    setattr(config, field, value)
+    original = copy.deepcopy(draft_hf_config.to_dict())
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
     assert draft_hf_config.to_dict() == original

--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -2,7 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Test whether spec decoding handles the max model length properly."""
 
+import copy
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
+from transformers import PretrainedConfig
 
 from tests.utils import get_attn_backend_list_based_on_platform
 from vllm import LLM, SamplingParams
@@ -98,3 +103,100 @@ def test_mtp_speculative_config_max_model_len(spec_max_model_len: int):
         max_model_len=spec_max_model_len,
     )
     assert spec_config.draft_model_config.max_model_len == spec_max_model_len
+
+
+def _native_mtp_yarn_config(
+    *,
+    max_model_len: int = 1_000_000,
+    rope_parameters: dict[str, Any] | None = None,
+) -> tuple[Any, PretrainedConfig]:
+    if rope_parameters is None:
+        rope_parameters = {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 262_144,
+        }
+    target_hf_config = PretrainedConfig(rope_parameters=rope_parameters)
+    draft_hf_config = PretrainedConfig(max_position_embeddings=262_144)
+    target_model_config = SimpleNamespace(
+        model="test/native-mtp",
+        max_model_len=1_000_000,
+        hf_config=target_hf_config,
+    )
+    config = SimpleNamespace(
+        method="mtp",
+        model=target_model_config.model,
+        max_model_len=max_model_len,
+        target_model_config=target_model_config,
+        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+    )
+    return config, draft_hf_config
+
+
+def test_native_mtp_inherits_validated_target_yarn() -> None:
+    config, draft_hf_config = _native_mtp_yarn_config()
+    target_rope = config.target_model_config.hf_config.rope_parameters
+
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+    assert draft_hf_config.rope_parameters == target_rope
+    assert draft_hf_config.rope_parameters is not target_rope
+    target_rope["factor"] = 2.0
+    assert draft_hf_config.rope_parameters["factor"] == 4.0
+
+
+@pytest.mark.parametrize(
+    ("rope_parameters", "match"),
+    [
+        ({}, "explicit target YaRN"),
+        (
+            {
+                "rope_type": "dynamic",
+                "factor": 4.0,
+                "original_max_position_embeddings": 262_144,
+            },
+            "explicit target YaRN",
+        ),
+        (
+            {
+                "rope_type": "yarn",
+                "factor": "invalid",
+                "original_max_position_embeddings": 262_144,
+            },
+            "requires numeric",
+        ),
+        (
+            {
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 131_072,
+            },
+            "to match the drafter",
+        ),
+    ],
+)
+def test_native_mtp_rejects_unvalidated_rope(
+    rope_parameters: dict[str, Any],
+    match: str,
+) -> None:
+    config, _ = _native_mtp_yarn_config(rope_parameters=rope_parameters)
+
+    with pytest.raises(ValueError, match=match):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+def test_native_mtp_rejects_length_above_validated_yarn_limit() -> None:
+    config, _ = _native_mtp_yarn_config(max_model_len=1_048_577)
+    config.target_model_config.max_model_len = 1_048_577
+
+    with pytest.raises(ValueError, match="validated target YaRN limit=1048576"):
+        SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+
+def test_native_mtp_does_not_modify_unextended_drafter() -> None:
+    config, draft_hf_config = _native_mtp_yarn_config(max_model_len=262_144)
+    original = copy.deepcopy(draft_hf_config.to_dict())
+
+    SpeculativeConfig._inherit_target_rope_for_extended_native_mtp(config)
+
+    assert draft_hf_config.to_dict() == original

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1124,10 +1124,12 @@ class SpeculativeConfig:
         original_limit = rope_parameters.get("original_max_position_embeddings")
         factor = rope_parameters.get("factor")
         try:
+            if original_limit is None or factor is None:
+                raise TypeError("YaRN original limit and factor must be present")
             original_limit_value = float(original_limit)
             factor_value = float(factor)
             draft_native_limit_value = float(draft_native_limit)
-        except (TypeError, ValueError) as error:
+        except (TypeError, ValueError, OverflowError) as error:
             raise ValueError(
                 "Native MTP YaRN extension requires numeric "
                 "original_max_position_embeddings and factor."
@@ -1148,7 +1150,12 @@ class SpeculativeConfig:
                 f"native={draft_native_limit!r}, factor={factor!r}."
             )
 
-        validated_yarn_limit = int(original_limit_value * factor_value)
+        scaled_limit = original_limit_value * factor_value
+        if not math.isfinite(scaled_limit):
+            raise ValueError(
+                "Native MTP YaRN extension requires a finite scaled limit."
+            )
+        validated_yarn_limit = int(scaled_limit)
         validated_limit = min(
             validated_yarn_limit,
             self.target_model_config.max_model_len,

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1111,6 +1111,14 @@ class SpeculativeConfig:
 
         target_text_config = get_hf_text_config(self.target_model_config.hf_config)
         rope_parameters = getattr(target_text_config, "rope_parameters", None)
+        # A checkpoint may already carry valid scaling (including non-YaRN
+        # scaling). Preserve it when both models agree and its derived limit
+        # covers the request. Only missing extensions need target inheritance.
+        if (
+            getattr(draft_text_config, "rope_parameters", None) == rope_parameters
+            and self.max_model_len <= self.draft_model_config.get_and_verify_max_len(-1)
+        ):
+            return
         if (
             not isinstance(rope_parameters, dict)
             or rope_parameters.get("rope_type") != "yarn"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -881,6 +881,7 @@ class SpeculativeConfig:
                     MTPModelTypes
                 ):
                     self.method = "mtp"
+                    self._inherit_target_rope_for_extended_native_mtp()
                     if (
                         self.num_speculative_tokens > 1
                         and self.draft_model_config.hf_config.model_type
@@ -1070,6 +1071,81 @@ class SpeculativeConfig:
                 f"stage [{last_start}, {last_end}); got {layer_ids}. Adjust "
                 "VLLM_PP_LAYER_PARTITION or the DSpark layer contract."
             )
+
+    def _inherit_target_rope_for_extended_native_mtp(self) -> None:
+        """Validate and inherit target YaRN for an extended native drafter."""
+        if (
+            self.method != "mtp"
+            or self.max_model_len is None
+            or self.target_model_config is None
+            or self.draft_model_config is None
+            or self.model != self.target_model_config.model
+        ):
+            return
+
+        draft_text_config = get_hf_text_config(self.draft_model_config.hf_config)
+        draft_native_limit = getattr(draft_text_config, "max_position_embeddings", None)
+        if draft_native_limit is None or self.max_model_len <= draft_native_limit:
+            return
+
+        target_text_config = get_hf_text_config(self.target_model_config.hf_config)
+        rope_parameters = getattr(target_text_config, "rope_parameters", None)
+        if (
+            not isinstance(rope_parameters, dict)
+            or rope_parameters.get("rope_type") != "yarn"
+        ):
+            raise ValueError(
+                "Extending native MTP beyond max_position_embeddings requires "
+                "explicit target YaRN rope_parameters; got "
+                f"{rope_parameters!r}."
+            )
+
+        original_limit = rope_parameters.get("original_max_position_embeddings")
+        factor = rope_parameters.get("factor")
+        try:
+            original_limit_value = float(original_limit)
+            factor_value = float(factor)
+            draft_native_limit_value = float(draft_native_limit)
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                "Native MTP YaRN extension requires numeric "
+                "original_max_position_embeddings and factor."
+            ) from error
+
+        if (
+            not math.isfinite(original_limit_value)
+            or not math.isfinite(factor_value)
+            or original_limit_value <= 0
+            or factor_value <= 1
+            or original_limit_value != draft_native_limit_value
+        ):
+            raise ValueError(
+                "Native MTP YaRN extension requires the target's positive "
+                "original_max_position_embeddings to match the drafter's "
+                "native max_position_embeddings and factor to be greater "
+                f"than one; got original={original_limit!r}, "
+                f"native={draft_native_limit!r}, factor={factor!r}."
+            )
+
+        validated_yarn_limit = int(original_limit_value * factor_value)
+        validated_limit = min(
+            validated_yarn_limit,
+            self.target_model_config.max_model_len,
+        )
+        if self.max_model_len > validated_limit:
+            raise ValueError(
+                f"Native MTP max_model_len={self.max_model_len} exceeds the "
+                f"validated target YaRN limit={validated_limit}."
+            )
+
+        draft_text_config.rope_parameters = copy.deepcopy(rope_parameters)
+        logger.info(
+            "Extended native MTP context from %s to %s with validated target "
+            "YaRN parameters (factor=%s).",
+            draft_native_limit,
+            self.max_model_len,
+            factor,
+        )
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -9336,14 +9336,13 @@ class GPUModelRunner(
                 # make token id 0 look like a real speculative token to the
                 # scheduler and verifier.
                 logger.warning_once(
-                    "Skipping speculative drafts because the drafter context "
-                    "limit is reached: max_seq_len=%s, num_spec_tokens=%s, "
-                    "effective_drafter_max_model_len=%s.",
-                    spec_decode_common_attn_metadata.max_seq_len
-                    if spec_decode_common_attn_metadata is not None
-                    else None,
+                    "Skipping speculative drafts after reaching the drafter "
+                    "context limit: num_spec_tokens=%s, "
+                    "effective_drafter_max_model_len=%s. Future over-limit "
+                    "batches are suppressed.",
                     self.num_spec_tokens,
                     self.effective_drafter_max_model_len,
+                    scope="global",
                 )
                 self._draft_token_ids = [[] for _ in self.input_batch.req_ids]
                 self._draft_probs = None


### PR DESCRIPTION
## Purpose
Integrate #410 against latest public main `586026e7c575febd6f2f321bf7df17bbbb7e98fe`, preserving its original commits. Inherit validated explicit target YaRN for an extended native MTP drafter, and eliminate changing-argument warning spam above its configured cap.

## Audit repairs
- Current Transformers 5.12.1 rejected the old unit-test fixtures before vLLM validation (5 failed / 2 passed). Initialize complete config fixtures first and then inject deliberately malformed values to test vLLM's own guards.
- Repair missing-value mypy errors; reject numeric-conversion overflow and non-finite scaled limits with a configuration ValueError.
- Preserve existing matching checkpoint RoPE scaling, including linear and YaRN, when the engine-derived context limit already covers the request. The new target-inheritance restriction must not reject previously supported scaled checkpoints.
- Add missing-field, finite/overflow, target-ceiling, unrelated-drafter and existing-RoPE regression coverage.

## Test Plan / Result
19 targeted CPU/meta configuration tests passed, including the real ModelConfig length derivation helper for existing scaling. Scoped pre-commit including mypy passed. No model download, server startup, full E2E or new GPU benchmark. Await fresh GitHub integration CI before ready/merge.

## Boundaries
This is configuration and warning behavior, not a new attention kernel or new numerical approximation. The original PR's historical 564K MTP service evidence is retained but is not a fresh latest-main benchmark or proof of 1M output quality. Only explicitly requested extended native MTP configuration inherits new scaling; unrelated drafts and unextended contexts remain unchanged.

## Ownership / evidence
Owned worktree `/home/ymzx/桌面/1cat-vllm/worktrees/v100-sep07-mtp-yarn-audit-20260907-031538`. Logs `/tmp/1cat-sep07-yarn-cpu.log` (original failures), `/tmp/1cat-sep07-yarn-cpu4.log` (19 passed), `/tmp/1cat-sep07-yarn-commit4.log` (static gates). Canonical dirty checkout untouched.