### PR TITLE
[Bugfix][SM70] Audit FP8 packing tails and preserve valid fast paths (#484)

### DIFF
--- a/tests/quantization/test_sm70_channel_fp8_layout_guard.py
+++ b/tests/quantization/test_sm70_channel_fp8_layout_guard.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a16_fp8 import (  # noqa: E501
+    CompressedTensorsW8A16Fp8,
+    _sm70_channel_fp8_shape_is_validated,
+    _sm70_unpack_channel_fp8,
+)
+
+
+@pytest.mark.parametrize(
+    "shape,expected",
+    [
+        ((4096, 2560), True),
+        ((3328, 2560), True),
+        ((2560, 1536), True),
+        ((320, 2560), True),
+        ((32, 128), True),
+        ((96, 384), True),
+        ((2560, 160), False),
+        ((8, 256), False),
+        ((40, 128), False),
+        ((0, 128), False),
+    ],
+)
+def test_layout_gate_is_independent_of_checkpoint_and_tp(shape, expected):
+    layer = SimpleNamespace(
+        weight=torch.empty(shape, device="meta"),
+        prefix="unlisted.projection",
+        tp_size=2,
+    )
+    assert _sm70_channel_fp8_shape_is_validated(layer) is expected
+
+
+def _layer(raw, scale):
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(
+        raw.view(torch.float8_e4m3fn), requires_grad=False
+    )
+    layer.weight_scale = torch.nn.Parameter(scale, requires_grad=False)
+    layer.orig_dtype = torch.float16
+    layer.output_size_per_partition = raw.shape[0]
+    layer.prefix = "arbitrary.projection"
+    return layer
+
+
+def test_fallback_bounds_fp32_scratch_and_rounds_checkpoint_scales_once(monkeypatch):
+    raw = torch.full((4100, 257), 0x38, dtype=torch.uint8)
+    scale = torch.linspace(0.001, 0.1, 4100).view(-1, 1)
+    layer = _layer(raw, scale)
+    expected = (layer.weight.float() * scale).half()
+    converted_sizes = []
+    original_to = torch.Tensor.to
+
+    def tracked_to(tensor, *args, **kwargs):
+        if tensor.dtype == torch.float8_e4m3fn and args == (torch.float32,):
+            converted_sizes.append(tensor.numel())
+        return original_to(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "to", tracked_to)
+    _sm70_unpack_channel_fp8(layer)
+    assert len(converted_sizes) > 1
+    assert max(converted_sizes) * 4 <= 4 * 1024**2
+    assert torch.equal(layer.weight, expected)
+    assert layer.sm70_fp8_fp16_dequant
+    assert not hasattr(layer, "weight_scale")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    "shape", [(32, 128), (320, 2560), (2560, 160), (8, 256), (40, 128)]
+)
+def test_layout_dispatch_values_and_changing_input_graph(shape):
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("requires SM70")
+    torch.manual_seed(484)
+    n, k = shape
+    raw = torch.randint(0, 64, (n, k), dtype=torch.uint8)
+    raw[::2].bitwise_or_(128)
+    scale = torch.full((n, 1), 0.03125)
+    reference_weight = (raw.view(torch.float8_e4m3fn).float() * scale).half().cuda()
+    layer = _layer(raw.cuda(), scale.cuda())
+    scheme = object.__new__(CompressedTensorsW8A16Fp8)
+    scheme.use_sm70_fp8_turbomind = True
+    scheme.use_sm70_fp8_qpn8 = False
+    scheme.process_weights_after_loading(layer)
+    packed = n % 32 == 0 and k % 128 == 0
+    assert getattr(layer, "sm70_fp8_turbomind", False) is packed
+    assert getattr(layer, "sm70_fp8_fp16_dequant", False) is (not packed)
+    for m in (1, 17):
+        x = torch.randn(m, k, dtype=torch.float16, device="cuda") * 0.1
+        bias = torch.zeros(n, dtype=torch.float16, device="cuda")
+        output = scheme.apply_weights(layer, x, bias)
+        reference = torch.nn.functional.linear(x, reference_weight, bias)
+        torch.testing.assert_close(output, reference, atol=0.002, rtol=0.01)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            scheme.apply_weights(layer, x)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        output = scheme.apply_weights(layer, x)
+    for _ in range(8):
+        x.normal_(std=0.1)
+        graph.replay()
+        reference = torch.nn.functional.linear(x, reference_weight)
+        assert torch.isfinite(output).all()
+        torch.testing.assert_close(output, reference, atol=0.002, rtol=0.01)

--- a/tests/quantization/test_sm70_compressed_tensors_fastpaths.py
+++ b/tests/quantization/test_sm70_compressed_tensors_fastpaths.py
@@ -95,6 +95,10 @@ def test_compressed_tensors_channel_fp8_prepares_and_dispatches_turbomind(
         "compressed_tensors_w8a16_fp8"
     )
     monkeypatch.setattr(f"{module}.sm70_ops.fp8_sm70_prepare", fake_prepare)
+    # Isolate dispatch from the real packing geometry in this tiny mocked case.
+    monkeypatch.setattr(
+        f"{module}._sm70_channel_fp8_shape_is_validated", lambda _: True
+    )
     scheme.process_weights_after_loading(layer)
 
     assert prepare_calls == [((6, 4), (6, 1), 128, False)]

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -140,6 +140,12 @@ def test_compressed_tensors_channel_fp8_prepares_and_dispatches_turbomind(
         "compressed_tensors_w8a16_fp8.sm70_ops.fp8_sm70_prepare",
         fake_prepare,
     )
+    # Isolate dispatch from the real packing geometry in this tiny mocked case.
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8._sm70_channel_fp8_shape_is_validated",
+        lambda _: True,
+    )
     scheme.process_weights_after_loading(layer)
 
     assert prepare_calls == [((6, 4), (6, 1), 128, False)]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -84,6 +84,35 @@ def _sm70_channel_fp8_qpn8_config(
     return _SM70_CHANNEL_FP8_QPN8_CONFIGS.get((k_dim, n_dim))
 
 
+def _sm70_channel_fp8_shape_is_validated(layer: torch.nn.Module) -> bool:
+    """Whether an SM70 channel-FP8 GEMM has been validated for this shape.
+
+    ``_SM70_CHANNEL_FP8_QPN8_SHAPES`` is the only record of which dense shapes
+    have been exercised on SM70. ``fp8_gemm_sm70_out`` does not raise on the
+    others -- it spins without returning -- so the layout conversion below is
+    gated on this instead of on the QPN8 route being selected.
+    """
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    return tuple(layer.weight.shape) == _SM70_CHANNEL_FP8_QPN8_SHAPES.get(suffix)
+
+
+def _sm70_unpack_channel_fp8(layer: torch.nn.Module) -> None:
+    """Dequantize channel-FP8 weights to the model dtype, in place.
+
+    FP8 E4M3 to FP16 is exact, so this costs one extra byte per element on the
+    affected projections and nothing in accuracy.
+    """
+    scale = layer.weight_scale.data.to(torch.float32)
+    if scale.ndim == 1:
+        scale = scale.view(-1, 1)
+    dequantized = (layer.weight.data.to(torch.float32) * scale).to(layer.orig_dtype)
+    replace_parameter(layer, "weight", dequantized)
+    for stale in ("weight_scale", "weight_scale_inv", "input_scale"):
+        if stale in layer._parameters:
+            del layer._parameters[stale]
+    layer.sm70_fp8_fp16_dequant = True
+
+
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def __init__(
         self,
@@ -271,6 +300,20 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
                         "Insufficient memory for the SM70 channel-FP8 QPN8 "
                         "prefill workspace; retaining the TurboMind layout."
                     )
+            if not _sm70_channel_fp8_shape_is_validated(layer):
+                # No validated SM70 tile covers this shape. fp8_gemm_sm70_out
+                # neither falls back nor raises on such shapes: it spins,
+                # leaving the GPU at 100% utilization near idle power with no
+                # progress and no error. Unpack instead, which is exact.
+                logger.warning_once(
+                    "No validated SM70 channel-FP8 GEMM covers %s with shape "
+                    "%s; unpacking these weights to %s instead.",
+                    getattr(layer, "prefix", "<unknown>"),
+                    tuple(layer.weight.shape),
+                    layer.orig_dtype,
+                )
+                _sm70_unpack_channel_fp8(layer)
+                return
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 layer.weight, weight_scale, 128, False
             )
@@ -317,6 +360,8 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "sm70_fp8_fp16_dequant", False):
+            return torch.nn.functional.linear(x, layer.weight, bias)
         if getattr(layer, "sm70_fp8_turbomind", False):
             if x.dtype != torch.float16:
                 raise RuntimeError(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -85,27 +85,35 @@ def _sm70_channel_fp8_qpn8_config(
 
 
 def _sm70_channel_fp8_shape_is_validated(layer: torch.nn.Module) -> bool:
-    """Whether an SM70 channel-FP8 GEMM has been validated for this shape.
+    """Require complete SM70 packed output rows and FP8 scale groups.
 
-    ``_SM70_CHANNEL_FP8_QPN8_SHAPES`` is the only record of which dense shapes
-    have been exercised on SM70. ``fp8_gemm_sm70_out`` does not raise on the
-    others -- it spins without returning -- so the layout conversion below is
-    gated on this instead of on the QPN8 route being selected.
+    PackingImpl<HMMA_884, OPERAND_B> packs 32 output rows, independently of
+    QPN8 tuning or checkpoint identity. Partial N tiles and partial 128-wide
+    K scale groups produce incorrect values with the current dense converter.
+    Preserve generic TurboMind shapes that meet these layout constraints.
     """
-    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
-    return tuple(layer.weight.shape) == _SM70_CHANNEL_FP8_QPN8_SHAPES.get(suffix)
+    n_dim, k_dim = layer.weight.shape
+    return n_dim > 0 and k_dim > 0 and n_dim % 32 == 0 and k_dim % 128 == 0
 
 
 def _sm70_unpack_channel_fp8(layer: torch.nn.Module) -> None:
     """Dequantize channel-FP8 weights to the model dtype, in place.
 
-    FP8 E4M3 to FP16 is exact, so this costs one extra byte per element on the
-    affected projections and nothing in accuracy.
+    Multiply checkpoint scales in FP32, then round once to the model dtype.
+    Only partial packing tiles take this fallback. Bound FP32 scratch to
+    4 MiB (or one row), rather than expanding a whole matrix in FP32.
     """
     scale = layer.weight_scale.data.to(torch.float32)
     if scale.ndim == 1:
         scale = scale.view(-1, 1)
-    dequantized = (layer.weight.data.to(torch.float32) * scale).to(layer.orig_dtype)
+    weight = layer.weight.data
+    dequantized = torch.empty_like(weight, dtype=layer.orig_dtype)
+    rows_per_chunk = max(1, (4 * 1024**2) // (max(1, weight.shape[1]) * 4))
+    for start in range(0, weight.shape[0], rows_per_chunk):
+        end = start + rows_per_chunk
+        chunk = weight[start:end].to(torch.float32)
+        chunk.mul_(scale[start:end])
+        dequantized[start:end].copy_(chunk)
     replace_parameter(layer, "weight", dequantized)
     for stale in ("weight_scale", "weight_scale_inv", "input_scale"):
         if stale in layer._parameters:
@@ -301,13 +309,11 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
                         "prefill workspace; retaining the TurboMind layout."
                     )
             if not _sm70_channel_fp8_shape_is_validated(layer):
-                # No validated SM70 tile covers this shape. fp8_gemm_sm70_out
-                # neither falls back nor raises on such shapes: it spins,
-                # leaving the GPU at 100% utilization near idle power with no
-                # progress and no error. Unpack instead, which is exact.
+                # Partial packing tiles are a numerical/layout restriction,
+                # not an absence from the QPN8 performance-tuning table.
                 logger.warning_once(
-                    "No validated SM70 channel-FP8 GEMM covers %s with shape "
-                    "%s; unpacking these weights to %s instead.",
+                    "SM70 channel-FP8 packing needs full N32/K128 tiles for "
+                    "%s with shape %s; unpacking these weights to %s instead.",
                     getattr(layer, "prefix", "<unknown>"),
                     tuple(layer.weight.shape),
                     layer.orig_dtype,


### PR DESCRIPTION
## Purpose
AI-assisted audited integration of #484 on main d1b5e412491f52979790a16cf1cfa741139050d8, preserving source PR history. This repair removes the checkpoint/prefix/TP whitelist and guards the actual TurboMind packing contract (complete N32/K128 tiles).

Unsupported tails use a bounded FP32 dequantization temporary (4 MiB or one row), applying checkpoint scales before one FP16 rounding. Full packed shapes retain TurboMind/QPN dispatch. This is not an unconditional conversion of all previously untuned layers.

## Test Plan / Test Result
45 tests passed on physical V100 GPU4 (Torch2.10+cu128), including actual FP8 prepare/apply, M1/M17 values, changing-input CUDA Graph replay, scaled fallback and scratch bound. CPU-only run:40 passed/5 skipped. Scoped pre-commit including mypy passed. Existing installed native extension used; this PR changes no native sources.

Independent native probes: N4096/K2560, N3328/K2560, N2560/K1536, N320/K2560 are finite/accurate. N2560/K160 partial K produced large errors. Padding fixes K only for N32-aligned shapes; partial N also needs fallback. A synthetic M1 48-call CUDA Graph N2560/K160 measured padded FP8 0.461375ms vs FP16 fallback0.155003ms, so the selective fallback avoids an approx3x slowdown from padding. These are layer measurements, not model throughput or end-to-end output-quality claims. Greedy equality is not required.

Keep original open until integration merges.