### PR TITLE
[Core] Integrate warm KV profiling with allocation regressions (#518)

### DIFF
--- a/tests/v1/worker/test_gpu_worker_memory_profile.py
+++ b/tests/v1/worker/test_gpu_worker_memory_profile.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import vllm.envs as envs
 from vllm.config import CUDAGraphMode
 from vllm.platforms import current_platform
 from vllm.utils.mem_utils import MemorySnapshot
@@ -28,6 +29,7 @@ class _FakeRunner:
         self.model_memory_usage = weights_bytes
         self._device = device
         self.calls = 0
+        self.graph_calls = 0
         self._kept: list[torch.Tensor] = []
 
     def profile_run(self) -> None:
@@ -44,10 +46,24 @@ class _FakeRunner:
         torch.accelerator.synchronize(self._device)
 
     def profile_cudagraph_memory(self) -> int:
-        return 0
+        self.graph_calls += 1
+        return 32 * MiB
 
 
-def test_kv_budget_ignores_cold_compile_scratch() -> None:
+@pytest.mark.parametrize(
+    "graph_mode,estimate_graphs,graph_bytes",
+    [
+        (CUDAGraphMode.NONE, True, 0),
+        (CUDAGraphMode.FULL, False, 0),
+        (CUDAGraphMode.FULL, True, 32 * MiB),
+    ],
+)
+def test_kv_budget_ignores_cold_compile_scratch(
+    monkeypatch, graph_mode, estimate_graphs, graph_bytes
+) -> None:
+    monkeypatch.setattr(
+        envs, "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", estimate_graphs
+    )
     device = torch.device("cuda:0")
     torch.accelerator.empty_cache()
     worker = Worker.__new__(Worker)
@@ -60,7 +76,7 @@ def test_kv_budget_ignores_cold_compile_scratch() -> None:
         kv_cache_memory_bytes=None, gpu_memory_utilization=0.9
     )
     worker.vllm_config = SimpleNamespace(
-        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE)
+        compilation_config=SimpleNamespace(cudagraph_mode=graph_mode)
     )
     runner = _FakeRunner(device, weights_bytes)
     worker.model_runner = runner
@@ -77,7 +93,20 @@ def test_kv_budget_ignores_cold_compile_scratch() -> None:
         - worker.non_torch_memory
         - worker.peak_activation_memory
         - weights_bytes
+        - graph_bytes
     )
     assert abs(charged - 64 * MiB) <= 32 * MiB
     assert runner.calls == 2
+    assert runner.graph_calls == int(graph_bytes > 0)
+    assert worker.cudagraph_memory_estimate == graph_bytes
     del weights
+
+
+def test_explicit_kv_bytes_profiles_once_and_skips_memory_estimation() -> None:
+    calls = []
+    worker = Worker.__new__(Worker)
+    worker.cache_config = SimpleNamespace(kv_cache_memory_bytes=128 * MiB)
+    worker.init_snapshot = SimpleNamespace(free_memory=1024 * MiB)
+    worker.model_runner = SimpleNamespace(profile_run=lambda: calls.append("profile"))
+    assert worker.determine_available_memory() == 128 * MiB
+    assert calls == ["profile"]

--- a/tests/v1/worker/test_gpu_worker_memory_profile.py
+++ b/tests/v1/worker/test_gpu_worker_memory_profile.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The KV budget must reflect the steady-state forward, not the first
+(compiling) one: a cold torch.compile allocates scratch that has nothing to
+do with serving, and on a cache miss it shrank the budget by GiBs."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.platforms import current_platform
+from vllm.utils.mem_utils import MemorySnapshot
+from vllm.v1.worker.gpu_worker import Worker
+
+MiB = 1024 * 1024
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="needs a CUDA device for memory stats"
+)
+
+
+class _FakeRunner:
+    """First profile_run behaves like a cold compile: a large transient
+    allocation plus a small one that stays; the second is the plain forward."""
+
+    def __init__(self, device: torch.device, weights_bytes: int) -> None:
+        self.model_memory_usage = weights_bytes
+        self._device = device
+        self.calls = 0
+        self._kept: list[torch.Tensor] = []
+
+    def profile_run(self) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            scratch = torch.empty(1024 * MiB, dtype=torch.uint8, device=self._device)
+            self._kept.append(
+                torch.empty(64 * MiB, dtype=torch.uint8, device=self._device)
+            )
+            del scratch
+        else:
+            activations = torch.empty(256 * MiB, dtype=torch.uint8, device=self._device)
+            del activations
+        torch.accelerator.synchronize(self._device)
+
+    def profile_cudagraph_memory(self) -> int:
+        return 0
+
+
+def test_kv_budget_ignores_cold_compile_scratch() -> None:
+    device = torch.device("cuda:0")
+    torch.accelerator.empty_cache()
+    worker = Worker.__new__(Worker)
+    worker.device = device
+    worker.init_snapshot = MemorySnapshot(device=device)
+    weights_bytes = 512 * MiB
+    weights = torch.empty(weights_bytes, dtype=torch.uint8, device=device)
+    worker.requested_memory = int(worker.init_snapshot.free_memory * 0.9)
+    worker.cache_config = SimpleNamespace(
+        kv_cache_memory_bytes=None, gpu_memory_utilization=0.9
+    )
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE)
+    )
+    runner = _FakeRunner(device, weights_bytes)
+    worker.model_runner = runner
+
+    available = worker.determine_available_memory()
+
+    # Peak activation is the second (steady-state) forward, not the 1 GiB scratch.
+    assert abs(worker.peak_activation_memory - 256 * MiB) <= 16 * MiB
+    # What the warm-up left allocated is still charged to the budget. Other
+    # processes on the device show up in non_torch_memory, so account for it.
+    charged = (
+        worker.requested_memory
+        - available
+        - worker.non_torch_memory
+        - worker.peak_activation_memory
+        - weights_bytes
+    )
+    assert abs(charged - 64 * MiB) <= 32 * MiB
+    assert runner.calls == 2
+    del weights

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -527,6 +527,17 @@ class Worker(WorkerBase):
             logger.info(msg)
             return kv_cache_memory_bytes
 
+        # The first forward triggers torch.compile, and a cold compile (cache
+        # miss) is not steady-state serving: on a 27B NVFP4 model on a 48 GB
+        # card it added 1.85 GiB of torch peak (inductor autotuning, AOT
+        # export) and 0.64 GiB of non-torch memory on top of the forward
+        # itself, so the KV budget came out at 3.5 instead of 6.0 GiB and
+        # depended on the state of the compile cache. Warm the compiled
+        # graphs up first and measure the second forward. Memory the warm-up
+        # keeps allocated still counts: non-torch is measured against the
+        # init snapshot, and torch memory the warm-up left behind beyond the
+        # weights is added below as warmup_torch_residual.
+        self.model_runner.profile_run()
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -555,10 +566,17 @@ class Worker(WorkerBase):
         profile_result.torch_peak_increase = (
             profile_torch_peak - profile_result.before_profile.torch_peak
         )
+        warmup_torch_residual = max(
+            0,
+            profile_result.before_profile.torch_memory
+            - self.init_snapshot.torch_memory
+            - profile_result.weights_memory,
+        )
         profile_result.non_kv_cache_memory = (
             profile_result.non_torch_increase
             + profile_result.torch_peak_increase
             + profile_result.weights_memory
+            + warmup_torch_residual
         )
 
         # On ROCm, cudagraph_memory_estimate is always 0 so this is a no-op.


### PR DESCRIPTION
## Purpose
AI-assisted mainline integration of #518, preserving original commits and unchanged production fix. Base `2946e0ed664e0dca452b38745df601c1d9f4404d`. This is the audit/test integration of the existing PR, not an independent competing implementation.

Warm the profile once before measuring steady-state KV capacity, and retain persistent torch/non-torch allocations in the budget. No decoding arithmetic or kernel dispatch change.

## Test Plan / Result
8 focused tests passed on reserved physical V100 GPU 3 (Python 3.12, Torch 2.10+cu128): cold compile scratch exclusion, persistent residual charging, CUDA Graph estimates enabled/disabled, explicit KV-byte override preserving one profile, and static-PP worker regressions. Scoped pre-commit passed. No full E2E rerun or model-level speed claim.

## Boundaries
The original RTX 8000 cold/warm capacity evidence is retained on #518, not attributed to new V100 decode acceleration. Automatic profiling adds one warm-up forward during startup. Explicit `kv_cache_memory_bytes` remains unchanged. Await fresh GitHub static CI before promotion/merge.

Evidence: `/tmp/1cat-five-memory-test.log`, `/tmp/1cat-five-memory-commit2.log`; owned worktree `/home/ymzx/桌面/1cat-vllm/worktrees/v100-sep07-memory-integration-20260907-040344`. Canonical dirty checkout untouched.