### PR TITLE
[Kernel][SM70] Integrate copy-only GDN projection split from #504

### DIFF
--- a/benchmarks/kernels/benchmark_sm70_gdn_projection_split.py
+++ b/benchmarks/kernels/benchmark_sm70_gdn_projection_split.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fuse only the four GDN projection copies, never the GEMM arithmetic.
+
+The current opaque M1 op falls back to two unchanged GEMMs followed by four
+contiguous copies at M>1. Screen one bit-preserving copy kernel including
+both GEMMs and rotating weight allocations. No model-quality claim.
+"""
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from benchmarks.kernels.benchmark_sm70_moe_packed_w13 import graph, latency
+from vllm.models.qwen4_exp.nvidia.sm70_fp16_gemv import (
+    _qwen38_gdn_projection_split_kernel as split_kernel,
+)
+from vllm.models.qwen4_exp.nvidia.sm70_fp16_gemv import (
+    _split_gdn_projection_outputs as split,
+)
+
+
+def reference(qkvz, ba):
+    return (
+        qkvz[:, :2560].contiguous(),
+        qkvz[:, 2560:].contiguous(),
+        ba[:, :12].contiguous(),
+        ba[:, 12:].contiguous(),
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", type=Path, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--tokens", nargs="+", type=int, default=[2, 4, 8, 16, 32, 64])
+    args = p.parse_args()
+    if args.out.exists() or min(args.tokens) < 2:
+        p.error("Output must be new; this screen is for M>=2")
+    assert torch.cuda.get_device_capability() == (7, 0)
+    torch.manual_seed(20260905)
+    # Exercise every 16-bit payload in each of the four store branches.
+    bits = torch.arange(65536, device="cuda").to(torch.int16)
+    exhaustive = bits.view(torch.float16)[:, None].expand(-1, 2).contiguous()
+    exhaustive_out = tuple(torch.empty_like(bits).view(torch.float16) for _ in range(4))
+    split_kernel[(65536, 1)](
+        exhaustive,
+        exhaustive,
+        *exhaustive_out,
+        QKV=1,
+        Z=1,
+        B=1,
+        A=1,
+        BLOCK=256,
+        num_warps=4,
+        num_stages=1,
+    )
+    assert all(torch.equal(value.view(torch.int16), bits) for value in exhaustive_out)
+    index = json.loads((args.model / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    weights = {}
+    for name in ("qkv", "z", "b", "a"):
+        key = f"model.language_model.layers.0.linear_attn.in_proj_{name}.weight"
+        with safe_open(args.model / index[key], framework="pt", device="cpu") as f:
+            weights[name] = f.get_tensor(key).half().cuda()
+    q, k, v = weights["qkv"].split((2048, 2048, 6144))
+    wq = torch.cat((q[:512], k[:512], v[:1536], weights["z"][:1536])).contiguous()
+    wb = torch.cat((weights["b"][:12], weights["a"][:12])).contiguous()
+    assert wq.shape == (4096, 2560) and wb.shape == (24, 2560)
+    # Sixteen allocations exceed L2, but contain the same actual layer's weights.
+    copies = [(wq.clone(), wb.clone()) for _ in range(16)]
+    rows = []
+    for m in args.tokens:
+        x = torch.randn(m, 2560, device="cuda", dtype=torch.float16) * 0.1
+        qkvz = torch.empty(m, 4096, device="cuda", dtype=torch.float16)
+        ba = torch.empty(m, 24, device="cuda", dtype=torch.float16)
+        saved = [None, None]
+
+        def run(mode, linear=False, x=x, qkvz=qkvz, ba=ba, saved=saved):
+            if linear:
+                for w, wg in copies:
+                    q = torch.nn.functional.linear(x, w)
+                    g = torch.nn.functional.linear(x, wg)
+                    saved[mode] = (reference if mode == 0 else split)(q, g)
+            else:
+                saved[mode] = (reference if mode == 0 else split)(qkvz, ba)
+
+        gs = [graph(lambda mode=mode: run(mode)) for mode in (0, 1)]
+        # Raw payload patterns include signed zero, subnormals, infinities, NaNs.
+        for shift in (0, 17, 32768, 65500):
+            for value in (qkvz, ba):
+                bits = (
+                    (torch.arange(value.numel(), device="cuda") + shift) % 65536
+                ).to(torch.int16)
+                value.view(torch.int16).copy_(bits.reshape_as(value))
+            for mode in (0, 1):
+                for value in saved[mode]:
+                    value.view(torch.int16).fill_(12345)
+                gs[mode].replay()
+            for actual, expected in zip(saved[1], saved[0], strict=True):
+                assert actual.is_contiguous()
+                assert torch.equal(actual.view(torch.int16), expected.view(torch.int16))
+        for scope in ("copies", "complete_projection_rotating_weights"):
+            graphs = (
+                gs
+                if scope == "copies"
+                else [
+                    graph(lambda mode=mode: run(mode, True), unroll=1)
+                    for mode in (0, 1)
+                ]
+            )
+            for mode in (0, 1):
+                graphs[mode].replay()
+            assert all(
+                torch.equal(a.view(torch.int16), b.view(torch.int16))
+                for a, b in zip(saved[0], saved[1], strict=True)
+            )
+            times = [[], []]
+            for sample in range(5):
+                for mode in (0, 1) if sample % 2 == 0 else (1, 0):
+                    times[mode].append(latency(graphs[mode], 20, 16))
+            result = dict(
+                m=m,
+                scope=scope,
+                median_us=list(map(statistics.median, times)),
+                samples_us=times,
+                bitwise_copy_replays=4,
+                final_projection_bitwise=True,
+            )
+            rows.append(result)
+            print(json.dumps(result), flush=True)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(
+            dict(
+                model=str(args.model),
+                layer=0,
+                tp4_rank=0,
+                synthetic_activations=True,
+                weight_copies=16,
+                torch=torch.__version__,
+                cuda=torch.version.cuda,
+                results=rows,
+            ),
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/sm70_gdn_projection_copy_audit.md
+++ b/docs/design/sm70_gdn_projection_copy_audit.md
@@ -1,0 +1,43 @@
+# SM70 GDN projection copy fusion
+
+This is the copy-only extraction from PR #504, audited against main
+`8d9c3518992059105d89939e8a46d75184505d8e`. The remaining HC/QSA experiments
+in that PR are not included. AI-assisted implementation and review.
+
+## Runtime contract
+
+The existing opaque FP16 GDN input operation computes two unchanged linear
+projections for M > 1, then makes four contiguous outputs. On SM70, packed
+FP16 tensors of widths 4096 and 24 now use one copy kernel for those outputs.
+M <= 1, other devices, dtypes and layouts retain their original paths.
+No model identity or maximum batch-size condition is added.
+
+`VLLM_SM70_GDN_BATCH_SPLIT_COPY` defaults to 1; set it to 0 to roll back
+only this copy optimization. It does not enable the separately opt-in M1
+GEMV or fused-input arithmetic. Ordinary GDN slicing remains unchanged:
+that path does not necessarily need all four copies.
+
+## Focused validation
+
+- V100-SXM2-32GB, single owned GPU; Python 3.12.13, Torch 2.10.0+cu128,
+  CUDA 12.8 runtime, FP16 inputs, TP4-local layer-0 checkpoint weights.
+- 61 tests passed: projection admission, CPU fallback, role-specific
+  GEMV plans, existing HC kernels, and changing-input CUDA Graph replay.
+- The benchmark exercises all 65,536 half payloads, including NaNs,
+  infinities and signed zero. All four branches preserve the payload.
+- Alternating paired CUDA Graph timing, five samples, sixteen rotating
+  copies of the same actual checkpoint layer; activations are synthetic.
+
+| M | Two GEMMs + old copies (us) | Two GEMMs + fused copy (us) |
+| --- | --- | --- |
+| 2 | 66.682 | 54.042 |
+| 4 | 62.960 | 52.528 |
+| 8 | 63.504 | 53.181 |
+| 16 | 64.970 | 54.358 |
+| 32 | 66.762 | 56.093 |
+| 64 | 82.038 | 72.794 |
+
+These are complete-projection operator measurements, not model throughput
+or a new end-to-end quality claim. Arithmetic is unchanged. The dedicated
+benchmark and tests retain reproduction steps; full end-to-end testing was
+not run for this extraction.

--- a/tests/models/qwen4_exp/test_sm70_gdn_projection_split.py
+++ b/tests/models/qwen4_exp/test_sm70_gdn_projection_split.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.models.qwen4_exp.nvidia import sm70_fp16_gemv as module
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.fixture(autouse=True)
+def uncached_environment():
+    envs.disable_envs_cache()
+
+
+def metadata(rows, width, **overrides):
+    values = dict(
+        ndim=2,
+        shape=(rows, width),
+        dtype=torch.float16,
+        is_cuda=True,
+        device=torch.device("cuda:0"),
+        stride=lambda: (width, 1),
+    )
+    return SimpleNamespace(**(values | overrides))
+
+
+@pytest.mark.parametrize("rows", (0, 1, 2, 3, 4, 8, 16, 17, 32, 64, 127, 256, 4096))
+def test_admission_has_no_max_batch_binding(monkeypatch, rows):
+    monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "1")
+    monkeypatch.setattr(module.current_platform, "is_device_capability", lambda _: True)
+    assert module._can_fuse_gdn_projection_split(
+        metadata(rows, 4096), metadata(rows, 24)
+    ) == (rows > 1)
+
+
+@pytest.mark.parametrize(
+    "change",
+    (
+        dict(dtype=torch.float32),
+        dict(dtype=torch.bfloat16),
+        dict(is_cuda=False),
+        dict(ndim=3),
+        dict(shape=(4, 4095)),
+        dict(stride=lambda: (8192, 2)),
+        dict(device=torch.device("cuda:1")),
+    ),
+)
+def test_unsupported_input_falls_back(monkeypatch, change):
+    monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "1")
+    monkeypatch.setattr(module.current_platform, "is_device_capability", lambda _: True)
+    assert not module._can_fuse_gdn_projection_split(
+        metadata(4, 4096, **change), metadata(4, 24)
+    )
+
+
+def test_off_and_non_sm70_fall_back(monkeypatch):
+    q, ba = metadata(4, 4096), metadata(4, 24)
+    monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "0")
+    assert not module._can_fuse_gdn_projection_split(q, ba)
+    monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "1")
+    monkeypatch.setattr(
+        module.current_platform, "is_device_capability", lambda _: False
+    )
+    assert not module._can_fuse_gdn_projection_split(q, ba)
+
+
+def test_default_is_on(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", raising=False)
+    assert envs.environment_variables["VLLM_SM70_GDN_BATCH_SPLIT_COPY"]()
+
+
+def test_fusion_keeps_both_linear_calls(monkeypatch):
+    x = torch.empty(4, 2560)
+    wq, wb = torch.empty(4096, 2560), torch.empty(24, 2560)
+    q, ba = torch.empty(4, 4096), torch.empty(4, 24)
+    calls = []
+
+    def linear(value, weight):
+        assert value is x
+        calls.append(weight)
+        return q if weight is wq else ba
+
+    expected = tuple(torch.empty(4, width) for width in (2560, 1536, 12, 12))
+
+    def fused(value, gate):
+        assert value is q and gate is ba
+        return expected
+
+    monkeypatch.setattr(torch.nn.functional, "linear", linear)
+    monkeypatch.setattr(module, "_can_fuse_gdn_projection_split", lambda *args: True)
+    monkeypatch.setattr(module, "_split_gdn_projection_outputs", fused)
+    actual = module._qwen38_sm70_fp16_gdn_input(x, wq, wb)
+    assert actual is expected
+    assert len(calls) == 2 and calls[0] is wq and calls[1] is wb
+
+
+@pytest.mark.parametrize("rows", (0, 1, 4, 17))
+def test_cpu_original_fallback_is_unchanged(rows):
+    # Small K is sufficient to exercise fallback slicing, including empty input.
+    x, wq, wb = torch.randn(rows, 3), torch.randn(4096, 3), torch.randn(24, 3)
+    actual = module._qwen38_sm70_fp16_gdn_input(x, wq, wb)
+    q, ba = torch.nn.functional.linear(x, wq), torch.nn.functional.linear(x, wb)
+    expected = q[:, :2560], q[:, 2560:], ba[:, :12], ba[:, 12:]
+    assert all(
+        torch.equal(a, b) and a.is_contiguous()
+        for a, b in zip(actual, expected, strict=True)
+    )
+
+
+@pytest.mark.parametrize("rows", (1, 2, 4, 8, 16, 17, 32, 64))
+def test_cuda_public_op_graph_replay_is_bitwise(monkeypatch, rows):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("Requires an owned SM70 GPU")
+    envs.disable_envs_cache()
+    torch.manual_seed(51 + rows)
+    x = torch.randn(rows, 2560, device="cuda", dtype=torch.float16)
+    wq = torch.randn(4096, 2560, device="cuda", dtype=torch.float16) * 0.01
+    wb = torch.randn(24, 2560, device="cuda", dtype=torch.float16) * 0.01
+    op = torch.ops.vllm.qwen38_sm70_fp16_gdn_input
+    route_hits = []
+    fused = module._split_gdn_projection_outputs
+
+    def tracked(q, ba):
+        route_hits.append(q.shape[0])
+        return fused(q, ba)
+
+    monkeypatch.setattr(module, "_split_gdn_projection_outputs", tracked)
+    monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "1")
+    op(x, wq, wb)
+    torch.accelerator.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        outputs = op(x, wq, wb)
+    assert route_hits == ([rows, rows] if rows > 1 else [])
+    route_hits.clear()
+    for i in range(4):
+        x.normal_(0, 0.1 * (i + 1))
+        wq.mul_(0.9)
+        wb.mul_(0.9)
+        for out in outputs:
+            out.fill_(float("nan"))
+        monkeypatch.setenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "0")
+        reference = op(x, wq, wb)
+        g.replay()
+        assert not route_hits
+        assert all(
+            a.is_contiguous() and torch.equal(a.view(torch.int16), b.view(torch.int16))
+            for a, b in zip(outputs, reference, strict=True)
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -174,6 +174,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_QPN8: bool = False
     VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = False
     VLLM_SM70_QWEN38_FP16_GEMV: bool = False
+    VLLM_SM70_GDN_BATCH_SPLIT_COPY: bool = True
     VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16: bool = False
     VLLM_SM70_QWEN38_FUSED_HC_FP16: bool = False
     VLLM_SM70_QWEN38_DUAL_COMPILE: bool = False
@@ -1804,6 +1805,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Precision-preserving checkpoint-FP16 row GEMV for the exact no-MTP,
     # TP4 Qwen3.8 Flash Next single-token decode contract on SM70. This stays
     # opt-in until operator, token, task-quality, and matched speed gates pass.
+    # Copy-only optimization of the existing batched fused-input fallback.
+    # Does not opt a model into the separate FP16 GEMV arithmetic path.
+    "VLLM_SM70_GDN_BATCH_SPLIT_COPY": lambda: bool(
+        int(os.getenv("VLLM_SM70_GDN_BATCH_SPLIT_COPY", "1"))
+    ),
     "VLLM_SM70_QWEN38_FP16_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_QWEN38_FP16_GEMV", "0"))
     ),

--- a/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
+++ b/vllm/models/qwen4_exp/nvidia/sm70_fp16_gemv.py
@@ -61,6 +61,69 @@ _SHAPE_PLANS = {shape: plan for _, shape, plan in _ROLE_PLANS}
 
 
 @triton.jit
+def _qwen38_gdn_projection_split_kernel(
+    qkvz,
+    ba,
+    qkv,
+    z,
+    b,
+    a,
+    QKV: tl.constexpr,
+    Z: tl.constexpr,
+    B: tl.constexpr,
+    A: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    col = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    value = tl.load(qkvz + row * (QKV + Z) + col, col < QKV + Z, other=0)
+    tl.store(qkv + row * QKV + col, value, col < QKV)
+    tl.store(z + row * Z + col - QKV, value, (col >= QKV) & (col < QKV + Z))
+    if tl.program_id(1) == 0:
+        tl.static_assert(B + A <= BLOCK)
+        gate_col = tl.arange(0, BLOCK)
+        gate = tl.load(ba + row * (B + A) + gate_col, gate_col < B + A, other=0)
+        tl.store(b + row * B + gate_col, gate, gate_col < B)
+        tl.store(a + row * A + gate_col - B, gate, (gate_col >= B) & (gate_col < B + A))
+
+
+def _split_gdn_projection_outputs(qkvz, ba):
+    m = qkvz.shape[0]
+    out = tuple(qkvz.new_empty((m, n)) for n in (2560, 1536, 12, 12))
+    _qwen38_gdn_projection_split_kernel[(m, triton.cdiv(4096, 256))](
+        qkvz,
+        ba,
+        *out,
+        QKV=2560,
+        Z=1536,
+        B=12,
+        A=12,
+        BLOCK=256,
+        num_warps=4,
+        num_stages=1,
+    )
+    return out
+
+
+def _can_fuse_gdn_projection_split(qkvz: torch.Tensor, ba: torch.Tensor) -> bool:
+    # This copy-only operation does not change either GEMM. Keep the existing
+    # M1 path and all unsupported layouts; no maximum batch/sequence binding.
+    return bool(
+        envs.VLLM_SM70_GDN_BATCH_SPLIT_COPY
+        and _is_packed_row_major(qkvz)
+        and _is_packed_row_major(ba)
+        and qkvz.shape[0] > 1
+        and qkvz.shape[1] == 4096
+        and ba.shape == (qkvz.shape[0], 24)
+        and qkvz.dtype == ba.dtype == torch.float16
+        and qkvz.is_cuda
+        and ba.is_cuda
+        and qkvz.device == ba.device
+        and current_platform.is_device_capability(70)
+    )
+
+
+@triton.jit
 def _qwen38_fp16_row_gemv_kernel(
     x_ptr,
     weight_ptr,
@@ -211,6 +274,9 @@ def _qwen38_sm70_fp16_gdn_input(
     ):
         qkvz = torch.nn.functional.linear(x, qkvz_weight)
         ba = torch.nn.functional.linear(x, ba_weight)
+        if _can_fuse_gdn_projection_split(qkvz, ba):
+            logger.info_once("SM70 GDN batched projection split-copy fusion enabled.")
+            return _split_gdn_projection_outputs(qkvz, ba)
         return (
             qkvz[..., :2560].contiguous(),
             qkvz[..., 2560:].contiguous(),


### PR DESCRIPTION
AI-assisted integration requested by the maintainer. Narrow extraction from #504; the parent experimental HC/QSA bundle stays open. Base: 8d9c3518992059105d89939e8a46d75184505d8e.

Purpose: fuse only the four existing batched GDN output copies without changing either GEMM or latest-main role-specific plans. Copy flag defaults on; unrelated arithmetic flags unchanged.

Test Plan/Result: 61 targeted CPU/GPU tests passed on owned V100; changing-input CUDA Graph replays and exhaustive 65536 half-payload checks passed. Actual layer weights, synthetic activations, paired complete-projection graph latency improves 11–19% at M2/4/8/16/32/64. No E2E suite or model-throughput claim. Full evidence in docs/design/sm70_gdn_projection_copy_audit.md. Local scoped pre-commit passed. Draft pending hosted checks and final SHA review.