### PR TITLE
[Bugfix] Audit developer role compatibility and multimodal ordering (#449)

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -7,6 +7,9 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.renderers.hf import (
+    _consolidate_system_messages,
+    _convert_developer_to_system,
+    _detect_developer_role_support,
     _get_hf_base_chat_template_params,
     _try_extract_ast,
     resolve_chat_template,
@@ -592,3 +595,322 @@ def test_get_gen_prompt(
         f"The generated prompt does not match the expected output for "
         f"model {model} and template {template}"
     )
+
+
+class TestConvertDeveloperToSystem:
+    def test_converts_role(self):
+        conversation = [
+            {"role": "developer", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = _convert_developer_to_system(conversation)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are helpful."
+        assert result[1]["role"] == "user"
+
+    def test_removes_tools_key(self):
+        conversation = [
+            {
+                "role": "developer",
+                "content": "Instructions",
+                "tools": [{"type": "function"}],
+            },
+        ]
+        result = _convert_developer_to_system(conversation)
+        assert "tools" not in result[0]
+
+    def test_no_developer_messages_unchanged(self):
+        conversation = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = _convert_developer_to_system(conversation)
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+
+    def test_does_not_mutate_original(self):
+        original = {
+            "role": "developer",
+            "content": "Instructions",
+            "tools": [{"type": "function"}],
+        }
+        conversation = [original]
+        _convert_developer_to_system(conversation)
+        assert original["role"] == "developer"
+        assert "tools" in original
+
+
+# --- Developer role detection and conversion tests ---
+
+CHATML_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\\n' + message['content']}}"
+    "{% if (loop.last and add_generation_prompt) or not loop.last %}"
+    "{{ '<|im_end|>' + '\\n'}}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+
+TEMPLATE_WITH_DEVELOPER = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'developer' %}"
+    "{{'<|im_start|>developer\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'system' %}"
+    "{{'<|im_start|>system\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'user' %}"
+    "{{'<|im_start|>user\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'assistant' %}"
+    "{{'<|im_start|>assistant\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+
+STRICT_ROLE_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'system' %}"
+    "{{'<|im_start|>system\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'user' %}"
+    "{{'<|im_start|>user\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'assistant' %}"
+    "{{'<|im_start|>assistant\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% else %}"
+    "{{ raise_exception('Unexpected message role: ' + message['role']) }}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+
+
+class TestDetectDeveloperRoleSupport:
+    def test_absent_in_chatml(self):
+        assert _detect_developer_role_support(CHATML_TEMPLATE) is False
+
+    def test_present_double_quotes(self):
+        assert _detect_developer_role_support(TEMPLATE_WITH_DEVELOPER) is True
+
+    def test_present_single_quotes(self):
+        template = TEMPLATE_WITH_DEVELOPER.replace('"developer"', "'developer'")
+        assert _detect_developer_role_support(template) is True
+
+    def test_absent_in_strict_template(self):
+        assert _detect_developer_role_support(STRICT_ROLE_TEMPLATE) is False
+
+
+class TestSafeApplyChatTemplateDeveloperRole:
+    @pytest.fixture
+    def model_config(self):
+        return ModelConfig(
+            "facebook/opt-125m",
+            tokenizer="facebook/opt-125m",
+            tokenizer_mode="auto",
+            trust_remote_code=False,
+            dtype="float16",
+        )
+
+    @pytest.fixture
+    def tokenizer(self):
+        return get_tokenizer("facebook/opt-125m")
+
+    def test_developer_converted_to_system_for_chatml(self, model_config, tokenizer):
+        conversation = [
+            {"role": "developer", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=CHATML_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>system" in result
+        assert "You are a helpful assistant." in result
+        assert "<|im_start|>developer" not in result
+
+    def test_developer_preserved_when_template_supports_it(
+        self, model_config, tokenizer
+    ):
+        conversation = [
+            {"role": "developer", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=TEMPLATE_WITH_DEVELOPER,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>developer" in result
+        assert "You are a helpful assistant." in result
+
+    def test_developer_does_not_crash_strict_template(self, model_config, tokenizer):
+        conversation = [
+            {"role": "developer", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=STRICT_ROLE_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>system" in result
+        assert "You are a helpful assistant." in result
+
+    def test_no_developer_messages_no_overhead(self, model_config, tokenizer):
+        conversation = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=CHATML_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>system" in result
+        assert "You are helpful." in result
+
+    def test_developer_at_non_first_position_consolidated(
+        self, model_config, tokenizer
+    ):
+        conversation = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "developer", "content": "Be concise."},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=SYSTEM_FIRST_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>system" in result
+        assert "You are helpful." in result
+        assert "Be concise." in result
+        assert "What is 2+2?" in result
+
+    def test_developer_only_no_prior_system(self, model_config, tokenizer):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {"role": "developer", "content": "Be concise."},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=SYSTEM_FIRST_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert "<|im_start|>system" in result
+        assert "Be concise." in result
+
+
+SYSTEM_FIRST_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'system' %}"
+    "{% if not loop.first %}"
+    "{{ raise_exception('System message must be at the beginning.') }}"
+    "{% endif %}"
+    "{{'<|im_start|>system\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'user' %}"
+    "{{'<|im_start|>user\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% elif message['role'] == 'assistant' %}"
+    "{{'<|im_start|>assistant\\n' + message['content'] + '<|im_end|>\\n'}}"
+    "{% else %}"
+    "{{ raise_exception('Unexpected message role: ' + message['role']) }}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+
+
+class TestConsolidateSystemMessages:
+    def test_no_system_messages_unchanged(self):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        result = _consolidate_system_messages(conversation)
+        assert result == conversation
+
+    def test_single_system_at_start_unchanged(self):
+        conversation = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = _consolidate_system_messages(conversation)
+        assert result == conversation
+
+    def test_system_at_non_first_position_moved(self):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "You are helpful."},
+        ]
+        result = _consolidate_system_messages(conversation)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are helpful."
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "Hello"
+
+    def test_multiple_system_messages_merged(self):
+        conversation = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Be concise."},
+        ]
+        result = _consolidate_system_messages(conversation)
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are helpful.\n\nBe concise."
+        assert result[1]["role"] == "user"
+
+    def test_list_content_handled(self):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Rule 1."},
+                    {"type": "text", "text": "Rule 2."},
+                ],
+            },
+        ]
+        result = _consolidate_system_messages(conversation)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "Rule 1.\nRule 2."
+        assert result[1]["role"] == "user"
+
+    def test_does_not_mutate_original(self):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "You are helpful."},
+        ]
+        original_len = len(conversation)
+        _consolidate_system_messages(conversation)
+        assert len(conversation) == original_len
+        assert conversation[0]["role"] == "user"
+        assert conversation[1]["role"] == "system"

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+import copy
+from types import SimpleNamespace
+
 import pytest
 
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.renderers.hf import (
+    HfRenderer,
     _consolidate_system_messages,
     _convert_developer_to_system,
     _detect_developer_role_support,
@@ -703,6 +708,29 @@ class TestDetectDeveloperRoleSupport:
     def test_absent_in_strict_template(self):
         assert _detect_developer_role_support(STRICT_ROLE_TEMPLATE) is False
 
+    def test_comment_is_not_role_support(self):
+        template = (
+            "{# 'developer' is deliberately unsupported #}" + STRICT_ROLE_TEMPLATE
+        )
+        assert not _detect_developer_role_support(template)
+
+    def test_rejection_branch_is_not_role_support(self):
+        template = (
+            "{% for message in messages %}"
+            "{% if message.role == 'developer' %}"
+            "{{ raise_exception('unsupported role') }}"
+            "{% else %}{{ message.content }}{% endif %}{% endfor %}"
+        )
+        assert not _detect_developer_role_support(template)
+
+    def test_silent_drop_is_not_role_support(self):
+        template = (
+            "{% for message in messages %}"
+            "{% if message.role != 'developer' %}{{ message.content }}"
+            "{% endif %}{% endfor %}"
+        )
+        assert not _detect_developer_role_support(template)
+
 
 class TestSafeApplyChatTemplateDeveloperRole:
     @pytest.fixture
@@ -889,7 +917,7 @@ class TestConsolidateSystemMessages:
         assert result[1]["role"] == "user"
 
     def test_list_content_handled(self):
-        conversation = [
+        conversation: list[dict] = [
             {"role": "user", "content": "Hello"},
             {
                 "role": "system",
@@ -901,7 +929,7 @@ class TestConsolidateSystemMessages:
         ]
         result = _consolidate_system_messages(conversation)
         assert result[0]["role"] == "system"
-        assert result[0]["content"] == "Rule 1.\nRule 2."
+        assert result[0]["content"] == conversation[1]["content"]
         assert result[1]["role"] == "user"
 
     def test_does_not_mutate_original(self):
@@ -914,3 +942,87 @@ class TestConsolidateSystemMessages:
         assert len(conversation) == original_len
         assert conversation[0]["role"] == "user"
         assert conversation[1]["role"] == "system"
+
+    def test_structured_images_and_metadata_are_preserved(self):
+        parts = [
+            {"type": "text", "text": "Inspect this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.invalid/image"},
+            },
+        ]
+        conversation = [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "name": "policy", "content": parts},
+            {"role": "system", "name": "policy", "content": "Be concise"},
+        ]
+        original = copy.deepcopy(conversation)
+        result = _consolidate_system_messages(conversation)
+        assert result[0]["name"] == "policy"
+        assert result[0]["content"] == [*parts, {"type": "text", "text": "Be concise"}]
+        assert conversation == original
+
+    def test_conflicting_metadata_is_not_silently_lost(self):
+        conversation = [
+            {"role": "system", "name": "first", "content": "A"},
+            {"role": "system", "name": "second", "content": "B"},
+        ]
+        with pytest.raises(ValueError, match="conflicting metadata"):
+            _consolidate_system_messages(conversation)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_developer_normalization_precedes_multimodal_tracking(
+    monkeypatch, asynchronous
+):
+    import vllm.renderers.hf as hf
+
+    renderer = HfRenderer.__new__(HfRenderer)
+    renderer.model_config = SimpleNamespace(enable_prompt_embeds=False)
+    renderer.get_tokenizer = lambda: object()
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "user"}}],
+        },
+        {
+            "role": "system",
+            "content": [{"type": "image_url", "image_url": {"url": "system"}}],
+        },
+        {"role": "developer", "content": "instruction"},
+    ]
+    original = copy.deepcopy(messages)
+    params = SimpleNamespace(
+        chat_template=STRICT_ROLE_TEMPLATE,
+        chat_template_kwargs={},
+        chat_template_content_format="openai",
+        media_io_kwargs=None,
+        mm_processor_kwargs=None,
+    )
+    monkeypatch.setattr(
+        hf, "resolve_chat_template", lambda *args, **kwargs: STRICT_ROLE_TEMPLATE
+    )
+    monkeypatch.setattr(
+        hf, "resolve_chat_template_content_format", lambda **kwargs: "openai"
+    )
+
+    class ParserReached(Exception):
+        pass
+
+    def parse(parsed_messages, *args, **kwargs):
+        assert [message["role"] for message in parsed_messages] == ["system", "user"]
+        assert parsed_messages[0]["content"][0]["image_url"]["url"] == "system"
+        assert parsed_messages[1]["content"][0]["image_url"]["url"] == "user"
+        raise ParserReached
+
+    async def parse_async(*args, **kwargs):
+        return parse(*args, **kwargs)
+
+    monkeypatch.setattr(hf, "parse_chat_messages", parse)
+    monkeypatch.setattr(hf, "parse_chat_messages_async", parse_async)
+    with pytest.raises(ParserReached):
+        if asynchronous:
+            asyncio.run(renderer.render_messages_async(messages, params))
+        else:
+            renderer.render_messages(messages, params)
+    assert messages == original

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -450,6 +450,66 @@ def _detect_content_format(
         return "openai"
 
 
+@lru_cache(maxsize=32)
+def _detect_developer_role_support(chat_template: str) -> bool:
+    return '"developer"' in chat_template or "'developer'" in chat_template
+
+
+def _convert_developer_to_system(
+    conversation: list[ConversationMessage],
+) -> list[ConversationMessage]:
+    converted: list[ConversationMessage] = []
+    for msg in conversation:
+        if msg["role"] == "developer":
+            new_msg = dict(msg)
+            new_msg["role"] = "system"
+            new_msg.pop("tools", None)
+            converted.append(new_msg)  # type: ignore[arg-type]
+        else:
+            converted.append(msg)
+    return converted
+
+
+def _consolidate_system_messages(
+    conversation: list[ConversationMessage],
+) -> list[ConversationMessage]:
+    """Merge all system messages into one at position 0.
+
+    Some chat templates (e.g. Qwen 3.6) require the system message to be the
+    very first message.  After developer-to-system conversion, system messages
+    may appear at non-first positions; this merges them into a single message.
+    """
+    system_contents: list[str] = []
+    non_system: list[ConversationMessage] = []
+    needs_consolidation = False
+    for i, msg in enumerate(conversation):
+        if msg["role"] == "system":
+            if i > 0 or system_contents:
+                needs_consolidation = True
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                parts = []
+                for part in content:
+                    if isinstance(part, dict) and "text" in part:
+                        parts.append(part["text"])
+                    elif isinstance(part, str):
+                        parts.append(part)
+                content = "\n".join(parts)
+            if content:
+                system_contents.append(content)
+        else:
+            non_system.append(msg)
+
+    if not needs_consolidation:
+        return conversation
+
+    merged: ConversationMessage = {
+        "role": "system",
+        "content": "\n\n".join(system_contents),
+    }
+    return [merged, *non_system]
+
+
 def _resolve_chat_template_content_format(
     chat_template: str | None,
     tools: list[dict[str, Any]] | None,
@@ -653,7 +713,15 @@ def safe_apply_chat_template(
             "allowed, so you must provide a chat template if the tokenizer "
             "does not define one."
         )
-
+    if any(
+        msg["role"] == "developer" for msg in conversation
+    ) and not _detect_developer_role_support(chat_template):
+        conversation = _convert_developer_to_system(conversation)
+        conversation = _consolidate_system_messages(conversation)
+        logger.info_once(
+            "Chat template does not support the 'developer' message role. "
+            "Converting developer messages to 'system' role.",
+        )
     resolved_kwargs = resolve_chat_template_kwargs(
         tokenizer=tokenizer,
         chat_template=chat_template,

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -452,7 +452,45 @@ def _detect_content_format(
 
 @lru_cache(maxsize=32)
 def _detect_developer_role_support(chat_template: str) -> bool:
-    return '"developer"' in chat_template or "'developer'" in chat_template
+    """Require a role declaration and verify that it renders the instruction.
+
+    A quoted word in a comment or an explicit rejection branch is not support.
+    Probe only synthetic text; no request data or tokenizer/network work is
+    involved, and the result is cached per template.
+    """
+    from transformers.utils.chat_template_utils import _compile_jinja_template
+
+    ast = _try_extract_ast(chat_template)
+    if ast is None:
+        return False
+    declared = any(
+        node.value == "developer"
+        for comparison in ast.find_all(jinja2.nodes.Compare)
+        for node in comparison.find_all(jinja2.nodes.Const)
+    )
+    if not declared:
+        return False
+    marker = "vllmDeveloperRoleProbe92847"
+    for structured in (False, True):
+        content = [{"type": "text", "text": marker}] if structured else marker
+        for with_system in (False, True):
+            messages = [{"role": "developer", "content": content}]
+            if with_system:
+                messages.insert(0, {"role": "system", "content": "System probe"})
+            messages.append({"role": "user", "content": "User probe"})
+            try:
+                rendered = _compile_jinja_template(chat_template).render(
+                    messages=messages,
+                    tools=[],
+                    bos_token="",
+                    eos_token="",
+                    add_generation_prompt=False,
+                )
+            except (jinja2.TemplateError, TypeError, ValueError, IndexError):
+                continue
+            if marker in rendered:
+                return True
+    return False
 
 
 def _convert_developer_to_system(
@@ -479,35 +517,57 @@ def _consolidate_system_messages(
     very first message.  After developer-to-system conversion, system messages
     may appear at non-first positions; this merges them into a single message.
     """
-    system_contents: list[str] = []
+    system_messages: list[ConversationMessage] = []
     non_system: list[ConversationMessage] = []
     needs_consolidation = False
     for i, msg in enumerate(conversation):
         if msg["role"] == "system":
-            if i > 0 or system_contents:
+            if i > 0 or system_messages:
                 needs_consolidation = True
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                parts = []
-                for part in content:
-                    if isinstance(part, dict) and "text" in part:
-                        parts.append(part["text"])
-                    elif isinstance(part, str):
-                        parts.append(part)
-                content = "\n".join(parts)
-            if content:
-                system_contents.append(content)
+            system_messages.append(msg)
         else:
             non_system.append(msg)
 
     if not needs_consolidation:
         return conversation
 
-    merged: ConversationMessage = {
-        "role": "system",
-        "content": "\n\n".join(system_contents),
-    }
-    return [merged, *non_system]
+    contents = [msg.get("content") for msg in system_messages]
+    merged = dict(system_messages[0])
+    for msg in system_messages[1:]:
+        for key, value in msg.items():
+            if key not in ("role", "content"):
+                if key in merged and merged[key] != value:
+                    raise ValueError(
+                        "Cannot consolidate system messages with conflicting metadata"
+                    )
+                merged[key] = value
+    if any(isinstance(content, list) for content in contents):
+        parts = []
+        for content in contents:
+            if isinstance(content, list):
+                parts.extend(content)
+            elif content:
+                parts.append({"type": "text", "text": content})
+        merged["content"] = parts
+    else:
+        merged["content"] = "\n\n".join(
+            content for content in contents if isinstance(content, str) and content
+        )
+    return [cast("ConversationMessage", merged), *non_system]
+
+
+def _normalize_developer_messages(
+    conversation: list[ConversationMessage], chat_template: str | None
+) -> list[ConversationMessage]:
+    if not any(msg["role"] == "developer" for msg in conversation):
+        return conversation
+    if chat_template is None or _detect_developer_role_support(chat_template):
+        return conversation
+    logger.info_once(
+        "Chat template does not support the 'developer' message role. "
+        "Converting developer messages to 'system' role."
+    )
+    return _consolidate_system_messages(_convert_developer_to_system(conversation))
 
 
 def _resolve_chat_template_content_format(
@@ -713,15 +773,7 @@ def safe_apply_chat_template(
             "allowed, so you must provide a chat template if the tokenizer "
             "does not define one."
         )
-    if any(
-        msg["role"] == "developer" for msg in conversation
-    ) and not _detect_developer_role_support(chat_template):
-        conversation = _convert_developer_to_system(conversation)
-        conversation = _consolidate_system_messages(conversation)
-        logger.info_once(
-            "Chat template does not support the 'developer' message role. "
-            "Converting developer messages to 'system' role.",
-        )
+    conversation = _normalize_developer_messages(conversation, chat_template)
     resolved_kwargs = resolve_chat_template_kwargs(
         tokenizer=tokenizer,
         chat_template=chat_template,
@@ -882,6 +934,26 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 self.tokenizer, config.model_config.renderer_num_workers + 1
             )
 
+    def _prepare_developer_messages(
+        self, messages: list[ChatCompletionMessageParam], params: ChatParams
+    ) -> list[ChatCompletionMessageParam]:
+        if not any(msg["role"] == "developer" for msg in messages):
+            return messages
+        template = resolve_chat_template(
+            self.get_tokenizer(),
+            params.chat_template,
+            tools=params.chat_template_kwargs.get("tools"),
+            model_config=self.model_config,
+        )
+        # Normalize before multimodal parsing so moved placeholders and the
+        # tracker/UUID data retain the same order in sync and async rendering.
+        return cast(
+            "list[ChatCompletionMessageParam]",
+            _normalize_developer_messages(
+                cast("list[ConversationMessage]", messages), template
+            ),
+        )
+
     def render_messages(
         self,
         messages: list[ChatCompletionMessageParam],
@@ -896,6 +968,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 _ensure_prompt_embeds_placeholder_token(tokenizer)
             )
 
+        messages = self._prepare_developer_messages(messages, params)
         conversation, mm_data, mm_uuids = parse_chat_messages(
             messages,
             model_config,
@@ -1003,6 +1076,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 _ensure_prompt_embeds_placeholder_token(tokenizer)
             )
 
+        messages = self._prepare_developer_messages(messages, params)
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
             messages,
             model_config,


### PR DESCRIPTION
## Purpose
AI-assisted audited integration of #449 on main d1b5e412491f52979790a16cf1cfa741139050d8, preserving its history; this is the repair vehicle, not a competing submission.

Keep developer instructions when a template supports them; otherwise normalize to system without dropping structured image/audio content or silently discarding metadata. A cached AST/render probe avoids treating comments, rejection branches or silent dropping as support. Normalize before multimodal parsing in both sync and async renderer paths so placeholders and media data remain aligned.

## Test Plan / Test Result
27 focused renderer tests passed (47 unrelated deselected), including sync/async multimodal ordering, strict role templates, template comments/rejection, list content and input immutability. Scoped pre-commit including mypy passed. No end-to-end model generation or GPU performance claims; no checkpoint identity defaults. The cached probe only runs when developer messages occur.

Keep the source PR open until this integration merges.