### PR TITLE
feat: NVIDIA Qwen3.8 Flash-Next MTP loader

### DIFF
--- a/tests/quantization/test_modelopt_mtp_block_fp8.py
+++ b/tests/quantization/test_modelopt_mtp_block_fp8.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mixed ModelOpt draft experts must retain checkpoint block scaling."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptMixedPrecisionConfig,
+)
+from vllm.models.qwen4_exp.nvidia import mtp
+from vllm.models.qwen4_exp.nvidia.mtp_fp8 import (
+    dequantize_mtp_fp8_experts,
+    dequantize_mtp_fp8_weight,
+)
+
+
+def mixed_config(group_size=128):
+    return ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quant_algo": "MIXED_PRECISION",
+            "kv_cache_quant_algo": None,
+            "exclude_modules": [],
+            "quantized_layers": {
+                "mtp.layers.0.mlp.experts": {
+                    "quant_algo": "FP8_BLOCK_SCALES",
+                    "group_size": group_size,
+                },
+                "model.language_model.layers.0.mlp.experts": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                },
+            },
+        }
+    )
+
+
+def test_draft_mixed_assignments_follow_runtime_layer_offsets():
+    quant = mixed_config()
+    original = dict(quant.quantized_layers)
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=object())
+    )
+    with (
+        patch.object(mtp, "get_draft_quant_config", return_value=quant),
+        patch.object(mtp, "configure_quant_config"),
+        patch.object(mtp, "replace", return_value=SimpleNamespace()),
+    ):
+        draft = mtp._make_draft_vllm_config(config, 48)
+    assert draft.quant_config is quant
+    assert quant._resolve_quant_algo("mtp.layers.48.mlp.experts") == "FP8_BLOCK_SCALES"
+    assert quant._resolve_quant_algo("mtp.layers.0.mlp.experts") is None
+    assert (
+        quant.quantized_layers["model.language_model.layers.0.mlp.experts"]
+        == original["model.language_model.layers.0.mlp.experts"]
+    )
+    assert "mtp.layers.0.mlp.experts" in original
+
+
+def test_sm70_draft_experts_use_unquantized_dispatch_without_changing_target():
+    quant = mixed_config()
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=object())
+    )
+    with (
+        patch.object(mtp, "get_draft_quant_config", return_value=quant),
+        patch.object(mtp, "replace", return_value=SimpleNamespace()),
+        patch.object(mtp.sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
+    ):
+        draft = mtp._make_draft_vllm_config(config, 48)
+        assert mtp._sm70_mtp_fp8_blocks(draft.quant_config) == {
+            "mtp.layers.48.mlp.experts": 128
+        }
+    assert (
+        quant.get_quant_method(Mock(spec=RoutedExperts), "mtp.layers.48.mlp.experts")
+        is None
+    )
+    assert not quant.is_layer_excluded("model.language_model.layers.0.mlp.experts")
+    assert (
+        quant._resolve_quant_algo("model.language_model.layers.0.mlp.experts")
+        == "NVFP4"
+    )
+
+
+@pytest.mark.parametrize("group_size", [None, 0, -128, "128"])
+def test_mixed_block_fp8_rejects_invalid_group_size(group_size):
+    quant = mixed_config(group_size)
+    with (
+        patch.object(mtp.sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
+        pytest.raises(ValueError, match="Unsupported MTP FP8 block size"),
+    ):
+        mtp._sm70_mtp_fp8_blocks(quant)
+
+
+def test_non_sm70_preserves_native_quantization():
+    with patch.object(mtp.sm70_tm, "is_exact_sm70_cuda_platform", return_value=False):
+        assert mtp._sm70_mtp_fp8_blocks(mixed_config()) == {}
+
+
+@pytest.mark.parametrize("shape", [(640, 2560), (2560, 640), (129, 131)])
+def test_dequantization_matches_blockwise_reference_and_tp4_slices(shape):
+    rng = torch.Generator().manual_seed(19)
+    weight = (torch.randn(shape, generator=rng) * 4).to(torch.float8_e4m3fn)
+    scales = torch.rand(tuple((dim + 127) // 128 for dim in shape), generator=rng).to(
+        torch.bfloat16
+    )
+    expected = torch.empty(shape, dtype=torch.float16)
+    for row in range(scales.shape[0]):
+        for col in range(scales.shape[1]):
+            rows, cols = (
+                slice(row * 128, (row + 1) * 128),
+                slice(col * 128, (col + 1) * 128),
+            )
+            expected[rows, cols] = weight[rows, cols].float() * scales[row, col].float()
+    actual = dequantize_mtp_fp8_weight(weight, scales, 128)
+    assert actual.dtype == torch.float16
+    assert torch.equal(actual, expected)
+    if 640 in shape:
+        shard_dim = shape.index(640)
+        for rank in range(4):
+            assert torch.equal(
+                actual.narrow(shard_dim, rank * 160, 160),
+                expected.narrow(shard_dim, rank * 160, 160),
+            )
+
+
+@pytest.mark.parametrize("scale_first", [False, True])
+def test_expert_pairing_and_unrelated_weight_passthrough(scale_first):
+    prefix = "model.layers.0.mlp.experts"
+    name = prefix + ".3.gate_proj"
+    weight = torch.ones((640, 128)).to(torch.float8_e4m3fn)
+    scale = torch.arange(1, 6, dtype=torch.float32).reshape(5, 1)
+    pair = [(name + ".weight", weight), (name + ".weight_scale_inv", scale)]
+    if scale_first:
+        pair.reverse()
+    other = ("model.layers.0.self_attn.q_proj.weight", torch.ones(1))
+    output = list(dequantize_mtp_fp8_experts([pair[0], other, pair[1]], {prefix: 128}))
+    assert output[0][0] == other[0] and output[0][1] is other[1]
+    assert output[1][0] == name + ".weight"
+    assert torch.equal(output[1][1], dequantize_mtp_fp8_weight(weight, scale, 128))
+
+
+@pytest.mark.parametrize("suffix", ["weight", "weight_scale_inv"])
+def test_missing_pair_fails_closed(suffix):
+    prefix = "model.layers.0.mlp.experts"
+    with pytest.raises(ValueError, match="Unpaired MTP FP8"):
+        list(
+            dequantize_mtp_fp8_experts(
+                [(prefix + ".0.down_proj." + suffix, torch.ones(1))], {prefix: 128}
+            )
+        )
+
+
+def test_invalid_scale_shape_fails_closed():
+    weight = torch.ones((640, 128)).to(torch.float8_e4m3fn)
+    with pytest.raises(ValueError, match="scale shape/dtype mismatch"):
+        dequantize_mtp_fp8_weight(weight, torch.ones((4, 1)), 128)

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -22,9 +22,11 @@ from torch import nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, replace, set_current_vllm_config
 from vllm.distributed import get_pp_group
+from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -45,6 +47,7 @@ from vllm.transformers_utils.configs.qwen4_exp import (
 )
 
 from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .mtp_fp8 import dequantize_mtp_fp8_experts
 
 try:
     from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
@@ -66,6 +69,8 @@ from .model import (
     Qwen4ExpDecoderLayer,
     Qwen4ExpMixtureOfExperts,
 )
+
+logger = init_logger(__name__)
 
 
 def _remap_ignored_layers(
@@ -138,6 +143,23 @@ def _validate_mtp_expert_weights_loaded(
         )
 
 
+def _sm70_mtp_fp8_blocks(quant_config) -> dict[str, int]:
+    if quant_config is None or not sm70_tm.is_exact_sm70_cuda_platform():
+        return {}
+    if quant_config.get_name() != "modelopt_mixed":
+        return {}
+    blocks = {}
+    for name, info in quant_config.quantized_layers.items():
+        if (
+            re.fullmatch(r"mtp\.layers\.\d+\.mlp\.experts", name)
+            and info.get("quant_algo", "").upper() == "FP8_BLOCK_SCALES"
+        ):
+            if info.get("group_size") != 128:
+                raise ValueError(f"Unsupported MTP FP8 block size for {name}: {info}")
+            blocks[name] = 128
+    return blocks
+
+
 def _make_draft_vllm_config(
     vllm_config: VllmConfig,
     mtp_start_layer_idx: int,
@@ -152,6 +174,17 @@ def _make_draft_vllm_config(
     # inject packed and ignored modules to the quantization config of draft model
     if draft_quant_config is not None:
         configure_quant_config(draft_quant_config, Qwen4ExpMTP)
+        quantized_layers = getattr(draft_quant_config, "quantized_layers", None)
+        if quantized_layers:
+            # Checkpoint MTP layers start at zero, while decoder prefixes use
+            # target-layer offsets (e.g. mtp.layers.48). Keep mixed-precision
+            # assignments aligned with those prefixes, just like exclusions.
+            draft_quant_config.quantized_layers = dict(
+                zip(
+                    _remap_ignored_layers(list(quantized_layers), mtp_start_layer_idx),
+                    quantized_layers.values(),
+                )
+            )
         ignored_layers = getattr(draft_quant_config, "ignored_layers", None)
         if ignored_layers:
             setattr(  # noqa: B010
@@ -165,6 +198,14 @@ def _make_draft_vllm_config(
                 draft_quant_config,
                 "exclude_modules",
                 _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+        fp8_experts = _sm70_mtp_fp8_blocks(draft_quant_config)
+        if fp8_experts:
+            # Width 640 / TP4 = 160 crosses 128-wide scale blocks. Reconstruct
+            # these draft weights once at load time, then use ordinary FP16
+            # expert sharding and kernels, as for the BF16 Ark checkpoint.
+            draft_quant_config.exclude_modules = list(
+                dict.fromkeys([*draft_quant_config.exclude_modules, *fp8_experts])
             )
 
     draft_vllm_config = replace(
@@ -209,6 +250,20 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
             vllm_config,
             self.mtp_start_layer_idx,
         )
+        self.fp8_mtp_expert_blocks = {
+            f"model.layers.{int(name.split('.')[2]) - self.mtp_start_layer_idx}"
+            ".mlp.experts": block_size
+            for name, block_size in _sm70_mtp_fp8_blocks(
+                draft_vllm_config.quant_config
+            ).items()
+        }
+        if self.fp8_mtp_expert_blocks:
+            if model_config.dtype != torch.float16:
+                raise ValueError("SM70 block-FP8 MTP experts require dtype=float16")
+            logger.info_once(
+                "Loading Qwen4Exp MTP block-FP8 experts as resident FP16 on SM70; "
+                "checkpoint scales are applied once before TP sharding."
+            )
         with set_current_vllm_config(draft_vllm_config, prefix=prefix):
             # residual_linear_shared fusion: fc_embedding projects the token
             # embedding, fc_hidden (shared across HC branches) projects the
@@ -493,7 +548,11 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
             skip_substrs=["hyper_connection_mixer.block_inject_weight"],
             ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
         )
-        loaded_weights = loader.load_weights(remap_weight_names())
+        loaded_weights = loader.load_weights(
+            dequantize_mtp_fp8_experts(
+                remap_weight_names(), self.model.fp8_mtp_expert_blocks
+            )
+        )
         _validate_mtp_expert_weights_loaded(self, loaded_weights)
         return loaded_weights
 

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Load checkpoint block-FP8 MTP experts into the SM70 FP16 draft path."""
+
+from collections.abc import Iterable, Iterator
+
+import torch
+
+
+def dequantize_mtp_fp8_weight(
+    weight: torch.Tensor, scale: torch.Tensor, block_size: int
+) -> torch.Tensor:
+    """Apply checkpoint scales before TP sharding, without requantization."""
+    if weight.dtype != torch.float8_e4m3fn or weight.ndim != 2:
+        raise ValueError("MTP FP8 expert weights must be 2D float8_e4m3fn tensors")
+    if block_size != 128:
+        raise ValueError("SM70 MTP FP8 loading requires 128x128 checkpoint blocks")
+    expected = tuple((dim + block_size - 1) // block_size for dim in weight.shape)
+    if tuple(scale.shape) != expected or not scale.is_floating_point():
+        raise ValueError(
+            f"MTP FP8 scale shape/dtype mismatch: expected {expected} floating "
+            f"scales, got {tuple(scale.shape)} {scale.dtype}"
+        )
+    expanded = scale.to(device=weight.device, dtype=torch.float32)
+    expanded = expanded.repeat_interleave(block_size, 0).repeat_interleave(
+        block_size, 1
+    )
+    expanded = expanded[: weight.shape[0], : weight.shape[1]]
+    return (weight.float() * expanded).to(torch.float16)
+
+
+def dequantize_mtp_fp8_experts(
+    weights: Iterable[tuple[str, torch.Tensor]], expert_blocks: dict[str, int]
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Pair per-expert weights/scales in either order; yield only FP16 weights.
+
+    Names have already been mapped into the standalone draft model. Other
+    weights pass through unchanged. No checkpoint file is modified and no
+    conversion is installed on the inference path.
+    """
+    if not expert_blocks:
+        yield from weights
+        return
+    pending: dict[str, dict[str, torch.Tensor]] = {}
+    for name, tensor in weights:
+        parts = name.rsplit(".", 3)
+        if (
+            len(parts) != 4
+            or parts[0] not in expert_blocks
+            or not parts[1].isdigit()
+            or parts[2] not in ("gate_proj", "up_proj", "down_proj")
+            or parts[3] not in ("weight", "weight_scale_inv")
+        ):
+            yield name, tensor
+            continue
+        base = name.rsplit(".", 1)[0]
+        pair = pending.setdefault(base, {})
+        if parts[3] in pair:
+            raise ValueError(f"Duplicate MTP FP8 checkpoint tensor: {name}")
+        pair[parts[3]] = tensor
+        if len(pair) == 2:
+            del pending[base]
+            yield (
+                base + ".weight",
+                dequantize_mtp_fp8_weight(
+                    pair["weight"], pair["weight_scale_inv"], expert_blocks[parts[0]]
+                ),
+            )
+    if pending:
+        missing = ", ".join(sorted(pending)[:5])
+        raise ValueError(f"Unpaired MTP FP8 expert weights/scales: {missing}")


### PR DESCRIPTION
## Purpose

Fix the official NVIDIA Qwen3.8-Flash-Next checkpoint on SM70 when MTP is
enabled. Its MTP routed experts are FP8 E4M3 block-scaled weights with 128-wide
blocks, while TP4 shards the 640-wide expert projections into 160-wide slices.
The existing mixed-quantization path missed the runtime MTP layer metadata and
could not dispatch this block-scale format, so MTP K=4 failed during loading.

The change:

- remaps checkpoint `mtp.layers.0` metadata to the runtime MTP layer index;
- converts only the official MTP block-FP8 expert weights to resident FP16 at
  load time, applying the checkpoint scales once before TP sharding;
- leaves the main NVFP4 model path and non-SM70 behavior unchanged; and
- adds focused validation for ordering, scale expansion, TP slicing, and
  malformed/incomplete tensor pairs.

This is the correctness-first FP16 path. Native block-FP8 dispatch remains a
future optimization requiring block-aligned sharding and separate accuracy and
performance qualification.

## Test Plan

Run from the repository root in the CUDA/SM70 test container:

```bash
pytest -q tests/quantization/test_modelopt_mtp_block_fp8.py
ruff check vllm/models/qwen4_exp/nvidia/mtp.py \
  vllm/models/qwen4_exp/nvidia/mtp_fp8.py \
  tests/quantization/test_modelopt_mtp_block_fp8.py
git diff --check origin/main...HEAD
```

Build and runtime qualification:

```bash
TORCH_CUDA_ARCH_LIST=7.0 MAX_JOBS=4 docker build ...
./vllm/vllm_ctl.sh status
node vllm/tmp/probe_pi_stream.mjs qwen-3.8-flash
```

The live NVIDIA checkpoint gate should show TP4, MTP K=4, the resident-FP16
loader witness, health 200, and zero restarts. Re-run the standard
`llama-benchy` stan command at the selected power limit for performance data;
the archived 300 W samples are a reference, not a claim about the current
250 W run.

## Test Result

Previously validated in the combined image based on the earlier upstream
base:

- 15 focused NVIDIA quantization tests passed.
- A real NVIDIA checkpoint probe matched an independent FP32-scale-then-FP16
  reference bit-for-bit for 27 sampled tensors and all 108 TP4 slices; outputs
  were finite.
- The four-V100 service loaded all 11 shards, selected the resident-FP16 MTP
  path, completed exact-shape MTP4 warmup and CUDA graph capture, returned
  health 200, and had zero restarts/OOMs.
- The standard pure stream-timestamp stan measurement at 300 W averaged
  3347.5 PP tok/s, 135.3 TG tok/s, and 20.25 s TTFR/E2E over three samples.
