### PR TITLE
[Kernel][WIP] Screen SM70 FlashNext EP4 and DeepEP

### DIFF
--- a/benchmarks/kernels/benchmark_sm70_nvfp4_ep4.py
+++ b/benchmarks/kernels/benchmark_sm70_nvfp4_ep4.py
@@ -1,0 +1,712 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: B023
+"""Compare the production TP4 and TP-local EP4 FlashNext NVFP4 MoE chains.
+
+The four TP ranks receive the same token rows. The control keeps all 512
+experts on every rank with a 160-wide intermediate shard. EP4 keeps 128 full
+640-wide experts on each rank, maps global routes to their owning rank, and
+uses the same final four-rank all-reduce. Timings include routing, W13,
+SwiGLU, W2, weighted unpermutation, and NCCL all-reduce.
+
+This is a one-layer screening benchmark. It does not replace end-to-end model
+or quality validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+from collections.abc import Callable
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from safetensors import safe_open
+
+from vllm import _sm70_ops as sm70_ops
+from vllm.model_executor.layers.quantization.sm70_turbomind import (
+    unpack_mxfp4_weight,
+)
+
+HIDDEN = 2560
+INTERMEDIATE = 640
+GLOBAL_EXPERTS = 512
+LOCAL_EXPERTS = 128
+TOP_K = 10
+GROUP_SIZE = 16
+
+
+@dataclass
+class PreparedWeights:
+    w13: torch.Tensor
+    s13: torch.Tensor
+    w2: torch.Tensor
+    s2: torch.Tensor
+    p13w: torch.Tensor
+    p13s: torch.Tensor
+    p2w: torch.Tensor
+    p2s: torch.Tensor
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while block := handle.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _require_contract() -> None:
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("This benchmark requires an SM70 GPU.")
+    for namespace, name in (
+        (torch.ops._C, "nvfp4_sm70_prepare"),
+        (torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"),
+        (torch.ops._C, "awq_moe_build_strided_ptrs"),
+        (torch.ops._C, "nvfp4_moe_qpn_w13_swiglu_batch_sm70_out"),
+        (torch.ops._C, "nvfp4_moe_qpn_w2_reduce_sm70_out"),
+        (torch.ops._C, "nvfp4_moe_fused_swiglu_stage_sm70_out"),
+        (torch.ops._C, "nvfp4_qwen38_ep4_permute_sm70_out"),
+        (torch.ops._C, "nvfp4_qwen38_ep4_combine_sm70_out"),
+        (torch.ops._C, "nvfp4_grouped_w13_sm70_out"),
+        (torch.ops._C, "nvfp4_grouped_w2_sm70_out"),
+        (torch.ops._C, "nvfp4_grouped_ep4_w13_sm70_out"),
+        (torch.ops._C, "nvfp4_grouped_ep4_w2_sm70_out"),
+        (torch.ops._moe_C, "moe_permute_with_scratch"),
+        (torch.ops._moe_C, "moe_unpermute"),
+    ):
+        if not hasattr(namespace, name):
+            raise RuntimeError(f"Required operator is missing: {namespace}.{name}")
+
+
+def _prepare(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    interleaved: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return tuple(
+        sm70_ops.nvfp4_sm70_prepare(
+            unpack_mxfp4_weight(packed.cuda()),
+            scales.half().t().contiguous().cuda(),
+            GROUP_SIZE,
+            interleave_gated_silu=interleaved,
+        )
+    )
+
+
+def _load_weights(
+    model: Path, layer: int, rank: int
+) -> tuple[PreparedWeights, PreparedWeights]:
+    index_path = model / "model.safetensors.index.json"
+    weight_map = json.loads(index_path.read_text())["weight_map"]
+    tp: list[list[torch.Tensor]] = [[], [], [], []]
+    ep: list[list[torch.Tensor]] = [[], [], [], []]
+    tp_meta: tuple[torch.Tensor, torch.Tensor] | None = None
+    ep_meta: tuple[torch.Tensor, torch.Tensor] | None = None
+    ep_start = rank * LOCAL_EXPERTS
+    ep_stop = ep_start + LOCAL_EXPERTS
+
+    with ExitStack() as stack:
+        handles: dict[str, object] = {}
+
+        def get(expert: int, projection: str, suffix: str) -> torch.Tensor:
+            key = (
+                f"model.language_model.layers.{layer}.mlp.experts."
+                f"{expert}.{projection}.{suffix}"
+            )
+            shard = weight_map[key]
+            if shard not in handles:
+                handles[shard] = stack.enter_context(
+                    safe_open(model / shard, framework="pt", device="cpu")
+                )
+            return handles[shard].get_tensor(key)  # type: ignore[union-attr]
+
+        for expert in range(GLOBAL_EXPERTS):
+            gate_w = get(expert, "gate_proj", "weight")
+            up_w = get(expert, "up_proj", "weight")
+            gate_scale = get(expert, "gate_proj", "weight_scale").float()
+            up_scale = get(expert, "up_proj", "weight_scale").float()
+            gate_global = get(expert, "gate_proj", "weight_scale_2").float()
+            up_global = get(expert, "up_proj", "weight_scale_2").float()
+            down_w = get(expert, "down_proj", "weight")
+            down_scale = get(expert, "down_proj", "weight_scale").float()
+            down_global = get(expert, "down_proj", "weight_scale_2").float()
+
+            lo = rank * (INTERMEDIATE // 4)
+            hi = lo + INTERMEDIATE // 4
+            tp_w13, tp_s13, meta13 = _prepare(
+                torch.cat((gate_w[lo:hi], up_w[lo:hi])),
+                torch.cat(
+                    (gate_scale[lo:hi] * gate_global, up_scale[lo:hi] * up_global)
+                ),
+                interleaved=True,
+            )
+            tp_w2, tp_s2, meta2 = _prepare(
+                down_w[:, lo // 2 : hi // 2].contiguous(),
+                down_scale[:, lo // GROUP_SIZE : hi // GROUP_SIZE] * down_global,
+            )
+            for destination, value in zip(tp, (tp_w13, tp_s13, tp_w2, tp_s2)):
+                destination.append(value)
+            if tp_meta is None:
+                tp_meta = (meta13, meta2)
+
+            if ep_start <= expert < ep_stop:
+                ep_w13, ep_s13, ep_meta13 = _prepare(
+                    torch.cat((gate_w, up_w)),
+                    torch.cat((gate_scale * gate_global, up_scale * up_global)),
+                    interleaved=True,
+                )
+                ep_w2, ep_s2, ep_meta2 = _prepare(
+                    down_w,
+                    down_scale * down_global,
+                )
+                for destination, value in zip(ep, (ep_w13, ep_s13, ep_w2, ep_s2)):
+                    destination.append(value)
+                if ep_meta is None:
+                    ep_meta = (ep_meta13, ep_meta2)
+
+    if tp_meta is None or ep_meta is None:
+        raise RuntimeError("Weight preparation produced no metadata.")
+
+    def finish(
+        values: list[list[torch.Tensor]],
+        metadata: tuple[torch.Tensor, torch.Tensor],
+        experts: int,
+    ) -> PreparedWeights:
+        w13, s13, w2, s2 = (torch.stack(items) for items in values)
+        meta13, meta2 = metadata
+        p13w, p13s = sm70_ops.awq_moe_build_strided_ptrs(
+            w13,
+            s13,
+            int(meta13[0].item()),
+            int(meta13[1].item()),
+            experts,
+        )
+        p2w, p2s = sm70_ops.awq_moe_build_strided_ptrs(
+            w2,
+            s2,
+            int(meta2[0].item()),
+            int(meta2[1].item()),
+            experts,
+        )
+        return PreparedWeights(w13, s13, w2, s2, p13w, p13s, p2w, p2s)
+
+    return (
+        finish(tp, tp_meta, GLOBAL_EXPERTS),
+        finish(ep, ep_meta, LOCAL_EXPERTS),
+    )
+
+
+def _time_distributed(
+    fn: Callable[[], None],
+    *,
+    rank: int,
+    repeats: int,
+    samples: int,
+    warmup: int = 5,
+) -> tuple[float, list[float], list[list[float]]]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    dist.barrier()
+    max_samples: list[float] = []
+    rank_samples: list[list[float]] = []
+    for _ in range(samples):
+        dist.barrier()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(repeats):
+            fn()
+        end.record()
+        end.synchronize()
+        local_us = start.elapsed_time(end) * 1000.0 / repeats
+        gathered: list[float | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered, local_us)
+        per_rank = [float(value) for value in gathered if value is not None]
+        rank_samples.append(per_rank)
+        max_samples.append(max(per_rank))
+    median = statistics.median(max_samples)
+    if rank == 0:
+        print(
+            json.dumps({"median_us": median, "samples_us": max_samples}),
+            flush=True,
+        )
+    return median, max_samples, rank_samples
+
+
+def _error(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float | bool]:
+    delta = actual.float() - expected.float()
+    expected_f = expected.float()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().reshape(1, -1), expected_f.reshape(1, -1)
+    )
+    return {
+        "finite": bool(torch.isfinite(actual).all().item()),
+        "max_abs": float(delta.abs().max().item()),
+        "mean_abs": float(delta.abs().mean().item()),
+        "relative_l2": float(
+            (delta.norm() / expected_f.norm().clamp_min(1e-12)).item()
+        ),
+        "cosine": float(cosine.item()),
+    }
+
+
+def _load_routes(path: Path, tokens: int) -> torch.Tensor:
+    value = torch.load(path, weights_only=True, map_location="cpu")
+    if isinstance(value, dict):
+        value = value["tensor"]
+    if value.ndim != 2 or value.shape[1] != TOP_K or value.shape[0] < tokens:
+        raise ValueError(
+            f"Expected at least [{tokens},{TOP_K}] routes, got {value.shape}"
+        )
+    return value[:tokens].to(torch.int32).contiguous().cuda()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--routes", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=0)
+    parser.add_argument("--tokens", default="4,8,16")
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--samples", type=int, default=7)
+    parser.add_argument("--ep4-blocks", default="80,160,240,320")
+    args = parser.parse_args()
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    if world_size != 4:
+        raise RuntimeError(f"This benchmark requires four ranks, got {world_size}.")
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    _require_contract()
+    torch.manual_seed(20260907)
+
+    if rank == 0:
+        print("Preparing TP4 and EP4 checkpoint weights...", flush=True)
+    tp, ep = _load_weights(args.model, args.layer, rank)
+    torch.cuda.synchronize()
+    dist.barrier()
+    if rank == 0:
+        print("Checkpoint weights prepared.", flush=True)
+
+    cases: list[dict[str, object]] = []
+    for tokens in map(int, args.tokens.split(",")):
+        if tokens not in (4, 8, 16):
+            parser.error("Production QPN control supports token counts 4, 8, and 16.")
+        slots = tokens * TOP_K
+        x = torch.randn(tokens, HIDDEN, dtype=torch.float16, device="cuda") * 0.02
+        topk_ids = _load_routes(args.routes, tokens)
+        topk_weights = torch.softmax(
+            torch.randn(tokens, TOP_K, dtype=torch.float32, device="cuda"), dim=-1
+        )
+        for tensor in (x, topk_ids, topk_weights):
+            dist.broadcast(tensor, src=0)
+
+        tp_intermediate = torch.empty(
+            slots, INTERMEDIATE // 4, dtype=torch.float16, device="cuda"
+        )
+        tp_routed = torch.empty(slots, HIDDEN, dtype=torch.float16, device="cuda")
+        tp_output = torch.empty(tokens, HIDDEN, dtype=torch.float16, device="cuda")
+        tp_grouped_rows = torch.empty(160, 8, dtype=torch.int32, device="cuda")
+        tp_grouped_experts = torch.empty(160, dtype=torch.int32, device="cuda")
+        tp_grouped_sizes = torch.empty(160, dtype=torch.int32, device="cuda")
+        tp_grouped_total = torch.empty(1, dtype=torch.int32, device="cuda")
+
+        expert_map = torch.full((GLOBAL_EXPERTS,), -1, dtype=torch.int32, device="cuda")
+        ep_start = rank * LOCAL_EXPERTS
+        expert_map[ep_start : ep_start + LOCAL_EXPERTS] = torch.arange(
+            LOCAL_EXPERTS, dtype=torch.int32, device="cuda"
+        )
+        topk_ids_buffer = torch.empty_like(topk_ids)
+        token_expert_indices = torch.arange(
+            slots, dtype=torch.int32, device="cuda"
+        ).view(tokens, TOP_K)
+        permuted_input = torch.empty(slots, HIDDEN, dtype=torch.float16, device="cuda")
+        expert_offsets64 = torch.empty(
+            LOCAL_EXPERTS + 1, dtype=torch.int64, device="cuda"
+        )
+        expert_offsets = torch.empty(
+            LOCAL_EXPERTS + 1, dtype=torch.int32, device="cuda"
+        )
+        inv_permuted_idx = torch.empty_like(topk_ids)
+        permuted_idx = torch.empty(slots, dtype=torch.int32, device="cuda")
+        permuted_expert_ids = torch.empty(slots, dtype=torch.int32, device="cuda")
+        sorted_row_idx = torch.empty(slots, dtype=torch.int32, device="cuda")
+        topk_ids_for_sort = torch.empty(slots, dtype=torch.int32, device="cuda")
+        workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+            slots, GLOBAL_EXPERTS
+        )
+        sort_workspace = torch.empty(workspace_size, dtype=torch.int8, device="cuda")
+        dense_expert_ids = torch.arange(LOCAL_EXPERTS, dtype=torch.int32, device="cuda")
+        ep_gate_up = torch.empty(
+            slots, 2 * INTERMEDIATE, dtype=torch.float16, device="cuda"
+        )
+        ep_intermediate = torch.empty(
+            slots, INTERMEDIATE, dtype=torch.float16, device="cuda"
+        )
+        ep_sorted_output = torch.empty(
+            slots, HIDDEN, dtype=torch.float16, device="cuda"
+        )
+        ep_output = torch.empty_like(tp_output)
+        ep_grouped_intermediate = torch.empty_like(ep_intermediate)
+        ep_grouped_routed = torch.empty_like(ep_sorted_output)
+        ep_grouped_output = torch.empty_like(tp_output)
+        ep_grouped_rows = torch.empty(160, 8, dtype=torch.int32, device="cuda")
+        ep_grouped_experts = torch.empty(160, dtype=torch.int32, device="cuda")
+        ep_grouped_sizes = torch.empty(160, dtype=torch.int32, device="cuda")
+        ep_grouped_total = torch.empty(1, dtype=torch.int32, device="cuda")
+
+        def tp_qpn_chain() -> None:
+            sm70_ops.nvfp4_moe_qpn_w13_swiglu_batch_sm70_out(
+                tp_intermediate,
+                x,
+                tp.w13,
+                tp.s13,
+                topk_ids.view(-1),
+                True,
+            )
+            sm70_ops.nvfp4_moe_qpn_w2_reduce_sm70_out(
+                tp_output,
+                tp_intermediate,
+                tp.w2,
+                tp.s2,
+                topk_ids.view(-1),
+                topk_weights,
+            )
+            dist.all_reduce(tp_output)
+
+        def tp_grouped_chain() -> None:
+            sm70_ops.nvfp4_grouped_w13_sm70_out(
+                tp_intermediate,
+                x,
+                tp.w13,
+                tp.s13,
+                topk_ids.view(-1),
+                tp_grouped_rows,
+                tp_grouped_experts,
+                tp_grouped_sizes,
+                tp_grouped_total,
+                4 if tokens == 8 else 8,
+                True,
+            )
+            sm70_ops.nvfp4_grouped_w2_sm70_out(
+                tp_output,
+                tp_routed,
+                tp_intermediate,
+                tp.w2,
+                tp.s2,
+                topk_weights,
+                tp_grouped_rows,
+                tp_grouped_experts,
+                tp_grouped_sizes,
+                tp_grouped_total,
+            )
+            dist.all_reduce(tp_output)
+
+        tp_chain = tp_grouped_chain if tokens in (8, 16) else tp_qpn_chain
+
+        def ep_legacy_permute() -> None:
+            ep_output.zero_()
+            topk_ids_buffer.copy_(topk_ids)
+            permuted_idx.fill_(slots)
+            torch.ops._moe_C.moe_permute_with_scratch(
+                x,
+                topk_ids_buffer,
+                token_expert_indices,
+                expert_map,
+                GLOBAL_EXPERTS,
+                LOCAL_EXPERTS,
+                TOP_K,
+                permuted_input,
+                expert_offsets64,
+                inv_permuted_idx,
+                permuted_idx,
+                sort_workspace,
+                permuted_expert_ids,
+                sorted_row_idx,
+                topk_ids_for_sort,
+            )
+            expert_offsets.copy_(expert_offsets64)
+
+        def ep_legacy_w13() -> None:
+            sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+                ep_gate_up,
+                permuted_input,
+                expert_offsets,
+                dense_expert_ids,
+                ep.p13w,
+                ep.p13s,
+                LOCAL_EXPERTS,
+                HIDDEN,
+                2 * INTERMEDIATE,
+                GROUP_SIZE,
+            )
+
+        def ep_activation() -> None:
+            torch.ops._C.silu_and_mul_interleaved(ep_intermediate, ep_gate_up)
+
+        def ep_fast_permute() -> None:
+            sm70_ops.nvfp4_qwen38_ep4_permute_sm70_out(
+                permuted_input,
+                expert_offsets,
+                inv_permuted_idx,
+                x,
+                topk_ids,
+                ep_start,
+            )
+
+        def ep_fast_w13() -> None:
+            sm70_ops.nvfp4_moe_fused_swiglu_stage_sm70_out(
+                ep_intermediate,
+                permuted_input,
+                expert_offsets,
+                dense_expert_ids,
+                ep.p13w,
+                ep.p13s,
+                LOCAL_EXPERTS,
+                HIDDEN,
+                2 * INTERMEDIATE,
+                GROUP_SIZE,
+            )
+
+        def ep_w2() -> None:
+            sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+                ep_sorted_output,
+                ep_intermediate,
+                expert_offsets,
+                dense_expert_ids,
+                ep.p2w,
+                ep.p2s,
+                LOCAL_EXPERTS,
+                INTERMEDIATE,
+                HIDDEN,
+                GROUP_SIZE,
+            )
+
+        def ep_legacy_unpermute() -> None:
+            ep_output.zero_()
+            torch.ops._moe_C.moe_unpermute(
+                ep_sorted_output,
+                topk_weights,
+                inv_permuted_idx,
+                expert_offsets64,
+                TOP_K,
+                ep_output,
+            )
+
+        def ep_fast_combine() -> None:
+            sm70_ops.nvfp4_qwen38_ep4_combine_sm70_out(
+                ep_output,
+                ep_sorted_output,
+                topk_weights,
+                inv_permuted_idx,
+            )
+
+        def ep_legacy_chain() -> None:
+            ep_legacy_permute()
+            ep_legacy_w13()
+            ep_activation()
+            ep_w2()
+            ep_legacy_unpermute()
+            dist.all_reduce(ep_output)
+
+        def ep_chain() -> None:
+            ep_fast_permute()
+            ep_fast_w13()
+            ep_w2()
+            ep_fast_combine()
+            dist.all_reduce(ep_output)
+
+        def ep_grouped_chain(blocks: int) -> None:
+            sm70_ops.nvfp4_grouped_ep4_w13_sm70_out(
+                ep_grouped_intermediate,
+                x,
+                ep.w13,
+                ep.s13,
+                topk_ids.view(-1),
+                ep_grouped_rows,
+                ep_grouped_experts,
+                ep_grouped_sizes,
+                ep_grouped_total,
+                ep_start,
+                4 if tokens == 8 else 8,
+                True,
+                blocks,
+            )
+            sm70_ops.nvfp4_grouped_ep4_w2_sm70_out(
+                ep_grouped_output,
+                ep_grouped_routed,
+                ep_grouped_intermediate,
+                ep.w2,
+                ep.s2,
+                topk_weights,
+                topk_ids.view(-1),
+                ep_grouped_rows,
+                ep_grouped_experts,
+                ep_grouped_sizes,
+                ep_grouped_total,
+                ep_start,
+                blocks,
+            )
+            dist.all_reduce(ep_grouped_output)
+
+        tp_chain()
+        tp_reference = tp_output.clone()
+        ep_legacy_chain()
+        ep_legacy_reference = ep_output.clone()
+        ep_chain()
+        torch.cuda.synchronize()
+        correctness = _error(ep_output, tp_reference)
+        fastpath_correctness = _error(ep_output, ep_legacy_reference)
+        if not correctness["finite"]:
+            raise RuntimeError(f"EP4 produced non-finite output: {correctness}")
+
+        if rank == 0:
+            print(f"Timing M={tokens} TP4 control...", flush=True)
+        tp_us, tp_samples, tp_rank_samples = _time_distributed(
+            tp_chain,
+            rank=rank,
+            repeats=args.repeats,
+            samples=args.samples,
+        )
+        if rank == 0:
+            print(f"Timing M={tokens} EP4 legacy candidate...", flush=True)
+        ep_legacy_us, _, _ = _time_distributed(
+            ep_legacy_chain,
+            rank=rank,
+            repeats=args.repeats,
+            samples=args.samples,
+        )
+        if rank == 0:
+            print(f"Timing M={tokens} EP4 fast candidate...", flush=True)
+        ep_us, ep_samples, ep_rank_samples = _time_distributed(
+            ep_chain,
+            rank=rank,
+            repeats=args.repeats,
+            samples=args.samples,
+        )
+
+        ep_grouped_results: list[dict[str, object]] = []
+        for blocks in map(int, args.ep4_blocks.split(",")):
+            ep_grouped_chain(blocks)
+            torch.cuda.synchronize()
+            grouped_vs_tp = _error(ep_grouped_output, tp_reference)
+            grouped_vs_ep = _error(ep_grouped_output, ep_legacy_reference)
+            if not grouped_vs_ep["finite"]:
+                raise RuntimeError(
+                    f"Grouped EP4 produced non-finite output: {grouped_vs_ep}"
+                )
+            if rank == 0:
+                print(
+                    f"Timing M={tokens} grouped EP4 candidate blocks={blocks}...",
+                    flush=True,
+                )
+            grouped_us, grouped_samples, grouped_rank_samples = _time_distributed(
+                lambda blocks=blocks: ep_grouped_chain(blocks),
+                rank=rank,
+                repeats=args.repeats,
+                samples=args.samples,
+            )
+            ep_grouped_results.append(
+                {
+                    "blocks": blocks,
+                    "full_chain_us": grouped_us,
+                    "saving_vs_tp_us": tp_us - grouped_us,
+                    "speedup_vs_tp": tp_us / grouped_us,
+                    "correctness_vs_tp4": grouped_vs_tp,
+                    "correctness_vs_legacy_ep4": grouped_vs_ep,
+                    "max_rank_samples_us": grouped_samples,
+                    "per_rank_samples_us": grouped_rank_samples,
+                }
+            )
+
+        ep_fast_permute()
+        ep_fast_w13()
+        ep_w2()
+        ep_fast_combine()
+        stage_times: dict[str, float] = {}
+        for name, fn in (
+            ("permute", ep_fast_permute),
+            ("w13_fused_swiglu", ep_fast_w13),
+            ("w2", ep_w2),
+            ("combine", ep_fast_combine),
+        ):
+            median, _, _ = _time_distributed(
+                fn,
+                rank=rank,
+                repeats=max(args.repeats, 40),
+                samples=max(3, args.samples // 2),
+                warmup=3,
+            )
+            stage_times[name] = median
+        comm_tensor = torch.zeros_like(ep_output)
+        allreduce_us, _, _ = _time_distributed(
+            lambda: dist.all_reduce(comm_tensor),
+            rank=rank,
+            repeats=max(args.repeats, 40),
+            samples=max(3, args.samples // 2),
+            warmup=3,
+        )
+        stage_times["allreduce"] = allreduce_us
+
+        local_routes = int(
+            ((topk_ids >= ep_start) & (topk_ids < ep_start + LOCAL_EXPERTS))
+            .sum()
+            .item()
+        )
+        route_counts: list[int | None] = [None] * world_size
+        dist.all_gather_object(route_counts, local_routes)
+        case = {
+            "tokens": tokens,
+            "route_counts_per_rank": [int(v) for v in route_counts if v is not None],
+            "tp4_full_chain_us": tp_us,
+            "ep4_legacy_full_chain_us": ep_legacy_us,
+            "ep4_full_chain_us": ep_us,
+            "saving_us": tp_us - ep_us,
+            "speedup": tp_us / ep_us,
+            "correctness_vs_tp4": correctness,
+            "fastpath_correctness_vs_legacy_ep4": fastpath_correctness,
+            "tp4_max_rank_samples_us": tp_samples,
+            "ep4_max_rank_samples_us": ep_samples,
+            "tp4_per_rank_samples_us": tp_rank_samples,
+            "ep4_per_rank_samples_us": ep_rank_samples,
+            "ep4_stage_diagnostics_us": stage_times,
+            "ep4_grouped_candidates": ep_grouped_results,
+        }
+        cases.append(case)
+        if rank == 0:
+            print(json.dumps(case), flush=True)
+
+    if rank == 0:
+        report = {
+            "model": str(args.model),
+            "layer": args.layer,
+            "routes": str(args.routes),
+            "route_sha256": _sha256(args.routes),
+            "world_size": world_size,
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "device": torch.cuda.get_device_name(),
+            "mode": "eager full chain with NCCL all-reduce",
+            "cases": cases,
+        }
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"Wrote {args.out}", flush=True)
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -617,6 +617,23 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     int64_t num_experts, int64_t k, int64_t n,
                                     int64_t group_size);
 
+void nvfp4_moe_fused_swiglu_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor dense_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size);
+
+void nvfp4_qwen38_ep4_permute_sm70_out(torch::Tensor permuted_input,
+                                       torch::Tensor expert_offsets,
+                                       torch::Tensor inv_permuted_idx,
+                                       torch::Tensor input,
+                                       torch::Tensor topk_ids,
+                                       int64_t expert_start);
+
+void nvfp4_qwen38_ep4_combine_sm70_out(torch::Tensor out,
+                                       torch::Tensor sorted_output,
+                                       torch::Tensor topk_weights,
+                                       torch::Tensor inv_permuted_idx);
+
 void nvfp4_moe_indexed_dense_stage_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
     torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -9631,6 +9631,244 @@ void nvfp4_moe_indexed_fused_swiglu_sm70_out(
       ptrs_s, num_experts, k, n, group_size, true);
 }
 
+namespace {
+
+constexpr int kQwen38Ep4LocalExperts = 128;
+constexpr int kQwen38Ep4TopK = 10;
+constexpr int kQwen38Ep4Hidden = 2560;
+constexpr int kQwen38Ep4MaxTokens = 18;
+
+__global__ void nvfp4_qwen38_ep4_build_metadata_kernel(
+    const int* __restrict__ topk_ids, int* __restrict__ expert_offsets,
+    int* __restrict__ inv_permuted_idx, int slots, int expert_start) {
+  __shared__ int counts[kQwen38Ep4LocalExperts];
+  __shared__ int cursors[kQwen38Ep4LocalExperts];
+
+  if (threadIdx.x < kQwen38Ep4LocalExperts) {
+    counts[threadIdx.x] = 0;
+  }
+  if (threadIdx.x < slots) {
+    inv_permuted_idx[threadIdx.x] = -1;
+  }
+  __syncthreads();
+
+  if (threadIdx.x < slots) {
+    const int local_expert = topk_ids[threadIdx.x] - expert_start;
+    if (0 <= local_expert && local_expert < kQwen38Ep4LocalExperts) {
+      atomicAdd(counts + local_expert, 1);
+    }
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    int prefix = 0;
+    expert_offsets[0] = 0;
+    for (int expert = 0; expert < kQwen38Ep4LocalExperts; ++expert) {
+      cursors[expert] = prefix;
+      prefix += counts[expert];
+      expert_offsets[expert + 1] = prefix;
+    }
+  }
+  __syncthreads();
+
+  if (threadIdx.x < slots) {
+    const int local_expert = topk_ids[threadIdx.x] - expert_start;
+    if (0 <= local_expert && local_expert < kQwen38Ep4LocalExperts) {
+      inv_permuted_idx[threadIdx.x] = atomicAdd(cursors + local_expert, 1);
+    }
+  }
+}
+
+__global__ void nvfp4_qwen38_ep4_expand_rows_kernel(
+    const __half* __restrict__ input, const int* __restrict__ inv_permuted_idx,
+    __half* __restrict__ permuted_input, int slots) {
+  const int route = blockIdx.x;
+  if (route >= slots) {
+    return;
+  }
+  const int destination = inv_permuted_idx[route];
+  if (destination < 0) {
+    return;
+  }
+  const int token = route / kQwen38Ep4TopK;
+  const __half2* source =
+      reinterpret_cast<const __half2*>(input + token * kQwen38Ep4Hidden);
+  __half2* destination_row = reinterpret_cast<__half2*>(
+      permuted_input + destination * kQwen38Ep4Hidden);
+  constexpr int kHiddenPairs = kQwen38Ep4Hidden / 2;
+  for (int pair = threadIdx.x; pair < kHiddenPairs; pair += blockDim.x) {
+    destination_row[pair] = source[pair];
+  }
+}
+
+__global__ void nvfp4_qwen38_ep4_combine_kernel(
+    const __half* __restrict__ sorted_output,
+    const float* __restrict__ topk_weights,
+    const int* __restrict__ inv_permuted_idx, __half* __restrict__ output,
+    int tokens) {
+  constexpr int kThreads = 256;
+  constexpr int kHiddenPairs = kQwen38Ep4Hidden / 2;
+  constexpr int kTiles = (kHiddenPairs + kThreads - 1) / kThreads;
+  const int token = blockIdx.x / kTiles;
+  const int tile = blockIdx.x % kTiles;
+  if (token >= tokens) {
+    return;
+  }
+  const int pair = tile * kThreads + threadIdx.x;
+  if (pair >= kHiddenPairs) {
+    return;
+  }
+
+  float2 acc = {0.f, 0.f};
+  const int route_base = token * kQwen38Ep4TopK;
+  #pragma unroll
+  for (int slot = 0; slot < kQwen38Ep4TopK; ++slot) {
+    const int route = route_base + slot;
+    const int source_row = inv_permuted_idx[route];
+    if (source_row >= 0) {
+      const __half2 value = reinterpret_cast<const __half2*>(
+          sorted_output + source_row * kQwen38Ep4Hidden)[pair];
+      const float2 value_f = __half22float2(value);
+      const float weight = topk_weights[route];
+      acc.x = fmaf(weight, value_f.x, acc.x);
+      acc.y = fmaf(weight, value_f.y, acc.y);
+    }
+  }
+  reinterpret_cast<__half2*>(output + token * kQwen38Ep4Hidden)[pair] =
+      __floats2half2_rn(acc.x, acc.y);
+}
+
+}  // namespace
+
+void nvfp4_qwen38_ep4_permute_sm70_out(torch::Tensor permuted_input,
+                                       torch::Tensor expert_offsets,
+                                       torch::Tensor inv_permuted_idx,
+                                       torch::Tensor input,
+                                       torch::Tensor topk_ids,
+                                       int64_t expert_start) {
+  TORCH_CHECK(input.is_cuda() && input.scalar_type() == torch::kFloat16 &&
+                  input.dim() == 2 && input.size(0) > 0 &&
+                  input.size(0) <= kQwen38Ep4MaxTokens &&
+                  input.size(1) == kQwen38Ep4Hidden && input.is_contiguous(),
+              "nvfp4_qwen38_ep4_permute_sm70_out: input must be contiguous "
+              "CUDA FP16 [1..18,2560].");
+  const int64_t tokens = input.size(0);
+  const int64_t slots = tokens * kQwen38Ep4TopK;
+  TORCH_CHECK(topk_ids.is_cuda() && topk_ids.scalar_type() == torch::kInt32 &&
+                  topk_ids.is_contiguous() && topk_ids.dim() == 2 &&
+                  topk_ids.size(0) == tokens &&
+                  topk_ids.size(1) == kQwen38Ep4TopK,
+              "nvfp4_qwen38_ep4_permute_sm70_out: topk_ids must be "
+              "contiguous CUDA int32 [tokens,10].");
+  TORCH_CHECK(permuted_input.is_cuda() &&
+                  permuted_input.scalar_type() == torch::kFloat16 &&
+                  permuted_input.is_contiguous() &&
+                  permuted_input.size(0) == slots &&
+                  permuted_input.size(1) == kQwen38Ep4Hidden,
+              "nvfp4_qwen38_ep4_permute_sm70_out: permuted_input shape "
+              "mismatch.");
+  TORCH_CHECK(expert_offsets.is_cuda() &&
+                  expert_offsets.scalar_type() == torch::kInt32 &&
+                  expert_offsets.is_contiguous() &&
+                  expert_offsets.numel() >= kQwen38Ep4LocalExperts + 1,
+              "nvfp4_qwen38_ep4_permute_sm70_out: expert_offsets must be "
+              "contiguous CUDA int32 [129].");
+  TORCH_CHECK(inv_permuted_idx.is_cuda() &&
+                  inv_permuted_idx.scalar_type() == torch::kInt32 &&
+                  inv_permuted_idx.is_contiguous() &&
+                  inv_permuted_idx.numel() == slots,
+              "nvfp4_qwen38_ep4_permute_sm70_out: inv_permuted_idx shape "
+              "mismatch.");
+  TORCH_CHECK(expert_start >= 0 &&
+                  expert_start + kQwen38Ep4LocalExperts <= 512 &&
+                  expert_start % kQwen38Ep4LocalExperts == 0,
+              "nvfp4_qwen38_ep4_permute_sm70_out: invalid expert_start.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  constexpr int kThreads = 256;
+  nvfp4_qwen38_ep4_build_metadata_kernel<<<1, kThreads, 0, stream>>>(
+      topk_ids.data_ptr<int32_t>(), expert_offsets.data_ptr<int32_t>(),
+      inv_permuted_idx.data_ptr<int32_t>(), static_cast<int>(slots),
+      static_cast<int>(expert_start));
+  nvfp4_qwen38_ep4_expand_rows_kernel<<<static_cast<int>(slots), kThreads, 0,
+                                        stream>>>(
+      reinterpret_cast<const __half*>(input.data_ptr<at::Half>()),
+      inv_permuted_idx.data_ptr<int32_t>(),
+      reinterpret_cast<__half*>(permuted_input.data_ptr<at::Half>()),
+      static_cast<int>(slots));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qwen38_ep4_combine_sm70_out(torch::Tensor out,
+                                       torch::Tensor sorted_output,
+                                       torch::Tensor topk_weights,
+                                       torch::Tensor inv_permuted_idx) {
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat16 &&
+                  out.is_contiguous() && out.dim() == 2 && out.size(0) > 0 &&
+                  out.size(0) <= kQwen38Ep4MaxTokens &&
+                  out.size(1) == kQwen38Ep4Hidden,
+              "nvfp4_qwen38_ep4_combine_sm70_out: out must be contiguous "
+              "CUDA FP16 [1..18,2560].");
+  const int64_t tokens = out.size(0);
+  const int64_t slots = tokens * kQwen38Ep4TopK;
+  TORCH_CHECK(sorted_output.is_cuda() &&
+                  sorted_output.scalar_type() == torch::kFloat16 &&
+                  sorted_output.is_contiguous() &&
+                  sorted_output.size(0) == slots &&
+                  sorted_output.size(1) == kQwen38Ep4Hidden,
+              "nvfp4_qwen38_ep4_combine_sm70_out: sorted_output shape "
+              "mismatch.");
+  TORCH_CHECK(topk_weights.is_cuda() &&
+                  topk_weights.scalar_type() == torch::kFloat32 &&
+                  topk_weights.is_contiguous() && topk_weights.numel() == slots,
+              "nvfp4_qwen38_ep4_combine_sm70_out: topk_weights must be "
+              "contiguous CUDA FP32 [tokens,10].");
+  TORCH_CHECK(inv_permuted_idx.is_cuda() &&
+                  inv_permuted_idx.scalar_type() == torch::kInt32 &&
+                  inv_permuted_idx.is_contiguous() &&
+                  inv_permuted_idx.numel() == slots,
+              "nvfp4_qwen38_ep4_combine_sm70_out: inv_permuted_idx shape "
+              "mismatch.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  constexpr int kThreads = 256;
+  constexpr int kHiddenPairs = kQwen38Ep4Hidden / 2;
+  constexpr int kTiles = (kHiddenPairs + kThreads - 1) / kThreads;
+  nvfp4_qwen38_ep4_combine_kernel<<<static_cast<int>(tokens) * kTiles, kThreads,
+                                    0, stream>>>(
+      reinterpret_cast<const __half*>(sorted_output.data_ptr<at::Half>()),
+      topk_weights.data_ptr<float>(), inv_permuted_idx.data_ptr<int32_t>(),
+      reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
+      static_cast<int>(tokens));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_moe_fused_swiglu_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor dense_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size) {
+  TORCH_CHECK(num_experts == kQwen38Ep4LocalExperts && k == kQwen38Ep4Hidden &&
+                  n == 2 * 640 && group_size == 16,
+              "nvfp4_moe_fused_swiglu_stage_sm70_out: exact Qwen3.8 EP4 "
+              "W13 contract is required.");
+  TORCH_CHECK(input.is_cuda() && input.scalar_type() == torch::kFloat16 &&
+                  input.dim() == 2 && input.size(1) == k &&
+                  input.is_contiguous(),
+              "nvfp4_moe_fused_swiglu_stage_sm70_out: input mismatch.");
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat16 &&
+                  out.dim() == 2 && out.size(0) == input.size(0) &&
+                  out.size(1) == n / 2 && out.is_contiguous(),
+              "nvfp4_moe_fused_swiglu_stage_sm70_out: out mismatch.");
+  TORCH_CHECK(vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled(),
+              "nvfp4_moe_fused_swiglu_stage_sm70_out requires grouped "
+              "dispatch.");
+  nvfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
+                               num_experts, k, n, group_size, dense_expert_ids,
+                               false, -1, torch::Tensor(), true);
+}
+
 void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     torch::Tensor expert_offsets,
                                     torch::Tensor dense_expert_ids,
@@ -9692,11 +9930,19 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       input.size(0) > kNvfp4LegacyCompactGroups && num_experts == 256 &&
       ((k == 2048 && (n == 1024 || n == 512 || n == 256)) ||
        (n == 2048 && (k == 512 || k == 256 || k == 128)));
-  const bool exact_qwen4_exp_prefill_shape =
+  const bool exact_qwen4_exp_tp_shape =
       input.size(0) > kNvfp4LegacyCompactGroups && num_experts == 512 &&
       ((k == 2560 && n == 320) || (k == 160 && n == 2560));
+  // In TP-local EP4 every rank receives the same token rows, owns 128 full
+  // experts and reduces its local expert outputs through the existing TP
+  // group.  Keep all 128 (including zero-row experts) in one grouped launch;
+  // the legacy per-expert loop would otherwise create 256 launches per layer.
+  const bool exact_qwen4_exp_ep4_shape =
+      num_experts == 128 &&
+      ((k == 2560 && n == 1280) || (k == 640 && n == 2560));
   if (vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled() &&
-      (exact_qwen36_prefill_shape || exact_qwen4_exp_prefill_shape)) {
+      (exact_qwen36_prefill_shape || exact_qwen4_exp_tp_shape ||
+       exact_qwen4_exp_ep4_shape)) {
     static std::atomic<unsigned> logged_nvfp4_grouped_prefill{0u};
     maybe_log_sm70_moe_route_once(
         logged_nvfp4_grouped_prefill,

--- a/csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_grouped_decode_sm70.cu
@@ -286,6 +286,308 @@ void w2(torch::Tensor out, torch::Tensor routed, torch::Tensor x,
       reinterpret_cast<half*>(out.data_ptr()));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
+
+constexpr int kEp4Experts = 128;
+constexpr int kEp4Intermediate = 640;
+constexpr int kEp4W13Tiles = kEp4Intermediate / 32;
+constexpr int kEp4W2Tiles = 2560 / 32;
+constexpr int kEp4ChunksPerExpert = kChunks;
+
+// Build only rank-local groups. Keep the full route-count bound instead of
+// relying on top-k uniqueness: malformed or alternative routers must not
+// overflow shared metadata. Remote routes remain absent from the local
+// projection and are supplied by the owning rank through the final all-reduce.
+__global__ void ep4_plan_kernel(const int32_t* ids, int32_t* rows,
+                                int32_t* experts, int32_t* sizes,
+                                int32_t* total, int routes, int expert_start) {
+  __shared__ int counts[kEp4Experts];
+  __shared__ int groups[kEp4Experts][kEp4ChunksPerExpert];
+  const int t = threadIdx.x;
+  if (t < kEp4Experts) counts[t] = 0;
+  if (t == 0) *total = 0;
+  __syncthreads();
+
+  int expert = -1;
+  int ordinal = -1;
+  if (t < routes) {
+    expert = ids[t] - expert_start;
+    if (0 <= expert && expert < kEp4Experts) {
+      ordinal = atomicAdd(counts + expert, 1);
+    }
+  }
+  __syncthreads();
+
+  if (ordinal >= 0 && ordinal % kPack == 0) {
+    const int group = atomicAdd(total, 1);
+    groups[expert][ordinal / kPack] = group;
+    experts[group] = expert;
+    sizes[group] = min(kPack, counts[expert] - ordinal);
+  }
+  __syncthreads();
+  if (ordinal >= 0) {
+    const int group = groups[expert][ordinal / kPack];
+    rows[group * kPack + ordinal % kPack] = t;
+  }
+}
+
+template <int Split, bool Interleaved>
+__global__ void ep4_w13_kernel(const half* x, const uint32_t* weights,
+                               const half* scales, const int32_t* rows,
+                               const int32_t* experts, const int32_t* sizes,
+                               const int32_t* total, half* out) {
+  __shared__ float partial[2][Split][kPack][32];
+  __shared__ half projected[2][kPack][32];
+  const int lane = threadIdx.x % 32;
+  const int warp = threadIdx.x / 32;
+  const int projection = warp / Split;
+  const int split = warp % Split;
+  const int mma_row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int quad = (lane >> 2) & 3;
+  const int col = quad * 8 + mma_row;
+  const int task_count = *total * kEp4W13Tiles;
+
+  for (int task = blockIdx.x; task < task_count; task += gridDim.x) {
+    const int group_id = task / kEp4W13Tiles;
+    const int output_tile = task % kEp4W13Tiles;
+    const int count = sizes[group_id];
+    const int expert = experts[group_id];
+    const int tile = Interleaved ? output_tile * 2 + projection
+                                 : output_tile + projection * kEp4W13Tiles;
+    const int route = mma_row < count ? rows[group_id * kPack + mma_row] : 0;
+    float accum[8] = {};
+    const uint32_t* w = weights + static_cast<size_t>(expert) * 2560 * 160;
+    const half* scale_base = scales + static_cast<size_t>(expert) * 160 * 1280;
+    const half* input = x + static_cast<size_t>(route / 10) * 2560;
+#pragma unroll 4
+    for (int g = split * (160 / Split); g < (split + 1) * (160 / Split); ++g) {
+      const size_t offset =
+          (static_cast<size_t>(tile) * 320 + g * 2) * 32 + col;
+      const half scalar = __hmul(__ldg(scale_base + (g * 40 + tile) * 32 + col),
+                                 __float2half_rn(16384.0f));
+      const half2 scale = __halves2half2(scalar, scalar);
+      half2 decoded[8];
+      decode(__ldcs(w + offset), scale, decoded);
+      decode(__ldcs(w + offset + 32), scale, decoded + 4);
+      const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+      uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+      if (mma_row < count) {
+        lo = *reinterpret_cast<const uint4*>(input + g * 16);
+        hi = *reinterpret_cast<const uint4*>(input + g * 16 + 8);
+      }
+      PACKED_MMA(accum, lo.x, lo.y, b[0], b[1]);
+      PACKED_MMA(accum, lo.z, lo.w, b[2], b[3]);
+      PACKED_MMA(accum, hi.x, hi.y, b[4], b[5]);
+      PACKED_MMA(accum, hi.z, hi.w, b[6], b[7]);
+    }
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int r = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int c = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+      partial[projection][split][r][quad * 8 + c] = accum[i];
+    }
+    __syncthreads();
+    for (int idx = threadIdx.x; idx < 2 * kPack * 32; idx += blockDim.x) {
+      const int p = idx / (kPack * 32);
+      const int r = idx / 32 % kPack;
+      const int c = idx % 32;
+      float value = 0;
+#pragma unroll
+      for (int s = 0; s < Split; ++s) value += partial[p][s][r][c];
+      projected[p][r][c] = __float2half_rn(value);
+    }
+    __syncthreads();
+    for (int idx = threadIdx.x; idx < count * 32; idx += blockDim.x) {
+      const int r = idx / 32;
+      const int c = idx % 32;
+      const int p = Interleaved ? c / 16 : 0;
+      const int pc = Interleaved ? c % 16 * 2 : c;
+      const half gate = projected[p][r][pc];
+      const half up =
+          Interleaved ? projected[p][r][pc + 1] : projected[1][r][c];
+      const float gf = __half2float(gate);
+      const half activated = __float2half_rn(gf / (1.0f + expf(-gf)));
+      out[static_cast<size_t>(rows[group_id * kPack + r]) * kEp4Intermediate +
+          output_tile * 32 + c] = __hmul(activated, up);
+    }
+    __syncthreads();
+  }
+}
+
+__global__ void ep4_w2_kernel(const half* x, const uint32_t* weights,
+                              const half* scales, const int32_t* rows,
+                              const int32_t* experts, const int32_t* sizes,
+                              const int32_t* total, half* routed) {
+  const int warp = threadIdx.x / 32;
+  const int lane = threadIdx.x % 32;
+  const int quad = (lane >> 2) & 3;
+  const int r = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int col = quad * 8 + r;
+  const int group_batches = (*total + 3) / 4;
+  const int task_count = group_batches * kEp4W2Tiles;
+
+  for (int task = blockIdx.x; task < task_count; task += gridDim.x) {
+    const int output_tile = task % kEp4W2Tiles;
+    const int group = task / kEp4W2Tiles * 4 + warp;
+    if (group < *total) {
+      const int count = sizes[group];
+      const int expert = experts[group];
+      const int route = r < count ? rows[group * kPack + r] : 0;
+      float accum[8] = {};
+      const uint32_t* w =
+          weights + static_cast<size_t>(expert) * kEp4Intermediate * 320;
+      const half* scale_base = scales + static_cast<size_t>(expert) * 40 * 2560;
+      const half* input = x + static_cast<size_t>(route) * kEp4Intermediate;
+#pragma unroll
+      for (int g = 0; g < 40; ++g) {
+        const int offset = (output_tile * 80 + g * 2) * 32 + col;
+        const half scalar =
+            __hmul(__ldg(scale_base + (g * 80 + output_tile) * 32 + col),
+                   __float2half_rn(16384.0f));
+        const half2 scale = __halves2half2(scalar, scalar);
+        half2 decoded[8];
+        decode(__ldcs(w + offset), scale, decoded);
+        decode(__ldcs(w + offset + 32), scale, decoded + 4);
+        const unsigned* b = reinterpret_cast<const unsigned*>(decoded);
+        uint4 lo = make_uint4(0, 0, 0, 0), hi = make_uint4(0, 0, 0, 0);
+        if (r < count) {
+          lo = *reinterpret_cast<const uint4*>(input + g * 16);
+          hi = *reinterpret_cast<const uint4*>(input + g * 16 + 8);
+        }
+        PACKED_MMA(accum, lo.x, lo.y, b[0], b[1]);
+        PACKED_MMA(accum, lo.z, lo.w, b[2], b[3]);
+        PACKED_MMA(accum, hi.x, hi.y, b[4], b[5]);
+        PACKED_MMA(accum, hi.z, hi.w, b[6], b[7]);
+      }
+#pragma unroll
+      for (int i = 0; i < 8; ++i) {
+        const int row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+        const int c = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+        if (row < count) {
+          const int dst = rows[group * kPack + row];
+          routed[static_cast<size_t>(dst) * 2560 + output_tile * 32 + quad * 8 +
+                 c] = __float2half_rn(accum[i]);
+        }
+      }
+    }
+  }
+}
+
+__global__ void ep4_reduce_kernel(const half* routed, const float* weights,
+                                  const int32_t* ids, half* out, int tokens,
+                                  int expert_start) {
+  const int token = blockIdx.y;
+  const int col = blockIdx.x * 256 + threadIdx.x;
+  float result = 0;
+#pragma unroll
+  for (int slot = 0; slot < 10; ++slot) {
+    const int route = token * 10 + slot;
+    const int expert = ids[route] - expert_start;
+    if (0 <= expert && expert < kEp4Experts) {
+      result = fmaf(__half2float(routed[route * 2560 + col]), weights[route],
+                    result);
+    }
+  }
+  out[token * 2560 + col] = __float2half_rn(result);
+}
+
+void ep4_run(torch::Tensor out, torch::Tensor x, torch::Tensor w,
+             torch::Tensor s, torch::Tensor ids, torch::Tensor rows,
+             torch::Tensor experts, torch::Tensor sizes, torch::Tensor total,
+             int64_t expert_start, int64_t split, bool interleaved,
+             int64_t blocks) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  const int routes = x.size(0) * 10;
+  TORCH_CHECK(x.dim() == 2 && x.size(1) == 2560 && routes > 0 &&
+              routes <= kMaxRoutes);
+  TORCH_CHECK(expert_start >= 0 && expert_start % kEp4Experts == 0 &&
+              expert_start + kEp4Experts <= kExperts);
+  TORCH_CHECK(blocks > 0 && blocks <= 640);
+  for (const auto& t : {out, x, w, s, ids, rows, experts, sizes, total}) {
+    TORCH_CHECK(t.is_cuda() && t.device() == x.device() && t.is_contiguous());
+  }
+  TORCH_CHECK(x.scalar_type() == at::kHalf && s.scalar_type() == at::kHalf &&
+              out.scalar_type() == at::kHalf && w.scalar_type() == at::kInt);
+  for (const auto& t : {ids, rows, experts, sizes, total})
+    TORCH_CHECK(t.scalar_type() == at::kInt);
+  TORCH_CHECK(ids.numel() == routes && rows.numel() >= routes * kPack &&
+              experts.numel() >= routes && sizes.numel() >= routes &&
+              total.numel() == 1 && out.numel() == routes * kEp4Intermediate &&
+              w.numel() == kEp4Experts * 2560 * 160 &&
+              s.numel() == kEp4Experts * 160 * 1280);
+  const auto stream = at::cuda::getCurrentCUDAStream(x.get_device());
+  ep4_plan_kernel<<<1, 256, 0, stream>>>(
+      ids.data_ptr<int32_t>(), rows.data_ptr<int32_t>(),
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),
+      total.data_ptr<int32_t>(), routes, static_cast<int>(expert_start));
+#define EP4_LAUNCH(S, I)                                                     \
+  ep4_w13_kernel<S, I><<<static_cast<int>(blocks), 64 * S, 0, stream>>>(     \
+      reinterpret_cast<const half*>(x.data_ptr()),                           \
+      reinterpret_cast<const uint32_t*>(w.data_ptr()),                       \
+      reinterpret_cast<const half*>(s.data_ptr()), rows.data_ptr<int32_t>(), \
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),                \
+      total.data_ptr<int32_t>(), reinterpret_cast<half*>(out.data_ptr()))
+#define EP4_CASE(S)         \
+  case S:                   \
+    if (interleaved) {      \
+      EP4_LAUNCH(S, true);  \
+    } else {                \
+      EP4_LAUNCH(S, false); \
+    }                       \
+    break
+  switch (split) {
+    EP4_CASE(1);
+    EP4_CASE(2);
+    EP4_CASE(4);
+    EP4_CASE(5);
+    EP4_CASE(8);
+    default:
+      TORCH_CHECK(false, "Unsupported EP4 W13 split");
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+#undef EP4_CASE
+#undef EP4_LAUNCH
+}
+
+void ep4_w2(torch::Tensor out, torch::Tensor routed, torch::Tensor x,
+            torch::Tensor w, torch::Tensor s, torch::Tensor topk,
+            torch::Tensor ids, torch::Tensor rows, torch::Tensor experts,
+            torch::Tensor sizes, torch::Tensor total, int64_t expert_start,
+            int64_t blocks) {
+  const c10::cuda::CUDAGuard guard(x.device());
+  TORCH_CHECK(x.dim() == 2 && x.size(1) == kEp4Intermediate &&
+              x.size(0) % 10 == 0);
+  const int routes = x.size(0);
+  const int tokens = routes / 10;
+  TORCH_CHECK(tokens >= 1 && tokens <= 16 && blocks > 0 && blocks <= 640);
+  TORCH_CHECK(expert_start >= 0 && expert_start % kEp4Experts == 0 &&
+              expert_start + kEp4Experts <= kExperts);
+  for (const auto& t :
+       {out, routed, x, w, s, topk, ids, rows, experts, sizes, total})
+    TORCH_CHECK(t.is_cuda() && t.device() == x.device() && t.is_contiguous());
+  for (const auto& t : {out, routed, x, s})
+    TORCH_CHECK(t.scalar_type() == at::kHalf);
+  for (const auto& t : {w, ids, rows, experts, sizes, total})
+    TORCH_CHECK(t.scalar_type() == at::kInt);
+  TORCH_CHECK(topk.scalar_type() == at::kFloat && topk.numel() == routes &&
+              ids.numel() == routes && out.numel() == tokens * 2560 &&
+              routed.numel() == routes * 2560 &&
+              rows.numel() >= routes * kPack && experts.numel() >= routes &&
+              sizes.numel() >= routes && total.numel() == 1 &&
+              w.numel() == kEp4Experts * kEp4Intermediate * 320 &&
+              s.numel() == kEp4Experts * 40 * 2560);
+  const auto stream = at::cuda::getCurrentCUDAStream(x.get_device());
+  ep4_w2_kernel<<<static_cast<int>(blocks), 128, 0, stream>>>(
+      reinterpret_cast<const half*>(x.data_ptr()),
+      reinterpret_cast<const uint32_t*>(w.data_ptr()),
+      reinterpret_cast<const half*>(s.data_ptr()), rows.data_ptr<int32_t>(),
+      experts.data_ptr<int32_t>(), sizes.data_ptr<int32_t>(),
+      total.data_ptr<int32_t>(), reinterpret_cast<half*>(routed.data_ptr()));
+  ep4_reduce_kernel<<<dim3(10, tokens), 256, 0, stream>>>(
+      reinterpret_cast<const half*>(routed.data_ptr()), topk.data_ptr<float>(),
+      ids.data_ptr<int32_t>(), reinterpret_cast<half*>(out.data_ptr()), tokens,
+      static_cast<int>(expert_start));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
 }  // namespace
 
 TORCH_LIBRARY_FRAGMENT(_C, m) {
@@ -300,8 +602,20 @@ TORCH_LIBRARY_FRAGMENT(_C, m) {
       "Tensor w, Tensor s, "
       "Tensor topk, Tensor rows, Tensor experts, Tensor sizes, Tensor total) "
       "-> ()");
+  m.def(
+      "nvfp4_grouped_ep4_w13_sm70_out(Tensor(a!) out, Tensor x, Tensor w, "
+      "Tensor s, Tensor ids, Tensor(b!) rows, Tensor(c!) experts, Tensor(d!) "
+      "sizes, Tensor(e!) total, int expert_start, int split, bool interleaved, "
+      "int blocks) -> ()");
+  m.def(
+      "nvfp4_grouped_ep4_w2_sm70_out(Tensor(a!) out, Tensor(b!) routed, "
+      "Tensor x, Tensor w, Tensor s, Tensor topk, Tensor ids, Tensor rows, "
+      "Tensor experts, Tensor sizes, Tensor total, int expert_start, int "
+      "blocks) -> ()");
 }
 TORCH_LIBRARY_IMPL(_C, CUDA, m) {
   m.impl("nvfp4_grouped_w13_sm70_out", &run);
   m.impl("nvfp4_grouped_w2_sm70_out", &w2);
+  m.impl("nvfp4_grouped_ep4_w13_sm70_out", &ep4_run);
+  m.impl("nvfp4_grouped_ep4_w2_sm70_out", &ep4_w2);
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -821,6 +821,29 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &nvfp4_moe_dense_stage_sm70_out);
 
   ops.def(
+      "nvfp4_moe_fused_swiglu_stage_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor expert_offsets, "
+      "Tensor dense_expert_ids, Tensor ptrs_w, Tensor ptrs_s, "
+      "int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("nvfp4_moe_fused_swiglu_stage_sm70_out", torch::kCUDA,
+           &nvfp4_moe_fused_swiglu_stage_sm70_out);
+
+  ops.def(
+      "nvfp4_qwen38_ep4_permute_sm70_out("
+      "Tensor(a!) permuted_input, Tensor(b!) expert_offsets, "
+      "Tensor(c!) inv_permuted_idx, Tensor input, Tensor topk_ids, "
+      "int expert_start) -> ()");
+  ops.impl("nvfp4_qwen38_ep4_permute_sm70_out", torch::kCUDA,
+           &nvfp4_qwen38_ep4_permute_sm70_out);
+
+  ops.def(
+      "nvfp4_qwen38_ep4_combine_sm70_out("
+      "Tensor(a!) out, Tensor sorted_output, Tensor topk_weights, "
+      "Tensor inv_permuted_idx) -> ()");
+  ops.impl("nvfp4_qwen38_ep4_combine_sm70_out", torch::kCUDA,
+           &nvfp4_qwen38_ep4_combine_sm70_out);
+
+  ops.def(
       "nvfp4_moe_indexed_dense_stage_sm70_out("
       "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
       "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -45766,3 +45766,69 @@ Interpretation:
   fused variants compile with 31 registers/16 bytes shared/zero stack or
   spills. Compare complete HC with the newly registered up fusion held fixed,
   including actual auxiliary sum2 and post-wrap checks. GPU gate pending.
+
+## DeepEP SM70 true-EP screen, 2026-09-07
+
+- The screen uses the fixed FlashNext contract: NVFP4, four V100-SXM2-32GB,
+  no MTP, CUDA Graph, 8,192 input tokens, 256 output tokens, global concurrency
+  16, 262,144 maximum context, prefix caching, Mamba align, FP16 QSA KV, and
+  FP32 GDN state. The topology is real TP2 x DP2 / EP4 sequence parallelism;
+  it is not the earlier TP-local expert filter.
+- The current DeepEP head still requires SM90 features. The bounded port is
+  based on official DeepEP commit `b8d90fb` (the official non-TMA Ampere
+  intranode fallback), compiled with `DISABLE_SM90_FEATURES=1` and
+  `TORCH_CUDA_ARCH_LIST=7.0`. Two SM70 compile/contract changes are required:
+  include `cuda_fp16.h`, and admit FP16 combine dispatch. DeepEP remains an
+  external experiment dependency and is not bundled into the wheel.
+- The exact communication microbenchmark uses four source rows per rank,
+  hidden 2,560, 512 experts and top-k 10. Fixed-capacity graph dispatch plus
+  combine has a median of `0.080896 ms/layer` on all four ranks. Identity
+  dispatch/expert/combine differs from the FP32 reference by at most
+  `0.00390625`, within the FP16 contract. The same harness's independent three
+  all-gather plus one reduce-scatter sequence has medians of
+  `0.163328-0.184320 ms`, but this eager microbenchmark overstates the current
+  graph AG/RS path; the matched model trace already spends only about
+  `0.09-0.10 ms/layer` on the MoE AG/RS operations.
+- The first integrated capture exposed a lifecycle error: vLLM's generic
+  DeepEP cache is weak, because modular prepare/finalize objects normally own
+  the strong handle. This monolithic SM70 quant method owns dispatch itself, so
+  the Buffer was collected and recreated during graph capture. The experiment
+  now holds one Buffer for the communicator lifetime, initializes all four IPC
+  peers before capture, and releases it during communicator teardown. A later
+  startup OOM was removed by releasing raw converted expert tensors before the
+  one-time workspace allocation and reducing the ring from 64 MiB to 8 MiB.
+  FULL graph capture then succeeds on all ranks and logs the dedicated DeepEP
+  route rather than the AG/RS fallback.
+- A 64-output smoke measures `418.784 tok/s` and `38.2058 ms/step`. The formal
+  256-output run supplies 210 steady critical-path steps and measures
+  **`408.609 tok/s` and `39.1572 ms/step`**. The same-source AG/RS EP4 control
+  is **`422.211 tok/s` and `37.8958 ms/step`**. Therefore DeepEP changes
+  throughput by **`-3.22%`** and adds **`1.2615 ms/step`**; it is rejected for
+  default routing. Capacity remains valid at 318,423 cache tokens (1.21 times
+  the 262,144-token boundary).
+- This workload provides almost no sparse communication leverage. With 512
+  experts, top-k 10 and four equal EP ranks, a token misses a given rank with
+  probability approximately `(3/4)^10 = 5.63%`; the expected fanout is 3.775
+  of four ranks. DeepEP consequently transfers about 94.4% of an all-gather's
+  hidden rows. Sixteen requests create only 160 routes over roughly 140-150
+  distinct experts, so most expert weights are used by a single row and a
+  larger expert-local GEMM does not amortize their HBM reads. EP also exposes
+  small-batch rank imbalance, while replicated TP4 shards every selected
+  expert evenly.
+- DeepEP and AG/RS use different FP16 reduction orders. Only 4 of 16 full
+  completion hashes match on the formal run. This is not by itself a quality
+  failure, but the surrounding experimental sparse-QSA/HC route already has
+  an unresolved quality signal, so this screen is not a quality acceptance.
+  No DeepEP result may be promoted before the fixed tool/structured-output
+  battery passes against the production control.
+- Evidence is under `.artifacts/dp-ep-results/`, principally
+  `deepep-sm70-a2a-graph-v1.log`, `c16-deepep-sm70-q8graph-v5.json`, and
+  the matching AG/RS control JSON. The focused contract/lifetime suite passes
+  8 tests; the complete SM70 ModelOpt NVFP4 unit file passes 80 tests. All
+  owned model processes and GPU allocations were released after measurement.
+- Decision: keep this true-EP/DeepEP route experimental and default off. Do
+  not spend the next performance round replacing its already-small transport.
+  Re-open it only if the workload supplies a materially larger expert batch
+  (for example verified multi-token decode) or a measured placement scheme
+  reduces fanout. For the fixed C4/C8/C16 no-MTP target, retain TP4 and attack
+  the larger QSA, GDN, HC and expert-GEMM critical paths.

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -109,6 +109,47 @@ def _qwen4_moe_contract(**overrides):
     return SimpleNamespace(**values)
 
 
+def _qwen4_ep4_moe_contract(**overrides):
+    values = {
+        "num_experts": 512,
+        "num_local_experts": 128,
+        "experts_per_token": 10,
+        "hidden_dim": 2560,
+        "intermediate_size_per_partition": 640,
+        "tp_size": 1,
+        "moe_parallel_config": SimpleNamespace(
+            use_all2all_kernels=False,
+            use_ep=True,
+            tp_size=1,
+            ep_size=4,
+        ),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _qwen4_dp_ep4_moe_contract(**overrides):
+    values = {
+        "num_experts": 512,
+        "num_local_experts": 128,
+        "experts_per_token": 10,
+        "hidden_dim": 2560,
+        "intermediate_size_per_partition": 640,
+        "tp_size": 1,
+        "moe_parallel_config": SimpleNamespace(
+            use_all2all_kernels=True,
+            use_ep=True,
+            all2all_backend="allgather_reducescatter",
+            dp_size=2,
+            sp_size=2,
+            tp_size=1,
+            ep_size=4,
+        ),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
 def test_mixed_min_capability_requires_exact_sm70_and_both_turbomind_routes():
     with (
         patch.object(sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
@@ -188,6 +229,99 @@ def test_nvfp4_moe_contract_rejects_unvalidated_shapes(field, value):
 
 def test_nvfp4_moe_contract_accepts_qwen4_exp_tp4():
     validate_nvfp4_sm70_moe_contract(_qwen4_moe_contract())
+
+
+def test_nvfp4_moe_contract_accepts_qwen4_exp_tp_local_ep4():
+    validate_nvfp4_sm70_moe_contract(_qwen4_ep4_moe_contract())
+
+
+def test_nvfp4_moe_contract_gates_qwen4_exp_tp2_dp2_ep4(monkeypatch):
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH"
+    monkeypatch.setenv(name, "0")
+    envs.disable_envs_cache()
+    with pytest.raises(NotImplementedError, match=r"DP\+EP"):
+        validate_nvfp4_sm70_moe_contract(_qwen4_dp_ep4_moe_contract())
+
+    monkeypatch.setenv(name, "1")
+    envs.disable_envs_cache()
+    try:
+        validate_nvfp4_sm70_moe_contract(_qwen4_dp_ep4_moe_contract())
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_nvfp4_moe_contract_accepts_sm70_deepep_tp2_dp2_ep4(monkeypatch):
+    name = "VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH"
+    monkeypatch.setenv(name, "1")
+    envs.disable_envs_cache()
+    contract = _qwen4_dp_ep4_moe_contract()
+    contract.moe_parallel_config.all2all_backend = "deepep_high_throughput"
+    try:
+        validate_nvfp4_sm70_moe_contract(contract)
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_sm70_deepep_buffer_is_owned_for_communicator_lifetime():
+    class FakeManager:
+        def __init__(self):
+            self.calls = 0
+            self._sm70_deepep_handle: object | None = None
+
+        def get_handle(self, kwargs):
+            assert kwargs == {}
+            self.calls += 1
+            return object()
+
+    manager = FakeManager()
+    ep_group = SimpleNamespace(
+        device_communicator=SimpleNamespace(all2all_manager=manager)
+    )
+    with patch(
+        "vllm.model_executor.layers.quantization.nvfp4_sm70_moe.get_ep_group",
+        return_value=ep_group,
+    ):
+        first = ModelOptNvFp4SM70MoEMethod._get_sm70_deepep_buffer()
+        second = ModelOptNvFp4SM70MoEMethod._get_sm70_deepep_buffer()
+
+    assert first is second
+    assert manager._sm70_deepep_handle is first
+    assert manager.calls == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("all2all_backend", "deepep_low_latency"),
+        ("dp_size", 4),
+        ("sp_size", 1),
+        ("ep_size", 2),
+    ],
+)
+def test_nvfp4_moe_contract_rejects_other_dp_ep_topologies(monkeypatch, field, value):
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH", "1")
+    envs.disable_envs_cache()
+    contract = _qwen4_dp_ep4_moe_contract()
+    setattr(contract.moe_parallel_config, field, value)
+    try:
+        with pytest.raises(NotImplementedError, match=r"DP\+EP"):
+            validate_nvfp4_sm70_moe_contract(contract)
+    finally:
+        envs.disable_envs_cache()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("ep_size", 2),
+        ("tp_size", 2),
+    ],
+)
+def test_nvfp4_moe_contract_rejects_unvalidated_ep_topology(field, value):
+    contract = _qwen4_ep4_moe_contract()
+    setattr(contract.moe_parallel_config, field, value)
+    with pytest.raises(NotImplementedError, match="EP4 contract"):
+        validate_nvfp4_sm70_moe_contract(contract)
 
 
 def test_qwen38_qpn_m1_decode_is_default_on_and_exact_shape_only(monkeypatch):

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -207,6 +207,16 @@ def has_nvfp4_grouped_decode_dispatch() -> bool:
     )
 
 
+def has_nvfp4_grouped_ep4_decode_dispatch() -> bool:
+    return all(
+        hasattr(torch.ops._C, name)
+        for name in (
+            "nvfp4_grouped_ep4_w13_sm70_out",
+            "nvfp4_grouped_ep4_w2_sm70_out",
+        )
+    )
+
+
 def nvfp4_grouped_w13_sm70_out(
     out: torch.Tensor,
     x: torch.Tensor,
@@ -242,6 +252,70 @@ def nvfp4_grouped_w2_sm70_out(
     )
 
 
+def nvfp4_grouped_ep4_w13_sm70_out(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    w: torch.Tensor,
+    s: torch.Tensor,
+    ids: torch.Tensor,
+    rows: torch.Tensor,
+    experts: torch.Tensor,
+    sizes: torch.Tensor,
+    total: torch.Tensor,
+    expert_start: int,
+    split: int,
+    interleaved: bool,
+    blocks: int,
+) -> None:
+    torch.ops._C.nvfp4_grouped_ep4_w13_sm70_out(
+        out,
+        x,
+        w,
+        s,
+        ids,
+        rows,
+        experts,
+        sizes,
+        total,
+        expert_start,
+        split,
+        interleaved,
+        blocks,
+    )
+
+
+def nvfp4_grouped_ep4_w2_sm70_out(
+    out: torch.Tensor,
+    routed: torch.Tensor,
+    x: torch.Tensor,
+    w: torch.Tensor,
+    s: torch.Tensor,
+    topk: torch.Tensor,
+    ids: torch.Tensor,
+    rows: torch.Tensor,
+    experts: torch.Tensor,
+    sizes: torch.Tensor,
+    total: torch.Tensor,
+    expert_start: int,
+    blocks: int,
+) -> None:
+    torch.ops._C.nvfp4_grouped_ep4_w2_sm70_out(
+        out,
+        routed,
+        x,
+        w,
+        s,
+        topk,
+        ids,
+        rows,
+        experts,
+        sizes,
+        total,
+        expert_start,
+        blocks,
+    )
+
+
 if has_nvfp4_grouped_decode_dispatch():
 
     @register_fake("_C::nvfp4_grouped_w13_sm70_out")
@@ -252,6 +326,45 @@ if has_nvfp4_grouped_decode_dispatch():
 
     @register_fake("_C::nvfp4_grouped_w2_sm70_out")
     def _grouped_w2_fake(out, routed, x, w, s, topk, rows, experts, sizes, total):
+        return None
+
+
+if has_nvfp4_grouped_ep4_decode_dispatch():
+
+    @register_fake("_C::nvfp4_grouped_ep4_w13_sm70_out")
+    def _grouped_ep4_w13_fake(
+        out,
+        x,
+        w,
+        s,
+        ids,
+        rows,
+        experts,
+        sizes,
+        total,
+        expert_start,
+        split,
+        interleaved,
+        blocks,
+    ):
+        return None
+
+    @register_fake("_C::nvfp4_grouped_ep4_w2_sm70_out")
+    def _grouped_ep4_w2_fake(
+        out,
+        routed,
+        x,
+        w,
+        s,
+        topk,
+        ids,
+        rows,
+        experts,
+        sizes,
+        total,
+        expert_start,
+        blocks,
+    ):
         return None
 
 
@@ -2165,6 +2278,105 @@ if hasattr(torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"):
         k: int,
         n: int,
         group_size: int,
+    ) -> None:
+        return None
+
+
+def nvfp4_moe_fused_swiglu_stage_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("nvfp4_moe_fused_swiglu_stage_sm70_out")(
+        out,
+        input,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+def nvfp4_qwen38_ep4_permute_sm70_out(
+    permuted_input: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    inv_permuted_idx: torch.Tensor,
+    input: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_start: int,
+) -> None:
+    _op("nvfp4_qwen38_ep4_permute_sm70_out")(
+        permuted_input,
+        expert_offsets,
+        inv_permuted_idx,
+        input,
+        topk_ids,
+        expert_start,
+    )
+
+
+def nvfp4_qwen38_ep4_combine_sm70_out(
+    out: torch.Tensor,
+    sorted_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    inv_permuted_idx: torch.Tensor,
+) -> None:
+    _op("nvfp4_qwen38_ep4_combine_sm70_out")(
+        out, sorted_output, topk_weights, inv_permuted_idx
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_fused_swiglu_stage_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_fused_swiglu_stage_sm70_out")
+    def _nvfp4_moe_fused_swiglu_stage_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C, "nvfp4_qwen38_ep4_permute_sm70_out"):
+
+    @register_fake("_C::nvfp4_qwen38_ep4_permute_sm70_out")
+    def _nvfp4_qwen38_ep4_permute_sm70_out_fake(
+        permuted_input: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        inv_permuted_idx: torch.Tensor,
+        input: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_start: int,
+    ) -> None:
+        return None
+
+
+if hasattr(torch.ops._C, "nvfp4_qwen38_ep4_combine_sm70_out"):
+
+    @register_fake("_C::nvfp4_qwen38_ep4_combine_sm70_out")
+    def _nvfp4_qwen38_ep4_combine_sm70_out_fake(
+        out: torch.Tensor,
+        sorted_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        inv_permuted_idx: torch.Tensor,
     ) -> None:
         return None
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1212,6 +1212,7 @@ class CompilationConfig:
             all2all_backend == "deepep_high_throughput"
             and data_parallel_size > 1
             and self.cudagraph_mode != CUDAGraphMode.NONE
+            and not envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
         ):
             # TODO: Piecewise Cuda graph might be enabled
             # if torch compile cache key issue fixed

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -152,6 +152,11 @@ class DeepEPAll2AllManagerBase(All2AllManagerBase):
         )  # noqa
         super().__init__(cpu_group, tcp_store_group)
         self.handle_cache = Cache()
+        # Some legacy quant methods still own their routing and therefore call
+        # dispatch_router_logits before a modular DeepEP prepare/finalize can
+        # run. Keep an exact AG/RS fallback for those shapes; SM70's dedicated
+        # NVFP4 path bypasses it only for the audited decode contract.
+        self._ag_rs_fallback = AgRsAll2AllManager(cpu_group, tcp_store_group)
 
         # This is the DeepEP default. Stick to it till we can establish
         # reasonable defaults based on profiling.
@@ -166,8 +171,16 @@ class DeepEPAll2AllManagerBase(All2AllManagerBase):
         router_logits: torch.Tensor,
         is_sequence_parallel: bool = False,
         extra_tensors: list[torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]
+    ):
+        return self._ag_rs_fallback.dispatch_router_logits(
+            hidden_states,
+            router_logits,
+            is_sequence_parallel=is_sequence_parallel,
+            extra_tensors=extra_tensors,
+        )
 
     def dispatch(
         self,
@@ -180,17 +193,32 @@ class DeepEPAll2AllManagerBase(All2AllManagerBase):
         tuple[torch.Tensor, torch.Tensor, torch.Tensor]
         | tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[torch.Tensor]]
     ):
-        raise NotImplementedError
+        return self._ag_rs_fallback.dispatch(
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            is_sequence_parallel=is_sequence_parallel,
+            extra_tensors=extra_tensors,
+        )
 
     def combine(
         self, hidden_states: torch.Tensor, is_sequence_parallel: bool = False
     ) -> torch.Tensor:
-        raise NotImplementedError
+        return self._ag_rs_fallback.combine(
+            hidden_states, is_sequence_parallel=is_sequence_parallel
+        )
 
     def destroy(self):
+        persistent_handle = getattr(self, "_sm70_deepep_handle", None)
+        if persistent_handle is not None and hasattr(persistent_handle, "destroy"):
+            persistent_handle.destroy()
+        self._sm70_deepep_handle = None
         with self.handle_cache._lock:
             for _, handle in self.handle_cache._cache.items():
-                handle.destroy()
+                if handle is persistent_handle:
+                    continue
+                if hasattr(handle, "destroy"):
+                    handle.destroy()
             self.handle_cache._cache.clear()
 
 
@@ -225,8 +253,15 @@ class DeepEPHTAll2AllManager(DeepEPAll2AllManagerBase):
             num_rdma_bytes=num_rdma_bytes,
             low_latency_mode=False,
             num_qps_per_rank=num_qps_per_rank,
-            explicitly_destroy=True,
         )
+        # EPv2 owns explicit lifecycle, while the official legacy intranode
+        # implementation (used by the SM70 port) predates this argument.
+        import inspect
+
+        import deep_ep  # type: ignore[import-not-found]
+
+        if "explicitly_destroy" in inspect.signature(deep_ep.Buffer).parameters:
+            kwargs["explicitly_destroy"] = True
         return kwargs
 
     def get_handle(self, kwargs):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -194,6 +194,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_DECODE: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE: bool = False
+    VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH: bool = False
     VLLM_SM70_NVFP4_MOE_GROUPED_DECODE: bool = False
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W13: bool = True
     VLLM_SM70_NVFP4_QWEN38_MOE_QPN_BATCH_FUSED_W2: bool = True
@@ -1954,6 +1955,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Keep off until dynamic-width endpoint quality admission is complete.
     "VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_DYNAMIC_DECODE", "0"))
+    ),
+    # TP-local EP4 dispatch/combine for Qwen3.8 FlashNext NVFP4. The exact
+    # shape gate uses contiguous 128-expert ownership and keeps the existing
+    # TP-group all-reduce. Opt-in until full-model quality and throughput gates
+    # are recorded.
+    "VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH", "0"))
     ),
     # Experimental grouped native-NVFP4 W13/W2 decode. Local weight shapes and
     # attention metadata gates preserve M1, prefill and multi-token verify.

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -608,9 +608,7 @@ class MoERunner(MoERunnerInterface):
             return False
         if self._fused_output_is_reduced:
             return False
-        if self.moe_config.tp_size <= 1:
-            return False
-        if self.moe_config.ep_size != 1 or self.moe_config.pcp_size != 1:
+        if self.moe_config.pcp_size != 1:
             return False
         if (
             shared_output.shape != fused_output.shape
@@ -619,6 +617,18 @@ class MoERunner(MoERunnerInterface):
             return False
 
         tp_size = self.moe_config.tp_size
+        ep_size = self.moe_config.ep_size
+        tp_local_ep4 = bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+            and tp_size == 1
+            and ep_size == 4
+            and fused_output.dtype == torch.float16
+            and fused_output.ndim == 2
+            and 0 < fused_output.shape[0] <= 18
+            and fused_output.shape[1] == 2560
+        )
+        if not tp_local_ep4 and (tp_size <= 1 or ep_size != 1):
+            return False
         glm53_q8 = bool(
             envs.VLLM_SM70_GLM53_MOE_SUM2_ALLREDUCE_Q8
             and tp_size == 8
@@ -627,7 +637,8 @@ class MoERunner(MoERunnerInterface):
         )
         if not envs.VLLM_SM70_MOE_ADD_ALLREDUCE and not glm53_q8:
             return False
-        return tp_size in (2, 4, 6, 8)
+        collective_size = ep_size if tp_local_ep4 else tp_size
+        return collective_size in (2, 4, 6, 8)
 
     def _maybe_sm70_moe_sum2_allreduce(
         self,
@@ -1038,6 +1049,14 @@ class MoERunner(MoERunnerInterface):
         else:
             return hidden_states
 
+    def _quant_method_owns_sm70_deepep_dispatch(
+        self,
+        layer: torch.nn.Module,
+        hidden_states: torch.Tensor,
+    ) -> bool:
+        owns_dispatch = getattr(self._quant_method, "owns_sm70_deepep_dispatch", None)
+        return bool(owns_dispatch is not None and owns_dispatch(layer, hidden_states))
+
     def _forward_impl(
         self,
         layer: torch.nn.Module,
@@ -1083,11 +1102,15 @@ class MoERunner(MoERunnerInterface):
             # TODO(bnell): parts of the dispatch/combine steps will go away once
             # #32567 lands and the remaining kernels are made MKs.  The PCP
             # code will probably remain
-            hidden_states, router_logits = self._maybe_dispatch(
-                layer,
-                hidden_states,
-                router_logits,
+            quant_owns_dispatch = self._quant_method_owns_sm70_deepep_dispatch(
+                layer, hidden_states
             )
+            if not quant_owns_dispatch:
+                hidden_states, router_logits = self._maybe_dispatch(
+                    layer,
+                    hidden_states,
+                    router_logits,
+                )
 
             shared_output, hidden_states = self._apply_quant_method(
                 layer=layer,
@@ -1097,7 +1120,10 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
             )
 
-            return self._maybe_combine(
-                shared_output,
-                hidden_states,
-            )
+            if quant_owns_dispatch:
+                if self.shared_experts is not None:
+                    assert shared_output is not None
+                    return shared_output, hidden_states
+                return hidden_states
+
+            return self._maybe_combine(shared_output, hidden_states)

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -11,7 +11,7 @@ expert-weight copy.
 from __future__ import annotations
 
 import os
-from typing import Final
+from typing import Any, Final
 
 import torch
 from torch.nn import Parameter
@@ -19,6 +19,7 @@ from torch.nn import Parameter
 from vllm import _sm70_ops as sm70_ops
 from vllm import envs
 from vllm.config.vllm import get_current_vllm_config_or_none
+from vllm.distributed import get_ep_group
 from vllm.forward_context import (
     get_forward_context,
     is_forward_context_available,
@@ -253,6 +254,38 @@ def _use_qwen38_qpn_batch_decode(
         and int(layer.sm70_nvfp4_hidden_size) == 2560
         and int(layer.sm70_nvfp4_intermediate_size) == 160
         and int(layer.sm70_nvfp4_top_k) == 10
+    )
+
+
+def _use_qwen38_ep4_fastpath(
+    layer: RoutedExperts,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> bool:
+    """Admit the exact TP-local EP4 device dispatch/combine route."""
+    return bool(
+        envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+        and 0 < x.shape[0] <= _GRAPH_SAFE_MAX_TOKENS
+        and x.shape[1] == 2560
+        and x.dtype == torch.float16
+        and x.is_contiguous()
+        and topk_ids.shape == (x.shape[0], 10)
+        and topk_ids.dtype == torch.int32
+        and topk_ids.is_contiguous()
+        and int(layer.moe_config.tp_size) == 1
+        and int(layer.moe_config.ep_size) == 4
+        and int(layer.sm70_nvfp4_num_experts) == 128
+        and int(layer.sm70_nvfp4_hidden_size) == 2560
+        and int(layer.sm70_nvfp4_intermediate_size) == 640
+        and int(layer.sm70_nvfp4_top_k) == 10
+        and all(
+            hasattr(torch.ops._C, name)
+            for name in (
+                "nvfp4_qwen38_ep4_permute_sm70_out",
+                "nvfp4_qwen38_ep4_combine_sm70_out",
+                "nvfp4_moe_fused_swiglu_stage_sm70_out",
+            )
+        )
     )
 
 
@@ -651,10 +684,83 @@ def validate_nvfp4_sm70_moe_contract(moe: FusedMoEConfig) -> None:
             f"experts={moe.num_experts}, top_k={moe.experts_per_token}. "
             f"Validated contracts: {sorted(_SUPPORTED_CONTRACTS)}."
         )
-    if moe.moe_parallel_config.use_all2all_kernels:
+    dp_ep_contract = (
+        envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+        and moe.moe_parallel_config.use_all2all_kernels
+        and moe.moe_parallel_config.use_ep
+        and moe.moe_parallel_config.all2all_backend
+        in ("allgather_reducescatter", "deepep_high_throughput")
+        and moe.moe_parallel_config.dp_size == 2
+        and moe.moe_parallel_config.sp_size == 2
+        and moe.moe_parallel_config.tp_size == 1
+        and moe.moe_parallel_config.ep_size == 4
+        and moe.num_local_experts == 128
+        and contract == (2560, 640, 512, 10)
+    )
+    if moe.moe_parallel_config.use_all2all_kernels and not dp_ep_contract:
         raise NotImplementedError(
-            "SM70 TurboMind NVFP4 MoE does not support DP+EP all-to-all."
+            "SM70 TurboMind NVFP4 DP+EP currently supports only the explicit "
+            "Qwen3.8 TP2xDP2/EP4 sequence-parallel experiment with the "
+            "allgather_reducescatter or DeepEP high-throughput backend. "
+            "Other all-to-all topologies "
+            "remain fail-closed."
         )
+    if getattr(moe.moe_parallel_config, "use_ep", False):
+        ep_contract = (
+            moe.moe_parallel_config.tp_size,
+            moe.moe_parallel_config.ep_size,
+            moe.num_local_experts,
+            moe.hidden_dim,
+            moe.intermediate_size_per_partition,
+            moe.num_experts,
+            moe.experts_per_token,
+        )
+        if ep_contract != (1, 4, 128, 2560, 640, 512, 10):
+            raise NotImplementedError(
+                "SM70 TurboMind NVFP4 TP-local expert parallelism currently "
+                "requires the validated EP4 contract "
+                "(TP=1 inside MoE, EP=4, local/global experts=128/512, "
+                "hidden=2560, intermediate=640, top-k=10); got "
+                f"{ep_contract}."
+            )
+
+
+def _validate_expert_placement(layer: RoutedExperts) -> bool:
+    """Validate replicated-TP or the exact TP-local EP4 placement.
+
+    TP-local EP receives replicated token rows from the surrounding TP model.
+    The experimental TP2xDP2 route first gathers sequence-parallel token rows
+    and reduce-scatters the local-expert sum through the standard EP manager.
+    Both retain the same contiguous 128-expert ownership contract.
+    """
+    expert_map = layer.expert_map
+    if expert_map is None:
+        if layer.local_num_experts != layer.global_num_experts:
+            raise NotImplementedError(
+                "SM70 NVFP4 MoE without an expert map requires local and "
+                "global experts to match."
+            )
+        return False
+
+    validate_nvfp4_sm70_moe_contract(layer.moe_config)
+    if tuple(expert_map.shape) != (int(layer.global_num_experts),):
+        raise ValueError(
+            "SM70 NVFP4 EP expert map must contain one entry per global "
+            f"expert; got {tuple(expert_map.shape)} for "
+            f"{layer.global_num_experts} experts."
+        )
+    if expert_map.dtype != torch.int32:
+        raise TypeError("SM70 NVFP4 EP expert map must use int32 entries.")
+    local = expert_map[expert_map >= 0]
+    expected = torch.arange(
+        int(layer.local_num_experts), dtype=torch.int32, device=expert_map.device
+    )
+    if not torch.equal(local, expected):
+        raise ValueError(
+            "SM70 NVFP4 EP currently requires a contiguous linear mapping of "
+            "the rank's global experts to local IDs."
+        )
+    return True
 
 
 def _validate_weight_layout(layer: RoutedExperts) -> None:
@@ -715,6 +821,25 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
     @property
     def supports_eplb(self) -> bool:
         return False
+
+    @staticmethod
+    def _get_sm70_deepep_buffer():
+        ep_group = get_ep_group()
+        communicator = ep_group.device_communicator
+        if communicator is None or communicator.all2all_manager is None:
+            raise RuntimeError("SM70 DeepEP requires an initialized EP communicator.")
+        manager: Any = communicator.all2all_manager
+        # DeepEP's generic handle cache intentionally keeps weak references:
+        # modular MoE prepare/finalize objects normally own the strong one.
+        # This quant method owns dispatch itself, so a local-only reference
+        # would be collected after weight post-processing and recreate the
+        # IPC Buffer inside CUDA Graph capture. Keep one manager-scoped handle
+        # alive until communicator teardown instead.
+        handle = getattr(manager, "_sm70_deepep_handle", None)
+        if handle is None:
+            handle = manager.get_handle({})
+            manager._sm70_deepep_handle = handle
+        return handle
 
     def maybe_make_prepare_finalize(
         self,
@@ -808,31 +933,41 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             raise NotImplementedError(
                 "SM70 NVFP4 MoE does not support router weights on input."
             )
-        if layer.expert_map is not None:
-            raise NotImplementedError(
-                "SM70 NVFP4 MoE currently requires fully replicated experts."
-            )
-        if layer.local_num_experts != layer.global_num_experts:
-            raise NotImplementedError(
-                "SM70 NVFP4 MoE currently requires local and global experts to match."
-            )
-
         validate_nvfp4_sm70_moe_contract(layer.moe_config)
+        expert_parallel = _validate_expert_placement(layer)
         _validate_weight_layout(layer)
         num_experts = int(layer.local_num_experts)
         hidden = int(layer.moe_config.hidden_dim)
         intermediate = int(layer.moe_config.intermediate_size_per_partition)
-        fused_swiglu_requested = bool(
-            envs.VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL
-            and int(layer.moe_config.tp_size) == 4
+        exact_qwen38_tp4 = bool(
+            int(layer.moe_config.tp_size) == 4
+            and int(layer.moe_config.ep_size) == 1
             and num_experts == 512
             and hidden == 2560
             and intermediate == 160
             and int(layer.moe_config.experts_per_token) == 10
+        )
+        exact_qwen38_ep4 = bool(
+            expert_parallel
+            and int(layer.moe_config.tp_size) == 1
+            and int(layer.moe_config.ep_size) == 4
+            and num_experts == 128
+            and hidden == 2560
+            and intermediate == 640
+            and int(layer.moe_config.experts_per_token) == 10
+        )
+        fused_swiglu_requested = bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL
+            and (exact_qwen38_tp4 or exact_qwen38_ep4)
             and layer.swiglu_limit is None
         )
         fused_swiglu_available = hasattr(
-            torch.ops._C, "nvfp4_moe_indexed_fused_swiglu_sm70_out"
+            torch.ops._C,
+            (
+                "nvfp4_moe_fused_swiglu_stage_sm70_out"
+                if exact_qwen38_ep4
+                else "nvfp4_moe_indexed_fused_swiglu_sm70_out"
+            ),
         )
         fused_swiglu_explicit = (
             "VLLM_SM70_NVFP4_QWEN38_MOE_FUSED_SWIGLU_PREFILL" in os.environ
@@ -868,7 +1003,9 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 "retaining separate exact W13 and activation kernels."
             )
         fast_prefill = bool(
-            fused_swiglu_prefill and envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
+            exact_qwen38_tp4
+            and fused_swiglu_prefill
+            and envs.VLLM_SM70_NVFP4_QWEN38_MOE_FAST_PREFILL
         )
         raw_scale_requested = bool(
             envs.VLLM_SM70_NVFP4_QWEN38_MOE_RAW_SCALE
@@ -1141,6 +1278,12 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             indexed_prefill_requested and indexed_prefill_available
         )
         layer.sm70_nvfp4_qwen38_fused_swiglu_prefill = fused_swiglu_prefill
+        layer.sm70_nvfp4_qwen38_ep4_fastpath = bool(
+            exact_qwen38_ep4 and envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+        )
+        layer.sm70_nvfp4_qwen38_ep4_expert_start = (
+            int(layer.moe_config.ep_rank) * 128 if exact_qwen38_ep4 else 0
+        )
         layer.sm70_nvfp4_qwen38_fused_swiglu_decode = fused_swiglu_decode
         layer.sm70_nvfp4_qwen38_fast_prefill = fast_prefill
         layer.sm70_nvfp4_qwen38_raw_scale = raw_scale
@@ -1190,14 +1333,29 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         del layer.w2_weight_scale
         del layer.w2_weight_scale_2
         del layer.w2_input_scale
+        if (
+            layer.moe_config.moe_parallel_config.all2all_backend
+            == "deepep_high_throughput"
+        ):
+            # CUDA IPC export and peer-handle exchange are illegal once graph
+            # capture starts. Initialize only after releasing this layer's
+            # source tensors to avoid raising the peak weight-conversion use.
+            # All layers share the manager's cached workspace.
+            torch.accelerator.empty_cache()
+            self._get_sm70_deepep_buffer()
+            logger.info_once(
+                "SM70 DeepEP workspace and peer handles initialized before "
+                "CUDA Graph capture."
+            )
         logger.info_once(
             "SM70 ModelOpt NVFP4 TurboMind MoE path enabled "
-            "(hidden=%d, local_intermediate=%d, local_experts=%d, top_k=%d, "
+            "(hidden=%d, local_intermediate=%d, local_experts=%d, top_k=%d, EP=%s, "
             "graph_safe_decode=B1-B%d, compact_grouped_decode<=%d routed rows).",
             hidden,
             intermediate,
             num_experts,
             layer.sm70_nvfp4_top_k,
+            expert_parallel,
             _GRAPH_SAFE_MAX_TOKENS,
             _COMPACT_GROUPED_MAX_SLOTS,
         )
@@ -1425,6 +1583,103 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 out, gate_up, float(layer.swiglu_limit)
             )
 
+    @staticmethod
+    def owns_sm70_deepep_dispatch(
+        layer: RoutedExperts,
+        x: torch.Tensor,
+    ) -> bool:
+        """Return whether this call can use the graph-safe SM70 DeepEP route."""
+        parallel = layer.moe_config.moe_parallel_config
+        return bool(
+            envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+            and parallel.all2all_backend == "deepep_high_throughput"
+            and parallel.use_all2all_kernels
+            and parallel.dp_size == 2
+            and parallel.sp_size == 2
+            and parallel.ep_size == 4
+            and parallel.tp_size == 1
+            and 0 < x.shape[0] <= _GRAPH_SAFE_MAX_TOKENS // parallel.ep_size
+            and x.shape[1] == 2560
+            and x.dtype == torch.float16
+            and x.is_contiguous()
+            and _grouped_decode_context_ok()
+        )
+
+    def _apply_sm70_deepep(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Dispatch compact rows over NVLink, run local experts, then combine."""
+        import deep_ep
+
+        buffer = self._get_sm70_deepep_buffer()
+        ep_size = int(layer.moe_config.ep_size)
+        topk_ids_i64 = topk_ids.to(torch.int64)
+        (
+            num_tokens_per_rank,
+            _,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            _,
+        ) = buffer.get_dispatch_layout(topk_ids_i64, layer.global_num_experts)
+        config = deep_ep.Config(2, 4, 64)
+        (
+            recv_x,
+            recv_topk_ids,
+            recv_topk_weights,
+            _,
+            handle,
+            _,
+        ) = buffer.dispatch(
+            x=x,
+            num_tokens_per_rank=num_tokens_per_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            topk_idx=topk_ids_i64,
+            topk_weights=topk_weights,
+            expert_alignment=1,
+            num_worst_tokens=int(x.shape[0]) * ep_size,
+            config=config,
+            async_finish=False,
+            allocate_on_comm_stream=False,
+        )
+        if recv_topk_ids is None or recv_topk_weights is None:
+            raise RuntimeError("SM70 DeepEP dispatch did not return routing metadata.")
+
+        expert_start = int(layer.sm70_nvfp4_qwen38_ep4_expert_start)
+        invalid_global_id = layer.global_num_experts - 1 if expert_start == 0 else 0
+        recv_topk_ids = torch.where(
+            recv_topk_ids < 0,
+            invalid_global_id,
+            recv_topk_ids + expert_start,
+        ).to(torch.int32)
+        local_output = self.apply(
+            layer,
+            recv_x,
+            recv_topk_weights,
+            recv_topk_ids,
+            None,
+            None,
+            _sm70_deepep_local=True,
+        )
+        combined, _, _ = buffer.combine(
+            x=local_output,
+            handle=handle,
+            config=config,
+            async_finish=False,
+            allocate_on_comm_stream=False,
+        )
+        logger.info_once(
+            "Experimental SM70 DeepEP FP16 dispatch selected "
+            "(TP2xDP2/EP4, local tokens=%d, fixed receive rows=%d).",
+            x.shape[0],
+            recv_x.shape[0],
+        )
+        return combined
+
     def apply(
         self,
         layer: RoutedExperts,
@@ -1433,6 +1688,8 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         topk_ids: torch.Tensor,
         shared_experts: SharedExperts | None,
         shared_experts_input: torch.Tensor | None,
+        *,
+        _sm70_deepep_local: bool = False,
     ) -> torch.Tensor:
         del shared_experts, shared_experts_input
         if not x.is_cuda or x.dtype != torch.float16 or x.ndim != 2:
@@ -1459,6 +1716,8 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         num_tokens = x.shape[0]
         if num_tokens == 0:
             return x.new_empty((0, hidden))
+        if not _sm70_deepep_local and self.owns_sm70_deepep_dispatch(layer, x):
+            return self._apply_sm70_deepep(layer, x, topk_weights, topk_ids)
         indexed_w13 = _use_qwen38_indexed_prefill(layer, x, topk_ids)
         interleaved_w13 = bool(
             getattr(layer, "sm70_nvfp4_qwen38_fused_swiglu_prefill", False)
@@ -1509,10 +1768,14 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 num_tokens,
             )
             return output
-        direct_single_token = num_tokens == 1
+        # Direct routes consume global expert IDs as prepared-weight row IDs.
+        # Under EP those IDs must first be mapped and remote routes discarded,
+        # so use the graph-safe permutation path even for one token.
+        direct_single_token = num_tokens == 1 and layer.expert_map is None
         direct_qpn_m1 = _use_qwen38_qpn_m1_decode(layer, x, topk_ids)
         direct_qpn_batch = _use_qwen38_qpn_batch_decode(layer, x, topk_ids)
         direct_qpn_mtp5 = _use_qwen38_qpn_mtp5_decode(layer, x, topk_ids)
+        fast_ep4 = _use_qwen38_ep4_fastpath(layer, x, topk_ids)
         raw_scale = bool(getattr(layer, "sm70_nvfp4_qwen38_raw_scale", False))
         if os.getenv("VLLM_SM70_QWEN38_QPN_ROUTE_DEBUG") == "1" and num_tokens <= 16:
             logger.warning_once(
@@ -1702,7 +1965,24 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             else:
                 _mtp_weighted_reduce(buffers["sorted_output"], topk_weights, output)
             return output
-        if direct_single_token:
+        if fast_ep4:
+            logger.info_once(
+                "SM70 Qwen3.8 NVFP4 TP-local EP4 device dispatch enabled "
+                "(tokens=%d, local experts=128).",
+                num_tokens,
+            )
+            sm70_ops.nvfp4_qwen38_ep4_permute_sm70_out(
+                buffers["permuted_input"],
+                buffers["expert_offsets"],
+                buffers["inv_permuted_idx"],
+                x,
+                topk_ids,
+                int(layer.sm70_nvfp4_qwen38_ep4_expert_start),
+            )
+            stage_offsets = buffers["expert_offsets"]
+            stage_expert_ids = buffers["dense_expert_ids"]
+            stage_experts = int(layer.sm70_nvfp4_num_experts)
+        elif direct_single_token:
             _prepare_single_token_slots(
                 x,
                 topk_ids,
@@ -1773,6 +2053,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         if (
             not direct_single_token
             and not glm53_fused_permute_q8
+            and layer.expert_map is None
             and _use_compact_grouped(num_tokens, top_k)
         ):
             prepare_groups = (
@@ -1801,7 +2082,20 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 interleaved_w13,
             )
 
-        if split_fused_indexed_w13:
+        if fast_ep4 and interleaved_w13:
+            sm70_ops.nvfp4_moe_fused_swiglu_stage_sm70_out(
+                buffers["intermediate"],
+                buffers["permuted_input"],
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_experts,
+                layer.sm70_nvfp4_w13_k_dim,
+                layer.sm70_nvfp4_w13_n_dim,
+                layer.sm70_nvfp4_group_size,
+            )
+        elif split_fused_indexed_w13:
             logger.info_once(
                 "SM70 Qwen3.8 NVFP4 indexed-A fused-SwiGLU split-W13 "
                 "prefill route enabled (N256+N64)."
@@ -1896,7 +2190,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
                 layer.sm70_nvfp4_w13_n_dim,
                 layer.sm70_nvfp4_group_size,
             )
-        if not fused_indexed_w13:
+        if not fused_indexed_w13 and not (fast_ep4 and interleaved_w13):
             self._apply_swiglu(
                 layer,
                 buffers["intermediate"],
@@ -1922,7 +2216,14 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
             layer.sm70_nvfp4_w2_n_dim,
             layer.sm70_nvfp4_group_size,
         )
-        if direct_single_token:
+        if fast_ep4:
+            sm70_ops.nvfp4_qwen38_ep4_combine_sm70_out(
+                output,
+                buffers["sorted_output"],
+                topk_weights,
+                buffers["inv_permuted_idx"],
+            )
+        elif direct_single_token:
             _single_token_weighted_reduce(
                 buffers["sorted_output"], topk_weights, output
             )

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -243,9 +243,14 @@ class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
         parallel_config = vllm_config.parallel_config
-        if parallel_config.use_sequence_parallel_moe:
+        if (
+            parallel_config.use_sequence_parallel_moe
+            and not envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+        ):
             raise NotImplementedError(
-                "Qwen4Exp HC does not support sequence-parallel MoE"
+                "Qwen4Exp HC sequence-parallel MoE is experimental; enable "
+                "VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH only for the "
+                "validated SM70 TP2xDP2/EP4 contract."
             )
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         config = vllm_config.model_config.hf_text_config
@@ -281,9 +286,14 @@ class Qwen4ExpDecoderLayer(nn.Module):
         self.config = config
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
-        if vllm_config.parallel_config.use_sequence_parallel_moe:
+        if (
+            vllm_config.parallel_config.use_sequence_parallel_moe
+            and not envs.VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH
+        ):
             raise NotImplementedError(
-                "Qwen4Exp HC does not support sequence-parallel MoE"
+                "Qwen4Exp HC sequence-parallel MoE is experimental; enable "
+                "VLLM_SM70_NVFP4_QWEN38_MOE_EP4_FASTPATH only for the "
+                "validated SM70 TP2xDP2/EP4 contract."
             )
         self.ple: Qwen4ExpPLELayer | None = None
         ple_layer_ids = config.ple_layer_ids


### PR DESCRIPTION
## Purpose

- Prototype true TP2 x DP2 / EP4 for FlashNext NVFP4 on four V100 GPUs.
- Add an SM70-compatible DeepEP intranode experiment based on official commit b8d90fb.
- Preserve CUDA Graph execution and fail closed outside the audited shape/topology.
- Record positive microbenchmark evidence and negative end-to-end evidence before any default admission.

This PR is intentionally Draft and must not be merged in its current state: true EP is slower than the existing TP4 production candidate and the surrounding sparse-QSA/HC quality signal is not yet closed.

## Test Plan

- Build the native SM70 extension and run the dedicated TP4 versus TP-local EP4 kernel benchmark.
- Run DeepEP FP16 identity dispatch/combine in eager and CUDA Graph modes on four V100s.
- Run fixed FlashNext NVFP4 TP2 x DP2 / EP4 at C16, 8K input, 256 output, no MTP, CUDA Graph, 256K capacity.
- Run focused route/lifetime tests and the complete SM70 ModelOpt NVFP4 unit file.
- Run pre-commit, including Ruff, mypy, clang-format, markdownlint and DCO sign-off.

## Test Result

- DeepEP graph dispatch + combine microbenchmark: 0.080896 ms/layer; FP16 identity max abs error 0.00390625.
- FULL CUDA Graph captures on all four ranks and the dedicated DeepEP route is selected.
- DeepEP true EP4: 408.609 tok/s, 39.1572 ms/step.
- Matching AG/RS true EP4 control: 422.211 tok/s, 37.8958 ms/step.
- Net result: -3.22% throughput and +1.2615 ms/step; rejected for default routing.
- KV capacity: 318,423 tokens, sufficient for the 262,144-token boundary.
- Focused tests: 8 passed. Complete SM70 ModelOpt NVFP4 file: 80 passed.
- Pre-commit: passed.
- Quality is not accepted: only 4/16 full completion hashes match AG/RS, and the parent experimental sparse-QSA/HC path still has an unresolved quality signal.

Detailed evidence and the stop/re-open criteria are in docs/design/sm70_v100_migration_control.md.