### PR TITLE
[Bugfix][Config] Integrate participating-device SM70 defaults (#514)

### DIFF
--- a/tests/config/test_prefix_anchored_swa.py
+++ b/tests/config/test_prefix_anchored_swa.py
@@ -42,7 +42,8 @@ def sm70_platform(monkeypatch: pytest.MonkeyPatch) -> None:
         "current_platform",
         SimpleNamespace(
             is_cuda=lambda: True,
-            is_device_capability=lambda capability: capability == (7, 0),
+            device_count=lambda: 1,
+            is_device_capability=lambda capability, device_id=0: capability == (7, 0),
         ),
     )
 
@@ -113,7 +114,8 @@ def test_engine_contract_rejects_non_sm70(monkeypatch: pytest.MonkeyPatch):
         "current_platform",
         SimpleNamespace(
             is_cuda=lambda: True,
-            is_device_capability=lambda capability: False,
+            device_count=lambda: 1,
+            is_device_capability=lambda capability, device_id=0: False,
         ),
     )
 

--- a/tests/config/test_prefix_anchored_swa.py
+++ b/tests/config/test_prefix_anchored_swa.py
@@ -27,11 +27,21 @@ def _config(window: int = 128) -> SimpleNamespace:
         ),
         model_config=SimpleNamespace(dtype=torch.float16, use_mla=False),
         parallel_config=SimpleNamespace(
+            distributed_executor_backend="uni",
+            data_parallel_backend="mp",
+            world_size=1,
+            local_world_size=1,
+            nnodes_within_dp=1,
+            data_parallel_rank_local=0,
+            data_parallel_index=0,
+            tensor_parallel_size=1,
+            pipeline_parallel_size=1,
             decode_context_parallel_size=1,
             prefill_context_parallel_size=1,
         ),
         kv_transfer_config=None,
         speculative_config=None,
+        device_config=SimpleNamespace(device=torch.device("cuda")),
     )
 
 

--- a/tests/config/test_sm70_gates_any_visible_device.py
+++ b/tests/config/test_sm70_gates_any_visible_device.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for #412: the SM70 gates in ``VllmConfig`` must consider
+every visible device, not only device 0."""
+
+import os
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+from vllm import platforms
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
+from vllm.config.vllm import apply_prefix_anchored_swa_constraints
+
+SM70 = (7, 0)
+SM75 = (7, 5)
+
+# The unconditional part of the SM70 Flash-V100 baseline defaults.
+BASELINE_ENV = (
+    "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE",
+    "VLLM_SM70_GDN_KKT_SCHEDULE",
+    "VLLM_SM70_GDN_DELTA_H_SCHEDULE",
+    "VLLM_SM70_GDN_CHUNK_O_SCHEDULE",
+    "VLLM_SM70_FLA_RECURRENT_SCHEDULE",
+    "VLLM_SM70_FUSED_SIGMOID_GATING_SCHED",
+    "VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE",
+    "VLLM_SM70_GDN_DECODE_FLASHQLA",
+)
+
+
+def _fake_platform(capabilities: list[tuple[int, int]], is_cuda: bool = True):
+    return SimpleNamespace(
+        is_cuda=lambda: is_cuda,
+        device_count=lambda: len(capabilities),
+        is_device_capability=lambda capability, device_id=0: (
+            capabilities[device_id] == capability
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        pytest.param([SM70], True, id="single-sm70"),
+        pytest.param([SM75, SM70], True, id="sm75-first"),
+        pytest.param([SM70, SM75], True, id="sm70-first"),
+        pytest.param([SM75, SM75], False, id="homogeneous-sm75"),
+        pytest.param([], False, id="no-devices"),
+    ],
+)
+def test_any_visible_device_is_capability(monkeypatch, capabilities, expected):
+    from vllm.config.vllm import _any_visible_device_is_capability
+
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform(capabilities))
+    assert _any_visible_device_is_capability(SM70) is expected
+
+
+def test_any_visible_device_is_capability_requires_cuda(monkeypatch):
+    from vllm.config.vllm import _any_visible_device_is_capability
+
+    monkeypatch.setattr(
+        platforms, "current_platform", _fake_platform([SM70], is_cuda=False)
+    )
+    assert _any_visible_device_is_capability(SM70) is False
+
+
+def test_prefix_anchored_swa_accepts_sm70_behind_sm75(monkeypatch):
+    """The engine contract only needs an SM70 device somewhere in the grid."""
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform([SM75, SM70]))
+    cfg = SimpleNamespace(
+        attention_config=SimpleNamespace(prefix_anchored_decode_window=64),
+    )
+    # Passing the capability gate means reaching the model-config check.
+    with pytest.raises(ValueError, match="requires a model config"):
+        cfg.model_config = None
+        apply_prefix_anchored_swa_constraints(cfg)
+
+
+@pytest.fixture
+def isolated_baseline_env() -> Iterator[None]:
+    saved = {name: os.environ.get(name) for name in BASELINE_ENV}
+    for name in BASELINE_ENV:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _patch_visible_devices(monkeypatch, capabilities: list[tuple[int, int]]):
+    # Patch the platform instance, not its class: other tests leave
+    # instance-level attributes behind that would shadow a class patch.
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "device_count", lambda: len(capabilities))
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        lambda capability, device_id=0: capabilities[device_id] == capability,
+    )
+    assert current_platform.device_count() == len(capabilities)
+    assert current_platform.is_device_capability((7, 0)) is (capabilities[0] == (7, 0))
+
+
+def _build_vllm_config() -> VllmConfig:
+    model_config = ModelConfig(model="facebook/opt-125m", dtype="float16", seed=42)
+    return VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=16, gpu_memory_utilization=0.9, cache_dtype="auto"
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=10,
+            max_num_batched_tokens=512,
+            max_model_len=512,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        parallel_config=ParallelConfig(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        pytest.param([SM75, SM70], True, id="sm70-stage-behind-sm75"),
+        pytest.param([SM75, SM75], False, id="homogeneous-sm75"),
+    ],
+)
+def test_sm70_baseline_defaults_follow_any_visible_device(
+    monkeypatch, isolated_baseline_env, capabilities, expected
+):
+    """PP stage 0 on an sm75 card, stage 1 on sm70: the Flash-V100 baseline
+    defaults must still be applied; a homogeneous sm75 box must stay clean."""
+    _patch_visible_devices(monkeypatch, capabilities)
+
+    _build_vllm_config()
+
+    applied = {name for name in BASELINE_ENV if os.environ.get(name) == "1"}
+    assert (applied == set(BASELINE_ENV)) is expected
+    if not expected:
+        assert not applied

--- a/tests/config/test_sm70_gates_any_visible_device.py
+++ b/tests/config/test_sm70_gates_any_visible_device.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from vllm import platforms
 from vllm.config import (
@@ -45,6 +46,25 @@ def _fake_platform(capabilities: list[tuple[int, int]], is_cuda: bool = True):
     )
 
 
+def _placement_config(world_size=1, **overrides):
+    values = dict(
+        distributed_executor_backend="mp" if world_size > 1 else "uni",
+        data_parallel_backend="mp",
+        world_size=world_size,
+        local_world_size=world_size,
+        nnodes_within_dp=1,
+        data_parallel_rank_local=0,
+        data_parallel_index=0,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=world_size,
+    )
+    values.update(overrides)
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(**values),
+        device_config=SimpleNamespace(device=torch.device("cuda")),
+    )
+
+
 @pytest.mark.parametrize(
     ("capabilities", "expected"),
     [
@@ -55,31 +75,29 @@ def _fake_platform(capabilities: list[tuple[int, int]], is_cuda: bool = True):
         pytest.param([], False, id="no-devices"),
     ],
 )
-def test_any_visible_device_is_capability(monkeypatch, capabilities, expected):
-    from vllm.config.vllm import _any_visible_device_is_capability
+def test_any_participating_device_is_capability(monkeypatch, capabilities, expected):
+    from vllm.config.vllm import _any_participating_device_is_capability
 
     monkeypatch.setattr(platforms, "current_platform", _fake_platform(capabilities))
-    assert _any_visible_device_is_capability(SM70) is expected
+    cfg = _placement_config(world_size=len(capabilities))
+    assert _any_participating_device_is_capability(cfg, SM70) is expected
 
 
-def test_any_visible_device_is_capability_requires_cuda(monkeypatch):
-    from vllm.config.vllm import _any_visible_device_is_capability
+def test_any_participating_device_is_capability_requires_cuda(monkeypatch):
+    from vllm.config.vllm import _any_participating_device_is_capability
 
     monkeypatch.setattr(
         platforms, "current_platform", _fake_platform([SM70], is_cuda=False)
     )
-    assert _any_visible_device_is_capability(SM70) is False
+    assert _any_participating_device_is_capability(_placement_config(), SM70) is False
 
 
-def test_prefix_anchored_swa_accepts_sm70_behind_sm75(monkeypatch):
-    """The engine contract only needs an SM70 device somewhere in the grid."""
+def test_prefix_anchored_swa_requires_supported_hardware_on_every_rank(monkeypatch):
+    """Do not relax backend support because only one participant is SM70."""
     monkeypatch.setattr(platforms, "current_platform", _fake_platform([SM75, SM70]))
-    cfg = SimpleNamespace(
-        attention_config=SimpleNamespace(prefix_anchored_decode_window=64),
-    )
-    # Passing the capability gate means reaching the model-config check.
-    with pytest.raises(ValueError, match="requires a model config"):
-        cfg.model_config = None
+    cfg = _placement_config(world_size=2)
+    cfg.attention_config = SimpleNamespace(prefix_anchored_decode_window=64)
+    with pytest.raises(ValueError, match="every participating rank"):
         apply_prefix_anchored_swa_constraints(cfg)
 
 
@@ -113,7 +131,7 @@ def _patch_visible_devices(monkeypatch, capabilities: list[tuple[int, int]]):
     assert current_platform.is_device_capability((7, 0)) is (capabilities[0] == (7, 0))
 
 
-def _build_vllm_config() -> VllmConfig:
+def _build_vllm_config(pp_size: int = 1) -> VllmConfig:
     model_config = ModelConfig(model="facebook/opt-125m", dtype="float16", seed=42)
     return VllmConfig(
         model_config=model_config,
@@ -126,27 +144,59 @@ def _build_vllm_config() -> VllmConfig:
             max_model_len=512,
             is_encoder_decoder=model_config.is_encoder_decoder,
         ),
-        parallel_config=ParallelConfig(),
+        parallel_config=ParallelConfig(
+            pipeline_parallel_size=pp_size,
+            distributed_executor_backend="mp" if pp_size > 1 else "uni",
+        ),
     )
 
 
 @pytest.mark.parametrize(
-    ("capabilities", "expected"),
+    ("capabilities", "pp_size", "expected"),
     [
-        pytest.param([SM75, SM70], True, id="sm70-stage-behind-sm75"),
-        pytest.param([SM75, SM75], False, id="homogeneous-sm75"),
+        pytest.param([SM75, SM70], 2, True, id="sm70-stage-behind-sm75"),
+        pytest.param([SM75, SM75], 2, False, id="homogeneous-sm75"),
+        pytest.param([SM75, SM70], 1, False, id="unused-sm70-must-not-change-defaults"),
     ],
 )
 def test_sm70_baseline_defaults_follow_any_visible_device(
-    monkeypatch, isolated_baseline_env, capabilities, expected
+    monkeypatch, isolated_baseline_env, capabilities, pp_size, expected
 ):
     """PP stage 0 on an sm75 card, stage 1 on sm70: the Flash-V100 baseline
     defaults must still be applied; a homogeneous sm75 box must stay clean."""
     _patch_visible_devices(monkeypatch, capabilities)
 
-    _build_vllm_config()
+    _build_vllm_config(pp_size)
 
     applied = {name for name in BASELINE_ENV if os.environ.get(name) == "1"}
     assert (applied == set(BASELINE_ENV)) is expected
     if not expected:
         assert not applied
+
+
+@pytest.mark.parametrize(
+    "overrides,expected",
+    [
+        ({}, (0,)),
+        ({"data_parallel_rank_local": 2}, (2,)),
+        ({"data_parallel_rank_local": None, "data_parallel_index": 1}, (1,)),
+        ({"world_size": 4, "local_world_size": 2, "nnodes_within_dp": 2}, (0, 1)),
+        ({"distributed_executor_backend": "external_launcher"}, (3,)),
+        ({"distributed_executor_backend": "ray"}, (0,)),
+    ],
+)
+def test_participation_matches_executor_assignment(monkeypatch, overrides, expected):
+    from vllm.config.vllm import _participating_cuda_device_ids
+
+    monkeypatch.setenv("LOCAL_RANK", "3")
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform([SM75] * 4))
+    assert _participating_cuda_device_ids(_placement_config(**overrides)) == expected
+
+
+def test_explicit_uniproc_device_is_preserved(monkeypatch):
+    from vllm.config.vllm import _participating_cuda_device_ids
+
+    monkeypatch.setattr(platforms, "current_platform", _fake_platform([SM75, SM70]))
+    cfg = _placement_config()
+    cfg.device_config.device = torch.device("cuda:1")
+    assert _participating_cuda_device_ids(cfg) == (1,)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -218,22 +218,46 @@ def _is_sm70_qwen38_nomtp_dual_compile_contract(
     )
 
 
-def _any_visible_device_is_capability(capability: tuple[int, int]) -> bool:
-    """True if any visible CUDA device has exactly this compute capability.
+def _participating_cuda_device_ids(cfg: "VllmConfig") -> tuple[int, ...]:
+    """Local device assignment used by UniProc/Multiproc and GPUWorker.
 
-    ``current_platform.is_device_capability`` inspects device 0 only. On a
-    heterogeneous pipeline-parallel deployment the stage that needs the SM70
-    defaults is not necessarily the one on device 0; the defaults are gated
-    again per worker at their point of use, so applying them whenever an SM70
-    device is visible is safe for the other stages.
+    Visibility is not participation: unused devices must not change engine
+    defaults. Ray/custom placement is not known here, so preserve the legacy
+    device-zero decision for those executors instead of guessing their ranks.
     """
     from vllm.platforms import current_platform
 
-    if not current_platform.is_cuda():
-        return False
+    if not current_platform.is_cuda() or current_platform.device_count() == 0:
+        return ()
+    parallel = cfg.parallel_config
+    backend = parallel.distributed_executor_backend
+    if backend == "external_launcher":
+        return (int(os.environ.get("LOCAL_RANK", "0")),)
+    if backend not in (None, "uni", "mp") or parallel.data_parallel_backend == "ray":
+        return (0,)
+    start = 0
+    if parallel.world_size == 1:
+        device = cfg.device_config.device
+        if isinstance(device, torch.device) and device.index is not None:
+            start = device.index
+    if parallel.nnodes_within_dp == 1:
+        dp_rank = parallel.data_parallel_rank_local
+        if dp_rank is None:
+            dp_rank = parallel.data_parallel_index
+        start += (
+            dp_rank * parallel.tensor_parallel_size * parallel.pipeline_parallel_size
+        )
+    return tuple(range(start, start + parallel.local_world_size))
+
+
+def _any_participating_device_is_capability(
+    cfg: "VllmConfig", capability: tuple[int, int]
+) -> bool:
+    from vllm.platforms import current_platform
+
     return any(
         current_platform.is_device_capability(capability, device_id=device_id)
-        for device_id in range(current_platform.device_count())
+        for device_id in _participating_cuda_device_ids(cfg)
     )
 
 
@@ -591,8 +615,15 @@ def apply_prefix_anchored_swa_constraints(cfg: "VllmConfig") -> None:
     from vllm.platforms import current_platform
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-    if not (current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))):
-        raise ValueError("prefix_anchored_decode_window requires an NVIDIA SM70 GPU")
+    devices = _participating_cuda_device_ids(cfg)
+    if not devices or not all(
+        current_platform.is_device_capability((7, 0), device_id=device_id)
+        for device_id in devices
+    ):
+        raise ValueError(
+            "prefix_anchored_decode_window requires an NVIDIA SM70 GPU "
+            "for every participating rank"
+        )
 
     model_config = cfg.model_config
     if model_config is None:
@@ -1637,7 +1668,8 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
+                current_platform.is_cuda()
+                and _any_participating_device_is_capability(self, (7, 0))
             ),
         )
         sm70_glm5_dflash_tp8_pp1_verifier = (
@@ -1647,7 +1679,7 @@ class VllmConfig:
                 self.parallel_config,
                 is_sm70=(
                     current_platform.is_cuda()
-                    and _any_visible_device_is_capability((7, 0))
+                    and _any_participating_device_is_capability(self, (7, 0))
                 ),
             )
         )
@@ -1656,7 +1688,8 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
+                current_platform.is_cuda()
+                and _any_participating_device_is_capability(self, (7, 0))
             ),
         )
 
@@ -1673,7 +1706,9 @@ class VllmConfig:
             )
 
         if envs.VLLM_SM70_USE_BREAKABLE_CUDAGRAPH:
-            if current_platform.is_cuda() and _any_visible_device_is_capability((7, 0)):
+            if current_platform.is_cuda() and _any_participating_device_is_capability(
+                self, (7, 0)
+            ):
                 if "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ:
                     os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
                     logger.info_once(
@@ -1750,7 +1785,7 @@ class VllmConfig:
             and self.parallel_config.tensor_parallel_size <= 2
             and sm70_fp8_kv_requested
             and current_platform.is_cuda()
-            and _any_visible_device_is_capability((7, 0))
+            and _any_participating_device_is_capability(self, (7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             and "VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK" not in os.environ
@@ -1769,7 +1804,7 @@ class VllmConfig:
             and self.model_config.quantization == "fp8"
             and self.model_config.is_moe
             and current_platform.is_cuda()
-            and _any_visible_device_is_capability((7, 0))
+            and _any_participating_device_is_capability(self, (7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK
             and not envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
@@ -1791,7 +1826,7 @@ class VllmConfig:
         )
         sm70_flash_v100_baseline = (
             current_platform.is_cuda()
-            and _any_visible_device_is_capability((7, 0))
+            and _any_participating_device_is_capability(self, (7, 0))
             and envs.VLLM_SM70_FLASH_ATTN_V100
             and sm70_flash_v100_backend
         )
@@ -1962,7 +1997,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and _any_visible_device_is_capability((7, 0))
+                and _any_participating_device_is_capability(self, (7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 self.compilation_config.mode = CompilationMode.VLLM_COMPILE
@@ -2139,7 +2174,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and _any_visible_device_is_capability((7, 0))
+                and _any_participating_device_is_capability(self, (7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 capture_size = max(
@@ -2194,7 +2229,7 @@ class VllmConfig:
                 self.model_config is not None
                 and self.model_config.quantization == "fp8"
                 and current_platform.is_cuda()
-                and _any_visible_device_is_capability((7, 0))
+                and _any_participating_device_is_capability(self, (7, 0))
                 and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             )
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -218,6 +218,25 @@ def _is_sm70_qwen38_nomtp_dual_compile_contract(
     )
 
 
+def _any_visible_device_is_capability(capability: tuple[int, int]) -> bool:
+    """True if any visible CUDA device has exactly this compute capability.
+
+    ``current_platform.is_device_capability`` inspects device 0 only. On a
+    heterogeneous pipeline-parallel deployment the stage that needs the SM70
+    defaults is not necessarily the one on device 0; the defaults are gated
+    again per worker at their point of use, so applying them whenever an SM70
+    device is visible is safe for the other stages.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_cuda():
+        return False
+    return any(
+        current_platform.is_device_capability(capability, device_id=device_id)
+        for device_id in range(current_platform.device_count())
+    )
+
+
 def _apply_sm70_dflash2_verifier_defaults() -> tuple[str, ...]:
     """Set quality-audited defaults while preserving every explicit override."""
     applied = []
@@ -572,9 +591,7 @@ def apply_prefix_anchored_swa_constraints(cfg: "VllmConfig") -> None:
     from vllm.platforms import current_platform
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-    if not (
-        current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
-    ):
+    if not (current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))):
         raise ValueError("prefix_anchored_decode_window requires an NVIDIA SM70 GPU")
 
     model_config = cfg.model_config
@@ -1620,8 +1637,7 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
             ),
         )
         sm70_glm5_dflash_tp8_pp1_verifier = (
@@ -1631,7 +1647,7 @@ class VllmConfig:
                 self.parallel_config,
                 is_sm70=(
                     current_platform.is_cuda()
-                    and current_platform.is_device_capability((7, 0))
+                    and _any_visible_device_is_capability((7, 0))
                 ),
             )
         )
@@ -1640,8 +1656,7 @@ class VllmConfig:
             self.speculative_config,
             self.parallel_config,
             is_sm70=(
-                current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                current_platform.is_cuda() and _any_visible_device_is_capability((7, 0))
             ),
         )
 
@@ -1658,9 +1673,7 @@ class VllmConfig:
             )
 
         if envs.VLLM_SM70_USE_BREAKABLE_CUDAGRAPH:
-            if current_platform.is_cuda() and current_platform.is_device_capability(
-                (7, 0)
-            ):
+            if current_platform.is_cuda() and _any_visible_device_is_capability((7, 0)):
                 if "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ:
                     os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
                     logger.info_once(
@@ -1737,7 +1750,7 @@ class VllmConfig:
             and self.parallel_config.tensor_parallel_size <= 2
             and sm70_fp8_kv_requested
             and current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             and "VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK" not in os.environ
@@ -1756,7 +1769,7 @@ class VllmConfig:
             and self.model_config.quantization == "fp8"
             and self.model_config.is_moe
             and current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FP8_DEQUANT_FALLBACK
             and envs.VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK
             and not envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
@@ -1778,7 +1791,7 @@ class VllmConfig:
         )
         sm70_flash_v100_baseline = (
             current_platform.is_cuda()
-            and current_platform.is_device_capability((7, 0))
+            and _any_visible_device_is_capability((7, 0))
             and envs.VLLM_SM70_FLASH_ATTN_V100
             and sm70_flash_v100_backend
         )
@@ -1949,7 +1962,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 self.compilation_config.mode = CompilationMode.VLLM_COMPILE
@@ -2126,7 +2139,7 @@ class VllmConfig:
                 )
             elif (
                 current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.VLLM_SM70_FLASH_ATTN_V100
             ):
                 capture_size = max(
@@ -2181,7 +2194,7 @@ class VllmConfig:
                 self.model_config is not None
                 and self.model_config.quantization == "fp8"
                 and current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
+                and _any_visible_device_is_capability((7, 0))
                 and envs.use_sm70_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
             )
 


### PR DESCRIPTION
## Purpose
AI-assisted integration and repair of #514 on main `2946e0ed664e0dca452b38745df601c1d9f4404d`, preserving the original commits. This is the existing PR's audit integration, not duplicate independent feature work.

## Repairs
Use the devices actually assigned by UniProc/Multiproc/GPUWorker instead of every visible GPU. Respect explicit device indices, local DP offsets, multi-node local world size and external-launcher LOCAL_RANK. Unknown Ray/custom placement retains the previous device-zero decision rather than guessing remote placement.

Ordinary mixed-pipeline SM70 defaults are order independent for participating devices. Prefix-anchored attention retains an exact-SM70 hardware requirement on all known participating ranks, rather than weakening a backend requirement because just one GPU is Volta. This is an engine/hardware condition, not a checkpoint-name gate. Explicit environment overrides remain unchanged.

## Tests
46 focused tests passed on reserved physical V100 GPU 3, using offline model metadata and mocked heterogeneous assignments (not a claim of real mixed-hardware execution). Includes actual PP2 configuration, TP1 with an unused visible V100, DP/local/explicit-device assignment, prefix-anchored constraints, decode-graph and MTP tests. An earlier hidden-CUDA run had 44 passed / 2 CUDA-dependent failures; complete GPU run passed. Scoped pre-commit passed.

No full E2E or new throughput claim. Await fresh GitHub static CI before merge. Logs `/tmp/1cat-five-topology-gpu.log`, `/tmp/1cat-five-topology-commit.log`. Owned worktree `/home/ymzx/桌面/1cat-vllm/worktrees/v100-sep07-topology-integration-20260907-040346`; canonical dirty checkout untouched.