### PR TITLE
[Model] Add native MiniMax H3 generation and video serving

### DIFF
--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -1,0 +1,94 @@
+# Native MiniMax H3 migration control
+
+Status: implementation in progress; no video quality or 80 TFLOPS acceptance yet.
+
+## Fixed scope
+
+- Base: onecat/main 56f534e672657a6c7599afd6c0dcb2e2c211b2e3.
+- Native model/pipeline/service; no vllm-omni runtime dependency.
+- Model sources, licenses and revisions: see
+  `vllm/model_executor/models/minimax_h3/UPSTREAM.md`.
+- FL2VA and Ref2VA, original BF16 checkpoint and Comfy INT8 ConvRot AdaLN-pruned checkpoint.
+- Four V100-SXM2-32GB, TP4 DiT/text encoder, native four-rank VAE tile parallel.
+- FP16 compute with FP32 latent projections, timestep computation, pruned AdaLN and output heads.
+- Acceptance: 1344x768, 243 frames, 24 FPS, seed 42, 50 sigma positions,
+  no LoRA/step skipping/approximate cache; record actual DiT forwards.
+- Each rank median useful model FLOPs / complete-denoise wall time >80 TFLOPS;
+  warmup once, then three unprofiled measurements; denoise CV <=5%.
+- Two attention backends must pass quality. Fastest qualified backend carries
+  performance acceptance. BF16 checkpoint performance is reported separately.
+
+## Implementation evidence
+
+- Created isolated owned worktree and branch; canonical checkout left untouched.
+- Native H3 packed layouts, reference processing, scheduler, transformer, Qwen3VL
+  encoder and VAE adapter ports in progress. Omni framework, sequence-parallel,
+  LoRA and approximate cache dependencies removed from native execution path.
+- Signed INT8/FP32 scales, runtime QKV order, fused FFN shard loading and
+  pruned AdaLN interpolation ported from open PR 6894.
+- W8A16 currently has an explicit PyTorch numerical reference. This is not
+  TurboMind kernel completion or a performance result.
+- Flash-V100 path connected; FlashInfer D128 non-causal path must be implemented
+  before backend support or qualification is claimed.
+
+## Environment and failed paths
+
+- Owned Python 3.12 environment uses Torch 2.10.0+cu128, Transformers 5.15.1,
+  Diffusers 0.40.0. System nvcc is 12.0; owned CUDA 12.8 toolkit pending.
+- Initial dependency resolution tried to upgrade Torch/CUDA; interrupted before
+  installation and used pinned packages without replacing the shared environment.
+- Bootstrap vLLM binaries are read-only links from the local 1Cat 1.5.0 environment;
+  hashes are recorded in task artifacts. They are not a new source-build result.
+- Upstream modulation and QK/RoPE kernels contain explicit BF16 roundings. These
+  require FP16 adaptation and numerical tests on SM70 before performance use.
+
+## Remaining gates
+
+1. Targeted format, packing, TP/shard, FP16 numeric, padding and reference tests.
+2. Native serial CLI/API, dependency installation, media export and job lifecycle.
+3. TurboMind signed W8A16, bounded cache and real FlashInfer-SM70 non-causal D128.
+4. Actual checkpoint loading and both-partition GPU functional generation.
+5. Full video quality, fixed-shape performance measurements and profiler evidence.
+6. Three review scopes/Draft PRs with signed commits and reproducible artifacts.
+
+Every failed GPU experiment must record configuration, result and the resulting
+implementation decision here or in linked benchmark evidence. Do not repeat an
+unchanged experiment. No acceptance result may be inferred from route imports,
+GPU utilization, synthetic operator peaks, or estimated hardware capabilities.
+
+## 2026-09-08 native and operator checkpoint
+
+- `tests/video`: 14 passed, including signed INT8/row-scale restoration,
+  Kronecker ConvRot256/inverse, original QKV reorder, curve interpolation,
+  partition metadata, 243-frame/49-forward schedule, poisoned padding,
+  both non-causal attention backends on V100, W8A16 FP32 reduction, encoder
+  causal GQA, and serial HTTP job lifecycle.
+- Synthetic two-block INT8 curve DiT: TP1 versus TP4 on GPU 0–3 passed on every
+  rank. Repeated after replacing reference linear execution with native W8A16;
+  all four ranks passed (atol 0.0005, rtol 0.02). This is a correctness test,
+  not full-model or performance acceptance.
+- Native W8A16 decodes signed INT8 with original FP32 per-row scales, rotates
+  activations in FP32 with FP16 output and calls cuBLAS FP16 GEMM from the
+  TurboMind SM70 operator module. Uses explicit FP32 compute and disables
+  reduced-precision reductions. Initial cuBLAS math-mode comparison failed;
+  explicitly disabling reduced-precision reductions fixed the mismatch.
+- FlashInfer-SM70 now owns a D128 non-causal online-softmax WMMA operator using
+  the repository's Volta QK/PV primitives. Lengths 1,17,63,64,65,243,1025 passed
+  the FP32 reference (largest observed absolute error 0.0009765625). No
+  Flash-V100 delegation occurs in this route. Large-sequence optimization and
+  full-video quality remain pending.
+- CLI `vllm video generate/serve`, serial worker engine, HTTP jobs, optional
+  video dependencies, fixed-list FP16 cache, useful-FLOP hooks, NVML sampling,
+  media export and automated video checks are implemented. Runtime validation
+  with actual full checkpoints remains pending while weights download.
+- CUDA Toolkit 12.8.93 nvcc installed in the task artifact directory; independent
+  extension builds passed against Torch 2.10.0+cu128. Wheel targets added, but
+  complete wheel build has not yet been validated.
+- Nsight Compute on GPU 0 returned `ERR_NVGPUCTRPERM`. No counters were collected.
+  Do not claim Tensor Core activity/occupancy from this run. Nsight Systems
+  tracing is being checked separately. No global driver settings were changed.
+
+Raw evidence (not committed): task artifact directory
+`/data/minimax-h3/native-h3-20260908/`, including `native-tests.log`,
+`tp1-smoke.log`, `tp4-smoke.log`, `tp4-w8a16-smoke.log`,
+`build-owned-extensions.log`, `flashinfer-numerics.log`, and `profiles/`.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -219,3 +219,29 @@ audio, latents, frames and invalidated timing), `denoise-short-int8-final.log`
 directory. As of this checkpoint GPU groups 0–3 and 4–7 have other vLLM workers.
 No owned long-video or waiting-GPU process is being retained. BF16 and reference
 generation checks still need an available four-GPU group.
+
+### Twenty-step short-clip quality check requested
+
+The user prioritizes normal output quality over further throughput tuning and
+requested a 20-step check. The diagnostic now fixes 39 frames at 1344x768,
+24 FPS, seed 42, the same INT8 checkpoint and FlashInfer implementation, and
+20 actual DiT calls (`num_inference_steps=21` under the reference sigma-point
+convention). Video/audio shifts remain 12/3, Turbo LoRA is off, and FP16 weight
+cache is off. Reuse the verified text conditioning for the same prompt to keep
+the comparison focused on the changed step count. Assert the completed call
+count and retain latents before export.
+
+At preparation time both GPU groups were occupied. A later idle GPU snapshot
+was still covered by another task's group lease. Capacity-only preflight can
+race such a task during service replacement. H3 now acquires the shared 1Cat
+per-card/group locks, checks capacity again, and retains the lease until its
+workers have exited. Failed acquisition/startup releases its own partial locks.
+The quality diagnostic uses the same lease and propagates launch errors. Ten
+CPU lease/service tests pass, including partial-lock rollback, whole-group
+fallback and worker-startup failure. No unrelated process was stopped.
+
+The 20-step GPU/video result is pending; do not infer that low step count is
+the sole cause of the two-step clip's artifacts. Prepared contract and commands
+are retained as `quality39-20steps-contract.json`, `denoise_quality.py`,
+`run_quality_guarded.py`, and `quality39-20steps-launch.log` in the task artifact
+directory. `gpu-lease-tests.log` records the focused regression result.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -115,3 +115,45 @@ added a functional-collective regression. All four real TP4 encoder ranks now
 have finite layer-50 output with identical amax 16088. The diagnostic comparison
 initially attempted NCCL broadcast on the encoder's CPU result; the test is
 being corrected to broadcast a CUDA copy before checking all-rank identity.
+
+### Real INT8 FP16-range fixes (2026-09-08)
+
+- The corrected text-encoder comparison passed bitwise identity across all
+  four TP ranks, with finite layer-50 FP16 output. The full FL2VA INT8 file and
+  Ref2VA INT8 file are downloaded. Original BF16 DiT shards are still downloading.
+- Native explicit width/height requests previously failed Omni's separate
+  aspect-ratio requirement. The native canvas now supplies that ratio; two
+  canvas regressions pass, including the exact 1344x768 primary shape.
+- The first real single-step pipeline reached DiT, then rejected non-finite
+  velocity. Layer diagnostics found condition projection values up to 76615.5,
+  block residuals above four million, and overflowing row projections and
+  gated MLP products. FP16 accumulation settings alone cannot represent these
+  values. Preserve condition projection, residuals and gated products in FP32.
+  Normalize and convert attention/MLP GEMM inputs to FP16; use exact power-of-two
+  row scaling for wide MLP activations, restoring scale in FP32 GEMM output.
+  INT8 weights, FP32 checkpoint scales and ConvRot256 remain intact.
+- A real 50-block INT8 DiT forward at the 256x256 diagnostic shape now has finite
+  output on all four ranks (video amax 10.8243, audio amax 4.36589). This is one
+  forward, not a complete schedule, quality pass or performance result.
+- The current native suite passes 23 tests, including actual CUDA checks for
+  FP32 residuals, above-FP16-range Tensor Core outputs, restored activation
+  scales, signed INT8, padding and alias-preserving CPU/GPU staging.
+- Pinned staging now replaces one host allocation at a time. The old snapshot
+  retained all pageable weights while building the entire pinned copy, raising
+  transient TP4 host memory and swap pressure.
+- Nsight Compute succeeded with the user's sudo authorization. The earlier
+  ERR_NVGPUCTRPERM result is superseded: the isolated FP16-output GEMM recorded
+  462422016 Tensor Core instructions and 86.177% active tensor-pipe cycles.
+  The new FP32-output variant needs its own profile. Complete-denoise >80 TFLOPS,
+  main-shape memory, full-video quality and both-backend quality remain pending.
+- Review scopes: native #557, kernels #558 (stacked). The next end-to-end run
+  initially found both GPU groups occupied by other vLLM workers; the owned
+  launcher waits for a free group without changing those processes.
+
+Evidence: `encoder-real-tp4-final.log`, `pipeline-route-canvas.log`,
+`dit-nan-diagnostic.log`, `dit-nan-fp32-condition.log`,
+`dit-nan-fp32-residual.log`, `dit-nan-fp32-output.log`,
+`dit-nan-fp32-gated.log`, `native-tests-fp32-islands.log`,
+`kernel-build-fp32-output.log`, and `profiles/w8a16-hmma-root.ncu-rep`
+under the task artifact directory. Do not repeat superseded failing routes
+unless a new change requires them.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -157,3 +157,39 @@ Evidence: `encoder-real-tp4-final.log`, `pipeline-route-canvas.log`,
 `kernel-build-fp32-output.log`, and `profiles/w8a16-hmma-root.ncu-rep`
 under the task artifact directory. Do not repeat superseded failing routes
 unless a new change requires them.
+
+### Short development workloads and attention evidence (2026-09-08)
+
+- User requested 1–2 second development clips and no repeated full-video runs.
+  Native requests now accept 22 and 39 aligned frames; 39 frames at 24 FPS is
+  1.625 seconds. The primary 243-frame/49-forward acceptance contract is unchanged.
+  Ten targeted shape/schedule tests pass, including short audio latent alignment
+  and rejection below the streaming VAE's minimum temporal chunk.
+- The earlier primary run was interrupted before completion; the host rebooted.
+  Its log reaches 22/49 DiT calls. Preserve it as partial diagnostic evidence,
+  never as a completed run or acceptance measurement. Initial stable calls took
+  about 129.5 seconds; late slow calls are not a reproducible speed baseline.
+- NVML medians were 100% GPU utilization. Nsight Compute separately measured
+  13.886% tensor-pipe activity in main-shape Flash-V100 attention and 78.150% in
+  the FP16-input/FP32-output Tensor Core GEMM. Utilization is not useful TFLOPS.
+  Attention at 73483 tokens took about 2.262 seconds without profiler, explaining
+  most of the observed DiT time. The performance gate remains unqualified.
+- Native TP4 video VAE decoded 39 frames at 1344x768 using 28 tiles. All four
+  outputs were finite with the expected shape; each peak allocation was
+  17805820416 bytes (16.58 GiB). Decode took 4.62–5.50 seconds per rank, without
+  a synchronized performance protocol; this is a functional result only.
+- CMake configure/build/install succeeded for both H3 extension targets. Five
+  targeted CUDA numerical tests passed against those installed modules. This
+  does not yet establish a complete release-wheel build.
+- All fixed-revision original and Comfy weights have downloaded and checksum
+  manifests are retained. Host memory is shared with another service, so current
+  short denoise diagnostics reuse the previously validated TP4 text embeddings
+  and load the VAE after releasing DiT, rather than retaining every component.
+  Such runs must explicitly report cached text and separate loading costs.
+
+Evidence under `/data/minimax-h3/native-h3-20260908/`:
+`short-clip-contract-tests.log`, `vae-tp4-short.log`,
+`cmake-numerics-tests.log`, `interrupted-baseline-summary.json`,
+`original-checkpoint-manifest.json`, `comfy-checkpoint-manifest.json`,
+`profiles/flashv100-attention.summary.json`, and
+`profiles/w8a16-fp32-output.summary.json`.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -92,3 +92,18 @@ Raw evidence (not committed): task artifact directory
 `/data/minimax-h3/native-h3-20260908/`, including `native-tests.log`,
 `tp1-smoke.log`, `tp4-smoke.log`, `tp4-w8a16-smoke.log`,
 `build-owned-extensions.log`, `flashinfer-numerics.log`, and `profiles/`.
+
+### Actual components and loader recovery
+
+The first real TP4 Qwen3VL encode exposed a missing optional residual argument
+in the native RMSNorm adapter. Restored the reference residual-add/FP16 rounding
+contract and added a focused regression; full TP4 encode is being repeated to
+validate that fix. The VAE component checks produced finite 22-frame 64x64 video
+(15,278,413,824 peak allocated bytes on GPU 0) and finite 32-kHz mono audio. T=2
+was rejected by the VAE streaming decoder; the valid component smoke uses T=7.
+The original text-encoder shard 10 stalled in Xet reconstruction. Recovered it
+through HTTP, verified SHA256 `aded5a4d1d5e22dbd8b6f79266b6eb88c840411b09527c53917a1419ace22e2f`,
+and stopped only the owned stalled downloader. INT8 downloads continue separately.
+Nsight Systems 2025.1 CLI produced a usable trace; the W8A16 projection launched
+`cutlass_70_tensorop_f16_s884gemm_relu_f16_128x128_tn_align8`. This confirms the
+Tensor Core kernel route, not measured Tensor Core activity or full-denoise speed.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -107,3 +107,11 @@ and stopped only the owned stalled downloader. INT8 downloads continue separatel
 Nsight Systems 2025.1 CLI produced a usable trace; the W8A16 projection launched
 `cutlass_70_tensorop_f16_s884gemm_relu_f16_128x128_tn_align8`. This confirms the
 Tensor Core kernel route, not measured Tensor Core activity or full-denoise speed.
+
+The next real-encoder check exposed an integration mismatch: Omni's encoder
+ignored the return value of `group.all_reduce`, while native GroupCoordinator
+can return a new tensor. Fixed both embedding and row-parallel reductions and
+added a functional-collective regression. All four real TP4 encoder ranks now
+have finite layer-50 output with identical amax 16088. The diagnostic comparison
+initially attempted NCCL broadcast on the encoder's CPU result; the test is
+being corrected to broadcast a CUDA copy before checking all-rank identity.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -2,6 +2,12 @@
 
 Status: implementation in progress; no video quality or 80 TFLOPS acceptance yet.
 
+Current decision: the user selects FlashInfer-SM70 as the H3 denoiser mainline.
+Optimize complete denoise toward >80 useful TFLOPS on every participating GPU;
+keep Flash-V100 as an explicit control. Development uses 39-frame clips and
+20 actual updates for quality. The historical 60-TFLOPS D256/GQA Flash-V100
+architecture was audited, but its H3 adaptation is not the selected mainline.
+
 ## Fixed scope
 
 - Base: onecat/main 56f534e672657a6c7599afd6c0dcb2e2c211b2e3.
@@ -295,3 +301,50 @@ latents, NVML samples/curves, rank/phase CSV, automated checks, visual-review
 notes and backend comparison JSON. `quality-two-vs-twenty.png` compares the
 same-seed two- and twenty-call outputs. Raw logs are
 `quality39-20steps-run.log` and `quality39-20steps-flashv100.log`.
+
+### Original-checkpoint short quality and FlashInfer mainline profiling
+
+The original BF16 checkpoint also completed FL2VA text-to-video at 1344x768,
+39 frames, seed 42 and 20 updates through Flash-V100, using FP16 matrix inputs
+and FP32 sensitive intermediates on V100. Complete denoise took 110.569167 s
+(5.528458 s/update), with 31.328872 useful TFLOPS per rank. DiT-only peak Torch
+allocation was 17.186255 GiB; this does not include a whole-pipeline memory peak.
+All automatic media checks pass and inspected first/last frames show a clear
+boat and duck without the severe two-update artifacts. Human audio review,
+Ref2VA/reference generation and primary acceptance remain pending. Evidence is
+`outputs/quality39-original-20steps/FLASH_ATTN_V100/` in the artifact directory.
+
+The user subsequently fixed FlashInfer-SM70 as the optimization mainline and
+reaffirmed >80 TFLOPS/card. The CLI/config default now follows that choice.
+A four-rank Nsight Systems trace captures the first two updates from the
+unchanged 20-update schedule, with cached verified text, 39 frames and cache
+off. It truncates the schedule for profiling and makes no quality or acceptance
+claim. The rank-0 synchronized denoise span is 10.600430 s:
+
+| Exclusive wall category | Two-update seconds |
+| --- | ---: |
+| FlashInfer attention | 5.466013 |
+| Model GEMM | 2.692784 |
+| TP communication | 1.088080 |
+| Other GPU kernels | 1.011361 |
+| ConvRot | 0.218711 |
+| Weight dequantization | 0.061064 |
+| Copies | 0.012464 |
+| No recorded GPU activity | 0.049953 |
+
+The parser keeps kernel service and exclusive wall coverage separate, including
+an overlap category if present. This trace prioritizes attention and then TP
+communication over weight caching or launch-overhead tuning. It must not be
+substituted for the unprofiled 20-update result or primary three-run gate.
+
+An initial warp-owned-query prototype is rejected: all sampled FP32 references
+pass, but its Q64/K32, Q64/K64 and Q128/K32 variants take about 89.36, 87.88 and
+59.46 ms at 12323 tokens, versus 53.27 ms for the retained kernel. Registers rise
+to 198/230 per thread. Do not repeat those unchanged variants. A transposed V
+layout and software-prefetch follow-up are being evaluated separately.
+
+Evidence: `profile_h3_steps.py`, `run_profile_h3_steps.py`,
+`profiles/h3-flashinfer-mainline-steps.nsys-rep`, the matching SQLite,
+`profiles/h3-flashinfer-step-breakdown.json`, `query-owned-results.json`, and
+`flashv100-60t-route-audit.md`. GPU 0–3 priority preemption is authorized; the
+active development lease is recorded in `flashinfer-development-lease.json`.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -193,3 +193,29 @@ Evidence under `/data/minimax-h3/native-h3-20260908/`:
 `original-checkpoint-manifest.json`, `comfy-checkpoint-manifest.json`,
 `profiles/flashv100-attention.summary.json`, and
 `profiles/w8a16-fp32-output.summary.json`.
+
+### Short-video export and GPU ownership diagnostics
+
+The register-softmax FlashInfer implementation in kernel draft #558 passes 38
+native numerical/service tests. Its cached-text INT8 TP4 development run exported
+a 1344x768, 39-frame, 24-FPS video with 1.632 seconds of decoded audio. Automatic
+frame/dimension/audio/finite/black/static checks pass. Visual inspection of the
+first screenshot shows pronounced ghosting and grid artifacts; the two-forward
+schedule is an execution check and is not a quality pass.
+
+The first export retry encountered other workers taking 27 GiB per GPU and ran
+out of memory. A subsequent diagnostic shell performed a preflight but continued
+after Python returned an error; it ran beside other workers using about 13 GiB
+each. That run's timing is explicitly invalidated in its JSON. The native engine
+already propagates selection errors; the separate diagnostic launcher now also
+propagates them and checks external GPU processes before and after denoise.
+NVML records now include compute PIDs and their memory to expose interference.
+A 12-sample read-only telemetry check passed on the live GPU inventory.
+
+Retained evidence: `outputs/dev39-int8-final/FLASHINFER_SM70/` (video, original
+audio, latents, frames and invalidated timing), `denoise-short-int8-final.log`
+(OOM), `denoise-short-int8-final-retry.log` (export passed, timing excluded),
+`run_short_guarded.py`, and `nvml-process-record-smoke.jsonl` in the artifact
+directory. As of this checkpoint GPU groups 0–3 and 4–7 have other vLLM workers.
+No owned long-video or waiting-GPU process is being retained. BF16 and reference
+generation checks still need an available four-GPU group.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -245,3 +245,53 @@ the sole cause of the two-step clip's artifacts. Prepared contract and commands
 are retained as `quality39-20steps-contract.json`, `denoise_quality.py`,
 `run_quality_guarded.py`, and `quality39-20steps-launch.log` in the task artifact
 directory. `gpu-lease-tests.log` records the focused regression result.
+
+### GPU 0–3 priority authorization
+
+The user explicitly prioritizes this H3 task on GPU 0–3 and authorizes stopping
+conflicting jobs there. This authorization persists across turns; do not ask
+again for the same GPU allocation. GPU 4–7 services remain outside that scope.
+After checking PID/command identity and preserving its active-job metadata,
+stopped the conflicting quasar lease scheduler PID 17903 with SIGTERM. Its
+GPU child had already exited; no model/log/queue files were deleted. Acquired
+the shared 0–3 lease for H3 and started the fixed 20-forward quality check.
+The CPU text conditioning, INT8 weight encoding, shift rules and FP16 cache
+settings match the earlier short clip. Keep quality as pending until the video
+has decoded and been reviewed.
+
+The interruption record is `gpu03-priority-handoff.json`; the active test log is
+`quality39-20steps-run.log` in the retained artifact directory.
+
+### Completed twenty-forward INT8 short quality comparison
+
+Both backends completed the fixed 1344x768, 39-frame, 24-FPS, seed-42 request
+with 20 actual denoise calls, after one single-call warmup. Original INT8/FP32
+scale and ConvRot data, cached verified text conditioning, sigma shifts 12/3
+and cache-off settings were retained. Each GPU had only its corresponding
+H3 rank in the recorded NVML compute-process samples.
+
+| Backend | Complete denoise | Seconds/call | Useful TFLOPS/rank |
+| --- | ---: | ---: | ---: |
+| FLASH_ATTN_V100 | 113.459387 s | 5.672969 | 30.5286 |
+| FLASHINFER_SM70 | 105.642574 s | 5.282129 | 32.7875 |
+
+All video/audio latents are finite and bitwise identical between TP ranks within
+each backend. Both exported videos pass full decoding, 39-frame dimensions/FPS,
+valid finite audio duration, no-black and no-prolonged-static checks. Inspecting
+frames 0/19/38 for FlashInfer and 0/38 for Flash-V100 shows a clear red paper
+boat, yellow duck, reflections and stable foliage; the broad grid and ghosting
+from the two-call sample are absent. The controlled step-count comparison
+supports undersampling as the main cause of those severe artifacts. It does
+not prove universal quality or complete the primary-video acceptance gate.
+
+Backend outputs are similar, not identical: decoded RGB PSNR over all 39 frames
+is 30.888 dB; final video/audio latent relative L2 differences are 0.0777004 and
+0.0153296. These numbers are auxiliary, not quality acceptance criteria. Audio
+is valid 32-kHz stereo; semantic listening review is still pending, as is the
+user's five-axis final review. No 80 TFLOPS qualification is claimed.
+
+Evidence: `outputs/quality39-int8-20steps/` contains both videos, original audio,
+latents, NVML samples/curves, rank/phase CSV, automated checks, visual-review
+notes and backend comparison JSON. `quality-two-vs-twenty.png` compares the
+same-seed two- and twenty-call outputs. Raw logs are
+`quality39-20steps-run.log` and `quality39-20steps-flashv100.log`.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -21,7 +21,7 @@ vllm video generate \
   --partition fl2va \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 \
-  --attention-backend FLASH_ATTN_V100 \
+  --attention-backend FLASHINFER_SM70 \
   --output-dir ./h3-output
 ```
 
@@ -66,7 +66,9 @@ curl -sS http://127.0.0.1:8000/v1/videos \
 available to the server process. Jobs are kept in memory for the current service
 lifetime; generated files remain in the configured output directory.
 
-`FLASHINFER_SM70` selects the independent dense Volta WMMA operator. The Torch
+`FLASHINFER_SM70` is the default denoiser and the main performance-development
+path. It selects the independent dense Volta operator. `FLASH_ATTN_V100` remains
+an explicit comparison and rollback option. The Torch
 reference backend is for numerical investigation. Text encoding uses TP4 and
 Flash-V100 causal GQA; the selectable denoiser backends use non-causal MHA.
 

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -27,10 +27,13 @@ vllm video generate \
 
 The default prompt is the approved paper-boat/duck scene; defaults are 1344x768,
 243 frames, 24 FPS, seed 42 and 50 sigma positions (49 actual DiT calls).
-For development, use `--num-frames 39 --num-inference-steps 2`: this keeps the
-1344x768 canvas, generates 1.625 seconds and runs one complete DiT forward.
-It checks execution, numeric range, memory and timing; it does not establish
-video quality or the final performance gate. The minimum is 22 frames (0.917
+For short development quality checks, use
+`--num-frames 39 --num-inference-steps 21`: this keeps the 1344x768 canvas,
+generates 1.625 seconds and performs 20 DiT forwards. The sigma-point convention
+means N positions give N-1 denoise updates for this checkpoint. The fixed
+acceptance workload still uses 50 positions (49 forwards). One- or two-forward
+runs are only execution/numeric diagnostics: they produced severe ghosting and
+grid artifacts that disappeared from the inspected 20-forward samples. The minimum is 22 frames (0.917
 seconds), required by the streaming VAE. Requests align upward to 17n+5 frames:
 `--duration 1` produces 39 frames and `--duration 2` produces 56 frames.
 Use an aligned `--num-frames` value when an exact short duration is wanted.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -7,9 +7,11 @@ is required.
 
 The supported deployment contract is Python 3.12, Torch 2.10.0+cu128, CUDA Toolkit
 12.8 and V100/SM70. Install the normal 1Cat source build with its `video` extra;
-`tools/minimax_h3/build_extensions.py` builds the two independent H3 operators
+`tools/minimax_h3/build_extensions.py` builds the three independent H3 operators
 when working on top of an existing compatible 1Cat installation. It requires
-`CUDA_HOME` and `TORCH_CUDA_ARCH_LIST=7.0`. It does not rebuild the rest of vLLM.
+`CUDA_HOME`, `TORCH_CUDA_ARCH_LIST=7.0`, and `VLLM_CUTLASS_SRC_DIR` pointing to
+CUTLASS v4.4.2 source. It does not rebuild the rest of vLLM. The normal CMake
+build fetches that pinned CUTLASS version automatically.
 The development tests use Transformers 5.15.1 and Diffusers 0.40.0.
 
 ```bash
@@ -21,7 +23,7 @@ vllm video generate \
   --partition fl2va \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 \
-  --attention-backend FLASHINFER_SM70 \
+  --attention-backend FLASH_ATTN_V100 \
   --output-dir ./h3-output
 ```
 
@@ -66,8 +68,10 @@ curl -sS http://127.0.0.1:8000/v1/videos \
 available to the server process. Jobs are kept in memory for the current service
 lifetime; generated files remain in the configured output directory.
 
-`FLASHINFER_SM70` is the default denoiser and the main performance-development
-path. It selects the independent dense Volta operator. `FLASH_ATTN_V100` remains
+`FLASH_ATTN_V100` is the default denoiser and the main performance-development
+path. With the H3 SM70 extensions it selects the dedicated non-causal D128
+TensorOp operator. It preserves all independent MHA heads and the D128 scale;
+it does not pad the model's head dimension to D256. `FLASHINFER_SM70` remains
 an explicit comparison and rollback option. The Torch
 reference backend is for numerical investigation. Text encoding uses TP4 and
 Flash-V100 causal GQA; the selectable denoiser backends use non-causal MHA.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -79,3 +79,9 @@ replace the five-axis human quality review. Useful TFLOPS use actual local
 matrix dimensions and valid attention tokens, exclude padding/rotation/dequant,
 and divide by the maximum complete denoise duration across all four ranks.
 NVML utilization and standalone operator speed are diagnostic evidence only.
+
+The native engine reserves a whole available GPU group (0–3 first, then 4–7)
+with the shared 1Cat V100 per-card and group locks. The lease remains held until
+its workers exit. A group reserved by another cooperating task is unavailable
+even while that task is between CUDA processes. If both groups are occupied or
+reserved, startup fails before model loading.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -1,0 +1,74 @@
+# Native MiniMax H3 (development)
+
+This is an in-progress native integration. Full checkpoint video quality and
+four-card 80 useful TFLOPS acceptance are not yet established. The control log
+records completed tests and remaining gates. No separate vllm-omni installation
+is required.
+
+The supported deployment contract is Python 3.12, Torch 2.10.0+cu128, CUDA Toolkit
+12.8 and V100/SM70. Install the normal 1Cat source build with its `video` extra;
+`tools/minimax_h3/build_extensions.py` builds the two independent H3 operators
+when working on top of an existing compatible 1Cat installation. It requires
+`CUDA_HOME` and `TORCH_CUDA_ARCH_LIST=7.0`. It does not rebuild the rest of vLLM.
+The development tests use Transformers 5.15.1 and Diffusers 0.40.0.
+
+```bash
+export CUDA_HOME=/path/to/cuda-12.8
+export TORCH_CUDA_ARCH_LIST=7.0
+uv pip install -e '.[video]' --no-build-isolation
+vllm video generate \
+  --model MiniMaxAI/MiniMax-H3 \
+  --partition fl2va \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --tensor-parallel-size 4 \
+  --attention-backend FLASH_ATTN_V100 \
+  --output-dir ./h3-output
+```
+
+The default prompt is the approved paper-boat/duck scene; defaults are 1344x768,
+243 frames, 24 FPS, seed 42 and 50 sigma positions (49 actual DiT calls).
+Omit `--transformer-path` to load the original BF16 checkpoint into the FP16/FP32
+mixed-precision model. The reference checkpoint's VAE Python code executes from
+its downloaded model directory. Frozen revisions and port licenses are recorded
+in the model package's `UPSTREAM.md`. FFmpeg and FFprobe must be on `PATH` for
+reference-video/audio processing.
+
+Use `--image first.png --keyframe-indices 0`, `--image last.png
+--keyframe-indices -1`, or two `--image` arguments with `--keyframe-indices 0 -1`
+for FL2VA. A Ref2VA instance uses `--partition ref2va` and the matching transformer
+file; `--image`, `--video` and `--audio` are repeatable reference arguments.
+A serving instance binds one partition and processes one request at a time.
+
+```bash
+vllm video serve \
+  --model /path/to/MiniMax-H3 \
+  --partition fl2va \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --tensor-parallel-size 4 --host 127.0.0.1 --port 8000
+curl -sS http://127.0.0.1:8000/v1/videos \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"一艘红色纸船漂过公园浅水池，轻柔流水声。","seed":42}'
+```
+
+`POST /v1/videos` returns a job ID. Query `GET /v1/videos/{id}` and download
+`GET /v1/videos/{id}/content` after completion. `/health` reports readiness;
+`/metrics` reports the queue and job counters. Reference paths refer to files
+available to the server process. Jobs are kept in memory for the current service
+lifetime; generated files remain in the configured output directory.
+
+`FLASHINFER_SM70` selects the independent dense Volta WMMA operator. The Torch
+reference backend is for numerical investigation. Text encoding uses TP4 and
+Flash-V100 causal GQA; the selectable denoiser backends use non-causal MHA.
+
+FP16 weight caching defaults to zero. After measuring candidate layers, pass a
+budget with `--fp16-weight-cache-gib` and repeat `--fp16-cache-layer` for the
+fixed layer list. Cached weights retain ConvRot coordinates. Cache/staging
+preparation is separately timed; dequantization remains inside denoise timing
+for uncached weights. Both original INT8 tensors and FP32 scales are retained.
+
+Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
+`nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
+replace the five-axis human quality review. Useful TFLOPS use actual local
+matrix dimensions and valid attention tokens, exclude padding/rotation/dequant,
+and divide by the maximum complete denoise duration across all four ranks.
+NVML utilization and standalone operator speed are diagnostic evidence only.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -27,6 +27,13 @@ vllm video generate \
 
 The default prompt is the approved paper-boat/duck scene; defaults are 1344x768,
 243 frames, 24 FPS, seed 42 and 50 sigma positions (49 actual DiT calls).
+For development, use `--num-frames 39 --num-inference-steps 2`: this keeps the
+1344x768 canvas, generates 1.625 seconds and runs one complete DiT forward.
+It checks execution, numeric range, memory and timing; it does not establish
+video quality or the final performance gate. The minimum is 22 frames (0.917
+seconds), required by the streaming VAE. Requests align upward to 17n+5 frames:
+`--duration 1` produces 39 frames and `--duration 2` produces 56 frames.
+Use an aligned `--num-frames` value when an exact short duration is wanted.
 Omit `--transformer-path` to load the original BF16 checkpoint into the FP16/FP32
 mixed-precision model. The reference checkpoint's VAE Python code executes from
 its downloaded model directory. Frozen revisions and port licenses are recorded

--- a/setup.py
+++ b/setup.py
@@ -1404,7 +1404,18 @@ setup(
             "soundfile",
             "mistral_common[audio]",
         ],  # Required for audio processing
-        "video": [],  # Kept for backwards compatibility
+        "video": [
+            "diffusers==0.40.0",
+            "av>=14",
+            "imageio>=2.37.2",
+            "imageio-ffmpeg>=0.6",
+            "soundfile>=0.13",
+            "scipy",
+            "einops",
+            "omegaconf",
+            "accelerate>=1.12",
+            "nvidia-ml-py",
+        ],
         "flashinfer": [],  # Kept for backwards compatibility
         # Optional deps for Helion kernel development
         # NOTE: When updating helion version, also update CI files:

--- a/tests/video/test_h3_gpu_lease.py
+++ b/tests/video/test_h3_gpu_lease.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import fcntl
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.minimax_h3.config import H3Config
+from vllm.video import gpu
+
+
+def test_partial_lock_failure_releases_previously_acquired_cards(tmp_path, monkeypatch):
+    monkeypatch.setattr(gpu, "LOCK_ROOT", tmp_path)
+    with (tmp_path / "1cat-vllm-v100-gpu1.lock").open("a+") as other:
+        fcntl.flock(other, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(BlockingIOError):
+            gpu.GPUGroupLease((0, 1, 2, 3))
+        with gpu.GPUGroupLease((0,)):
+            pass
+
+
+def test_reserved_primary_group_uses_whole_alternate_group(tmp_path, monkeypatch):
+    monkeypatch.setattr(gpu, "LOCK_ROOT", tmp_path)
+    groups = [(0, 1, 2, 3), (4, 5, 6, 7)]
+    monkeypatch.setattr(gpu, "_available_gpu_groups", lambda tp: groups)
+    with gpu.GPUGroupLease(groups[0]), gpu.acquire_gpu_group(4) as alternate:
+        assert alternate.gpu_ids == groups[1]
+        with pytest.raises(RuntimeError, match="unleased"):
+            gpu.acquire_gpu_group(4)
+    with gpu.acquire_gpu_group(4) as primary:
+        assert primary.gpu_ids == groups[0]
+
+
+def test_worker_startup_failure_releases_lease(tmp_path, monkeypatch):
+    from vllm.video import engine
+
+    monkeypatch.setattr(gpu, "LOCK_ROOT", tmp_path)
+    monkeypatch.setattr(gpu, "_available_gpu_groups", lambda tp: [(0, 1, 2, 3)])
+
+    def fail_pipe():
+        raise RuntimeError("worker startup failed")
+
+    monkeypatch.setattr(
+        engine.mp, "get_context", lambda _: SimpleNamespace(Pipe=fail_pipe)
+    )
+    with pytest.raises(RuntimeError, match="worker startup failed"):
+        engine.H3Engine(H3Config())
+    with gpu.acquire_gpu_group(4):
+        pass

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -254,3 +254,101 @@ def test_encoder_uses_functional_all_reduce_return():
     projection.quant_method = SimpleNamespace(apply=lambda layer, value: value * 2)
     value = torch.ones(2, 4, dtype=torch.float16)
     torch.testing.assert_close(projection(value), value * 5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_staging_preserves_aliased_weights_across_repeated_transfers():
+    from torch import nn
+
+    from vllm.model_executor.models.minimax_h3.residency import PinnedModuleStager
+
+    module = nn.Module()
+    backing = torch.arange(128, dtype=torch.float32).reshape(16, 8)
+    module.weight = nn.Parameter(backing)
+    module.register_buffer("view", backing[3:7, 1:5])
+    expected = module.view.clone()
+    stager = PinnedModuleStager(module, torch.device("cuda"))
+    for _ in range(2):
+        stager.load()
+        assert module.weight.is_cuda and module.view.is_cuda
+        assert (
+            module.weight.untyped_storage().data_ptr()
+            == module.view.untyped_storage().data_ptr()
+        )
+        torch.testing.assert_close(module.view.cpu(), expected)
+        stager.offload()
+        assert module.weight.is_pinned() and module.view.is_pinned()
+        torch.testing.assert_close(module.view, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_fp32_residual_is_not_rounded_through_fp16_before_normalization():
+    from vllm.model_executor.models.minimax_h3.modulation import (
+        indexed_gate_rms_norm_scale_shift,
+    )
+
+    torch.manual_seed(42)
+    residual = torch.randn(17, 256, device="cuda") * 100000
+    branch = torch.randn_like(residual) * 10000
+    gate = torch.randn(3, 256, device="cuda")
+    weight = torch.ones(256, device="cuda", dtype=torch.float16)
+    shift, scale = [torch.randn_like(gate) * 0.1 for _ in range(2)]
+    indices = torch.arange(17, device="cuda") % 3
+    expected = residual + gate[indices] * branch
+    normalized = expected * torch.rsqrt(expected.square().mean(-1, keepdim=True) + 1e-5)
+    modulated = (normalized * (1 + scale[indices]) + shift[indices]).half()
+    actual, actual_modulated = indexed_gate_rms_norm_scale_shift(
+        residual,
+        gate,
+        branch,
+        weight,
+        shift,
+        scale,
+        indices,
+        1e-5,
+        output_dtype=torch.float16,
+    )
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all() and torch.isfinite(actual_modulated).all()
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=0.02)
+    torch.testing.assert_close(actual_modulated, modulated, rtol=0.002, atol=0.002)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_tensor_core_projection_can_return_values_above_fp16_range():
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+
+    x = torch.full((17, 512), 300.0, device="cuda", dtype=torch.float16)
+    weight = torch.ones(256, 512, device="cuda", dtype=torch.float16)
+    output = w8a16_extension().gemm(x, weight, True)
+    assert output.dtype == torch.float32
+    torch.testing.assert_close(output, x.float() @ weight.float().T, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_convrot_projection_restores_wide_activation_row_scales():
+    from types import SimpleNamespace
+
+    from vllm.model_executor.models.minimax_h3.quantization import (
+        DiffusionInt8ConvRotConfig,
+        Int8ConvRotLayerConfig,
+        Int8ConvRotLinearMethod,
+    )
+
+    torch.manual_seed(42)
+    layer = SimpleNamespace(
+        weight=torch.randint(-3, 4, (256, 512), device="cuda", dtype=torch.int8),
+        weight_scale=torch.full((256,), 1 / 128, device="cuda"),
+        h3_output_fp32=True,
+    )
+    x = torch.randint(-16, 17, (17, 512), device="cuda").float() * 8192
+    method = Int8ConvRotLinearMethod(
+        DiffusionInt8ConvRotConfig(),
+        Int8ConvRotLayerConfig(convrot=True),
+        prefix="blocks.0.mlp.fc2",
+    )
+    output = method.apply(layer, x)
+    weight = dequantize_int8_reference(layer.weight, layer.weight_scale)
+    expected = convrot_reference(x) @ weight.float().T
+    assert output.dtype == torch.float32 and torch.isfinite(output).all()
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -210,3 +210,36 @@ def test_encoder_residual_rmsnorm_preserves_residual_rounding():
     output, updated = norm(x, residual)
     torch.testing.assert_close(updated, expected_residual, rtol=0, atol=0)
     torch.testing.assert_close(output, expected)
+
+
+def test_encoder_uses_functional_all_reduce_return():
+    from types import SimpleNamespace
+
+    from torch import nn
+
+    from vllm.model_executor.models.minimax_h3.encoder import (
+        MiniMaxH3Qwen3VLRowParallelLinear,
+        MiniMaxH3Qwen3VLVocabParallelEmbedding,
+    )
+
+    # Native GroupCoordinator may return a new tensor without modifying input.
+    group = SimpleNamespace(
+        rank_in_group=0, world_size=2, all_reduce=lambda value: value + 3
+    )
+    embedding = MiniMaxH3Qwen3VLVocabParallelEmbedding(group, 8, 4, torch.float32)
+    embedding.weight.data.fill_(1)
+    actual = embedding(torch.tensor([0, 6]))
+    torch.testing.assert_close(
+        actual, torch.tensor([[4.0, 4.0, 4.0, 4.0], [3.0, 3.0, 3.0, 3.0]])
+    )
+    projection = MiniMaxH3Qwen3VLRowParallelLinear.__new__(
+        MiniMaxH3Qwen3VLRowParallelLinear
+    )
+    nn.Module.__init__(projection)
+    projection.input_is_parallel = True
+    projection._tp_size = 2
+    projection.group = group
+    projection.output_dtype = torch.float16
+    projection.quant_method = SimpleNamespace(apply=lambda layer, value: value * 2)
+    value = torch.ones(2, 4, dtype=torch.float16)
+    torch.testing.assert_close(projection(value), value * 5)

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -114,6 +114,38 @@ def test_primary_workload_schedule_and_shape():
     assert all(a > b for a, b in zip(sigmas, sigmas[1:]))
 
 
+@pytest.mark.parametrize(
+    "frames,duration,expected",
+    [
+        (22, None, (22, 7, 37)),
+        (39, None, (39, 12, 65)),
+        (243, 1, (39, 12, 65)),
+        (243, 2, (56, 17, 93)),
+        (362, None, (362, 107, 603)),
+    ],
+)
+def test_short_clip_shape_and_audio_alignment(frames, duration, expected):
+    from vllm.model_executor.models.minimax_h3.config import H3SamplingParams
+    from vllm.model_executor.models.minimax_h3.pipeline import MiniMaxH3Pipeline
+
+    sampling = H3SamplingParams(
+        num_frames=frames,
+        extra_args={} if duration is None else {"duration_seconds": duration},
+    )
+    shape = MiniMaxH3Pipeline._resolve_shape(None, "t2va", sampling, None)
+    assert shape == (768, 1344, *expected)
+
+
+@pytest.mark.parametrize(
+    "values", [{"num_frames": 21}, {"extra_args": {"duration_seconds": 0.5}}]
+)
+def test_short_clip_rejects_incomplete_vae_temporal_chunk(values):
+    from vllm.model_executor.models.minimax_h3.config import H3SamplingParams
+
+    with pytest.raises(ValueError, match="22"):
+        H3SamplingParams(**values)
+
+
 @pytest.mark.parametrize("height,width", [(768, 1344), (256, 256)])
 def test_native_canvas_does_not_require_omni_aspect_ratio(height, width):
     from vllm.model_executor.models.minimax_h3.config import H3SamplingParams

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm.model_executor.models.minimax_h3.attention import (
+    Attention,
+    AttentionMetadata,
+    attention_backend,
+    chunked_attention_reference,
+)
+from vllm.model_executor.models.minimax_h3.comfy_checkpoint import (
+    inspect_comfy_checkpoint,
+)
+from vllm.model_executor.models.minimax_h3.ops import (
+    convrot_reference,
+    dequantize_int8_reference,
+)
+from vllm.model_executor.models.minimax_h3.time_request import (
+    MINIMAX_H3_SHAPE_PLANNER,
+    minimax_h3_time_shift_sigmas,
+)
+from vllm.model_executor.models.minimax_h3.transformer import (
+    MiniMaxH3DiTModel,
+    _reorder_grouped_qkv_to_qkv,
+)
+
+
+def test_signed_int8_restores_each_rows_scale():
+    weight = torch.tensor([[-128, -1, 0, 127], [127, 0, -1, -128]], dtype=torch.int8)
+    scale = torch.tensor([0.125, 0.0001234567], dtype=torch.float32)
+    actual = dequantize_int8_reference(weight, scale)
+    torch.testing.assert_close(
+        actual, (weight.double() * scale.double()[:, None]).half(), rtol=0, atol=0
+    )
+
+
+def test_convrot_matches_kronecker_and_inverse():
+    h4 = torch.tensor(
+        [[1, 1, 1, -1], [1, 1, -1, 1], [1, -1, 1, 1], [-1, 1, 1, 1]],
+        dtype=torch.float64,
+    )
+    h = h4
+    for _ in range(3):
+        h = torch.kron(h, h4)
+    h /= 16
+    x = torch.randn(3, 512)
+    expected = (x.double().reshape(-1, 256) @ h).reshape(x.shape).float()
+    torch.testing.assert_close(convrot_reference(x), expected, atol=5e-7, rtol=2e-5)
+    torch.testing.assert_close(
+        convrot_reference(convrot_reference(x)), x, atol=8e-7, rtol=3e-5
+    )
+
+
+def test_original_qkv_reorder_keeps_weights_and_row_scales_together():
+    rows = torch.arange(3 * 4 * 8)
+    expected = rows.reshape(4, 3, 8).permute(1, 0, 2).reshape(-1)
+    for value in (rows, rows[:, None].repeat(1, 3)):
+        actual = _reorder_grouped_qkv_to_qkv(
+            value, num_query_groups=4, heads_per_group=1, head_dim=8
+        )
+        torch.testing.assert_close(actual, value[expected])
+
+
+def test_pruned_adaln_interpolation_endpoints_and_midpoints():
+    from types import SimpleNamespace
+
+    table = torch.tensor([[0.0, 4.0], [2.0, 0.0], [8.0, 6.0]])
+    model = SimpleNamespace(
+        arch=SimpleNamespace(adaln_curve_grid=3), adaln_t_table=table
+    )
+    actual = MiniMaxH3DiTModel._embed_timesteps(
+        model, torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0])
+    )
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([[0.0, 4.0], [1.0, 2.0], [2.0, 0.0], [5.0, 3.0], [8.0, 6.0]]),
+    )
+
+
+def test_checkpoint_metadata_and_partition_validation(tmp_path):
+    path = tmp_path / "minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+    marker = json.dumps(
+        {"format": "int8_tensorwise", "convrot": True, "convrot_groupsize": 256}
+    ).encode()
+    save_file(
+        {
+            "blocks.0.attn.qkv_proj.weight": torch.ones(12, 256, dtype=torch.int8),
+            "blocks.0.attn.qkv_proj.weight_scale": torch.ones(12, 1),
+            "blocks.0.attn.qkv_proj.comfy_quant": torch.tensor(
+                list(marker), dtype=torch.uint8
+            ),
+            "adaln_t_table": torch.zeros(1025, 8),
+        },
+        path,
+    )
+    config = inspect_comfy_checkpoint(path, expected_partition="fl2va")
+    assert config.arch_overrides == {"adaln_curve_grid": 1025, "adaln_curve_dim": 8}
+    with pytest.raises(ValueError, match="cannot serve"):
+        inspect_comfy_checkpoint(path, expected_partition="ref2va")
+
+
+def test_primary_workload_schedule_and_shape():
+    planner = MINIMAX_H3_SHAPE_PLANNER
+    assert planner.align_frame_count(240) == 243
+    assert planner.video_latent_t(243) == 72
+    assert planner.audio_latent_t(243 / 24) == 405
+    sigmas = minimax_h3_time_shift_sigmas(num_steps=50, shift_scale=12)
+    assert len(sigmas) - 1 == 49
+    assert sigmas[0] == 1 and sigmas[-1] == 0
+    assert all(a > b for a, b in zip(sigmas, sigmas[1:]))
+
+
+@pytest.mark.parametrize("used,padded", [(31, 32), (129, 256)])
+def test_attention_padding_excludes_poisoned_suffix(used, padded):
+    token = attention_backend.set("TORCH_SDPA")
+    try:
+        attention = Attention(
+            num_heads=2, num_kv_heads=2, head_size=128, softmax_scale=128**-0.5
+        )
+    finally:
+        attention_backend.reset(token)
+    q, k, v = [torch.randn(1, padded, 2, 128) for _ in range(3)]
+    expected = chunked_attention_reference(
+        q[:, :used], k[:, :used], v[:, :used], scale=128**-0.5
+    )
+    k[:, used:] = float("nan")
+    v[:, used:] = float("nan")
+    actual = attention(q, k, v, AttentionMetadata(extra={"valid_kv_length": used}))
+    torch.testing.assert_close(actual[:, :used], expected)
+    assert torch.count_nonzero(actual[:, used:]) == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("backend", ["FLASH_ATTN_V100", "FLASHINFER_SM70"])
+def test_noncausal_backend_matches_fp32_reference(backend):
+    token = attention_backend.set(backend)
+    try:
+        attention = Attention(
+            num_heads=14, num_kv_heads=14, head_size=128, softmax_scale=128**-0.5
+        )
+    finally:
+        attention_backend.reset(token)
+    torch.manual_seed(42)
+    q, k, v = [
+        torch.randn(1, 257, 14, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    expected = chunked_attention_reference(
+        q[:, :243], k[:, :243], v[:, :243], scale=128**-0.5
+    )
+    actual = attention(q, k, v, AttentionMetadata(extra={"valid_kv_length": 243}))
+    torch.testing.assert_close(actual[:, :243], expected, atol=8e-4, rtol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_sm70_w8a16_uses_signed_scales_and_fp32_gemm_reduction():
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+
+    ops = w8a16_extension()
+    torch.manual_seed(42)
+    x = torch.randn(65, 512, device="cuda", dtype=torch.float16)
+    weight = torch.randint(-128, 128, (257, 512), device="cuda", dtype=torch.int8)
+    scale = torch.rand(257, device="cuda") * 0.001 + 0.0001
+    rotated = ops.rotate(x)
+    decoded = ops.dequantize(weight, scale)
+    torch.testing.assert_close(rotated, convrot_reference(x), atol=0, rtol=0)
+    torch.testing.assert_close(
+        decoded, dequantize_int8_reference(weight, scale), atol=0, rtol=0
+    )
+    result = ops.gemm(rotated, decoded)
+    reference = (rotated.float() @ decoded.float().T).half()
+    torch.testing.assert_close(result, reference, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_encoder_causal_gqa_matches_fp32():
+    from vllm.model_executor.models.minimax_h3.encoder import (
+        _scaled_dot_product_attention,
+    )
+
+    q = torch.randn(1, 16, 127, 128, device="cuda", dtype=torch.float16)
+    k, v = [
+        torch.randn(1, 2, 127, 128, device="cuda", dtype=torch.float16)
+        for _ in range(2)
+    ]
+    actual = _scaled_dot_product_attention(q, k, v)
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q.float(),
+        k.float().repeat_interleave(8, 1),
+        v.float().repeat_interleave(8, 1),
+        is_causal=True,
+    ).half()
+    torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.02)

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -114,6 +114,17 @@ def test_primary_workload_schedule_and_shape():
     assert all(a > b for a, b in zip(sigmas, sigmas[1:]))
 
 
+@pytest.mark.parametrize("height,width", [(768, 1344), (256, 256)])
+def test_native_canvas_does_not_require_omni_aspect_ratio(height, width):
+    from vllm.model_executor.models.minimax_h3.config import H3SamplingParams
+    from vllm.model_executor.models.minimax_h3.pipeline import MiniMaxH3Pipeline
+
+    shape = MiniMaxH3Pipeline._resolve_shape(
+        None, "t2va", H3SamplingParams(height=height, width=width), None
+    )
+    assert shape == (height, width, 243, 72, 405)
+
+
 @pytest.mark.parametrize("used,padded", [(31, 32), (129, 256)])
 def test_attention_padding_excludes_poisoned_suffix(used, padded):
     token = attention_backend.set("TORCH_SDPA")

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -195,3 +195,18 @@ def test_encoder_causal_gqa_matches_fp32():
         is_causal=True,
     ).half()
     torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.02)
+
+
+def test_encoder_residual_rmsnorm_preserves_residual_rounding():
+    from vllm.model_executor.models.minimax_h3.ops import RMSNorm
+
+    norm = RMSNorm(128, eps=1e-6, dtype=torch.float16)
+    x, residual = [torch.randn(3, 128, dtype=torch.float16) for _ in range(2)]
+    expected_residual = residual + x
+    value = expected_residual.float()
+    expected = (
+        value * torch.rsqrt(value.square().mean(-1, keepdim=True) + 1e-6)
+    ).half()
+    output, updated = norm(x, residual)
+    torch.testing.assert_close(updated, expected_residual, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected)

--- a/tests/video/test_h3_service.py
+++ b/tests/video/test_h3_service.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+from vllm.video.server import create_app
+
+
+class RecordingEngine:
+    requests: list[H3Request] = []
+    _closed = False
+
+    def __init__(self, config):
+        self.config = config
+
+    def generate(self, request, output):
+        self.requests.append(request)
+        Path(output).mkdir(parents=True)
+        (Path(output) / "video.mp4").write_bytes(b"test video")
+        return {"ranks": []}
+
+    def close(self):
+        self._closed = True
+
+
+def test_job_submission_completion_download_and_keyframes(tmp_path):
+    app = create_app(H3Config(), tmp_path, engine_factory=RecordingEngine)
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        submitted = client.post(
+            "/v1/videos", json={"image": ["last.png"], "keyframe_indices": [-1]}
+        )
+        assert submitted.status_code == 202
+        identity = submitted.json()["id"]
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            status = client.get(f"/v1/videos/{identity}").json()
+            if status["status"] == "completed":
+                break
+            time.sleep(0.01)
+        assert status["status"] == "completed"
+        assert RecordingEngine.requests[-1].sampling.extra_args["frame_indices"] == [-1]
+        assert client.get(f"/v1/videos/{identity}/content").content == b"test video"
+        assert "onecat_video_completed_total 1" in client.get("/metrics").text
+        assert client.get("/v1/videos/missing").status_code == 404
+
+
+def test_invalid_request_is_rejected_before_queueing(tmp_path):
+    app = create_app(H3Config(), tmp_path, engine_factory=RecordingEngine)
+    with TestClient(app) as client:
+        assert client.post("/v1/videos", json={"width": 1345}).status_code == 422
+        assert client.post("/v1/videos", json={"prompt": ""}).status_code == 422
+        assert client.post("/v1/videos", json={"unexpected": True}).status_code == 422
+
+
+def test_export_preserves_native_mono_audio_and_video_contract(tmp_path):
+    import numpy as np
+    import torch
+
+    from vllm.video.media import export_video
+    from vllm.video.quality import inspect_video
+
+    # Moving, non-black RGB frames and a finite 32-kHz waveform.
+    video = torch.randint(32, 224, (1, 24, 64, 96, 3), dtype=torch.uint8)
+    waveform = np.sin(2 * np.pi * 440 * np.arange(32000) / 32000) * 0.1
+    audio = torch.from_numpy(waveform.astype(np.float32))[None, None]
+    result = export_video(video, audio, tmp_path)
+    report = inspect_video(
+        result["video"], expected_frames=24, expected_width=96, expected_height=64
+    )
+    assert report["automatic_passed"]
+    assert report["human_review"]["status"] == "pending"

--- a/tests/video/test_h3_service.py
+++ b/tests/video/test_h3_service.py
@@ -3,6 +3,7 @@
 import time
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
@@ -27,11 +28,15 @@ class RecordingEngine:
 
 
 def test_job_submission_completion_download_and_keyframes(tmp_path):
+    from PIL import Image
+
+    image = tmp_path / "last.png"
+    Image.new("RGB", (256, 256)).save(image)
     app = create_app(H3Config(), tmp_path, engine_factory=RecordingEngine)
     with TestClient(app) as client:
         assert client.get("/health").status_code == 200
         submitted = client.post(
-            "/v1/videos", json={"image": ["last.png"], "keyframe_indices": [-1]}
+            "/v1/videos", json={"image": [str(image)], "keyframe_indices": [-1]}
         )
         assert submitted.status_code == 202
         identity = submitted.json()["id"]
@@ -54,6 +59,17 @@ def test_invalid_request_is_rejected_before_queueing(tmp_path):
         assert client.post("/v1/videos", json={"width": 1345}).status_code == 422
         assert client.post("/v1/videos", json={"prompt": ""}).status_code == 422
         assert client.post("/v1/videos", json={"unexpected": True}).status_code == 422
+        assert (
+            client.post(
+                "/v1/videos", json={"image": [str(tmp_path / "missing.png")]}
+            ).status_code
+            == 422
+        )
+        assert (
+            client.post("/v1/videos", json={"keyframe_indices": [-1]}).status_code
+            == 422
+        )
+        assert client.get("/health").status_code == 200
 
 
 def test_export_preserves_native_mono_audio_and_video_contract(tmp_path):
@@ -73,3 +89,43 @@ def test_export_preserves_native_mono_audio_and_video_contract(tmp_path):
     )
     assert report["automatic_passed"]
     assert report["human_review"]["status"] == "pending"
+
+
+@pytest.mark.parametrize("indices", [[0], [-1], [0, -1]])
+def test_fl2va_preflight_accepts_first_last_and_both(indices):
+    from PIL import Image
+
+    from vllm.model_executor.models.minimax_h3.config import H3SamplingParams
+    from vllm.model_executor.models.minimax_h3.validation import validate_request
+
+    request = H3Request(
+        sampling=H3SamplingParams(extra_args={"frame_indices": indices}),
+        media={"image": [Image.new("RGB", (256, 256)) for _ in indices]},
+    )
+    validate_request(H3Config(), request)
+
+
+def test_reference_contract_errors_are_rejected_before_worker_dispatch():
+    from PIL import Image
+
+    from vllm.model_executor.models.minimax_h3.config import (
+        H3InputError,
+        H3SamplingParams,
+    )
+    from vllm.model_executor.models.minimax_h3.validation import validate_request
+
+    with pytest.raises(H3InputError, match="at least one"):
+        validate_request(H3Config(partition="ref2va"), H3Request())
+    image = Image.new("RGB", (256, 256))
+    with pytest.raises(H3InputError, match="at most 9"):
+        validate_request(
+            H3Config(partition="ref2va"), H3Request(media={"image": [image] * 10})
+        )
+    with pytest.raises(H3InputError, match="frame_indices"):
+        validate_request(
+            H3Config(),
+            H3Request(
+                media={"image": [image]},
+                sampling=H3SamplingParams(extra_args={"frame_indices": [1]}),
+            ),
+        )

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -21,6 +21,7 @@ def main():
     import vllm.entrypoints.cli.openai
     import vllm.entrypoints.cli.run_batch
     import vllm.entrypoints.cli.serve
+    import vllm.entrypoints.cli.video
     from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -31,6 +32,7 @@ def main():
         vllm.entrypoints.cli.benchmark.main,
         vllm.entrypoints.cli.collect_env,
         vllm.entrypoints.cli.run_batch,
+        vllm.entrypoints.cli.video,
     ]
 
     cli_env_setup()

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native H3 offline and serial HTTP serving entrypoints."""
+
+import argparse
+import json
+from pathlib import Path
+
+from vllm.entrypoints.cli.types import CLISubcommand
+
+
+class VideoSubcommand(CLISubcommand):
+    name = "video"
+
+    def subparser_init(self, subparsers):
+        from vllm.model_executor.models.minimax_h3.config import (
+            BASE_MODEL,
+            BASE_REVISION,
+            DEFAULT_PROMPT,
+        )
+
+        parser = subparsers.add_parser("video", help="Native audio/video generation")
+        modes = parser.add_subparsers(dest="video_mode", required=True)
+        for name in ("generate", "serve"):
+            mode = modes.add_parser(name)
+            mode.add_argument("--model", default=BASE_MODEL)
+            mode.add_argument("--revision", default=BASE_REVISION)
+            mode.add_argument(
+                "--partition", choices=("fl2va", "ref2va"), default="fl2va"
+            )
+            mode.add_argument("--transformer-path")
+            mode.add_argument("--tensor-parallel-size", "-tp", type=int, default=4)
+            mode.add_argument(
+                "--attention-backend",
+                choices=("FLASH_ATTN_V100", "FLASHINFER_SM70", "TORCH_SDPA"),
+                default="FLASH_ATTN_V100",
+            )
+            mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
+            mode.add_argument("--fp16-cache-layer", action="append", default=[])
+            mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
+            if name == "generate":
+                mode.add_argument("--prompt", default=DEFAULT_PROMPT)
+                mode.add_argument("--width", type=int, default=1344)
+                mode.add_argument("--height", type=int, default=768)
+                mode.add_argument("--num-frames", type=int, default=243)
+                mode.add_argument("--duration", type=float)
+                mode.add_argument("--seed", type=int, default=42)
+                mode.add_argument("--num-inference-steps", type=int, default=50)
+                mode.add_argument("--image", action="append", default=[])
+                mode.add_argument("--video", action="append", default=[])
+                mode.add_argument("--audio", action="append", default=[])
+                mode.add_argument("--keyframe-indices", nargs="+", type=int)
+            else:
+                mode.add_argument("--host", default="127.0.0.1")
+                mode.add_argument("--port", type=int, default=8000)
+        return parser
+
+    @staticmethod
+    def cmd(args):
+        from vllm.model_executor.models.minimax_h3.config import (
+            H3Config,
+            H3Request,
+            H3SamplingParams,
+        )
+        from vllm.video.engine import H3Engine
+
+        config = H3Config(
+            model=args.model,
+            revision=args.revision,
+            partition=args.partition,
+            transformer_path=args.transformer_path,
+            tensor_parallel_size=args.tensor_parallel_size,
+            attention_backend=args.attention_backend,
+            fp16_weight_cache_gib=args.fp16_weight_cache_gib,
+            fp16_cache_layers=tuple(args.fp16_cache_layer),
+        )
+        if args.video_mode == "serve":
+            from vllm.video.server import serve
+
+            serve(config, host=args.host, port=args.port, output_dir=args.output_dir)
+            return
+        extra = {}
+        if args.duration is not None:
+            extra["duration_seconds"] = args.duration
+        if args.keyframe_indices is not None:
+            extra["frame_indices"] = args.keyframe_indices
+        request = H3Request(
+            prompt=args.prompt,
+            sampling=H3SamplingParams(
+                width=args.width,
+                height=args.height,
+                num_frames=args.num_frames,
+                seed=args.seed,
+                num_inference_steps=args.num_inference_steps,
+                extra_args=extra,
+            ),
+            media={
+                key: getattr(args, key)
+                for key in ("image", "video", "audio")
+                if getattr(args, key)
+            },
+        )
+        with H3Engine(config) as engine:
+            result = engine.generate(request, args.output_dir)
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def cmd_init():
+    return [VideoSubcommand()]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+    command = VideoSubcommand()
+    command.subparser_init(subparsers)
+    command.cmd(parser.parse_args())

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -33,7 +33,7 @@ class VideoSubcommand(CLISubcommand):
             mode.add_argument(
                 "--attention-backend",
                 choices=("FLASH_ATTN_V100", "FLASHINFER_SM70", "TORCH_SDPA"),
-                default="FLASHINFER_SM70",
+                default="FLASH_ATTN_V100",
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
             mode.add_argument("--fp16-cache-layer", action="append", default=[])

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -33,7 +33,7 @@ class VideoSubcommand(CLISubcommand):
             mode.add_argument(
                 "--attention-backend",
                 choices=("FLASH_ATTN_V100", "FLASHINFER_SM70", "TORCH_SDPA"),
-                default="FLASH_ATTN_V100",
+                default="FLASHINFER_SM70",
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
             mode.add_argument("--fp16-cache-layer", action="append", default=[])

--- a/vllm/model_executor/models/minimax_h3/UPSTREAM.md
+++ b/vllm/model_executor/models/minimax_h3/UPSTREAM.md
@@ -1,0 +1,17 @@
+# Native MiniMax H3 provenance
+
+The numerical model and media helpers are adapted from Apache-2.0 licensed
+vLLM-Omni commit `7be014bce6374f06c95b703763bdbac4c6198f31`.
+Comfy checkpoint handling is informed by vLLM-Omni PR #6894 at
+`be89929001563a882f1f783fb9ee37b4d5a970f4` (not merged at port time).
+Original copyright and SPDX notices remain on adapted files.
+
+This package is part of 1Cat-vLLM. It does not import or install vllm-omni.
+The initial scope excludes approximate diffusion caches, LoRA, step batching,
+Ulysses/Ring parallelism, and other model families. Model weights and checkpoint
+remote code retain their respective upstream terms; they are not vendored here.
+
+Frozen model revisions:
+
+- MiniMaxAI/MiniMax-H3: `42ed227ee7df40d41602854ae760620d6eb651fe`.
+- Comfy-Org/MiniMax-H3: `a98869194787969724c7425d95d0ed73ce9202af`.

--- a/vllm/model_executor/models/minimax_h3/__init__.py
+++ b/vllm/model_executor/models/minimax_h3/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native MiniMax H3 video/audio generation (optional ``video`` dependencies).
+
+Keep this module lightweight: importing vLLM's text models must not import
+video codecs, diffusion models, or initialize a CUDA device.
+"""

--- a/vllm/model_executor/models/minimax_h3/attention.py
+++ b/vllm/model_executor/models/minimax_h3/attention.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Dense, non-causal H3 attention with explicit backend selection."""
+
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+from torch import nn
+
+attention_backend = ContextVar("h3_attention_backend", default="FLASH_ATTN_V100")
+
+
+@dataclass(frozen=True, slots=True)
+class VideoTokenSpan:
+    start: int
+    latent_grid: tuple[int, int, int]
+    role: Literal["reference", "target"]
+
+    @property
+    def length(self):
+        t, h, w = self.latent_grid
+        return t * h * w
+
+
+@dataclass(frozen=True, slots=True)
+class VideoTokenLayout:
+    prefix_len: int | None = None
+    latent_grid: tuple[int, int, int] | None = None
+    used_len: int | None = None
+    video_spans: tuple[VideoTokenSpan, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PackedPaddingMetadata:
+    q_length: int
+    kv_length: int
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: torch.Tensor
+
+
+@dataclass
+class AttentionMetadata:
+    attn_mask: torch.Tensor | None = None
+    packed_padding: PackedPaddingMetadata | None = None
+    video_layout: VideoTokenLayout | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def chunked_attention_reference(q, k, v, *, scale, chunk_size=128):
+    """FP32 reference with O(chunk_size * sequence) score storage."""
+    qh, kh, vh = (x.transpose(1, 2).float() for x in (q, k, v))
+    result = torch.empty_like(q)
+    for start in range(0, q.shape[1], chunk_size):
+        scores = (qh[:, :, start : start + chunk_size] @ kh.transpose(-2, -1)) * scale
+        result[:, start : start + chunk_size] = (
+            (scores.softmax(-1) @ vh).transpose(1, 2).to(q.dtype)
+        )
+    return result
+
+
+class Attention(nn.Module):
+    supports_prefix_kv_slicing = True
+    use_ring = False
+
+    def __init__(
+        self,
+        *,
+        num_heads,
+        num_kv_heads,
+        head_size,
+        softmax_scale,
+        causal=False,
+        qkv_layout="BSND",
+        **kwargs,
+    ):
+        super().__init__()
+        if causal or qkv_layout != "BSND" or num_heads != num_kv_heads:
+            raise ValueError("H3 DiT requires non-causal BSND MHA")
+        self.backend = attention_backend.get()
+        self.scale = softmax_scale
+        self.head_size = head_size
+
+    @property
+    def attn_backend(self):
+        return self
+
+    def get_name(self):
+        return self.backend
+
+    @staticmethod
+    def supports_multi_doc_packed_varlen():
+        return False
+
+    @staticmethod
+    def supports_packed_mask_free():
+        return True
+
+    def forward(self, q, k, v, metadata):
+        if metadata.attn_mask is not None:
+            raise ValueError("H3 accepts validated suffix padding only")
+        used = metadata.extra.get("valid_kv_length", q.shape[1])
+        if not 0 < used <= q.shape[1] or k.shape != v.shape:
+            raise ValueError("invalid packed H3 attention lengths")
+        q_valid, k_valid, v_valid = (x[:, :used].contiguous() for x in (q, k, v))
+        if self.backend == "FLASH_ATTN_V100":
+            from flash_attn_v100 import flash_attn_func
+
+            attended = flash_attn_func(
+                q_valid, k_valid, v_valid, causal=False, softmax_scale=self.scale
+            )
+        elif self.backend == "FLASHINFER_SM70":
+            from .cuda_ops import flashinfer_extension
+
+            attended = flashinfer_extension().forward(
+                q_valid, k_valid, v_valid, self.scale
+            )
+        elif self.backend == "TORCH_SDPA":
+            attended = chunked_attention_reference(
+                q_valid, k_valid, v_valid, scale=self.scale
+            )
+        else:
+            raise ValueError(f"unknown H3 backend {self.backend}")
+        if used == q.shape[1]:
+            return attended
+        result = torch.zeros_like(q)
+        result[:, :used] = attended
+        return result

--- a/vllm/model_executor/models/minimax_h3/comfy_checkpoint.py
+++ b/vllm/model_executor/models/minimax_h3/comfy_checkpoint.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Inspection and resolution helpers for ComfyUI MiniMax-H3 checkpoints."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote, urlparse
+
+import regex as re
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+
+from .quantization import Int8ConvRotLayerConfig
+
+
+@dataclass(frozen=True)
+class MiniMaxH3ComfyCheckpoint:
+    path: Path
+    partition: Literal["fl2va", "ref2va"]
+    layer_configs: dict[str, Int8ConvRotLayerConfig]
+    adaln_curve_grid: int | None
+    adaln_curve_dim: int | None
+
+    @property
+    def arch_overrides(self) -> dict[str, int]:
+        if self.adaln_curve_grid is None or self.adaln_curve_dim is None:
+            return {}
+        return {
+            "adaln_curve_grid": self.adaln_curve_grid,
+            "adaln_curve_dim": self.adaln_curve_dim,
+        }
+
+
+def resolve_comfy_checkpoint_path(value: str, *, cache_dir: str | None = None) -> Path:
+    """Resolve a local file/directory or a Hugging Face resolve URL."""
+    local = Path(value).expanduser()
+    if local.is_file():
+        # Preserve a Hub snapshot symlink's user-facing filename.  Resolving it
+        # to ``blobs/<sha>`` drops the ``.safetensors`` suffix, which makes the
+        # generic diffusion loader misclassify the file as a PyTorch checkpoint.
+        return local.absolute()
+    if local.is_dir():
+        candidates = sorted(local.glob("*.safetensors"))
+        if len(candidates) != 1:
+            raise ValueError(
+                f"MiniMax-H3 transformer directory {local} must contain exactly one "
+                f".safetensors file, found {len(candidates)}."
+            )
+        return candidates[0].absolute()
+
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or parsed.netloc not in {
+        "huggingface.co",
+        "www.huggingface.co",
+    }:
+        raise FileNotFoundError(
+            f"MiniMax-H3 ConvRot checkpoint {value!r} is not a local path or supported "
+            f"Hugging Face URL."
+        )
+    parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
+    try:
+        marker_index = next(
+            i for i, part in enumerate(parts) if part in {"resolve", "blob"}
+        )
+    except StopIteration as exc:
+        raise ValueError(
+            f"Hugging Face checkpoint URL lacks /resolve/<revision>/ or "
+            f"/blob/<revision>/: {value}"
+        ) from exc
+    if marker_index != 2 or len(parts) <= marker_index + 2:
+        raise ValueError(f"Unsupported Hugging Face checkpoint URL: {value}")
+    repo_id = "/".join(parts[:marker_index])
+    revision = parts[marker_index + 1]
+    filename = "/".join(parts[marker_index + 2 :])
+    return Path(
+        hf_hub_download(
+            repo_id=repo_id, filename=filename, revision=revision, cache_dir=cache_dir
+        )
+    )
+
+
+def _decode_marker(marker: torch.Tensor, *, name: str) -> dict[str, object]:
+    if marker.dtype != torch.uint8 or marker.dim() != 1:
+        raise ValueError(
+            f"{name} must be a one-dimensional uint8 JSON tensor, got {marker.dtype} "
+            f"{tuple(marker.shape)}."
+        )
+    try:
+        decoded = json.loads(bytes(marker.tolist()).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{name} does not contain valid UTF-8 JSON.") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{name} must decode to a JSON object.")
+    return decoded
+
+
+def _checkpoint_partition(path: Path) -> Literal["fl2va", "ref2va"]:
+    """Read the partition contract carried by official Comfy filenames.
+
+    The published MiniMax-H3 safetensors files do not contain safetensors
+    ``__metadata__`` identifying their partition, and FL2VA/Ref2VA use the
+    same tensor names and shapes.  The official filenames therefore provide
+    the only inspectable contract.  Refuse ambiguous renamed files instead of
+    silently loading one partition's weights into the other model.
+    """
+    matches = set(
+        re.findall(r"(?:^|[._-])(fl2va|ref2va)(?=$|[._-])", path.name.lower())
+    )
+    if len(matches) != 1:
+        raise ValueError(
+            f"MiniMax-H3 ConvRot checkpoint filename {path.name!r} must identify "
+            f"exactly one "
+            "partition with an 'fl2va' or 'ref2va' token."
+        )
+    return "fl2va" if "fl2va" in matches else "ref2va"
+
+
+def inspect_comfy_checkpoint(
+    path: str | Path,
+    *,
+    expected_partition: Literal["fl2va", "ref2va"] | None = None,
+) -> MiniMaxH3ComfyCheckpoint:
+    """Validate markers and derive mixed-precision/curve architecture metadata.
+
+    Only tiny marker tensors and the optional AdaLN curve table are read.  INT8
+    weights remain memory-mapped for the ordinary streaming loader.
+    """
+    checkpoint_path = Path(path)
+    partition = _checkpoint_partition(checkpoint_path)
+    if expected_partition is not None and partition != expected_partition:
+        raise ValueError(
+            f"{partition.upper()} checkpoint {checkpoint_path.name!r} cannot serve "
+            f"the {expected_partition.upper()} partition."
+        )
+    layer_configs: dict[str, Int8ConvRotLayerConfig] = {}
+    with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
+        keys = set(checkpoint.keys())
+        marker_names = sorted(name for name in keys if name.endswith(".comfy_quant"))
+        if not marker_names:
+            raise ValueError(
+                f"{checkpoint_path} contains no Comfy .comfy_quant layer metadata."
+            )
+
+        for marker_name in marker_names:
+            prefix = marker_name.removesuffix(".comfy_quant")
+            weight_name = f"{prefix}.weight"
+            scale_name = f"{prefix}.weight_scale"
+            if weight_name not in keys or scale_name not in keys:
+                raise ValueError(
+                    f"{marker_name} requires companion tensors {weight_name!r} and "
+                    f"{scale_name!r}."
+                )
+            marker = _decode_marker(
+                checkpoint.get_tensor(marker_name), name=marker_name
+            )
+            layer_config = Int8ConvRotLayerConfig.from_mapping(marker)
+            weight_slice = checkpoint.get_slice(weight_name)
+            scale_slice = checkpoint.get_slice(scale_name)
+            weight_shape = tuple(weight_slice.get_shape())
+            scale_shape = tuple(scale_slice.get_shape())
+            if weight_slice.get_dtype() != "I8" or len(weight_shape) != 2:
+                raise ValueError(
+                    f"{weight_name} must be a two-dimensional I8 tensor, got "
+                    f"{weight_slice.get_dtype()} {weight_shape}."
+                )
+            if scale_slice.get_dtype() != "F32" or scale_shape not in {
+                (weight_shape[0],),
+                (weight_shape[0], 1),
+            }:
+                raise ValueError(
+                    f"{scale_name} must be F32 with one value per output row, got "
+                    f"{scale_slice.get_dtype()} {scale_shape} for weight "
+                    f"{weight_shape}."
+                )
+            if (
+                layer_config.convrot
+                and weight_shape[1] % layer_config.convrot_groupsize
+            ):
+                raise ValueError(
+                    f"{weight_name} input width {weight_shape[1]} is not divisible by "
+                    f"ConvRot group size {layer_config.convrot_groupsize}."
+                )
+            layer_configs[prefix] = layer_config
+
+        marked_weights = {f"{prefix}.weight" for prefix in layer_configs}
+        unmarked_int8_weights = []
+        for name in sorted(keys):
+            if not name.endswith(".weight") or name in marked_weights:
+                continue
+            tensor_slice = checkpoint.get_slice(name)
+            if tensor_slice.get_dtype() == "I8" and len(tensor_slice.get_shape()) == 2:
+                unmarked_int8_weights.append(name)
+        if unmarked_int8_weights:
+            raise ValueError(
+                "Every two-dimensional INT8 weight in a ConvRot checkpoint must have "
+                "matching "
+                f".comfy_quant metadata; missing markers for "
+                f"{unmarked_int8_weights[:5]}."
+            )
+
+        if "adaln_t_table" in keys:
+            table = checkpoint.get_tensor("adaln_t_table")
+            if table.dtype != torch.float32 or table.dim() != 2 or table.shape[0] < 2:
+                raise ValueError(
+                    "adaln_t_table must be a two-dimensional FP32 table with at least "
+                    "two rows, "
+                    f"got {table.dtype} {tuple(table.shape)}."
+                )
+            curve_grid, curve_dim = (int(table.shape[0]), int(table.shape[1]))
+        else:
+            curve_grid = curve_dim = None
+
+    return MiniMaxH3ComfyCheckpoint(
+        path=checkpoint_path,
+        partition=partition,
+        layer_configs=layer_configs,
+        adaln_curve_grid=curve_grid,
+        adaln_curve_dim=curve_dim,
+    )
+
+
+__all__ = [
+    "MiniMaxH3ComfyCheckpoint",
+    "inspect_comfy_checkpoint",
+    "resolve_comfy_checkpoint_path",
+]

--- a/vllm/model_executor/models/minimax_h3/condition_noise.py
+++ b/vllm/model_executor/models/minimax_h3/condition_noise.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniMax H3 visual/audio condition-noise augmentation.
+
+The request's condition timestep is applied to both the tensor value and the
+DiT timestep. Tokenizer artifacts remain clean
+and reusable; this module materializes the fixed noised anchors immediately
+before the denoise loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+from .packed_tokens import minimax_h3_patchify_video_latent
+
+# Channel-major packed audio rows always carry a stereo layout.
+MINIMAX_H3_AUDIO_COND_CHANNELS = 2
+
+
+def minimax_h3_imgvid_cond_noise_aug_rows(
+    clean_rows: torch.Tensor,
+    *,
+    condition_shapes: Sequence[Sequence[int]],
+    target_latent_t: int,
+    imgvid_cond_num_frames: int,
+    seed: int,
+    noise_aug: float,
+) -> torch.Tensor:
+    """Apply the imgvid-condition RF noise recipe to packed clean rows.
+
+    ``condition_shapes`` contains ``(latent_t, latent_h, latent_w)`` in packed
+    visual-condition order. A new CPU generator with the same row seed is
+    created for every condition. Under the dependent-noise policy, each draw
+    uses the target temporal length plus the template's imgvid-condition frame
+    count, then slices the prefix matching the current condition.
+    """
+
+    noise_aug = float(noise_aug)
+    if not 0.0 <= noise_aug <= 1.0:
+        raise ValueError(f"noise_aug must be in [0, 1], got {noise_aug}")
+    if noise_aug == 1.0:
+        return clean_rows
+    if clean_rows.ndim != 2 or int(clean_rows.shape[1]) != 96:
+        raise ValueError(
+            f"clean imgvid condition rows must have shape [n, 96], got "
+            f"{list(clean_rows.shape)}"
+        )
+
+    target_latent_t = int(target_latent_t)
+    imgvid_cond_num_frames = int(imgvid_cond_num_frames)
+    if target_latent_t <= 0:
+        raise ValueError(f"target_latent_t must be positive, got {target_latent_t}")
+    if imgvid_cond_num_frames <= 0:
+        raise ValueError(
+            f"imgvid_cond_num_frames must be positive when condition rows exist, got "
+            f"{imgvid_cond_num_frames}"
+        )
+
+    parsed_shapes: list[tuple[int, int, int]] = []
+    expected_rows = 0
+    for raw_shape in condition_shapes:
+        if len(raw_shape) != 3:
+            raise ValueError(
+                f"each imgvid condition shape must be (latent_t, latent_h, latent_w), "
+                f"got {list(raw_shape)}"
+            )
+        latent_t, latent_h, latent_w = (int(value) for value in raw_shape)
+        if latent_t <= 0 or latent_h <= 0 or latent_w <= 0:
+            raise ValueError(
+                f"imgvid condition shape must be positive, got {list(raw_shape)}"
+            )
+        if latent_h % 2 or latent_w % 2:
+            raise ValueError(
+                f"imgvid condition spatial dimensions must be divisible by 2, got "
+                f"{(latent_t, latent_h, latent_w)}"
+            )
+        parsed_shapes.append((latent_t, latent_h, latent_w))
+        expected_rows += latent_t * (latent_h // 2) * (latent_w // 2)
+    if not parsed_shapes:
+        raise ValueError("condition_shapes must not be empty")
+    if int(clean_rows.shape[0]) != expected_rows:
+        raise ValueError(
+            f"clean imgvid condition rows {int(clean_rows.shape[0])} != shape-derived "
+            f"rows {expected_rows}"
+        )
+
+    output_device = clean_rows.device
+    clean_rows = clean_rows.detach().to(device="cpu", dtype=torch.float32)
+    out: list[torch.Tensor] = []
+    row_offset = 0
+    timestep = torch.tensor(noise_aug, dtype=torch.float32, device="cpu")
+    for latent_t, latent_h, latent_w in parsed_shapes:
+        # Official Ref2VA allows a reference video to be longer than the
+        # generated clip.  The old implementation sized the draw only from
+        # the target clip and consequently rejected valid long references.
+        full_t = max(target_latent_t + imgvid_cond_num_frames, latent_t)
+        generator = torch.Generator(device="cpu").manual_seed(int(seed))
+        noise = torch.randn(
+            1,
+            24,
+            full_t,
+            latent_h,
+            latent_w,
+            generator=generator,
+            dtype=torch.float32,
+            device="cpu",
+        )[:, :, :latent_t]
+        noise_rows = minimax_h3_patchify_video_latent(noise, patch_size=[1, 2, 2]).to(
+            dtype=torch.float32
+        )
+        row_count = int(noise_rows.shape[0])
+        clean_part = clean_rows[row_offset : row_offset + row_count].to(torch.float32)
+        out.append(timestep * clean_part + (1.0 - timestep) * noise_rows)
+        row_offset += row_count
+    return (
+        torch.cat(out, dim=0).to(device=output_device, dtype=torch.float32).contiguous()
+    )
+
+
+def minimax_h3_audio_cond_noise_aug_rows(
+    clean_rows: torch.Tensor,
+    *,
+    condition_audio_t: Sequence[int],
+    seed: int,
+    noise_aug: float,
+) -> torch.Tensor:
+    """Apply the audio-condition RF noise recipe to packed clean rows.
+
+    ``condition_audio_t`` contains the latent T of each audio-bearing
+    condition in canonical request order. Noise is drawn per condition
+    element, with a fresh CPU generator seeded with ``seed + 1`` for every
+    element.  Consequently each condition restarts the
+    same RNG stream; concatenating the rows and drawing once would be
+    numerically different for ordered multi-reference requests.
+
+    The mix is intentionally evaluated on CPU in fp32 before the packed rows
+    are transferred to the DiT device.
+    """
+
+    noise_aug = float(noise_aug)
+    if not 0.0 <= noise_aug <= 1.0:
+        raise ValueError(f"noise_aug must be in [0, 1], got {noise_aug}")
+    if noise_aug == 1.0:
+        return clean_rows
+    if clean_rows.ndim != 2 or int(clean_rows.shape[1]) != 32:
+        raise ValueError(
+            f"clean audio condition rows must have shape [n, 32], got "
+            f"{list(clean_rows.shape)}"
+        )
+
+    audio_channels = MINIMAX_H3_AUDIO_COND_CHANNELS
+    parsed_audio_t = [int(value) for value in condition_audio_t]
+    if not parsed_audio_t:
+        raise ValueError("condition_audio_t must not be empty")
+    if any(value <= 0 for value in parsed_audio_t):
+        raise ValueError(
+            f"condition audio latent lengths must be positive, got {parsed_audio_t}"
+        )
+    expected_rows = audio_channels * sum(parsed_audio_t)
+    if int(clean_rows.shape[0]) != expected_rows:
+        raise ValueError(
+            f"clean audio condition rows {int(clean_rows.shape[0])} != shape-derived "
+            f"rows {expected_rows}"
+        )
+
+    out: list[torch.Tensor] = []
+    row_offset = 0
+    timestep = torch.tensor(noise_aug, dtype=torch.float32, device="cpu")
+    for audio_t in parsed_audio_t:
+        row_count = audio_channels * audio_t
+        clean_part = (
+            clean_rows[row_offset : row_offset + row_count]
+            .detach()
+            .to(device="cpu", dtype=torch.float32)
+        )
+        generator = torch.Generator(device="cpu").manual_seed(int(seed) + 1)
+        noise = torch.randn(
+            clean_part.shape,
+            generator=generator,
+            dtype=torch.float32,
+            device="cpu",
+        )
+        out.append(timestep * clean_part + (1.0 - timestep) * noise)
+        row_offset += row_count
+    return (
+        torch.cat(out, dim=0)
+        .to(device=clean_rows.device, dtype=torch.float32)
+        .contiguous()
+    )
+
+
+__all__ = [
+    "minimax_h3_audio_cond_noise_aug_rows",
+    "minimax_h3_imgvid_cond_noise_aug_rows",
+]

--- a/vllm/model_executor/models/minimax_h3/conditioning.py
+++ b/vllm/model_executor/models/minimax_h3/conditioning.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""MiniMax H3 text-conditioning contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+MINIMAX_H3_TEXT_CONDITIONING_SCHEMA = "minimax_h3.text_conditioning/v1"
+MINIMAX_H3_TEXT_HIDDEN_SIZE = 5120
+MINIMAX_H3_PRESENTATION_TASK_KEY = "_minimax_h3_presentation_task"
+MINIMAX_H3_CONDITION_LABELS_KEY = "_minimax_h3_condition_labels"
+
+
+def _validate_contiguous_strided_layout(name: str, tensor: torch.Tensor) -> None:
+    if tensor.layout != torch.strided:
+        raise ValueError(
+            f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: {name} must use contiguous "
+            f"strided layout, got {tensor.layout}"
+        )
+    if not tensor.is_contiguous():
+        raise ValueError(
+            f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: {name} must use contiguous "
+            f"strided layout, got stride={tuple(tensor.stride())}"
+        )
+
+
+@dataclass(frozen=True)
+class MiniMaxH3TextConditioning:
+    """``minimax_h3.text_conditioning/v1`` semantic payload."""
+
+    hidden_states: torch.Tensor
+    token_tags: torch.Tensor
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> MiniMaxH3TextConditioning:
+        """Validate the semantic payload consumed by the diffusion stage."""
+        hidden_states = payload.get("hidden_states")
+        token_tags = payload.get("token_tags")
+        if not isinstance(hidden_states, torch.Tensor) or not isinstance(
+            token_tags, torch.Tensor
+        ):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: conditioning requires "
+                f"hidden_states and token_tags tensors"
+            )
+        if (
+            hidden_states.ndim != 2
+            or hidden_states.shape[-1] != MINIMAX_H3_TEXT_HIDDEN_SIZE
+        ):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: hidden_states must have shape "
+                f"[tokens, {MINIMAX_H3_TEXT_HIDDEN_SIZE}], got "
+                f"{tuple(hidden_states.shape)}"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: hidden_states must have dtype "
+                f"torch.bfloat16, got {hidden_states.dtype}"
+            )
+        _validate_contiguous_strided_layout("hidden_states", hidden_states)
+        if token_tags.ndim != 1 or token_tags.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: token_tags must align with "
+                f"hidden_states, got "
+                f"token_tags={tuple(token_tags.shape)} and "
+                f"hidden_states={tuple(hidden_states.shape)}"
+            )
+        if token_tags.dtype != torch.int64:
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: token_tags must have dtype "
+                f"torch.int64, got {token_tags.dtype}"
+            )
+        _validate_contiguous_strided_layout("token_tags", token_tags)
+        if not torch.all((token_tags == 0) | (token_tags == 1)):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: text-encoder token_tags must "
+                f"contain only 0 and 1"
+            )
+        return cls(hidden_states=hidden_states, token_tags=token_tags)
+
+    @classmethod
+    def from_omni_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> MiniMaxH3TextConditioning:
+        """Validate and adapt the existing ``OmniPayload`` stage-wire view."""
+        hidden_states = payload.get("hidden_states")
+        if not isinstance(hidden_states, Mapping):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: text encoder returned no "
+                f"hidden_states payload"
+            )
+        hidden = hidden_states.get("output")
+        if not isinstance(hidden, torch.Tensor):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: text encoder returned no "
+                f"hidden_states.output tensor"
+            )
+
+        meta = payload.get("meta")
+        if not isinstance(meta, Mapping):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: text encoder returned no "
+                f"conditioning metadata"
+            )
+        token_role_ids = meta.get("token_role_ids")
+        if not isinstance(token_role_ids, torch.Tensor):
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: text encoder returned no "
+                f"token_role_ids tensor"
+            )
+        if token_role_ids.ndim != 2 or token_role_ids.shape[-1] != 1:
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: stage-wire token_role_ids "
+                f"must have shape "
+                f"[tokens, 1], got {tuple(token_role_ids.shape)}"
+            )
+        if token_role_ids.dtype != torch.int64:
+            raise ValueError(
+                f"{MINIMAX_H3_TEXT_CONDITIONING_SCHEMA}: stage-wire token_role_ids "
+                f"must have dtype "
+                f"torch.int64, got {token_role_ids.dtype}"
+            )
+        _validate_contiguous_strided_layout("stage-wire token_role_ids", token_role_ids)
+
+        return cls.from_payload(
+            {
+                "hidden_states": hidden,
+                "token_tags": token_role_ids.squeeze(-1),
+            }
+        )
+
+    def to_payload(self) -> dict[str, torch.Tensor]:
+        return {
+            "hidden_states": self.hidden_states,
+            "token_tags": self.token_tags,
+        }

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -12,6 +12,12 @@ BASE_MODEL = "MiniMaxAI/MiniMax-H3"
 BASE_REVISION = "42ed227ee7df40d41602854ae760620d6eb651fe"
 COMFY_MODEL = "Comfy-Org/MiniMax-H3"
 COMFY_REVISION = "a98869194787969724c7425d95d0ed73ce9202af"
+# The streaming VAE needs at least one full temporal chunk (22 frames).
+# Short clips are useful development workloads; acceptance stays at 243 frames.
+MIN_OUTPUT_FRAMES = 22
+MAX_OUTPUT_FRAMES = 362
+MIN_OUTPUT_SECONDS = MIN_OUTPUT_FRAMES / 24
+MAX_OUTPUT_SECONDS = 15
 DEFAULT_PROMPT = (
     "一个连续的写实镜头。白天自然光下的公园浅水池，一艘红色纸船从画面左侧"
     "缓慢漂向右侧，一只黄色橡皮鸭从纸船后方经过。微风在水面形成细小涟漪，"
@@ -78,8 +84,8 @@ class H3SamplingParams:
             raise H3InputError("H3 canvas aspect ratio must be in [1:4, 4:1]")
         if self.fps != 24:
             raise H3InputError("H3 generates at 24 FPS")
-        if not 96 <= self.num_frames <= 362:
-            raise H3InputError("H3 duration must be between 4 and 15 seconds")
+        if not MIN_OUTPUT_FRAMES <= self.num_frames <= MAX_OUTPUT_FRAMES:
+            raise H3InputError("H3 requires between 22 and 362 frames")
         if self.num_inference_steps < 2:
             raise H3InputError("H3 needs at least two sigma positions")
         if self.num_outputs_per_prompt != 1:
@@ -91,9 +97,9 @@ class H3SamplingParams:
             isinstance(duration, bool)
             or not isinstance(duration, (int, float))
             or not math.isfinite(duration)
-            or not 4 <= duration <= 15
+            or not MIN_OUTPUT_SECONDS <= duration <= MAX_OUTPUT_SECONDS
         ):
-            raise H3InputError("H3 duration must be between 4 and 15 seconds")
+            raise H3InputError("H3 duration must be between 22/24 and 15 seconds")
 
 
 @dataclass

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -74,6 +74,8 @@ class H3SamplingParams:
             raise H3InputError("video dimensions must be positive")
         if self.height % 32 or self.width % 32:
             raise H3InputError("H3 video dimensions must be multiples of 32")
+        if not 0.25 <= self.width / self.height <= 4:
+            raise H3InputError("H3 canvas aspect ratio must be in [1:4, 4:1]")
         if self.fps != 24:
             raise H3InputError("H3 generates at 24 FPS")
         if not 96 <= self.num_frames <= 362:
@@ -84,6 +86,14 @@ class H3SamplingParams:
             raise H3InputError("native H3 generates one video per request")
         if self.quality not in (None, "lossless"):
             raise H3InputError("native H3 does not enable approximate step caches")
+        duration = self.extra_args.get("duration_seconds")
+        if duration is not None and (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not math.isfinite(duration)
+            or not 4 <= duration <= 15
+        ):
+            raise H3InputError("H3 duration must be between 4 and 15 seconds")
 
 
 @dataclass

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -37,7 +37,7 @@ class H3Config:
     partition: Literal["fl2va", "ref2va"] = "fl2va"
     transformer_path: str | None = None
     tensor_parallel_size: int = 4
-    attention_backend: str = "FLASH_ATTN_V100"
+    attention_backend: str = "FLASHINFER_SM70"
     fp16_weight_cache_gib: float = 0.0
     fp16_cache_layers: tuple[str, ...] = ()
 

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request and deployment contracts for native MiniMax H3."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+BASE_MODEL = "MiniMaxAI/MiniMax-H3"
+BASE_REVISION = "42ed227ee7df40d41602854ae760620d6eb651fe"
+COMFY_MODEL = "Comfy-Org/MiniMax-H3"
+COMFY_REVISION = "a98869194787969724c7425d95d0ed73ce9202af"
+DEFAULT_PROMPT = (
+    "一个连续的写实镜头。白天自然光下的公园浅水池，一艘红色纸船从画面左侧"
+    "缓慢漂向右侧，一只黄色橡皮鸭从纸船后方经过。微风在水面形成细小涟漪，"
+    "背景绿树保持稳定。镜头缓慢向前推进，纸船与橡皮鸭的颜色、形状和数量"
+    "始终一致。音轨包含轻柔流水声和远处鸟鸣，无人声、无音乐、无字幕。"
+)
+
+
+class H3InputError(ValueError):
+    """Invalid media or generation parameters, safe to report to a client."""
+
+
+@dataclass(frozen=True)
+class H3Config:
+    model: str = BASE_MODEL
+    revision: str = BASE_REVISION
+    partition: Literal["fl2va", "ref2va"] = "fl2va"
+    transformer_path: str | None = None
+    tensor_parallel_size: int = 4
+    attention_backend: str = "FLASH_ATTN_V100"
+    fp16_weight_cache_gib: float = 0.0
+    fp16_cache_layers: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.partition not in ("fl2va", "ref2va"):
+            raise H3InputError("partition must be fl2va or ref2va")
+        if self.tensor_parallel_size not in (1, 2, 4):
+            raise H3InputError("native H3 supports TP1, TP2, or TP4")
+        if self.attention_backend not in (
+            "FLASH_ATTN_V100",
+            "FLASHINFER_SM70",
+            "TORCH_SDPA",
+        ):
+            raise H3InputError(f"unsupported H3 attention: {self.attention_backend}")
+        if (
+            not math.isfinite(self.fp16_weight_cache_gib)
+            or self.fp16_weight_cache_gib < 0
+        ):
+            raise H3InputError("FP16 weight-cache budget must be finite and >= 0")
+        if self.fp16_weight_cache_gib and not self.fp16_cache_layers:
+            raise H3InputError("select measured cache layers with --fp16-cache-layer")
+        if len(set(self.fp16_cache_layers)) != len(self.fp16_cache_layers):
+            raise H3InputError("FP16 cache layers must be unique")
+
+
+@dataclass
+class H3SamplingParams:
+    height: int = 768
+    width: int = 1344
+    fps: int = 24
+    num_frames: int = 243
+    num_inference_steps: int = 50
+    seed: int = 42
+    num_outputs_per_prompt: int = 1
+    quality: str | None = None
+    extra_args: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.height <= 0 or self.width <= 0:
+            raise H3InputError("video dimensions must be positive")
+        if self.height % 32 or self.width % 32:
+            raise H3InputError("H3 video dimensions must be multiples of 32")
+        if self.fps != 24:
+            raise H3InputError("H3 generates at 24 FPS")
+        if not 96 <= self.num_frames <= 362:
+            raise H3InputError("H3 duration must be between 4 and 15 seconds")
+        if self.num_inference_steps < 2:
+            raise H3InputError("H3 needs at least two sigma positions")
+        if self.num_outputs_per_prompt != 1:
+            raise H3InputError("native H3 generates one video per request")
+        if self.quality not in (None, "lossless"):
+            raise H3InputError("native H3 does not enable approximate step caches")
+
+
+@dataclass
+class H3Request:
+    prompt: str = DEFAULT_PROMPT
+    sampling: H3SamplingParams = field(default_factory=H3SamplingParams)
+    media: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.prompt.strip():
+            raise H3InputError("prompt must not be empty")

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -37,7 +37,7 @@ class H3Config:
     partition: Literal["fl2va", "ref2va"] = "fl2va"
     transformer_path: str | None = None
     tensor_parallel_size: int = 4
-    attention_backend: str = "FLASHINFER_SM70"
+    attention_backend: str = "FLASH_ATTN_V100"
     fp16_weight_cache_gib: float = 0.0
     fp16_cache_layers: tuple[str, ...] = ()
 

--- a/vllm/model_executor/models/minimax_h3/cuda_ops.py
+++ b/vllm/model_executor/models/minimax_h3/cuda_ops.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lazy build of native H3 SM70 extensions for source development."""
+
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache(maxsize=1)
+def w8a16_extension():
+    try:
+        from vllm import _h3_w8a16_C
+
+        return _h3_w8a16_C
+    except ImportError:
+        pass
+    from torch.utils.cpp_extension import load
+
+    root = Path(__file__).resolve().parents[4]
+    source = root / "csrc/sm70_turbomind/ops/h3_w8a16.cu"
+    if not source.is_file():
+        raise RuntimeError("H3 W8A16 extension requires the 1Cat source build")
+    return load(
+        name="onecat_h3_w8a16",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
+        extra_ldflags=["-lcublas"],
+        verbose=False,
+    )
+
+
+@lru_cache(maxsize=1)
+def flashinfer_extension():
+    try:
+        from vllm import _h3_flashinfer_C
+
+        return _h3_flashinfer_C
+    except ImportError:
+        pass
+    from torch.utils.cpp_extension import load
+
+    root = Path(__file__).resolve().parents[4]
+    return load(
+        name="onecat_h3_flashinfer_sm70",
+        sources=[str(root / "flashinfer-sm70/csrc/h3_noncausal_sm70.cu")],
+        extra_include_paths=[str(root / "flashinfer-sm70/include")],
+        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
+        verbose=False,
+    )

--- a/vllm/model_executor/models/minimax_h3/denoise_loop.py
+++ b/vllm/model_executor/models/minimax_h3/denoise_loop.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""MiniMax H3 cfg-distilled full denoise loop.
+
+Per step, the positive presentation is forwarded exactly once. Video and audio
+target rows chain through the Euler-eta0 update while visual and audio condition
+rows stay pinned to their noised step-0 anchors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any
+
+import torch
+
+from .attention import VideoTokenLayout, VideoTokenSpan
+from .scheduling_minimax_h3_euler_ancestral import (
+    minimax_h3_euler_eta0_step,
+    minimax_h3_rf_v_to_x0,
+)
+
+MINIMAX_H3_IMGVID_COND_TIMESTEP = 0.999
+# ref2va audio reference anchor timestep
+MINIMAX_H3_AUDIO_REF_COND_TIMESTEP = 1.0
+# Packed row widths: video rows are [1,2,2]-patchified 24-channel latents
+# (24 * 1 * 2 * 2 = 96); audio rows carry the 32-dim audio latent.
+MINIMAX_H3_VIDEO_ROW_WIDTH = 96
+MINIMAX_H3_AUDIO_ROW_WIDTH = 32
+
+
+class MiniMaxH3DenoiseBranch:
+    """Static per-branch state: packed layout + fixed forward kwargs.
+
+    `packed` is a minimax_h3_packed_sequence(...) result (or equivalent layout
+    dict); `text_embeddings` is the branch's [text_len, 5120] hidden states;
+    `token_tags` must already carry any fl2va vision-span overrides.
+    """
+
+    def __init__(
+        self,
+        *,
+        packed: dict[str, torch.Tensor],
+        text_embeddings: torch.Tensor,
+        token_tags: torch.Tensor,
+        device: torch.device,
+    ) -> None:
+        seq_len = int(packed["seq_len"])
+        self.seq_len = seq_len
+        self.img_pos = packed["img_pos"].view(-1).to(torch.long)
+        self.audio_pos = packed["audio_pos"].view(-1).to(torch.long)
+        self.update_mask = packed["update_mask"].view(-1).to(torch.bool)
+        # ref2va: audio_pos may include reference-audio anchor rows
+        # (audio_update_mask False); absent means all rows are targets.
+        if "audio_update_mask" in packed:
+            self.audio_update_mask = packed["audio_update_mask"].view(-1).to(torch.bool)
+        else:
+            self.audio_update_mask = torch.ones(
+                self.audio_pos.shape[0], dtype=torch.bool
+            )
+        text_len = int(packed["text_pos"].view(-1).shape[0])
+        if list(text_embeddings.shape)[0] != text_len:
+            raise ValueError(
+                f"text_embeddings rows {list(text_embeddings.shape)} != packed "
+                f"text_len {text_len}"
+            )
+        if int(token_tags.view(-1).shape[0]) != seq_len:
+            raise ValueError(
+                f"token_tags length {int(token_tags.view(-1).shape[0])} != seq_len "
+                f"{seq_len}"
+            )
+        cu = packed["cu_seqlens"].to(torch.int32)
+        self.device = device
+        # ``used_len`` is the real (non-padding) document length; step-mode
+        # batching concatenates layouts and needs both bounds as Python ints so
+        # it can rebuild ``cu_seqlens`` without a device sync per step.
+        self.used_len = int(cu[1])
+        self.text_len = text_len
+        self.img_pos_dev = self.img_pos.to(device)
+        self.audio_pos_dev = self.audio_pos.to(device)
+        self.update_mask_dev = self.update_mask.to(device)
+        self.audio_update_mask_dev = self.audio_update_mask.to(device)
+        self.x_base = torch.zeros(
+            1, seq_len, MINIMAX_H3_VIDEO_ROW_WIDTH, dtype=torch.float32, device=device
+        )
+        self.audio_x_base = torch.zeros(
+            1, seq_len, MINIMAX_H3_AUDIO_ROW_WIDTH, dtype=torch.float32, device=device
+        )
+        self.text_pos_dev = packed["text_pos"].view(-1).to(torch.long).to(device)
+        self.token_tags_dev = token_tags.view(-1).to(torch.long).to(device)
+        self.img_position_ids_dev = packed["img_position_ids"].to(device)
+        self.text_embeddings_dev = text_embeddings.to(device)
+        self.static_kwargs: dict[str, Any] = {
+            "img_position_ids": self.img_position_ids_dev[None],
+            "update_mask": self.update_mask_dev,
+            "token_tags": self.token_tags_dev,
+            "skip_mask_out_condition": False,
+            "prompt_embeds": self.text_embeddings_dev,
+            "img_pos_info": {"position_ids": self.img_pos_dev},
+            "audio_pos_info": {"position_ids": self.audio_pos_dev},
+            "text_pos_info": {"position_ids": self.text_pos_dev},
+            "img_pos_for_infer_output_info": {"position_ids": self.img_pos_dev},
+            "packed_seq_params": {
+                "cu_seqlens_q": cu.to(device),
+                "max_seqlen_q": self.used_len,
+                # One request: valid rows are a prefix, so attention may use a
+                # KV prefix length or a 1-D pad mask. See batched_packing for the
+                # co-batched layout, where neither can describe the valid rows.
+                "num_requests": 1,
+            },
+            "refiner_packed_seq_params": {
+                "cu_seqlens_q": torch.tensor(
+                    [0, text_len, text_len], dtype=torch.int32, device=device
+                ),
+                "max_seqlen_q": text_len,
+            },
+        }
+        # Where the video segment sits in the packed sequence. Resolved to plain
+        # ints here so the attention layers never sync on it per step.
+        raw_spans = packed.get("video_spans")
+        if raw_spans:
+            spans = tuple(
+                VideoTokenSpan(
+                    start=int(span["start"]),
+                    latent_grid=tuple(int(dim) for dim in span["latent_grid"]),
+                    role=str(span["role"]),
+                )
+                for span in raw_spans
+            )
+            target_start = next(
+                span.start for span in reversed(spans) if span.role == "target"
+            )
+            prefix_tags = token_tags[:target_start]
+            prefix_segments: list[int] = []
+            if prefix_tags.numel():
+                # Run-lengths preserve modality/reference boundaries without
+                # carrying CUDA tensors into every attention layer.
+                boundaries = (
+                    torch.nonzero(prefix_tags[1:] != prefix_tags[:-1])
+                    .flatten()
+                    .tolist()
+                )
+                starts = [0, *(index + 1 for index in boundaries)]
+                stops = [*(index + 1 for index in boundaries), target_start]
+                prefix_segments = [
+                    stop - start for start, stop in zip(starts, stops, strict=True)
+                ]
+            self.static_kwargs["video_token_layout"] = VideoTokenLayout(
+                used_len=int(cu[1]),
+                video_spans=spans,
+            )
+            # FastH3-specific prefix geometry belongs to MiniMax-H3's packed
+            # attention contract, not the shared VideoTokenLayout interface.
+            self.static_kwargs["packed_seq_params"]["vsa_prefix_segments"] = tuple(
+                prefix_segments
+            )
+        else:
+            grid = packed["latent_grid"].tolist()
+            self.static_kwargs["video_token_layout"] = VideoTokenLayout(
+                prefix_len=int(packed["video_row_start"]),
+                latent_grid=(int(grid[0]), int(grid[1]), int(grid[2])),
+            )
+
+    def prepare_rope_table(self, model: Any) -> None:
+        """Materialize the branch-local DiT RoPE table once per denoise run.
+
+        ``img_position_ids`` is immutable for this branch while latents and
+        timesteps change every scheduler step. Keeping the table in
+        ``static_kwargs`` makes every model call reuse the exact same BF16
+        tensor without extending its lifetime beyond this request branch.
+        """
+        prepare = getattr(model, "prepare_rope_table", None)
+        if not callable(prepare):
+            return
+        self.static_kwargs["rope_table"] = prepare(
+            self.static_kwargs["img_position_ids"],
+            seq_len=self.seq_len,
+        )
+
+    def forward_kwargs(
+        self,
+        *,
+        video_rows: torch.Tensor,
+        audio_rows: torch.Tensor,
+        t_video: float,
+        t_audio: float,
+        imgvid_cond_timestep: float,
+        audio_ref_cond_timestep: float,
+    ) -> dict[str, Any]:
+        x = self.x_base.clone()
+        x[0].index_copy_(0, self.img_pos_dev, video_rows)
+        audio_x = self.audio_x_base.clone()
+        audio_x[0].index_copy_(0, self.audio_pos_dev, audio_rows)
+        # Packed-sequence timestep semantics: non-media rows (text and
+        # padding) inherit the current video timestep. Later steps must reuse
+        # the previous step's updated rows; re-initializing from zeros is only
+        # valid at step 0.
+        timesteps = torch.full(
+            (self.seq_len,),
+            float(t_video),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        timesteps[self.img_pos_dev[self.update_mask_dev]] = t_video
+        timesteps[self.img_pos_dev[~self.update_mask_dev]] = imgvid_cond_timestep
+        timesteps[self.audio_pos_dev[self.audio_update_mask_dev]] = t_audio
+        timesteps[self.audio_pos_dev[~self.audio_update_mask_dev]] = (
+            audio_ref_cond_timestep
+        )
+        unique_timesteps, inverse_indices = torch.unique(
+            timesteps, sorted=True, return_inverse=True
+        )
+        return {
+            **self.static_kwargs,
+            "x": x,
+            "audio_x": audio_x,
+            "unique_timesteps": unique_timesteps,
+            "inverse_indices": inverse_indices,
+        }
+
+
+def minimax_h3_prepare_denoise_rows(
+    *,
+    positive: MiniMaxH3DenoiseBranch,
+    initial_video_rows: torch.Tensor,
+    initial_audio_rows: torch.Tensor,
+    keyframe_cond_rows: torch.Tensor | None,
+    audio_ref_rows: torch.Tensor | None,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    """Validate the initial rows against the layout and pin the condition rows.
+
+    Returns ``(video_rows, audio_rows, cond_anchor, audio_anchor)`` with the
+    anchors already written into their rows, which is the state both the
+    request-mode loop and step-mode ``prepare_encode()`` start from.
+    """
+    n_cond = int((~positive.update_mask).sum())
+    if keyframe_cond_rows is None:
+        if n_cond != 0:
+            raise ValueError(
+                f"layout has {n_cond} cond rows but keyframe_cond_rows is None"
+            )
+    else:
+        if int(keyframe_cond_rows.shape[0]) != n_cond:
+            raise ValueError(
+                f"keyframe_cond_rows {int(keyframe_cond_rows.shape[0])} != layout cond "
+                f"rows {n_cond}"
+            )
+    video_rows = initial_video_rows.to(device=device, dtype=torch.float32).clone()
+    audio_rows = initial_audio_rows.to(device=device, dtype=torch.float32).clone()
+    update = positive.update_mask_dev
+    audio_update = positive.audio_update_mask_dev
+    if int(video_rows.shape[0]) != int(positive.img_pos.shape[0]):
+        raise ValueError(
+            f"initial video rows {int(video_rows.shape[0])} != positive layout rows "
+            f"{int(positive.img_pos.shape[0])}"
+        )
+    if int(audio_rows.shape[0]) != int(positive.audio_pos.shape[0]):
+        raise ValueError(
+            f"initial audio rows {int(audio_rows.shape[0])} != positive layout rows "
+            f"{int(positive.audio_pos.shape[0])}"
+        )
+    n_audio_ref = int((~positive.audio_update_mask).sum())
+    if audio_ref_rows is None:
+        if n_audio_ref != 0:
+            raise ValueError(
+                f"layout has {n_audio_ref} audio ref rows but audio_ref_rows is None"
+            )
+        audio_anchor = None
+    else:
+        if int(audio_ref_rows.shape[0]) != n_audio_ref:
+            raise ValueError(
+                f"audio_ref_rows {int(audio_ref_rows.shape[0])} != layout audio ref "
+                f"rows {n_audio_ref}"
+            )
+        audio_anchor = audio_ref_rows.to(device=device, dtype=torch.float32)
+    cond_anchor = (
+        keyframe_cond_rows.to(device=device, dtype=torch.float32)
+        if keyframe_cond_rows is not None
+        else None
+    )
+    if cond_anchor is not None:
+        video_rows[~update] = cond_anchor
+    if audio_anchor is not None:
+        audio_rows[~audio_update] = audio_anchor
+    return video_rows, audio_rows, cond_anchor, audio_anchor
+
+
+def minimax_h3_denoise_loop(
+    *,
+    model: Any,
+    positive: MiniMaxH3DenoiseBranch,
+    initial_video_rows: torch.Tensor,
+    initial_audio_rows: torch.Tensor,
+    keyframe_cond_rows: torch.Tensor | None,
+    audio_ref_rows: torch.Tensor | None = None,
+    sigmas_video: list[float],
+    sigmas_audio: list[float],
+    device: torch.device,
+    imgvid_cond_noise_aug_for_inference: float = MINIMAX_H3_IMGVID_COND_TIMESTEP,
+    audio_cond_noise_aug_for_inference: float = MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    on_step: Callable[[int, torch.Tensor, torch.Tensor], None] | None = None,
+    step_profiler: Callable[[int], AbstractContextManager] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the full denoise loop; returns final (video_rows, audio_rows).
+
+    ``initial_video_rows`` covers all image rows of the positive layout. For a
+    conditional task, pass ``keyframe_cond_rows`` and/or ``audio_ref_rows`` to
+    pin those rows across every step. The model's raw positive velocity is the
+    update signal; MiniMax H3 only supports cfg-distilled checkpoints.
+    """
+    if len(sigmas_video) != len(sigmas_audio):
+        raise ValueError("video/audio sigma schedules must have equal length")
+    if len(sigmas_video) < 2:
+        raise ValueError("sigma schedules need at least 2 entries")
+    # Keep CUDA/CPU on the reference path: its accuracy CI compares the
+    # generated video against the official artifact. The table reuse is an
+    # Ascend-specific performance optimization and must not alter that path.
+    positive.prepare_rope_table(model)
+    video_rows, audio_rows, cond_anchor, audio_anchor = minimax_h3_prepare_denoise_rows(
+        positive=positive,
+        initial_video_rows=initial_video_rows,
+        initial_audio_rows=initial_audio_rows,
+        keyframe_cond_rows=keyframe_cond_rows,
+        audio_ref_rows=audio_ref_rows,
+        device=device,
+    )
+    update = positive.update_mask_dev
+    audio_update = positive.audio_update_mask_dev
+
+    num_steps = len(sigmas_video) - 1
+    for step in range(num_steps):
+        step_cm = step_profiler(step) if step_profiler is not None else nullcontext()
+        with step_cm:
+            s_v, s_v_next = sigmas_video[step], sigmas_video[step + 1]
+            s_a, s_a_next = sigmas_audio[step], sigmas_audio[step + 1]
+            # Publish where we are so step-gated attention features (the dense
+            # warmup of RAINFUSION_ATTN, the timestep gate of TRTLLM_ATTN) can
+            # see it. Gates use the scheduler-style descending timestep, which
+            # for a rectified-flow schedule is the video sigma.
+            t_v, t_a = 1.0 - s_v, 1.0 - s_a
+            imgvid_cond_t = max(t_v, float(imgvid_cond_noise_aug_for_inference))
+            audio_ref_cond_t = max(t_a, float(audio_cond_noise_aug_for_inference))
+
+            fk = positive.forward_kwargs(
+                video_rows=video_rows,
+                audio_rows=audio_rows,
+                t_video=t_v,
+                t_audio=t_a,
+                imgvid_cond_timestep=imgvid_cond_t,
+                audio_ref_cond_timestep=audio_ref_cond_t,
+            )
+            with torch.inference_mode():
+                v_video, v_audio = model(**fk)
+            mv_video_t = v_video.float()[update]
+            mv_audio_t = v_audio.float()[audio_update]
+
+            x0_video = minimax_h3_rf_v_to_x0(
+                video_rows[update],
+                mv_video_t,
+                torch.tensor(t_v, dtype=torch.float32, device=device),
+            )
+            new_target = minimax_h3_euler_eta0_step(
+                video_rows[update], x0_video, sigma_curr=s_v, sigma_next=s_v_next
+            )
+            video_rows = video_rows.clone()
+            video_rows[update] = new_target
+            if cond_anchor is not None:
+                video_rows[~update] = cond_anchor  # per-step imgvid cond reset
+
+            x0_audio = minimax_h3_rf_v_to_x0(
+                audio_rows[audio_update],
+                mv_audio_t,
+                torch.tensor(t_a, dtype=torch.float32, device=device),
+            )
+            new_audio = minimax_h3_euler_eta0_step(
+                audio_rows[audio_update], x0_audio, sigma_curr=s_a, sigma_next=s_a_next
+            )
+            audio_rows = audio_rows.clone()
+            audio_rows[audio_update] = new_audio
+            if audio_anchor is not None:
+                audio_rows[~audio_update] = audio_anchor  # per-step audio ref reset
+            if on_step is not None:
+                on_step(step, video_rows, audio_rows)
+
+    return video_rows, audio_rows
+
+
+__all__ = [
+    "MINIMAX_H3_AUDIO_REF_COND_TIMESTEP",
+    "MINIMAX_H3_AUDIO_ROW_WIDTH",
+    "MINIMAX_H3_IMGVID_COND_TIMESTEP",
+    "MINIMAX_H3_VIDEO_ROW_WIDTH",
+    "MiniMaxH3DenoiseBranch",
+    "minimax_h3_denoise_loop",
+    "minimax_h3_prepare_denoise_rows",
+]

--- a/vllm/model_executor/models/minimax_h3/encoder.py
+++ b/vllm/model_executor/models/minimax_h3/encoder.py
@@ -132,7 +132,7 @@ class MiniMaxH3Qwen3VLVocabParallelEmbedding(nn.Module):
         masked_input[input_mask] = 0
         output = F.embedding(masked_input, self.weight)
         output[input_mask, :] = 0.0
-        self.group.all_reduce(output)
+        output = self.group.all_reduce(output)
         return output
 
     def weight_loader(
@@ -387,7 +387,7 @@ class MiniMaxH3Qwen3VLRowParallelLinear(LinearBase):
             # A bf16 all-reduce of the per-rank partial GEMMs would round twice
             # and amplify error on this model's large-magnitude activations.
             output_parallel = output_parallel.float()
-            self.group.all_reduce(output_parallel)
+            output_parallel = self.group.all_reduce(output_parallel)
             output_parallel = output_parallel.to(self.output_dtype)
         return output_parallel
 

--- a/vllm/model_executor/models/minimax_h3/encoder.py
+++ b/vllm/model_executor/models/minimax_h3/encoder.py
@@ -1,0 +1,1678 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""MiniMax H3 Qwen3-VL layer-50 text/vision encoder.
+
+The encoder is reimplemented on top of vLLM-style tensor-parallel building
+blocks (column/row/vocab-parallel linears bound to the MiniMax H3 encoder
+process group) instead of the single-GPU ``transformers`` backbone.  This
+makes the large Qwen3-VL text model TP-shardable across ``text_encoder_tp_size``
+ranks, which removes the rank-0 memory hotspot that dominates no-offload peak
+memory (the retained 50-layer encoder is ~51.5 GB in BF16).
+
+The computation contract is unchanged from the HF reference path:
+
+- plain BF16 weights, only the first ``MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER``
+  decoder layers are kept (the checkpoint consumes the unnormalized hidden
+  state after decoder layer 49);
+- cuDNN SDP is enabled during encode;
+- the multimodal backbone runs with an all-ones attention mask and
+  ``mm_token_type_ids`` derived from the image/video token ids;
+- DeepStack visual features are injected at the first
+  ``len(deepstack_visual_indexes)`` decoder layers;
+- the output is ``hidden_states[50]`` of shape ``[seq, 5120]``.
+
+Tensor parallelism follows vLLM's TP semantics: vocab-parallel embeddings and
+row-parallel projections all-reduce so the hidden state stays fully replicated
+on every encoder rank, while column-parallel projections (QKV / MLP up) keep a
+local shard.  After the final layer every encoder rank therefore holds the
+complete ``[seq, 5120]`` hidden state.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterable
+from typing import Any
+
+import regex as re
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+from .ops import RMSNorm as DiffusionRMSNorm
+from .residency import (
+    BoundedAllocatorCache,
+    PinnedModuleStager,
+)
+
+MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER = 50
+MINIMAX_H3_QWEN3VL_HIDDEN_DIM = 5120
+
+logger = init_logger(__name__)
+
+
+def _validate_encoder_quant_config(quant_config: QuantizationConfig | None) -> None:
+    if (
+        quant_config is not None
+        and quant_config.get_name() == "fp8"
+        and bool(getattr(quant_config, "is_checkpoint_fp8_serialized", False))
+    ):
+        raise ValueError(
+            "MiniMax-H3 text encoder supports online FP8 only, not serialized FP8 "
+            "checkpoints"
+        )
+
+
+def _is_quantized_linear(module: LinearBase) -> bool:
+    return not isinstance(module.quant_method, UnquantizedLinearMethod)
+
+
+def _default_weight_loader(
+    param: nn.Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_shard_id: str | None = None,
+) -> None:
+    del loaded_shard_id
+    param.data.copy_(loaded_weight)
+
+
+def _tp_range(group: Any) -> tuple[int, int]:
+    return group.rank_in_group, group.world_size
+
+
+# ---------------------------------------------------------------------------
+# Tensor-parallel primitives bound to the encoder process group.
+#
+# These mirror the math of vLLM's ``VocabParallelEmbedding``,
+# ``ColumnParallelLinear``, ``MergedColumnParallelLinear``, ``QKVParallelLinear``
+# and ``RowParallelLinear`` but route their collectives through the encoder
+# group instead of the (DiT) tensor-model-parallel group, so the text encoder
+# can be sharded independently of the DiT's TP configuration.
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxH3Qwen3VLVocabParallelEmbedding(nn.Module):
+    def __init__(
+        self, group: Any, num_embeddings: int, embedding_dim: int, dtype: torch.dtype
+    ) -> None:
+        super().__init__()
+        self.group = group
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        tp_rank, tp_size = _tp_range(group)
+        assert num_embeddings % tp_size == 0, (
+            f"vocab_size {num_embeddings} must be divisible by text_encoder_tp_size "
+            f"{tp_size}"
+        )
+        self.num_embeddings_per_partition = num_embeddings // tp_size
+        self.weight = nn.Parameter(
+            torch.empty(self.num_embeddings_per_partition, embedding_dim, dtype=dtype)
+        )
+        self.weight.weight_loader = self.weight_loader  # type: ignore[attr-defined]
+        self._tp_rank = tp_rank
+        self._tp_size = tp_size
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        if self._tp_size == 1:
+            return F.embedding(input_, self.weight)
+        # Mirror vLLM's `VocabParallelEmbedding`: token ids that fall outside
+        # this rank's vocab partition are masked to 0 and in-partition ids are
+        # shifted to local indices before the local gather.  The out-of-range
+        # rows are zeroed so the subsequent all-reduce reconstructs the full
+        # embedding for every token.
+        start_idx = self._tp_rank * self.num_embeddings_per_partition
+        end_idx = start_idx + self.num_embeddings_per_partition
+        input_mask = (input_ < start_idx) | (input_ >= end_idx)
+        masked_input = input_.clone() - start_idx
+        masked_input[input_mask] = 0
+        output = F.embedding(masked_input, self.weight)
+        output[input_mask, :] = 0.0
+        self.group.all_reduce(output)
+        return output
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        del loaded_shard_id
+        shard_size = self.num_embeddings_per_partition
+        start_idx = self._tp_rank * shard_size
+        param.data.copy_(loaded_weight.narrow(0, start_idx, shard_size))
+
+
+class MiniMaxH3Qwen3VLMergedColumnParallelLinear(LinearBase):
+    """Packed gate/up projection sharded along the output dimension."""
+
+    def __init__(
+        self,
+        group: Any,
+        input_size: int,
+        intermediate_size: int,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        self.group = group
+        self.intermediate_size = intermediate_size
+        tp_rank, tp_size = _tp_range(group)
+        assert intermediate_size % tp_size == 0, (
+            f"intermediate_size {intermediate_size} must be divisible by "
+            f"text_encoder_tp_size {tp_size}"
+        )
+        self.intermediate_size_per_partition = intermediate_size // tp_size
+        self.output_dtype = dtype
+        super().__init__(
+            input_size=input_size,
+            output_size=2 * intermediate_size,
+            bias=False,
+            params_dtype=dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            disable_tp=True,
+        )
+        self.quant_method.create_weights(
+            self,
+            input_size_per_partition=input_size,
+            output_partition_sizes=[
+                self.intermediate_size_per_partition,
+                self.intermediate_size_per_partition,
+            ],
+            input_size=input_size,
+            output_size=2 * intermediate_size,
+            params_dtype=dtype,
+            weight_loader=self.weight_loader,
+        )
+        self._tp_rank = tp_rank
+        self._tp_size = tp_size
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        return self.quant_method.apply(self, input_)
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        shard_size = self.intermediate_size_per_partition
+        start_idx = self._tp_rank * shard_size
+        if loaded_shard_id == 1:  # up_proj
+            param.data[shard_size : 2 * shard_size].copy_(
+                loaded_weight.narrow(0, start_idx, shard_size)
+            )
+        else:  # gate_proj
+            param.data[0:shard_size].copy_(
+                loaded_weight.narrow(0, start_idx, shard_size)
+            )
+
+
+class MiniMaxH3Qwen3VLQKVParallelLinear(LinearBase):
+    """QKV projection with GQA head sharding along the output dimension."""
+
+    def __init__(
+        self,
+        group: Any,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        self.group = group
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        tp_rank, tp_size = _tp_range(group)
+        assert num_heads % tp_size == 0, (
+            f"num_attention_heads {num_heads} must be divisible by "
+            f"text_encoder_tp_size {tp_size}"
+        )
+        assert num_kv_heads % tp_size == 0, (
+            f"num_key_value_heads {num_kv_heads} must be divisible by "
+            f"text_encoder_tp_size {tp_size}"
+        )
+        self.local_num_heads = num_heads // tp_size
+        self.local_num_kv_heads = num_kv_heads // tp_size
+        self.output_dtype = dtype
+        q_local = self.local_num_heads * head_dim
+        kv_local = self.local_num_kv_heads * head_dim
+        output_size = (num_heads + 2 * num_kv_heads) * head_dim
+        super().__init__(
+            input_size=hidden_size,
+            output_size=output_size,
+            bias=False,
+            params_dtype=dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            disable_tp=True,
+        )
+        self.quant_method.create_weights(
+            self,
+            input_size_per_partition=hidden_size,
+            output_partition_sizes=[q_local, kv_local, kv_local],
+            input_size=hidden_size,
+            output_size=output_size,
+            params_dtype=dtype,
+            weight_loader=self.weight_loader,
+        )
+        self._tp_rank = tp_rank
+        self._tp_size = tp_size
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        return self.quant_method.apply(self, input_)
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        head_dim = self.head_dim
+        q_local = self.local_num_heads * head_dim
+        kv_local = self.local_num_kv_heads * head_dim
+        if loaded_shard_id == "q":
+            start_idx = self._tp_rank * q_local
+            param.data[0:q_local].copy_(loaded_weight.narrow(0, start_idx, q_local))
+        elif loaded_shard_id == "k":
+            start_idx = self._tp_rank * kv_local
+            param.data[q_local : q_local + kv_local].copy_(
+                loaded_weight.narrow(0, start_idx, kv_local)
+            )
+        elif loaded_shard_id == "v":
+            start_idx = self._tp_rank * kv_local
+            param.data[q_local + kv_local : q_local + 2 * kv_local].copy_(
+                loaded_weight.narrow(0, start_idx, kv_local)
+            )
+        else:
+            raise ValueError(f"unexpected QKV shard id {loaded_shard_id!r}")
+
+
+# A fused weight is filled from several checkpoint tensors, so a partial load leaves
+# uninitialized `torch.empty` rows that no later check would catch. Keyed by the class
+# owning the multi-shard `weight_loader`; each entry is the source name reported to the
+# user paired with the shard id that loader expects, in projection order.
+_FUSED_SOURCE_SHARDS: dict[type[nn.Module], tuple[tuple[str, str | int], ...]] = {
+    MiniMaxH3Qwen3VLQKVParallelLinear: (("q", "q"), ("k", "k"), ("v", "v")),
+    MiniMaxH3Qwen3VLMergedColumnParallelLinear: (("gate", 0), ("up", 1)),
+}
+
+
+def _fused_source_shards(module: nn.Module) -> tuple[tuple[str, str | int], ...] | None:
+    for cls, sources in _FUSED_SOURCE_SHARDS.items():
+        if isinstance(module, cls):
+            return sources
+    return None
+
+
+def _verify_fused_shards_complete(
+    expected: dict[str, tuple[tuple[str, str | int], ...]],
+    loaded: dict[str, set[str | int]],
+) -> None:
+    missing = {
+        name: [source for source, shard_id in sources if shard_id not in loaded[name]]
+        for name, sources in expected.items()
+    }
+    missing = {name: sources for name, sources in missing.items() if sources}
+    if not missing:
+        return
+    details = "; ".join(
+        f"{name}: {sources}" for name, sources in sorted(missing.items())
+    )
+    raise RuntimeError(
+        f"MiniMax H3 text encoder fused weights are missing source shards: {details}"
+    )
+
+
+class MiniMaxH3Qwen3VLRowParallelLinear(LinearBase):
+    def __init__(
+        self,
+        group: Any,
+        input_size: int,
+        output_size: int,
+        dtype: torch.dtype,
+        input_is_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        self.group = group
+        self.input_is_parallel = input_is_parallel
+        self.output_dtype = dtype
+        tp_rank, tp_size = _tp_range(group)
+        assert input_size % tp_size == 0, (
+            f"input_size {input_size} must be divisible by text_encoder_tp_size "
+            f"{tp_size}"
+        )
+        self.input_size_per_partition = input_size // tp_size
+        super().__init__(
+            input_size=input_size,
+            output_size=output_size,
+            bias=False,
+            params_dtype=dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            disable_tp=True,
+        )
+        self.quant_method.create_weights(
+            self,
+            input_size_per_partition=self.input_size_per_partition,
+            output_partition_sizes=[output_size],
+            input_size=input_size,
+            output_size=output_size,
+            params_dtype=dtype,
+            weight_loader=self.weight_loader,
+        )
+        self._tp_rank = tp_rank
+        self._tp_size = tp_size
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            split_input = input_.split(self.input_size_per_partition, dim=-1)
+            input_parallel = split_input[self._tp_rank].contiguous()
+        output_parallel = self.quant_method.apply(self, input_parallel)
+        if self._tp_size > 1:
+            # Reduce in fp32: the reference path accumulates the full (K=8192)
+            # dot product inside a single cuBLAS GEMM before rounding to bf16.
+            # A bf16 all-reduce of the per-rank partial GEMMs would round twice
+            # and amplify error on this model's large-magnitude activations.
+            output_parallel = output_parallel.float()
+            self.group.all_reduce(output_parallel)
+            output_parallel = output_parallel.to(self.output_dtype)
+        return output_parallel
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        del loaded_shard_id
+        shard_size = self.input_size_per_partition
+        start_idx = self._tp_rank * shard_size
+        param.data.copy_(loaded_weight.narrow(1, start_idx, shard_size))
+
+
+# ---------------------------------------------------------------------------
+# Shared math ports (identical to the HF reference path).
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxH3Qwen3VLRMSNorm(DiffusionRMSNorm):
+    """Qwen3-VL RMSNorm using the common implementation.
+
+    The model-specific name keeps checkpoint weight keys stable, while the
+    common RMSNorm dispatches to torch_npu.npu_rms_norm on Ascend. Gamma uses
+    the checkpoint/model dtype, but native fallbacks keep the RMS variance
+    reduction and scaling in float32.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        super().__init__(hidden_size, eps=eps, dtype=dtype)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def _scaled_dot_product_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+) -> torch.Tensor:
+    """Run causal SDPA with the reference expanded-K/V GQA behavior."""
+    num_key_value_groups = query.shape[1] // key.shape[1]
+    if num_key_value_groups != 1:
+        key = key.repeat_interleave(num_key_value_groups, dim=1)
+        value = value.repeat_interleave(num_key_value_groups, dim=1)
+    if query.is_cuda and torch.cuda.get_device_capability(query.device) == (7, 0):
+        from flash_attn_v100 import flash_attn_func
+
+        q, k, v = (x.transpose(1, 2).contiguous() for x in (query, key, value))
+        return flash_attn_func(q, k, v, causal=True).transpose(1, 2)
+    return F.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        dropout_p=0.0,
+        is_causal=True,
+    )
+
+
+def _apply_interleaved_mrope(
+    freqs: torch.Tensor, mrope_section: list[int]
+) -> torch.Tensor:
+    """Reorganize chunked [TTT...HHH...WWW] into interleaved [THWTHW...] layout."""
+    freqs_t = freqs[0]
+    for dim, offset in enumerate((1, 2), start=1):
+        length = mrope_section[dim] * 3
+        idx = slice(offset, length, 3)
+        freqs_t[..., idx] = freqs[dim, ..., idx]
+    return freqs_t
+
+
+class MiniMaxH3Qwen3VLTextRotaryEmbedding(nn.Module):
+    """Qwen3-VL text M-RoPE (interleaved sections). Same math as the reference."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.config = config
+        # ``dim`` and ``base`` are plain attributes so the inverse frequencies
+        # are always recomputed in float32 (module-wide dtype casts must not
+        # degrade the RoPE cache precision).
+        self.dim = int(
+            getattr(config, "head_dim", None)
+            or config.hidden_size // config.num_attention_heads
+        )
+        self.base = float(config.rope_parameters["rope_theta"])
+        self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+
+    def _get_inv_freq(self, device: torch.device) -> torch.Tensor:
+        inv_freq = 1.0 / (
+            self.base
+            ** (torch.arange(0, self.dim, 2, dtype=torch.int64).float() / self.dim)
+        )
+        return inv_freq.to(device)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # position_ids: (3, 1, seq)
+        inv_freq = self._get_inv_freq(position_ids.device)
+        inv_freq_expanded = (
+            inv_freq[None, None, :, None]
+            .float()
+            .expand(3, position_ids.shape[1], -1, 1)
+        )
+        position_ids_expanded = position_ids[:, :, None, :].float()
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(
+            2, 3
+        )
+        freqs = _apply_interleaved_mrope(freqs, self.mrope_section)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Qwen3-VL vision tower (replicated on every encoder rank; ~1.2 GB BF16).
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxH3Qwen3VLVisionPatchEmbed(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+        self.embed_dim = config.hidden_size
+        kernel_size = [self.temporal_patch_size, self.patch_size, self.patch_size]
+        self.proj = nn.Conv3d(
+            self.in_channels,
+            self.embed_dim,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        target_dtype = self.proj.weight.dtype
+        hidden_states = hidden_states.view(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(
+            -1, self.embed_dim
+        )
+        return hidden_states
+
+
+class MiniMaxH3Qwen3VLVisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        # Plain attribute (not a registered buffer): the reference keeps this
+        # table in float32 and module-wide dtype casts must not touch it.
+        self._inv_freq = 1.0 / (
+            theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim)
+        )
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        inv_freq = self._inv_freq.to(device=self._inv_freq.device)
+        seq = torch.arange(seqlen, device=inv_freq.device, dtype=torch.float)
+        freqs = torch.outer(seq, inv_freq)
+        return freqs
+
+
+class MiniMaxH3Qwen3VLVisionPatchMerger(nn.Module):
+    def __init__(self, config: Any, use_postshuffle_norm: bool = False) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = use_postshuffle_norm
+        self.norm = nn.LayerNorm(
+            self.hidden_size if use_postshuffle_norm else config.hidden_size, eps=1e-6
+        )
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size)
+        self.act_fn = nn.GELU()
+        self.linear_fc2 = nn.Linear(self.hidden_size, config.out_hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm(
+            x.view(-1, self.hidden_size) if self.use_postshuffle_norm else x
+        ).view(-1, self.hidden_size)
+        x = self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+        return x
+
+
+class MiniMaxH3Qwen3VLVisionMLP(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(self.intermediate_size, self.hidden_size, bias=True)
+        # The reference vision MLP uses the tanh GELU approximation
+        # (``gelu_pytorch_tanh``), which differs from the exact erf GELU.
+        self.act_fn = nn.GELU(approximate="tanh")
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act_fn(self.linear_fc1(hidden_state)))
+
+
+def _apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    orig_q_dtype = q.dtype
+    orig_k_dtype = k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    q_embed = q_embed.to(orig_q_dtype)
+    k_embed = k_embed.to(orig_k_dtype)
+    return q_embed, k_embed
+
+
+class MiniMaxH3Qwen3VLVisionAttention(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.dim = config.hidden_size
+        self.num_heads = config.num_heads
+        self.head_dim = self.dim // self.num_heads
+        self.num_key_value_groups = 1
+        self.qkv = nn.Linear(self.dim, self.dim * 3, bias=True)
+        self.proj = nn.Linear(self.dim, self.dim)
+        self.scaling = self.head_dim**-0.5
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        query_states, key_states, value_states = (
+            self.qkv(hidden_states)
+            .reshape(seq_length, 3, self.num_heads, -1)
+            .permute(1, 0, 2, 3)
+            .unbind(0)
+        )
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb_vision(
+            query_states, key_states, cos, sin
+        )
+
+        query_states = query_states.transpose(0, 1).unsqueeze(0)
+        key_states = key_states.transpose(0, 1).unsqueeze(0)
+        value_states = value_states.transpose(0, 1).unsqueeze(0)
+
+        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        splits = [
+            torch.split(tensor, lengths.tolist(), dim=2)
+            for tensor in (query_states, key_states, value_states)
+        ]
+        attn_outputs = [
+            F.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=False)
+            for q, k, v in zip(*splits)
+        ]
+        attn_output = torch.cat(attn_outputs, dim=2)
+        # The SDPA kernel may return a non-contiguous (1, num_heads, seq_len, head_dim)
+        # tensor whose memory layout is seq-major; transpose before flattening exactly
+        # like the reference `sdpa_attention_forward` to avoid scrambling heads.
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(seq_length, -1).contiguous()
+        attn_output = self.proj(attn_output)
+        return attn_output
+
+
+class MiniMaxH3Qwen3VLVisionBlock(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6)
+        self.attn = MiniMaxH3Qwen3VLVisionAttention(config=config)
+        self.mlp = MiniMaxH3Qwen3VLVisionMLP(config=config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+        return hidden_states
+
+
+class MiniMaxH3Qwen3VLVisionModel(nn.Module):
+    """Qwen3-VL vision tower (patch embed + blocks + merger + DeepStack)."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.config = config
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+
+        self.patch_embed = MiniMaxH3Qwen3VLVisionPatchEmbed(config=config)
+        self.pos_embed = nn.Embedding(
+            config.num_position_embeddings, config.hidden_size
+        )
+        self.num_grid_per_side = int(config.num_position_embeddings**0.5)
+
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = MiniMaxH3Qwen3VLVisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList(
+            [MiniMaxH3Qwen3VLVisionBlock(config=config) for _ in range(config.depth)]
+        )
+        self.merger = MiniMaxH3Qwen3VLVisionPatchMerger(
+            config=config, use_postshuffle_norm=False
+        )
+        self.deepstack_visual_indexes = config.deepstack_visual_indexes
+        self.deepstack_merger_list = nn.ModuleList(
+            [
+                MiniMaxH3Qwen3VLVisionPatchMerger(
+                    config=config, use_postshuffle_norm=True
+                )
+                for _ in range(len(config.deepstack_visual_indexes))
+            ]
+        )
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        merge_size = self.spatial_merge_size
+        grid_thw_list = grid_thw.tolist()
+        max_hw = max(max(h, w) for _, h, w in grid_thw_list)
+        freq_table = self.rotary_pos_emb(max_hw).to(device=grid_thw.device)
+        device = freq_table.device
+        total_tokens = sum(t * h * w for t, h, w in grid_thw_list)
+        pos_ids = torch.empty((total_tokens, 2), dtype=torch.long, device=device)
+        offset = 0
+        for num_frames, height, width in grid_thw_list:
+            merged_h, merged_w = height // merge_size, width // merge_size
+            block_rows = torch.arange(merged_h, device=device)
+            block_cols = torch.arange(merged_w, device=device)
+            intra_row = torch.arange(merge_size, device=device)
+            intra_col = torch.arange(merge_size, device=device)
+            row_idx = (
+                block_rows[:, None, None, None] * merge_size
+                + intra_row[None, None, :, None]
+            )
+            col_idx = (
+                block_cols[None, :, None, None] * merge_size
+                + intra_col[None, None, None, :]
+            )
+            row_idx = row_idx.expand(
+                merged_h, merged_w, merge_size, merge_size
+            ).reshape(-1)
+            col_idx = col_idx.expand(
+                merged_h, merged_w, merge_size, merge_size
+            ).reshape(-1)
+            coords = torch.stack((row_idx, col_idx), dim=-1)
+            if num_frames > 1:
+                coords = coords.repeat(num_frames, 1)
+            num_tokens = coords.shape[0]
+            pos_ids[offset : offset + num_tokens] = coords
+            offset += num_tokens
+        embeddings = freq_table[pos_ids]
+        embeddings = embeddings.flatten(1)
+        return embeddings
+
+    def fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        grid_thw_list = grid_thw.tolist()
+        grid_ts = [row[0] for row in grid_thw_list]
+        grid_hs = [row[1] for row in grid_thw_list]
+        grid_ws = [row[2] for row in grid_thw_list]
+        device = self.pos_embed.weight.device
+        idx_list = [[] for _ in range(4)]
+        weight_list = [[] for _ in range(4)]
+        for _, h, w in grid_thw_list:
+            h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h)
+            w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w)
+            h_idxs_floor = h_idxs.int()
+            w_idxs_floor = w_idxs.int()
+            h_idxs_ceil = (h_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+            w_idxs_ceil = (w_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+            dh = h_idxs - h_idxs_floor
+            dw = w_idxs - w_idxs_floor
+            base_h = h_idxs_floor * self.num_grid_per_side
+            base_h_ceil = h_idxs_ceil * self.num_grid_per_side
+            indices = [
+                (base_h[None].T + w_idxs_floor[None]).flatten(),
+                (base_h[None].T + w_idxs_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(
+            weight_list, dtype=self.pos_embed.weight.dtype, device=device
+        )
+        pos_embeds = self.pos_embed(idx_tensor).to(device) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+        patch_pos_embeds = patch_pos_embeds.split(
+            [h * w for h, w in zip(grid_hs, grid_ws)]
+        )
+        patch_pos_embeds_permute = []
+        merge_size = self.spatial_merge_size
+        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+            pos_embed = pos_embed.repeat(t, 1)
+            pos_embed = (
+                pos_embed.view(
+                    t, h // merge_size, merge_size, w // merge_size, merge_size, -1
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            patch_pos_embeds_permute.append(pos_embed)
+        return torch.cat(patch_pos_embeds_permute)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        hidden_states = self.patch_embed(hidden_states)
+        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + pos_embeds
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        seq_len, _ = hidden_states.size()
+        hidden_states = hidden_states.reshape(seq_len, -1)
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+        cu_seqlens = torch.repeat_interleave(
+            grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
+        ).cumsum(dim=0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        deepstack_feature_lists = []
+        for layer_num, blk in enumerate(self.blocks):
+            hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+            )
+            if layer_num in self.deepstack_visual_indexes:
+                deepstack_feature = self.deepstack_merger_list[
+                    self.deepstack_visual_indexes.index(layer_num)
+                ](hidden_states)
+                deepstack_feature_lists.append(deepstack_feature)
+        merged_hidden_states = self.merger(hidden_states)
+        return merged_hidden_states, deepstack_feature_lists
+
+
+# ---------------------------------------------------------------------------
+# Qwen3-VL text decoder layers (TP-sharded).
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxH3Qwen3VLTextAttention(nn.Module):
+    def __init__(
+        self,
+        group: Any,
+        config: Any,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.group = group
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.scaling = self.head_dim**-0.5
+        self.is_causal = True
+
+        self.qkv_proj = MiniMaxH3Qwen3VLQKVParallelLinear(
+            group,
+            hidden_size=self.hidden_size,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_dim,
+            dtype=dtype,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = MiniMaxH3Qwen3VLRowParallelLinear(
+            group,
+            input_size=self.num_heads * self.head_dim,
+            output_size=self.hidden_size,
+            dtype=dtype,
+            input_is_parallel=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.q_norm = MiniMaxH3Qwen3VLRMSNorm(
+            self.head_dim, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.k_norm = MiniMaxH3Qwen3VLRMSNorm(
+            self.head_dim, eps=config.rms_norm_eps, dtype=dtype
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+        q_local = self.qkv_proj.local_num_heads * self.head_dim
+        kv_local = self.qkv_proj.local_num_kv_heads * self.head_dim
+        if _is_quantized_linear(self.qkv_proj):
+            query, key, value = self.qkv_proj(hidden_states).split(
+                (q_local, kv_local, kv_local),
+                dim=-1,
+            )
+        else:
+            q_weight = self.qkv_proj.weight[0:q_local]
+            k_weight = self.qkv_proj.weight[q_local : q_local + kv_local]
+            v_weight = self.qkv_proj.weight[q_local + kv_local : q_local + 2 * kv_local]
+            # Three separate GEMMs keep the numerics identical to the reference
+            # path (packed QKV changes cuBLAS tiling and shifts bf16 rounding).
+            query = F.linear(hidden_states, q_weight)
+            key = F.linear(hidden_states, k_weight)
+            value = F.linear(hidden_states, v_weight)
+        query_states = self.q_norm(query.view(hidden_shape)).transpose(1, 2)
+        key_states = self.k_norm(key.view(hidden_shape)).transpose(1, 2)
+        value_states = value.view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb(
+            query_states, key_states, cos, sin
+        )
+
+        attn_output = _scaled_dot_product_attention(
+            query_states, key_states, value_states
+        )
+        attn_output = attn_output.transpose(1, 2).reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output
+
+
+class MiniMaxH3Qwen3VLTextMLP(nn.Module):
+    def __init__(
+        self,
+        group: Any,
+        config: Any,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_up_proj = MiniMaxH3Qwen3VLMergedColumnParallelLinear(
+            group,
+            input_size=self.hidden_size,
+            intermediate_size=self.intermediate_size,
+            dtype=dtype,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = MiniMaxH3Qwen3VLRowParallelLinear(
+            group,
+            input_size=self.intermediate_size,
+            output_size=self.hidden_size,
+            dtype=dtype,
+            input_is_parallel=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        ip_local = self.gate_up_proj.intermediate_size_per_partition
+        if _is_quantized_linear(self.gate_up_proj):
+            gate, up = self.gate_up_proj(x).split(ip_local, dim=-1)
+        else:
+            gate = F.linear(x, self.gate_up_proj.weight[0:ip_local])
+            up = F.linear(x, self.gate_up_proj.weight[ip_local : 2 * ip_local])
+        x = F.silu(gate) * up
+        return self.down_proj(x)
+
+
+class MiniMaxH3Qwen3VLTextDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        group: Any,
+        config: Any,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = MiniMaxH3Qwen3VLTextAttention(
+            group,
+            config,
+            dtype,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+        self.mlp = MiniMaxH3Qwen3VLTextMLP(
+            group,
+            config,
+            dtype,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = MiniMaxH3Qwen3VLRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.post_attention_layernorm = MiniMaxH3Qwen3VLRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states, position_embeddings=position_embeddings
+        )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class MiniMaxH3Qwen3VLTextModel(nn.Module):
+    """TP-sharded Qwen3-VL text model returning unnormalized layer-50 states."""
+
+    def __init__(
+        self,
+        group: Any,
+        config: Any,
+        selected_layer: int,
+        dtype: torch.dtype,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "text_encoder.text_model",
+    ) -> None:
+        super().__init__()
+        self.group = group
+        self.config = config
+        self.selected_layer = selected_layer
+        self.vocab_size = config.vocab_size
+        self.hidden_size = config.hidden_size
+        self.num_layers = min(
+            int(getattr(config, "num_hidden_layers", 0)), selected_layer
+        )
+        self.embed_tokens = MiniMaxH3Qwen3VLVocabParallelEmbedding(
+            group,
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+            dtype=dtype,
+        )
+        self.rotary_emb = MiniMaxH3Qwen3VLTextRotaryEmbedding(config)
+        self.layers = nn.ModuleList(
+            [
+                MiniMaxH3Qwen3VLTextDecoderLayer(
+                    group,
+                    config,
+                    dtype,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.layers.{layer_idx}",
+                )
+                for layer_idx in range(self.num_layers)
+            ]
+        )
+
+    def _deepstack_process(
+        self,
+        hidden_states: torch.Tensor,
+        visual_pos_masks: torch.Tensor,
+        visual_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        visual_pos_masks = visual_pos_masks.to(hidden_states.device)
+        visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
+        hidden_states = hidden_states.clone()
+        hidden_states[visual_pos_masks, :] = (
+            hidden_states[visual_pos_masks, :] + visual_embeds
+        )
+        return hidden_states
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        positions: torch.Tensor,
+        *,
+        visual_pos_masks: torch.Tensor | None = None,
+        deepstack_visual_embeds: list[torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, positions)
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            hidden_states = decoder_layer(
+                hidden_states, position_embeddings=position_embeddings
+            )
+            if deepstack_visual_embeds is not None and layer_idx in range(
+                len(deepstack_visual_embeds)
+            ):
+                hidden_states = self._deepstack_process(
+                    hidden_states,
+                    visual_pos_masks,
+                    deepstack_visual_embeds[layer_idx],
+                )
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Multimodal position / placeholder-mask helpers (ported from the reference).
+# ---------------------------------------------------------------------------
+
+
+def _get_vision_position_ids(
+    start_position: int,
+    grid_thw: list[int] | torch.Tensor,
+    temp_merge_size: int,
+    spatial_merge_size: int,
+    device: str | torch.device,
+) -> torch.Tensor:
+    llm_grid_t, llm_grid_h, llm_grid_w = (
+        grid_thw[0].item() // temp_merge_size,
+        grid_thw[1].item() // spatial_merge_size,
+        grid_thw[2].item() // spatial_merge_size,
+    )
+    position_temporal = torch.arange(llm_grid_t, device=device)
+    position_width = torch.arange(llm_grid_w, device=device) + start_position
+    position_height = torch.arange(llm_grid_h, device=device) + start_position
+    position_width = position_width.repeat(llm_grid_h * llm_grid_t)
+    position_height = position_height.repeat_interleave(llm_grid_w).repeat(llm_grid_t)
+    position_temporal = (
+        position_temporal.repeat_interleave(llm_grid_h * llm_grid_w) + start_position
+    )
+    return torch.stack([position_temporal, position_height, position_width], dim=0)
+
+
+def _get_rope_index(
+    input_ids: torch.Tensor,
+    mm_token_type_ids: torch.Tensor,
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    attention_mask: torch.Tensor | None,
+    spatial_merge_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if video_grid_thw is not None:
+        video_grid_thw = torch.repeat_interleave(
+            video_grid_thw, video_grid_thw[:, 0], dim=0
+        )
+        video_grid_thw[:, 0] = 1
+
+    mrope_position_deltas = []
+    position_ids = torch.zeros(
+        3,
+        input_ids.shape[0],
+        input_ids.shape[1],
+        dtype=input_ids.dtype,
+        device=input_ids.device,
+    )
+    grid_iters = {
+        1: iter(image_grid_thw) if image_grid_thw is not None else None,
+        2: iter(video_grid_thw) if video_grid_thw is not None else None,
+    }
+
+    for batch_idx, current_input_ids in enumerate(input_ids):
+        input_token_type = mm_token_type_ids[batch_idx]
+        if attention_mask is not None:
+            current_input_ids = current_input_ids[attention_mask[batch_idx].bool()]
+            input_token_type = input_token_type[attention_mask[batch_idx].bool()]
+
+        input_type_group = []
+        for key, group in itertools.groupby(
+            enumerate(input_token_type.tolist()), lambda x: x[1]
+        ):
+            group = list(group)
+            start_index = group[0][0]
+            end_index = group[-1][0] + 1
+            input_type_group.append((key, start_index, end_index))
+
+        current_pos = 0
+        llm_pos_ids_list = []
+        for modality_type, start_idx, end_idx in input_type_group:
+            if modality_type == 0:
+                text_len = end_idx - start_idx
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=input_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + current_pos
+                )
+                current_pos += text_len
+            else:
+                grid_thw = next(grid_iters[modality_type])
+                vision_position_ids = _get_vision_position_ids(
+                    current_pos,
+                    grid_thw,
+                    1,
+                    spatial_merge_size,
+                    device=input_ids.device,
+                )
+                llm_pos_ids_list.append(vision_position_ids)
+                current_pos += max(grid_thw[1], grid_thw[2]) // spatial_merge_size
+        llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+        if attention_mask is not None:
+            position_ids[:, batch_idx, attention_mask[batch_idx].bool()] = (
+                llm_positions.to(position_ids.device)
+            )
+        else:
+            position_ids[:, batch_idx] = llm_positions.to(position_ids.device)
+        mrope_position_deltas.append(llm_positions.max() + 1 - len(current_input_ids))
+    mrope_position_deltas = torch.tensor(
+        mrope_position_deltas, device=input_ids.device
+    ).unsqueeze(1)
+    return position_ids, mrope_position_deltas
+
+
+# ---------------------------------------------------------------------------
+# Encoder entry point.
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxH3Qwen3VLEncoder(nn.Module):
+    """Frozen, TP-capable Qwen3-VL backbone returning layer-50 states.
+
+    ``encoder_group`` is a ``GroupCoordinator`` over the encoder tensor-parallel
+    ranks (by default the first ``text_encoder_tp_size`` DiT ranks).  Only
+    ranks inside the group load weights; other ranks construct a parameter-free
+    stub that never runs the forward.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: torch.device,
+        load_model: bool,
+        encoder_group: Any | None = None,
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.device_target = device
+        self.encoder_group = encoder_group
+        self.quant_config = quant_config
+        _validate_encoder_quant_config(quant_config)
+        self.image_token_id = 151655
+        self.video_token_id = 151656
+        self._tp_size = 1
+        if not load_model:
+            return
+
+        from transformers import Qwen3VLConfig
+
+        config = Qwen3VLConfig.from_pretrained(model_path, trust_remote_code=False)
+        self.image_token_id = int(config.image_token_id)
+        self.video_token_id = int(config.video_token_id)
+        self._tp_size = (
+            int(encoder_group.world_size) if encoder_group is not None else 1
+        )
+        dtype = torch.float16
+        self.vision = MiniMaxH3Qwen3VLVisionModel(config.vision_config)
+        self.vision.to(dtype=dtype)
+        self.text_model = MiniMaxH3Qwen3VLTextModel(
+            encoder_group,
+            config.text_config,
+            MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER,
+            dtype,
+            quant_config=quant_config,
+        )
+        self.text_model.to(dtype=dtype)
+        logger.info(
+            "MiniMax H3 Qwen3-VL encoder: %d retained decoder layers, "
+            "text_encoder_tp_size=%d, vision replicated",
+            MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER,
+            self._tp_size,
+        )
+
+    @property
+    def is_loaded(self) -> bool:
+        return hasattr(self, "text_model")
+
+    @property
+    def tp_size(self) -> int:
+        return self._tp_size
+
+    def _map_weight_name(self, name: str) -> tuple[str, str | int | None] | None:
+        if name == "lm_head.weight" or name == "model.language_model.norm.weight":
+            return None
+        if name.startswith("model.visual."):
+            return ("vision." + name[len("model.visual.") :], None)
+        if name.startswith("model.language_model."):
+            rest = name[len("model.language_model.") :]
+            if rest.startswith("embed_tokens."):
+                return ("text_model." + rest, None)
+            match = re.match(r"layers\.(\d+)\.", rest)
+            if (
+                match is not None
+                and int(match.group(1)) >= MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER
+            ):
+                return None
+            if ".self_attn.q_proj.weight" in rest:
+                return (
+                    "text_model."
+                    + rest.replace(
+                        ".self_attn.q_proj.weight", ".self_attn.qkv_proj.weight"
+                    ),
+                    "q",
+                )
+            if ".self_attn.k_proj.weight" in rest:
+                return (
+                    "text_model."
+                    + rest.replace(
+                        ".self_attn.k_proj.weight", ".self_attn.qkv_proj.weight"
+                    ),
+                    "k",
+                )
+            if ".self_attn.v_proj.weight" in rest:
+                return (
+                    "text_model."
+                    + rest.replace(
+                        ".self_attn.v_proj.weight", ".self_attn.qkv_proj.weight"
+                    ),
+                    "v",
+                )
+            if ".mlp.gate_proj.weight" in rest:
+                return (
+                    "text_model."
+                    + rest.replace(".mlp.gate_proj.weight", ".mlp.gate_up_proj.weight"),
+                    0,
+                )
+            if ".mlp.up_proj.weight" in rest:
+                return (
+                    "text_model."
+                    + rest.replace(".mlp.up_proj.weight", ".mlp.gate_up_proj.weight"),
+                    1,
+                )
+            return ("text_model." + rest, None)
+        return None
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params = dict(self.named_parameters())
+        loaded: set[str] = set()
+        # Seeded from modules that own a multi-shard loader, so a fused weight
+        # receiving no source shard is caught as well as a partially filled one.
+        expected_fused_shards: dict[str, tuple[tuple[str, str | int], ...]] = {
+            f"{module_name}.weight": sources
+            for module_name, module in self.named_modules()
+            if (sources := _fused_source_shards(module)) is not None
+        }
+        loaded_fused_shards: dict[str, set[str | int]] = {
+            name: set() for name in expected_fused_shards
+        }
+        for name, tensor in weights:
+            mapped = self._map_weight_name(name)
+            if mapped is None:
+                continue
+            param_name, shard_id = mapped
+            param = params.get(param_name)
+            if param is None:
+                logger.warning(
+                    "MiniMax H3 text encoder weight %s has no target parameter", name
+                )
+                continue
+            weight_loader = getattr(param, "weight_loader", _default_weight_loader)
+            weight_loader(param, tensor, shard_id)
+            loaded.add(param_name)
+            if shard_id is not None and param_name in loaded_fused_shards:
+                loaded_fused_shards[param_name].add(shard_id)
+        _verify_fused_shards_complete(expected_fused_shards, loaded_fused_shards)
+        missing = sorted(set(params) - loaded)
+        if missing:
+            # Listed in full: this aborts startup, so the message is the only
+            # diagnostic.
+            raise RuntimeError(
+                f"MiniMax H3 text encoder weights not loaded: {len(missing)} params: "
+                f"{missing}"
+            )
+        return loaded
+
+    def load_to_device(self) -> None:
+        if not self.is_loaded:
+            return
+        if getattr(self, "_omni_layerwise_enabled", False):
+            stager = getattr(self, "_omni_non_block_stager", None)
+            if stager is None:
+                hooks = getattr(self, "_omni_layerwise_hooks", ())
+                pin_memory = (
+                    bool(getattr(hooks[0], "pin_memory", True)) if hooks else True
+                )
+                stager = PinnedModuleStager(
+                    self._omni_non_block_modules(),
+                    self.device_target,
+                    pin_memory=pin_memory,
+                    cache_retention=getattr(self, "_omni_component_cache", None),
+                )
+                self._omni_non_block_stager = stager
+            stager.load()
+            return
+        self.vision.to(self.device_target)
+        self.text_model.to(self.device_target)
+
+    def offload_to_cpu(self) -> None:
+        if not self.is_loaded:
+            return
+        if getattr(self, "_omni_layerwise_enabled", False):
+            for hook in self._omni_layerwise_hooks:
+                hook.offload_layer()
+            stager = getattr(self, "_omni_non_block_stager", None)
+            if stager is not None:
+                stager.offload()
+            else:
+                # The initial DLO setup reaches this branch before the first
+                # load. These modules were constructed on CPU, so this is not
+                # a device-to-host rematerialization.
+                for child in self._omni_non_block_modules():
+                    child.to("cpu")
+                self._release_omni_component_cache()
+            return
+        self.vision.to("cpu")
+        self.text_model.to("cpu")
+        torch.accelerator.empty_cache()
+
+    def _omni_non_block_modules(self) -> list[nn.Module]:
+        modules = [
+            child for name, child in self.vision.named_children() if name != "blocks"
+        ]
+        modules.extend(
+            child
+            for name, child in self.text_model.named_children()
+            if name != "layers"
+        )
+        return modules
+
+    def set_omni_component_cache(self, cache: BoundedAllocatorCache | None) -> None:
+        self._omni_component_cache = cache
+        stager = getattr(self, "_omni_non_block_stager", None)
+        if stager is not None:
+            stager.set_cache_retention(cache)
+
+    def _release_omni_component_cache(self) -> None:
+        cache = getattr(self, "_omni_component_cache", None)
+        if cache is None:
+            torch.accelerator.empty_cache()
+        else:
+            cache.release_if_needed()
+
+    def _encode(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        device = self.device_target
+        ids = input_ids.to(device, torch.long)[None]
+        attention_mask = torch.ones_like(ids)
+        mm_types = torch.zeros_like(ids, dtype=torch.int32)
+        mm_types[ids == self.image_token_id] = 1
+        mm_types[ids == self.video_token_id] = 2
+
+        inputs_embeds = self.text_model.embed_tokens(ids)
+        image_mask = None
+        video_mask = None
+        deepstack_image_embeds: list[torch.Tensor] | None = None
+        deepstack_video_embeds: list[torch.Tensor] | None = None
+
+        if pixel_values is not None:
+            image_embeds, deepstack_image_embeds = self.vision(
+                pixel_values.to(device, torch.float16),
+                image_grid_thw.to(device, torch.long),
+            )
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            image_mask, _ = self._get_placeholder_mask(
+                ids, inputs_embeds=inputs_embeds, image_features=image_embeds
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+        if pixel_values_videos is not None:
+            video_embeds, deepstack_video_embeds = self.vision(
+                pixel_values_videos.to(device, torch.float16),
+                video_grid_thw.to(device, torch.long),
+            )
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            _, video_mask = self._get_placeholder_mask(
+                ids, inputs_embeds=inputs_embeds, video_features=video_embeds
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+        visual_pos_masks, deepstack_visual_embeds = self._aggregate_deepstack(
+            image_mask,
+            video_mask,
+            deepstack_image_embeds,
+            deepstack_video_embeds,
+        )
+
+        positions, _ = _get_rope_index(
+            ids,
+            mm_token_type_ids=mm_types,
+            image_grid_thw=image_grid_thw.to(device, torch.long)
+            if image_grid_thw is not None
+            else None,
+            video_grid_thw=video_grid_thw.to(device, torch.long)
+            if video_grid_thw is not None
+            else None,
+            attention_mask=attention_mask,
+            spatial_merge_size=int(self.vision.config.spatial_merge_size),
+        )
+        hidden = self.text_model(
+            inputs_embeds,
+            positions,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+        )[0]
+        expected = (int(ids.shape[1]), MINIMAX_H3_QWEN3VL_HIDDEN_DIM)
+        if tuple(hidden.shape) != expected:
+            raise ValueError(
+                f"unexpected Qwen3-VL hidden shape {tuple(hidden.shape)}, expected "
+                f"{expected}"
+            )
+        return hidden.to(torch.float16)
+
+    def _get_placeholder_mask(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        inputs_embeds: torch.Tensor,
+        image_features: torch.Tensor | None = None,
+        video_features: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        special_image_mask = input_ids == self.image_token_id
+        special_video_mask = input_ids == self.video_token_id
+        special_image_mask = (
+            special_image_mask.unsqueeze(-1)
+            .expand_as(inputs_embeds)
+            .to(inputs_embeds.device)
+        )
+        special_video_mask = (
+            special_video_mask.unsqueeze(-1)
+            .expand_as(inputs_embeds)
+            .to(inputs_embeds.device)
+        )
+        if (
+            image_features is not None
+            and special_image_mask.sum().item() != image_features.numel()
+        ):
+            raise ValueError(
+                "Image features and image tokens do not match: "
+                f"tokens: "
+                f"{special_image_mask.sum().item() // inputs_embeds.shape[-1]}, "
+                f"features: {image_features.shape[0]}"
+            )
+        if (
+            video_features is not None
+            and special_video_mask.sum().item() != video_features.numel()
+        ):
+            raise ValueError(
+                "Video features and video tokens do not match: "
+                f"tokens: "
+                f"{special_video_mask.sum().item() // inputs_embeds.shape[-1]}, "
+                f"features: {video_features.shape[0]}"
+            )
+        return special_image_mask, special_video_mask
+
+    def _aggregate_deepstack(
+        self,
+        image_mask: torch.Tensor | None,
+        video_mask: torch.Tensor | None,
+        deepstack_image_embeds: list[torch.Tensor] | None,
+        deepstack_video_embeds: list[torch.Tensor] | None,
+    ) -> tuple[torch.Tensor | None, list[torch.Tensor] | None]:
+        if image_mask is not None and video_mask is not None:
+            image_mask = image_mask[..., 0]
+            video_mask = video_mask[..., 0]
+            visual_pos_masks = image_mask | video_mask
+            deepstack_visual_embeds = []
+            image_mask_joint = image_mask[visual_pos_masks]
+            video_mask_joint = video_mask[visual_pos_masks]
+            for img_embed, vid_embed in zip(
+                deepstack_image_embeds, deepstack_video_embeds
+            ):
+                embed_joint = img_embed.new_zeros(
+                    visual_pos_masks.sum(), img_embed.shape[-1]
+                ).to(img_embed.device)
+                embed_joint[image_mask_joint, :] = img_embed
+                embed_joint[video_mask_joint, :] = vid_embed
+                deepstack_visual_embeds.append(embed_joint)
+            return visual_pos_masks, deepstack_visual_embeds
+        if image_mask is not None:
+            image_mask = image_mask[..., 0]
+            return image_mask, deepstack_image_embeds
+        if video_mask is not None:
+            video_mask = video_mask[..., 0]
+            return video_mask, deepstack_video_embeds
+        return None, None
+
+    @torch.inference_mode()
+    def encode_ids(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not self.is_loaded:
+            raise RuntimeError(
+                "MiniMax H3 text encoder is only loaded on the encoder TP ranks"
+            )
+        if input_ids.ndim != 1:
+            raise ValueError(f"input_ids must be 1-D, got {list(input_ids.shape)}")
+        if (pixel_values is None) != (image_grid_thw is None):
+            raise ValueError(
+                "pixel_values and image_grid_thw must be provided together"
+            )
+        if (pixel_values_videos is None) != (video_grid_thw is None):
+            raise ValueError(
+                "pixel_values_videos and video_grid_thw must be provided together"
+            )
+        if next(self.parameters()).device.type != self.device_target.type:
+            raise RuntimeError("call load_to_device() before encode_ids()")
+
+        cudnn_sdp_enabled = torch.backends.cuda.cudnn_sdp_enabled()
+        torch.backends.cuda.enable_cudnn_sdp(True)
+        try:
+            hidden = self._encode(
+                input_ids,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+            return hidden.cpu()
+        finally:
+            torch.backends.cuda.enable_cudnn_sdp(cudnn_sdp_enabled)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Hook-compatible entry point for model-level CPU offloading."""
+        kwargs = {
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }
+        if pixel_values_videos is not None or video_grid_thw is not None:
+            kwargs.update(
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+        return self.encode_ids(input_ids, **kwargs)
+
+
+__all__ = ["MiniMaxH3Qwen3VLEncoder"]

--- a/vllm/model_executor/models/minimax_h3/modulation.py
+++ b/vllm/model_executor/models/minimax_h3/modulation.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Fused MiniMax H3 modulation with FP32 accumulation."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _indexed_scale_shift_kernel(
+    output_ptr,
+    x_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size,
+    stride_x_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    shift = tl.load(
+        shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    scale = tl.load(
+        scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+
+    tl.store(
+        output_ptr + row * stride_x_row + columns,
+        x * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _indexed_gate_kernel(
+    output_ptr,
+    x_ptr,
+    gate_ptr,
+    other_ptr,
+    indices_ptr,
+    hidden_size,
+    stride_output_row,
+    stride_x_row,
+    stride_gate_row,
+    stride_other_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    gate = tl.load(
+        gate_ptr + index * stride_gate_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    other = tl.load(
+        other_ptr + row * stride_other_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+
+    tl.store(
+        output_ptr + row * stride_output_row + columns,
+        x + gate * other,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _rms_norm_indexed_scale_shift_kernel(
+    output_ptr,
+    x_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    stride_x_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(x * x, axis=0) / hidden_size
+    normalized = x * tl.rsqrt(variance + eps) * weight
+
+    shift = tl.load(
+        shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    scale = tl.load(
+        scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    tl.store(
+        output_ptr + row * hidden_size + columns,
+        normalized * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _indexed_gate_rms_norm_scale_shift_kernel(
+    residual_out_ptr,
+    modulated_out_ptr,
+    residual_ptr,
+    gate_ptr,
+    branch_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    stride_residual_row,
+    stride_gate_row,
+    stride_branch_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    residual = tl.load(
+        residual_ptr + row * stride_residual_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    gate = tl.load(
+        gate_ptr + index * stride_gate_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    branch = tl.load(
+        branch_ptr + row * stride_branch_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    # Match the FP16 residual value consumed by the unfused RMSNorm path.
+    updated = (residual + gate * branch).to(tl.float16).to(tl.float32)
+    tl.store(residual_out_ptr + row * hidden_size + columns, updated, mask=mask)
+
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(updated * updated, axis=0) / hidden_size
+    normalized = updated * tl.rsqrt(variance + eps) * weight
+    shift = tl.load(
+        shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    scale = tl.load(
+        scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0
+    ).to(tl.float32)
+    tl.store(
+        modulated_out_ptr + row * hidden_size + columns,
+        normalized * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+def indexed_scale_shift_(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Apply indexed scale/shift in-place to a disposable contiguous input."""
+    if x.is_cpu:
+        x.copy_(
+            (
+                x * (1.0 + scale.index_select(0, indices))
+                + shift.index_select(0, indices)
+            ).to(x.dtype)
+        )
+        return x
+    rows, hidden_size = x.shape
+    if rows == 0:
+        return x
+    _indexed_scale_shift_kernel[(rows,)](
+        x,
+        x,
+        shift,
+        scale,
+        indices,
+        hidden_size,
+        x.stride(0),
+        shift.stride(0),
+        scale.stride(0),
+        indices.stride(0),
+        block_n=triton.next_power_of_2(hidden_size),
+        num_warps=8,
+    )
+    return x
+
+
+def indexed_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Return ``x + gate[indices] * other`` without indexed temporaries."""
+    if x.is_cpu:
+        return (x + gate.index_select(0, indices) * other).to(x.dtype)
+    output = torch.empty_like(x)
+    rows, hidden_size = x.shape
+    if rows == 0:
+        return output
+    _indexed_gate_kernel[(rows,)](
+        output,
+        x,
+        gate,
+        other,
+        indices,
+        hidden_size,
+        output.stride(0),
+        x.stride(0),
+        gate.stride(0),
+        other.stride(0),
+        indices.stride(0),
+        block_n=triton.next_power_of_2(hidden_size),
+        num_warps=8,
+    )
+    return output
+
+
+def rms_norm_indexed_scale_shift(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Fuse H3 RMSNorm with its indexed AdaLN affine transform."""
+    if x.is_cpu:
+        input_dtype = x.dtype
+        normalized = x.float()
+        variance = normalized.pow(2).mean(-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + eps)
+        normalized = (weight.float() * normalized).to(input_dtype)
+        return (
+            normalized * (1.0 + scale.index_select(0, indices))
+            + shift.index_select(0, indices)
+        ).to(input_dtype)
+    output = torch.empty_like(x)
+    rows, hidden_size = x.shape
+    if rows:
+        _rms_norm_indexed_scale_shift_kernel[(rows,)](
+            output,
+            x,
+            weight,
+            shift,
+            scale,
+            indices,
+            hidden_size,
+            eps,
+            x.stride(0),
+            shift.stride(0),
+            scale.stride(0),
+            indices.stride(0),
+            block_n=triton.next_power_of_2(hidden_size),
+            num_warps=8,
+        )
+    return output
+
+
+def indexed_gate_rms_norm_scale_shift(
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    branch: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse gated residual, the following RMSNorm, and AdaLN affine."""
+    if residual.is_cpu:
+        input_dtype = residual.dtype
+        residual_out = (residual + gate.index_select(0, indices) * branch).to(
+            input_dtype
+        )
+        normalized = residual_out.float()
+        variance = normalized.pow(2).mean(-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + eps)
+        normalized = (weight.float() * normalized).to(input_dtype)
+        modulated_out = (
+            normalized * (1.0 + scale.index_select(0, indices))
+            + shift.index_select(0, indices)
+        ).to(input_dtype)
+        return residual_out, modulated_out
+    residual_out = torch.empty_like(residual)
+    modulated_out = torch.empty_like(residual)
+    rows, hidden_size = residual.shape
+    if rows:
+        _indexed_gate_rms_norm_scale_shift_kernel[(rows,)](
+            residual_out,
+            modulated_out,
+            residual,
+            gate,
+            branch,
+            weight,
+            shift,
+            scale,
+            indices,
+            hidden_size,
+            eps,
+            residual.stride(0),
+            gate.stride(0),
+            branch.stride(0),
+            shift.stride(0),
+            scale.stride(0),
+            indices.stride(0),
+            block_n=triton.next_power_of_2(hidden_size),
+            num_warps=8,
+        )
+    return residual_out, modulated_out
+
+
+__all__ = [
+    "indexed_gate",
+    "indexed_gate_rms_norm_scale_shift",
+    "indexed_scale_shift_",
+    "rms_norm_indexed_scale_shift",
+]

--- a/vllm/model_executor/models/minimax_h3/modulation.py
+++ b/vllm/model_executor/models/minimax_h3/modulation.py
@@ -159,8 +159,11 @@ def _indexed_gate_rms_norm_scale_shift_kernel(
     branch = tl.load(
         branch_ptr + row * stride_branch_row + columns, mask=mask, other=0.0
     ).to(tl.float32)
-    # Match the FP16 residual value consumed by the unfused RMSNorm path.
-    updated = (residual + gate * branch).to(tl.float16).to(tl.float32)
+    # Match the stored residual dtype. H3 uses FP32 residuals on Volta because
+    # real checkpoint gates can produce values above FP16's finite range.
+    updated = (
+        (residual + gate * branch).to(residual_out_ptr.dtype.element_ty).to(tl.float32)
+    )
     tl.store(residual_out_ptr + row * hidden_size + columns, updated, mask=mask)
 
     weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
@@ -252,6 +255,7 @@ def rms_norm_indexed_scale_shift(
     scale: torch.Tensor,
     indices: torch.Tensor,
     eps: float,
+    output_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     """Fuse H3 RMSNorm with its indexed AdaLN affine transform."""
     if x.is_cpu:
@@ -263,8 +267,8 @@ def rms_norm_indexed_scale_shift(
         return (
             normalized * (1.0 + scale.index_select(0, indices))
             + shift.index_select(0, indices)
-        ).to(input_dtype)
-    output = torch.empty_like(x)
+        ).to(output_dtype or input_dtype)
+    output = torch.empty_like(x, dtype=output_dtype or x.dtype)
     rows, hidden_size = x.shape
     if rows:
         _rms_norm_indexed_scale_shift_kernel[(rows,)](
@@ -295,6 +299,7 @@ def indexed_gate_rms_norm_scale_shift(
     scale: torch.Tensor,
     indices: torch.Tensor,
     eps: float,
+    output_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fuse gated residual, the following RMSNorm, and AdaLN affine."""
     if residual.is_cpu:
@@ -309,10 +314,10 @@ def indexed_gate_rms_norm_scale_shift(
         modulated_out = (
             normalized * (1.0 + scale.index_select(0, indices))
             + shift.index_select(0, indices)
-        ).to(input_dtype)
+        ).to(output_dtype or input_dtype)
         return residual_out, modulated_out
     residual_out = torch.empty_like(residual)
-    modulated_out = torch.empty_like(residual)
+    modulated_out = torch.empty_like(residual, dtype=output_dtype or residual.dtype)
     rows, hidden_size = residual.shape
     if rows:
         _indexed_gate_rms_norm_scale_shift_kernel[(rows,)](

--- a/vllm/model_executor/models/minimax_h3/ops.py
+++ b/vllm/model_executor/models/minimax_h3/ops.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Numerical reference operations for H3's FP16/FP32 execution contract."""
+
+import torch
+from torch import nn
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-5, dtype=None):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, x):
+        value = x.float()
+        value = value * torch.rsqrt(
+            value.square().mean(-1, keepdim=True) + self.variance_epsilon
+        )
+        return (value * self.weight.float()).to(x.dtype)
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(self, *, is_neox_style=True, half_head_dim=False):
+        super().__init__()
+        if not is_neox_style or half_head_dim:
+            raise ValueError("H3 uses non-interleaved full-width rotary tables")
+
+    def forward(self, x, cos, sin):
+        first, second = x.chunk(2, dim=-1)
+        rotated = torch.cat((-second, first), dim=-1)
+        return x * cos.unsqueeze(-2) + rotated * sin.unsqueeze(-2)
+
+
+def fused_qk_norm_rope(q, k, q_weight, k_weight, rope_table, eps):
+    # This reference retains the normalized FP16 rounding boundary. The CUDA
+    # implementation must preserve it, including partial (96/128) rotation.
+    def apply(x, weight):
+        value = x.float()
+        value = (
+            value
+            * torch.rsqrt(value.square().mean(-1, keepdim=True) + eps)
+            * weight.float()
+        ).to(x.dtype)
+        half = rope_table.shape[-1] // 2
+        cos, sin = rope_table.to(x.dtype).unsqueeze(1).chunk(2, dim=-1)
+        first, second = value[..., :half], value[..., half : 2 * half]
+        return torch.cat(
+            (
+                first * cos - second * sin,
+                second * cos + first * sin,
+                value[..., 2 * half :],
+            ),
+            dim=-1,
+        )
+
+    return apply(q, q_weight), apply(k, k_weight)
+
+
+def convrot_reference(x, group_size=256):
+    """Regular Hadamard (Kronecker power of H4), accumulated in FP32.
+
+    The checkpoint holds W @ H.T. H is symmetric and orthonormal, so the
+    activation must receive x @ H before multiplication by the stored W.
+    """
+    if group_size != 256 or x.shape[-1] % group_size:
+        raise ValueError("H3 ConvRot requires complete 256-channel groups")
+    value = x.float().reshape(-1, group_size)
+    stride = 1
+    while stride < group_size:
+        parts = value.reshape(-1, group_size // (4 * stride), 4, stride)
+        a, b, c, d = parts.unbind(-2)
+        value = torch.stack(
+            (a + b + c - d, a + b - c + d, a - b + c + d, -a + b + c + d), -2
+        )
+        stride *= 4
+    return (value.reshape(x.shape) / 16).to(x.dtype)
+
+
+def dequantize_int8_reference(weight, scale):
+    if weight.dtype != torch.int8 or weight.ndim != 2:
+        raise ValueError("W8A16 requires a signed INT8 matrix")
+    if scale.dtype != torch.float32 or scale.numel() != weight.shape[0]:
+        raise ValueError("W8A16 requires one FP32 scale per output row")
+    return (weight.float() * scale.reshape(-1, 1)).to(torch.float16)

--- a/vllm/model_executor/models/minimax_h3/ops.py
+++ b/vllm/model_executor/models/minimax_h3/ops.py
@@ -12,12 +12,16 @@ class RMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
         self.variance_epsilon = eps
 
-    def forward(self, x):
+    def forward(self, x, residual=None):
+        if residual is not None:
+            residual = residual + x
+            x = residual
         value = x.float()
         value = value * torch.rsqrt(
             value.square().mean(-1, keepdim=True) + self.variance_epsilon
         )
-        return (value * self.weight.float()).to(x.dtype)
+        output = (value * self.weight.float()).to(x.dtype)
+        return output if residual is None else (output, residual)
 
 
 class RotaryEmbedding(nn.Module):

--- a/vllm/model_executor/models/minimax_h3/packed_sequence.py
+++ b/vllm/model_executor/models/minimax_h3/packed_sequence.py
@@ -1,0 +1,633 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniMax H3 packed-sequence materialization for FL2VA and Ref2VA tasks.
+
+Layout: [text L | imgvid_cond C | audio A(=t*2ch) | video_target V | pad P].
+Builder rules:
+- placeholder ids; block-derived pos infos/masks/cu_seqlens/document_id
+- img_position_ids fp64 grid: text rows (row_idx,0,0); video/cond t counter
+  continues text_len with temporal interp spans (frame_rescale 5/3 x
+  frame_per_token (1,4,4,4,4)); each spatial sqrt_area axis uses evenly spaced
+  coordinates excluding the right endpoint, then scales them by INTERP;
+  audio channel-major blocks pinned to the w-grid extremes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+import torch
+
+MINIMAX_H3_FL2VA_KEYFRAME_SIGNATURES: tuple[tuple[int, ...], ...] = (
+    (0,),
+    (-1,),
+    (0, -1),
+)
+
+MINIMAX_H3_TEXT_ID = -5
+MINIMAX_H3_IMGVID_COND_ID = -11
+MINIMAX_H3_AUDIO_REF_COND_ID = -17
+MINIMAX_H3_AUDIO_FIRST_ID = -15
+MINIMAX_H3_AUDIO_ID = -14
+MINIMAX_H3_VIDEO_FIRST_ID = -3
+MINIMAX_H3_VIDEO_ID = -2
+MINIMAX_H3_VIDEO_LAST_ID = -4
+MINIMAX_H3_PAD_ID = -1
+
+_INTERP = 32
+_T_GROUP = 5
+_FRAME_PER_TOKEN = (1, 4, 4, 4, 4)
+_FRAME_RESCALE = 5.0 / 3.0
+_SEQ_ALIGN = 64
+# MiniMax H3 packs video latents with a fixed [1, 2, 2] (t, h, w) patch.
+_PATCH_T = 1
+_PATCH_H = 2
+_PATCH_W = 2
+
+
+def _keyframe_cond_frame_indices(
+    *,
+    include_keyframe_cond: bool,
+    keyframe_frame_indices: list[int] | tuple[int, ...] | None,
+) -> list[int]:
+    if not include_keyframe_cond:
+        if keyframe_frame_indices is not None:
+            raise ValueError(
+                "keyframe_frame_indices must be omitted when keyframe cond is not "
+                "included"
+            )
+        return []
+    if keyframe_frame_indices is None:
+        raise ValueError("strict fl2va packed layout requires keyframe_frame_indices")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in keyframe_frame_indices
+    ):
+        raise ValueError(
+            "strict fl2va packed layout requires integer keyframe_frame_indices"
+        )
+    out = list(keyframe_frame_indices)
+    if tuple(out) not in MINIMAX_H3_FL2VA_KEYFRAME_SIGNATURES:
+        raise ValueError(
+            "strict fl2va packed layout requires keyframe_frame_indices in "
+            f"{MINIMAX_H3_FL2VA_KEYFRAME_SIGNATURES!r}, got {out!r}"
+        )
+    return out
+
+
+def _resolve_keyframe_frame_indices(
+    frame_indices: Sequence[int],
+    *,
+    frame_count: int | None,
+) -> list[int]:
+    if frame_indices and frame_count is None:
+        raise ValueError(
+            "frame_count is required when keyframe_frame_indices are provided"
+        )
+    if frame_count is None:
+        return []
+    if frame_count <= 0:
+        raise ValueError("frame_count must be positive")
+    seen: dict[int, int] = {}
+    resolved: list[int] = []
+    for block_index, semantic_index in enumerate(frame_indices):
+        if semantic_index == -1:
+            resolved_index = frame_count - 1
+        elif 0 <= semantic_index < frame_count:
+            resolved_index = semantic_index
+        else:
+            raise ValueError(
+                f"keyframe frame index {semantic_index} must be -1 or in [0, "
+                f"{frame_count})"
+            )
+        previous = seen.get(resolved_index)
+        if previous is not None:
+            raise ValueError(
+                f"keyframe frame index at block {block_index} resolves to "
+                f"{resolved_index}, already bound by block {previous}"
+            )
+        seen[resolved_index] = block_index
+        resolved.append(resolved_index)
+    return resolved
+
+
+def _temporal_position_span(temporal_length: int) -> float:
+    """Temporal position span for patch_t=1, in fp64.
+
+    NOTE: intentionally NOT merged with ``_video_t_span``. This variant sums
+    via numpy (pairwise summation), matching the fl2va anchor computation,
+    while ``_video_t_span`` sums sequentially, matching the ref2va
+    t-origin accumulation. The two orders diverge in the last ulp
+    from n=16 onward, so each path must keep its own summation order.
+    """
+    spans = np.ones(int(temporal_length), dtype=np.float64) * _FRAME_RESCALE
+    for token_index in range(_T_GROUP):
+        spans[token_index::_T_GROUP] *= _FRAME_PER_TOKEN[token_index]
+    return float(spans.sum())
+
+
+def minimax_h3_packed_sequence(
+    *,
+    text_len: int,
+    latent_t: int,
+    latent_h: int,
+    latent_w: int,
+    audio_t: int,
+    audio_channel: int = 2,
+    include_keyframe_cond: bool,
+    keyframe_frame_indices: list[int] | tuple[int, ...] | None = None,
+    frame_count: int | None = None,
+) -> dict[str, object]:
+    """Build the packed-sequence structural fields for one CFG branch.
+
+    The used length is padded up to a multiple of 64.
+    """
+    ph, pw = latent_h // _PATCH_H, latent_w // _PATCH_W
+    frame_rows = ph * pw
+    cond_frame_indices = _keyframe_cond_frame_indices(
+        include_keyframe_cond=include_keyframe_cond,
+        keyframe_frame_indices=keyframe_frame_indices,
+    )
+    resolved_cond_frame_indices = _resolve_keyframe_frame_indices(
+        cond_frame_indices,
+        frame_count=frame_count,
+    )
+    cond_rows = len(cond_frame_indices) * frame_rows
+    video_rows = latent_t * frame_rows
+    audio_rows = audio_t * audio_channel
+    used = text_len + cond_rows + audio_rows + video_rows
+    seq_len = ((used + _SEQ_ALIGN - 1) // _SEQ_ALIGN) * _SEQ_ALIGN
+
+    text_sl = slice(0, text_len)
+    cond_sl = slice(text_len, text_len + cond_rows)
+    audio_sl = slice(cond_sl.stop, cond_sl.stop + audio_rows)
+    video_sl = slice(audio_sl.stop, audio_sl.stop + video_rows)
+    pad_sl = slice(video_sl.stop, seq_len)
+
+    input_ids = torch.full((seq_len,), MINIMAX_H3_PAD_ID, dtype=torch.int64)
+    input_ids[text_sl] = MINIMAX_H3_TEXT_ID
+    if cond_rows:
+        input_ids[cond_sl] = MINIMAX_H3_IMGVID_COND_ID
+    input_ids[audio_sl] = MINIMAX_H3_AUDIO_ID
+    input_ids[audio_sl.start] = MINIMAX_H3_AUDIO_FIRST_ID
+    input_ids[video_sl] = MINIMAX_H3_VIDEO_ID
+    input_ids[video_sl.start] = MINIMAX_H3_VIDEO_FIRST_ID
+    input_ids[video_sl.stop - 1] = MINIMAX_H3_VIDEO_LAST_ID
+
+    image_mask = torch.zeros(seq_len, dtype=torch.bool)
+    image_mask[cond_sl] = True
+    image_mask[video_sl] = True
+    audio_mask = torch.zeros(seq_len, dtype=torch.bool)
+    audio_mask[audio_sl] = True
+
+    img_pos = torch.cat(
+        [
+            torch.arange(cond_sl.start, cond_sl.stop),
+            torch.arange(video_sl.start, video_sl.stop),
+        ]
+    )
+    update_mask = torch.zeros(img_pos.shape[0], dtype=torch.bool)
+    update_mask[cond_rows:] = True
+    audio_pos = torch.arange(audio_sl.start, audio_sl.stop)
+    text_pos = torch.arange(0, text_len)
+
+    g = torch.zeros(seq_len, 3, dtype=torch.float64)
+    g[text_sl, 0] = torch.arange(text_len, dtype=torch.float64)
+
+    t_grid = _video_t_grid(latent_t, float(text_len))
+    sqrt_area = np.sqrt(latent_h * latent_w)
+    h_grid = _axis_from_sqrt_area(latent_h, _PATCH_H, sqrt_area)
+    w_grid = _axis_from_sqrt_area(latent_w, _PATCH_W, sqrt_area)
+    hh, ww = torch.meshgrid(h_grid, w_grid, indexing="ij")
+    frame = torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1)
+    video_g = torch.empty(latent_t, frame_rows, 3, dtype=torch.float64)
+    video_g[:, :, 0] = t_grid[:, None]
+    video_g[:, :, 1:] = frame[None]
+    for block_index, pixel_index in enumerate(resolved_cond_frame_indices):
+        sl = slice(
+            cond_sl.start + block_index * frame_rows,
+            cond_sl.start + (block_index + 1) * frame_rows,
+        )
+        if pixel_index == 0:
+            cond_t = float(text_len)
+        elif frame_count is not None and pixel_index == frame_count - 1:
+            cond_t = (
+                float(text_len) + _temporal_position_span(latent_t) - _FRAME_RESCALE
+            )
+        else:
+            raise ValueError(
+                f"fl2va packed layout only supports first/last keyframe anchors, got "
+                f"resolved frame index {pixel_index}"
+            )
+        g[sl, 0] = cond_t
+        g[sl, 1:] = frame
+    g[video_sl] = video_g.reshape(-1, 3)
+    audio_t_grid = float(text_len) + torch.arange(audio_t, dtype=torch.float64)
+    g[audio_sl, 0] = audio_t_grid.repeat(audio_channel)
+    g[audio_sl, 2] = torch.cat(
+        [
+            torch.full((audio_t,), float(w_grid[0]), dtype=torch.float64),
+            torch.full((audio_rows - audio_t,), float(w_grid[-1]), dtype=torch.float64),
+        ]
+    )
+
+    token_tags = torch.full((seq_len,), -1, dtype=torch.long)  # PADDING
+    token_tags[text_sl] = 1  # TEXT (fl2va image-segment override happens upstream)
+    token_tags[audio_sl] = 2  # AUDIO
+    token_tags[img_pos] = 0  # VIDEO
+
+    cu = torch.tensor([0, used, seq_len], dtype=torch.int32)
+    doc = torch.zeros(seq_len, dtype=torch.int32)
+    doc[pad_sl] = 1
+    return {
+        "seq_len": torch.tensor(seq_len),
+        "input_ids": input_ids,
+        "image_mask": image_mask,
+        "audio_mask": audio_mask,
+        "img_pos": img_pos,
+        "audio_pos": audio_pos,
+        "text_pos": text_pos,
+        "update_mask": update_mask,
+        "img_position_ids": g,
+        "token_tags": token_tags,
+        "cu_seqlens": cu,
+        "document_id": doc,
+        # Extent of the video segment within the packed sequence.
+        "latent_grid": torch.tensor([latent_t, ph, pw], dtype=torch.int64),
+        "video_row_start": torch.tensor(video_sl.start, dtype=torch.int64),
+        # The single target video uses the same span contract as Ref2VA.
+        "video_spans": (
+            {
+                "start": video_sl.start,
+                "latent_grid": (latent_t, ph, pw),
+                "role": "target",
+            },
+        ),
+    }
+
+
+def _positive_int(
+    block: Mapping[str, object],
+    key: str,
+    path: str,
+    *,
+    allow_zero: bool = False,
+) -> int:
+    value = block.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{path}.{key} must be an integer")
+    if value < 0 or (value == 0 and not allow_zero):
+        predicate = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{path}.{key} must be {predicate}")
+    return int(value)
+
+
+def _axis_from_sqrt_area(dim: int, patch: int, sqrt_area: float) -> torch.Tensor:
+    ratio = dim / sqrt_area
+    left = (1.0 - ratio) * 1.0 / 2.0
+    right = left + ratio * 1.0
+    grid = np.linspace(left, right, dim // patch, endpoint=False) * _INTERP
+    return torch.from_numpy(grid).to(torch.float64)
+
+
+def _video_t_grid(n: int, origin: float) -> torch.Tensor:
+    spans = torch.tensor(
+        [_FRAME_RESCALE * _FRAME_PER_TOKEN[k % _T_GROUP] for k in range(n)],
+        dtype=torch.float64,
+    )
+    return origin + torch.cat(
+        [torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)]
+    )
+
+
+def _video_t_span(n: int) -> float:
+    # Sequential fp64 summation on purpose — see _temporal_position_span for
+    # why the two span implementations must not be unified.
+    return sum(_FRAME_RESCALE * _FRAME_PER_TOKEN[k % _T_GROUP] for k in range(n))
+
+
+def _range_for_slice(sl: slice) -> torch.Tensor:
+    return torch.arange(sl.start, sl.stop, dtype=torch.long)
+
+
+def _cat_ranges(parts: list[torch.Tensor]) -> torch.Tensor:
+    if parts:
+        return torch.cat(parts)
+    return torch.empty(0, dtype=torch.long)
+
+
+def minimax_h3_packed_sequence_ref2va_blocks(
+    *,
+    text_len: int,
+    latent_t: int,
+    latent_h: int,
+    latent_w: int,
+    audio_t: int,
+    ref_blocks: Sequence[Mapping[str, object]],
+    audio_channel: int = 2,
+    seq_len: int | None = None,
+) -> dict[str, object]:
+    """General ref2va-family packed layout.
+
+    ``ref_blocks`` are consumed in request/plan order:
+    - ``{"kind": "image", "latent_h": H, "latent_w": W}``
+    - ``{"kind": "audio", "ref_audio_t": T}``
+    - ``{"kind": "video"|"video_audio", "ref_audio_t": T,
+       "latent_t": RT, "latent_h": RH, "latent_w": RW}``
+
+    Video-bearing blocks pack their audio rows immediately before their video
+    rows; both share the same temporal origin and advance by the longer of the
+    audio and video spans. Standalone audio advances the target origin by its
+    own T, and image blocks advance it by one integer slot.
+    """
+    if not isinstance(ref_blocks, Sequence) or isinstance(ref_blocks, (str, bytes)):
+        raise ValueError("ref_blocks must be a sequence")
+
+    parsed: list[dict[str, object]] = []
+    ref_visual_rows = 0
+    ref_audio_rows = 0
+    for index, raw in enumerate(ref_blocks):
+        path = f"ref_blocks[{index}]"
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"{path} must be an object")
+        kind = raw.get("kind", raw.get("type"))
+        if not isinstance(kind, str) or not kind:
+            raise ValueError(f"{path}.kind must be a non-empty string")
+        if kind == "image":
+            rh = _positive_int(raw, "latent_h", path)
+            rw = _positive_int(raw, "latent_w", path)
+            rows = (rh // _PATCH_H) * (rw // _PATCH_W)
+            item = {"kind": kind, "latent_h": rh, "latent_w": rw, "rows": rows}
+            ref_visual_rows += rows
+        elif kind == "audio":
+            rt = _positive_int(raw, "ref_audio_t", path, allow_zero=True)
+            rows = rt * audio_channel
+            item = {"kind": kind, "ref_audio_t": rt, "audio_rows": rows}
+            ref_audio_rows += rows
+        elif kind in ("video", "video_audio"):
+            rt = _positive_int(raw, "ref_audio_t", path, allow_zero=True)
+            vt = _positive_int(raw, "latent_t", path)
+            vh = _positive_int(raw, "latent_h", path)
+            vw = _positive_int(raw, "latent_w", path)
+            frame_rows = (vh // _PATCH_H) * (vw // _PATCH_W)
+            audio_rows = rt * audio_channel
+            video_rows = vt * frame_rows
+            item = {
+                "kind": kind,
+                "ref_audio_t": rt,
+                "latent_t": vt,
+                "latent_h": vh,
+                "latent_w": vw,
+                "frame_rows": frame_rows,
+                "audio_rows": audio_rows,
+                "video_rows": video_rows,
+            }
+            ref_audio_rows += audio_rows
+            ref_visual_rows += video_rows
+        else:
+            raise ValueError(f"{path}.kind unsupported for ref2va: {kind!r}")
+        parsed.append(item)
+
+    ph, pw = latent_h // _PATCH_H, latent_w // _PATCH_W
+    frame_rows = ph * pw
+    video_rows = latent_t * frame_rows
+    audio_rows = audio_t * audio_channel
+    ref_rows = ref_visual_rows + ref_audio_rows
+    used = text_len + ref_rows + audio_rows + video_rows
+    if seq_len is None:
+        seq_len = ((used + _SEQ_ALIGN - 1) // _SEQ_ALIGN) * _SEQ_ALIGN
+    if seq_len < used:
+        raise ValueError(f"seq_len {seq_len} < used rows {used}")
+
+    text_sl = slice(0, text_len)
+    cursor = text_len
+    block_slices: list[dict[str, object]] = []
+    for item in parsed:
+        kind = str(item["kind"])
+        if kind == "image":
+            rows = int(item["rows"])
+            visual_sl = slice(cursor, cursor + rows)
+            cursor = visual_sl.stop
+            block_slices.append({**item, "visual_sl": visual_sl})
+        elif kind == "audio":
+            rows = int(item["audio_rows"])
+            audio_sl = slice(cursor, cursor + rows)
+            cursor = audio_sl.stop
+            block_slices.append({**item, "audio_sl": audio_sl})
+        else:
+            a_rows = int(item["audio_rows"])
+            v_rows = int(item["video_rows"])
+            audio_sl = slice(cursor, cursor + a_rows)
+            visual_sl = slice(audio_sl.stop, audio_sl.stop + v_rows)
+            cursor = visual_sl.stop
+            block_slices.append({**item, "audio_sl": audio_sl, "visual_sl": visual_sl})
+
+    audio_sl = slice(cursor, cursor + audio_rows)
+    video_sl = slice(audio_sl.stop, audio_sl.stop + video_rows)
+    pad_sl = slice(video_sl.stop, seq_len)
+
+    # This is deliberately tensor-free metadata. It is constructed once by
+    # the denoise branch and consumed by every attention layer without a
+    # device-to-host synchronization.
+    video_spans: list[dict[str, object]] = []
+    for item in block_slices:
+        if item["kind"] in ("video", "video_audio"):
+            visual_sl = item["visual_sl"]
+            assert isinstance(visual_sl, slice)
+            video_spans.append(
+                {
+                    "start": visual_sl.start,
+                    "latent_grid": (
+                        int(item["latent_t"]),
+                        int(item["latent_h"]) // _PATCH_H,
+                        int(item["latent_w"]) // _PATCH_W,
+                    ),
+                    "role": "reference",
+                }
+            )
+    video_spans.append(
+        {
+            "start": video_sl.start,
+            "latent_grid": (latent_t, ph, pw),
+            "role": "target",
+        }
+    )
+
+    input_ids = torch.full((seq_len,), MINIMAX_H3_PAD_ID, dtype=torch.int64)
+    input_ids[text_sl] = MINIMAX_H3_TEXT_ID
+    image_mask = torch.zeros(seq_len, dtype=torch.bool)
+    audio_mask = torch.zeros(seq_len, dtype=torch.bool)
+
+    ref_img_pos_parts: list[torch.Tensor] = []
+    ref_audio_pos_parts: list[torch.Tensor] = []
+    g = torch.zeros(seq_len, 3, dtype=torch.float64)
+    g[text_sl, 0] = torch.arange(text_len, dtype=torch.float64)
+
+    target_area = np.sqrt(latent_h * latent_w)
+    h_grid = _axis_from_sqrt_area(latent_h, _PATCH_H, target_area)
+    w_grid = _axis_from_sqrt_area(latent_w, _PATCH_W, target_area)
+    hh, ww = torch.meshgrid(h_grid, w_grid, indexing="ij")
+    target_frame = torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1)
+
+    t_cursor = float(text_len)
+    for item in block_slices:
+        kind = str(item["kind"])
+        if kind == "image":
+            visual_sl = item["visual_sl"]
+            assert isinstance(visual_sl, slice)
+            input_ids[visual_sl] = MINIMAX_H3_IMGVID_COND_ID
+            image_mask[visual_sl] = True
+            ref_img_pos_parts.append(_range_for_slice(visual_sl))
+            rh = int(item["latent_h"])
+            rw = int(item["latent_w"])
+            area = np.sqrt(rh * rw)
+            ref_hh, ref_ww = torch.meshgrid(
+                _axis_from_sqrt_area(rh, _PATCH_H, area),
+                _axis_from_sqrt_area(rw, _PATCH_W, area),
+                indexing="ij",
+            )
+            g[visual_sl, 0] = t_cursor
+            g[visual_sl, 1] = ref_hh.reshape(-1)
+            g[visual_sl, 2] = ref_ww.reshape(-1)
+            t_cursor += 1.0
+        elif kind == "audio":
+            audio_ref_sl = item["audio_sl"]
+            assert isinstance(audio_ref_sl, slice)
+            ref_t = int(item["ref_audio_t"])
+            input_ids[audio_ref_sl] = MINIMAX_H3_AUDIO_REF_COND_ID
+            audio_mask[audio_ref_sl] = True
+            ref_audio_pos_parts.append(_range_for_slice(audio_ref_sl))
+            ref_t_grid = t_cursor + torch.arange(ref_t, dtype=torch.float64)
+            g[audio_ref_sl, 0] = ref_t_grid.repeat(audio_channel)
+            if ref_t:
+                g[audio_ref_sl, 2] = torch.cat(
+                    [
+                        torch.full((ref_t,), float(w_grid[0]), dtype=torch.float64),
+                        torch.full(
+                            (int(item["audio_rows"]) - ref_t,),
+                            float(w_grid[-1]),
+                            dtype=torch.float64,
+                        ),
+                    ]
+                )
+            t_cursor += float(ref_t)
+        else:
+            audio_ref_sl = item["audio_sl"]
+            visual_sl = item["visual_sl"]
+            assert isinstance(audio_ref_sl, slice)
+            assert isinstance(visual_sl, slice)
+            ref_t = int(item["ref_audio_t"])
+            vt = int(item["latent_t"])
+            vh = int(item["latent_h"])
+            vw = int(item["latent_w"])
+            input_ids[audio_ref_sl] = MINIMAX_H3_AUDIO_REF_COND_ID
+            input_ids[visual_sl] = MINIMAX_H3_IMGVID_COND_ID
+            audio_mask[audio_ref_sl] = True
+            image_mask[visual_sl] = True
+            ref_audio_pos_parts.append(_range_for_slice(audio_ref_sl))
+            ref_img_pos_parts.append(_range_for_slice(visual_sl))
+
+            ref_area = np.sqrt(vh * vw)
+            rv_h_grid = _axis_from_sqrt_area(vh, _PATCH_H, ref_area)
+            rv_w_grid = _axis_from_sqrt_area(vw, _PATCH_W, ref_area)
+            rv_hh, rv_ww = torch.meshgrid(rv_h_grid, rv_w_grid, indexing="ij")
+
+            ref_t_grid = t_cursor + torch.arange(ref_t, dtype=torch.float64)
+            g[audio_ref_sl, 0] = ref_t_grid.repeat(audio_channel)
+            if ref_t:
+                g[audio_ref_sl, 2] = torch.cat(
+                    [
+                        torch.full((ref_t,), float(rv_w_grid[0]), dtype=torch.float64),
+                        torch.full(
+                            (int(item["audio_rows"]) - ref_t,),
+                            float(rv_w_grid[-1]),
+                            dtype=torch.float64,
+                        ),
+                    ]
+                )
+
+            rv_frame = torch.stack([rv_hh.reshape(-1), rv_ww.reshape(-1)], dim=-1)
+            rv_g = torch.empty(vt, int(item["frame_rows"]), 3, dtype=torch.float64)
+            rv_g[:, :, 0] = _video_t_grid(vt, t_cursor)[:, None]
+            rv_g[:, :, 1:] = rv_frame[None]
+            g[visual_sl] = rv_g.reshape(-1, 3)
+            t_cursor += max(float(ref_t), _video_t_span(vt))
+
+    input_ids[audio_sl] = MINIMAX_H3_AUDIO_ID
+    input_ids[audio_sl.start] = MINIMAX_H3_AUDIO_FIRST_ID
+    input_ids[video_sl] = MINIMAX_H3_VIDEO_ID
+    input_ids[video_sl.start] = MINIMAX_H3_VIDEO_FIRST_ID
+    input_ids[video_sl.stop - 1] = MINIMAX_H3_VIDEO_LAST_ID
+    audio_mask[audio_sl] = True
+    image_mask[video_sl] = True
+
+    audio_t_grid = t_cursor + torch.arange(audio_t, dtype=torch.float64)
+    g[audio_sl, 0] = audio_t_grid.repeat(audio_channel)
+    g[audio_sl, 2] = torch.cat(
+        [
+            torch.full((audio_t,), float(w_grid[0]), dtype=torch.float64),
+            torch.full((audio_rows - audio_t,), float(w_grid[-1]), dtype=torch.float64),
+        ]
+    )
+
+    video_g = torch.empty(latent_t, frame_rows, 3, dtype=torch.float64)
+    video_g[:, :, 0] = _video_t_grid(latent_t, t_cursor)[:, None]
+    video_g[:, :, 1:] = target_frame[None]
+    g[video_sl] = video_g.reshape(-1, 3)
+
+    target_img_pos = _range_for_slice(video_sl)
+    target_audio_pos = _range_for_slice(audio_sl)
+    img_pos = _cat_ranges(ref_img_pos_parts + [target_img_pos])
+    audio_pos = _cat_ranges(ref_audio_pos_parts + [target_audio_pos])
+
+    update_mask = torch.zeros(img_pos.shape[0], dtype=torch.bool)
+    update_mask[ref_visual_rows:] = True
+    audio_update_mask = torch.zeros(audio_pos.shape[0], dtype=torch.bool)
+    audio_update_mask[ref_audio_rows:] = True
+    text_pos = torch.arange(0, text_len)
+
+    token_tags = torch.full((seq_len,), -1, dtype=torch.long)  # PADDING
+    token_tags[text_sl] = 1  # TEXT
+    if ref_audio_rows:
+        token_tags[_cat_ranges(ref_audio_pos_parts)] = 2  # AUDIO (reference)
+    token_tags[audio_sl] = 2  # AUDIO (target)
+    token_tags[img_pos] = 0  # VIDEO (refs + target)
+
+    cu = torch.tensor([0, used, seq_len], dtype=torch.int32)
+    doc = torch.zeros(seq_len, dtype=torch.int32)
+    doc[pad_sl] = 1
+    return {
+        "seq_len": torch.tensor(seq_len),
+        "input_ids": input_ids,
+        "image_mask": image_mask,
+        "audio_mask": audio_mask,
+        "img_pos": img_pos,
+        "audio_pos": audio_pos,
+        "text_pos": text_pos,
+        "update_mask": update_mask,
+        "audio_update_mask": audio_update_mask,
+        "img_position_ids": g,
+        "token_tags": token_tags,
+        "cu_seqlens": cu,
+        "document_id": doc,
+        # Extent of the video segment within the packed sequence.
+        "latent_grid": torch.tensor([latent_t, ph, pw], dtype=torch.int64),
+        "video_row_start": torch.tensor(video_sl.start, dtype=torch.int64),
+        "video_spans": tuple(video_spans),
+    }
+
+
+__all__ = [
+    "MINIMAX_H3_AUDIO_FIRST_ID",
+    "MINIMAX_H3_AUDIO_ID",
+    "MINIMAX_H3_AUDIO_REF_COND_ID",
+    "MINIMAX_H3_IMGVID_COND_ID",
+    "MINIMAX_H3_PAD_ID",
+    "MINIMAX_H3_TEXT_ID",
+    "MINIMAX_H3_VIDEO_FIRST_ID",
+    "MINIMAX_H3_VIDEO_ID",
+    "MINIMAX_H3_VIDEO_LAST_ID",
+    "minimax_h3_packed_sequence",
+    "minimax_h3_packed_sequence_ref2va_blocks",
+]

--- a/vllm/model_executor/models/minimax_h3/packed_tokens.py
+++ b/vllm/model_executor/models/minimax_h3/packed_tokens.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+
+def _int_tuple(value: Sequence[int], name: str, length: int) -> tuple[int, ...]:
+    if len(value) != length:
+        raise ValueError(f"{name} must have length {length}, got {list(value)!r}")
+    out = tuple(int(item) for item in value)
+    if any(item <= 0 for item in out):
+        raise ValueError(f"{name} values must be positive, got {list(value)!r}")
+    return out
+
+
+def _rank(tensor: torch.Tensor, name: str, rank: int) -> None:
+    if tensor.ndim != rank:
+        raise ValueError(f"{name} must be rank {rank}, got shape={list(tensor.shape)}")
+
+
+def minimax_h3_patchify_video_latent(
+    latent: torch.Tensor,
+    *,
+    patch_size: Sequence[int],
+) -> torch.Tensor:
+    """Pack video latent [B,C,T,H,W] into DiT token rows."""
+
+    _rank(latent, "video latent", 5)
+    pt, ph, pw = _int_tuple(patch_size, "patch_size", 3)
+    batch, channel, full_t, full_h, full_w = (int(dim) for dim in latent.shape)
+    if full_t % pt or full_h % ph or full_w % pw:
+        raise ValueError(
+            "video latent spatial/time dims must be divisible by patch_size: "
+            f"shape={list(latent.shape)}, patch_size={[pt, ph, pw]}"
+        )
+    t, h, w = full_t // pt, full_h // ph, full_w // pw
+    packed = latent.reshape(batch, channel, t, pt, h, ph, w, pw)
+    packed = torch.einsum("nctrhpwq->nthwcrpq", packed)
+    return packed.reshape(batch * t * h * w, channel * pt * ph * pw).contiguous()
+
+
+def minimax_h3_unpatchify_video_tokens(
+    rows: torch.Tensor,
+    *,
+    latent_shape: Sequence[int],
+    patch_size: Sequence[int],
+) -> torch.Tensor:
+    """Unpack DiT video token rows into latent [B,C,T,H,W]."""
+
+    _rank(rows, "video token rows", 2)
+    t, h, w, channel = _int_tuple(latent_shape, "latent_shape", 4)
+    pt, ph, pw = _int_tuple(patch_size, "patch_size", 3)
+    expected_dim = pt * ph * pw * channel
+    if int(rows.shape[-1]) != expected_dim:
+        raise ValueError(
+            f"video token dim {int(rows.shape[-1])} != patch volume * channel "
+            f"{expected_dim} for latent_shape={list(latent_shape)}, "
+            f"patch_size={[pt, ph, pw]}"
+        )
+    rows_per_sample = t * h * w
+    if int(rows.shape[0]) % rows_per_sample:
+        raise ValueError(
+            f"video rows {int(rows.shape[0])} must be divisible by t*h*w "
+            f"{rows_per_sample} for latent_shape={list(latent_shape)}"
+        )
+    packed = rows.reshape(-1, t, h, w, channel, pt, ph, pw)
+    latent = torch.einsum("nthwcrpq->nctrhpwq", packed)
+    return latent.reshape(-1, channel, t * pt, h * ph, w * pw).contiguous()
+
+
+def minimax_h3_pack_audio_latent(latent: torch.Tensor) -> torch.Tensor:
+    """Pack audio VAE latent [audio_channel, latent_dim, T] into rows."""
+
+    _rank(latent, "audio latent", 3)
+    audio_channel, latent_dim, steps = (int(dim) for dim in latent.shape)
+    return (
+        latent.permute(0, 2, 1)
+        .reshape(
+            audio_channel * steps,
+            latent_dim,
+        )
+        .contiguous()
+    )
+
+
+def minimax_h3_unpack_audio_tokens(
+    rows: torch.Tensor,
+    *,
+    audio_t: int,
+    audio_channel: int,
+) -> torch.Tensor:
+    """Unpack DiT audio token rows into audio VAE latent [C,latent_dim,T]."""
+
+    _rank(rows, "audio token rows", 2)
+    audio_t = int(audio_t)
+    audio_channel = int(audio_channel)
+    if audio_t <= 0 or audio_channel <= 0:
+        raise ValueError(
+            f"audio_t and audio_channel must be positive, got {audio_t=} "
+            f"{audio_channel=}"
+        )
+    if int(rows.shape[0]) != audio_t:
+        raise ValueError(f"audio rows {int(rows.shape[0])} != audio_t {audio_t}")
+    if audio_t % audio_channel:
+        raise ValueError(
+            f"audio_t must be divisible by audio_channel, got {audio_t=} "
+            f"{audio_channel=}"
+        )
+    native = rows.reshape(audio_channel, audio_t // audio_channel, int(rows.shape[-1]))
+    return native.permute(0, 2, 1).contiguous()
+
+
+__all__ = [
+    "minimax_h3_pack_audio_latent",
+    "minimax_h3_patchify_video_latent",
+    "minimax_h3_unpack_audio_tokens",
+    "minimax_h3_unpatchify_video_tokens",
+]

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -1,0 +1,1827 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Native serial MiniMax H3 pipeline. See UPSTREAM.md for port provenance."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager, nullcontext
+from typing import Any
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from PIL import Image
+from torch import nn
+from tqdm.auto import tqdm
+from transformers import Qwen2TokenizerFast, Qwen3VLProcessor
+
+from vllm.distributed import get_tp_group, get_world_group
+from vllm.logger import init_logger
+from vllm.video.metrics import DenoiseWorkCounter
+
+from .attention import attention_backend
+from .comfy_checkpoint import inspect_comfy_checkpoint, resolve_comfy_checkpoint_path
+from .condition_noise import (
+    minimax_h3_audio_cond_noise_aug_rows,
+    minimax_h3_imgvid_cond_noise_aug_rows,
+)
+from .conditioning import MiniMaxH3TextConditioning
+from .config import H3Config, H3InputError, H3Request
+from .denoise_loop import MiniMaxH3DenoiseBranch, minimax_h3_denoise_loop
+from .encoder import MiniMaxH3Qwen3VLEncoder
+from .packed_sequence import (
+    minimax_h3_packed_sequence,
+    minimax_h3_packed_sequence_ref2va_blocks,
+)
+from .packed_tokens import (
+    minimax_h3_patchify_video_latent,
+    minimax_h3_unpack_audio_tokens,
+    minimax_h3_unpatchify_video_tokens,
+)
+from .preprocessing import (
+    load_minimax_h3_images as _load_images,
+)
+from .preprocessing import (
+    minimax_h3_multi_image_presentation,
+    minimax_h3_ref2va_presentation,
+    minimax_h3_ref2va_video_presentation,
+    minimax_h3_text_only_ids,
+)
+from .preprocessing import (
+    resolve_minimax_h3_aspect_ratio as _resolve_minimax_h3_aspect_ratio,
+)
+from .preprocessing import (
+    resolve_minimax_h3_output_canvas as _resolve_output_canvas,
+)
+from .preprocessing import (
+    resolve_minimax_h3_reference_image_shape as _reference_image_shape,
+)
+from .quantization import DiffusionInt8ConvRotConfig
+from .reference_video import (
+    load_audio_file,
+    load_video_audio,
+    load_video_frames,
+    prepare_reference_videos,
+    sample_reference_video_frames,
+    validate_reference_audio_files,
+    validate_reference_audio_waveforms,
+)
+from .residency import PinnedModuleStager
+from .sigma_schedule import DMD2SigmaSchedule
+from .time_request import (
+    MINIMAX_H3_SHAPE_PLANNER,
+    minimax_h3_align_frame_count,
+    minimax_h3_time_shift_sigmas,
+)
+from .transformer import MiniMaxH3DiTModel
+from .vae import MiniMaxH3AudioVAE, MiniMaxH3VideoVAE
+from .weight_cache import FP16WeightCache
+from .weights import iter_checkpoint_weights, resolve_model_root
+
+logger = init_logger(__name__)
+
+MINIMAX_H3_FPS = 24
+
+
+MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
+
+
+MINIMAX_H3_IMGVID_COND_TIMESTEP = 0.999
+
+
+MINIMAX_H3_AUDIO_REF_COND_TIMESTEP = 1.0
+
+
+MINIMAX_H3_OUTPUT_SHORT_EDGE = 768
+
+
+MINIMAX_H3_OUTPUT_MAX_PIXELS = 768 * 1344
+
+
+MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE = 2048
+
+
+MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE = 32
+
+
+MINIMAX_H3_SUPPORTED_ASPECT_RATIOS = {
+    "21:9": 21.0 / 9.0,
+    "16:9": 16.0 / 9.0,
+    "4:3": 4.0 / 3.0,
+    "1:1": 1.0,
+    "3:4": 3.0 / 4.0,
+    "9:16": 9.0 / 16.0,
+}
+
+
+MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES = 30 * 1024 * 1024
+
+
+MINIMAX_H3_REFERENCE_IMAGE_FORMATS = frozenset({"jpeg", "png", "webp", "heic", "heif"})
+
+
+MINIMAX_H3_MIN_OUTPUT_SECONDS = 4.0
+
+
+MINIMAX_H3_MAX_OUTPUT_SECONDS = 15.0
+
+
+_MINIMAX_H3_DENOISE_INPUT_KEYS = (
+    "task",
+    "text_embeddings",
+    "text_tags",
+    "seed",
+    "latent_t",
+    "latent_h",
+    "latent_w",
+    "audio_t",
+    "num_frames",
+    "num_steps",
+    "video_shift",
+    "audio_shift",
+    "base_schedule",
+    "visual_condition",
+    "visual_condition_shape",
+    "audio_condition",
+    "ref_audio_t",
+    "ref_blocks",
+    "visual_condition_shapes",
+    "audio_condition_lengths",
+    "keyframe_frame_indices",
+)
+
+
+def _read_base_schedule(release: Mapping[str, Any]) -> DMD2SigmaSchedule | None:
+    """Read a partition's distilled schedule. An absent key means legacy uniform."""
+    return DMD2SigmaSchedule.from_metadata(release)
+
+
+def _prepare_minimax_h3_video_output(video: torch.Tensor) -> torch.Tensor:
+    """Quantize decoded frames in place before worker-to-engine transfer."""
+    if not torch.isfinite(video).all():
+        raise RuntimeError("H3 VAE produced non-finite video")
+    video = video.detach().float()
+    video.clamp_(0, 1).mul_(255).round_()
+    return video.permute(0, 2, 3, 4, 1).to(
+        dtype=torch.uint8,
+        memory_format=torch.contiguous_format,
+    )
+
+
+def _align_multiple(value: float, multiple: int = 32) -> int:
+    return max(multiple, int(round(float(value) / multiple)) * multiple)
+
+
+def _load_image(value: Any) -> Image.Image:
+    images = _load_images(value)
+    if len(images) != 1:
+        raise H3InputError(f"MiniMax H3 expected one image, got {len(images)}")
+    return images[0]
+
+
+def _load_audio(value: Any) -> tuple[torch.Tensor, int]:
+    if isinstance(value, (list, tuple)) and not (
+        len(value) == 2 and isinstance(value[1], (int, np.integer))
+    ):
+        audios = _load_audios(value)
+        if len(audios) != 1:
+            raise H3InputError(f"MiniMax H3 expected one audio, got {len(audios)}")
+        return audios[0]
+    if isinstance(value, (str, os.PathLike)):
+        return load_audio_file(str(value))
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        waveform, sample_rate = value
+        waveform = torch.as_tensor(waveform).float()
+        return waveform, int(sample_rate)
+    if isinstance(value, dict):
+        waveform = value.get("waveform", value.get("array"))
+        sample_rate = value.get("sample_rate", value.get("sampling_rate"))
+        if waveform is not None and sample_rate is not None:
+            return torch.as_tensor(waveform).float(), int(sample_rate)
+    raise H3InputError(
+        "MiniMax H3 audio input must be a path, (waveform, sample_rate), or a waveform "
+        "mapping"
+    )
+
+
+def _load_audios(value: Any) -> list[tuple[torch.Tensor, int]]:
+    if isinstance(value, (list, tuple)) and not (
+        len(value) == 2 and isinstance(value[1], (int, np.integer))
+    ):
+        if not value:
+            raise H3InputError("MiniMax H3 audio input must not be empty")
+        return [_load_audio(item) for item in value]
+    return [_load_audio(value)]
+
+
+def _as_int_list(value: Any, *, name: str) -> list[int]:
+    if isinstance(value, bool):
+        raise H3InputError(f"{name} must be an integer or a list of integers")
+    if isinstance(value, (int, np.integer)):
+        return [int(value)]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        result = list(value)
+        if not result:
+            raise H3InputError(f"{name} must not be empty")
+        if any(
+            isinstance(item, bool) or not isinstance(item, (int, np.integer))
+            for item in result
+        ):
+            raise H3InputError(f"{name} must contain only integers")
+        return [int(item) for item in result]
+    raise H3InputError(f"{name} must be an integer or a list of integers")
+
+
+def _resolve_fl2va_keyframe_indices(
+    extra: Mapping[str, Any], image_count: int
+) -> list[int]:
+    target = extra.get("target")
+    target = target if isinstance(target, Mapping) else {}
+    raw = extra.get("frame_indices", extra.get("frame_index"))
+    if raw is None:
+        raw = target.get("frame_indices", target.get("frame_index"))
+    if raw is None:
+        raw_indices = [0] if image_count == 1 else [0, -1]
+    else:
+        raw_indices = _as_int_list(raw, name="frame_indices")
+    if len(raw_indices) != image_count:
+        raise H3InputError(
+            f"MiniMax H3 FL2VA requires one frame index per image: got {raw_indices!r} "
+            f"for {image_count} image(s)"
+        )
+    if tuple(raw_indices) not in ((0,), (-1,), (0, -1)):
+        raise H3InputError(
+            "MiniMax H3 FL2VA frame_indices must be [0], [-1], or [0, -1]"
+        )
+    return raw_indices
+
+
+def _reuse_prepared_reference_videos(
+    prepared: list[dict[str, Any]] | None,
+    *,
+    expected_count: int,
+) -> list[dict[str, Any]] | None:
+    if prepared is None:
+        return None
+    if len(prepared) != expected_count:
+        raise H3InputError(
+            "MiniMax H3 prepared-reference-video count does not match the request"
+        )
+    for item in prepared:
+        if not os.path.isfile(item["prepared_path"]):
+            raise H3InputError(
+                f"MiniMax H3 prepared reference video is unavailable: "
+                f"{item['prepared_path']}"
+            )
+    return prepared
+
+
+def _validate_ref2va_reference_counts(
+    image_count: int,
+    video_count: int,
+    audio_count: int,
+) -> None:
+    """Validate the official Ref2VA reference-count contract."""
+    if image_count < 0 or video_count < 0 or audio_count < 0:
+        raise H3InputError("MiniMax H3 reference counts must be non-negative")
+    if image_count + video_count == 0:
+        raise H3InputError("ref2va requires at least one image or video reference")
+    if image_count > 9:
+        raise H3InputError("ref2va accepts at most 9 image references")
+    if video_count > 3:
+        raise H3InputError("ref2va accepts at most 3 video references")
+    if audio_count > 3:
+        raise H3InputError("ref2va accepts at most 3 standalone audio references")
+    if image_count + video_count + audio_count > 12:
+        raise H3InputError("ref2va accepts at most 12 total references")
+
+
+def _resolve_minimax_h3_num_outputs(value: Any) -> int:
+    if value is None:
+        return 1
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise H3InputError(
+            "MiniMax H3 num_outputs_per_prompt must be an integer in [1, 10]"
+        )
+    value = int(value)
+    if not 1 <= value <= 10:
+        raise H3InputError(
+            f"MiniMax H3 num_outputs_per_prompt must be in [1, 10], got {value}"
+        )
+    return value
+
+
+def _minimax_h3_output_seeds(seed: int, num_outputs: int) -> list[int]:
+    return [int(seed) + output_index for output_index in range(int(num_outputs))]
+
+
+def _validate_reference_image(image: Image.Image) -> None:
+    width, height = image.size
+    if min(width, height) < 256 or max(width, height) > 5760:
+        raise H3InputError(
+            f"MiniMax H3 reference image dimensions must be in [256, 5760] pixels, got "
+            f"{width}x{height}"
+        )
+    ratio = width / height
+    if not 0.4 <= ratio <= 2.5:
+        raise H3InputError(
+            f"MiniMax H3 reference image aspect ratio must be in [0.4, 2.5], got "
+            f"{width}x{height}"
+        )
+
+
+def _dit_rank_world() -> tuple[Any, int, int]:
+    if not dist.is_initialized():
+        return None, 0, 1
+    group = get_world_group().device_group
+    return group, dist.get_rank(group), dist.get_world_size(group)
+
+
+def _broadcast_rank0_exception(exc: Exception | None) -> None:
+    """Synchronize a rank-0-only exception across every DiT rank.
+
+    H3 reference-video preparation runs only on rank 0; the other DiT ranks
+    return ``None`` without touching disk. When rank 0 raises inside that
+    path it exits :meth:`prepare_encode` before reaching the downstream
+    ``dist.broadcast`` calls, and non-zero ranks then hang on those
+    collectives forever. Every rank calls this helper right after the
+    rank-0-only work, before any subsequent collective, so all ranks either
+    raise the same error together or all continue.
+    """
+    group, rank, world_size = _dit_rank_world()
+    if world_size == 1:
+        if exc is not None:
+            raise exc
+        return
+    if rank == 0:
+        if exc is None:
+            payload: list[Any] = [None]
+        else:
+            payload = [
+                {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                    "status_code": getattr(exc, "status_code", None),
+                    "error_type": getattr(exc, "error_type", None),
+                }
+            ]
+    else:
+        payload = [None]
+    dist.broadcast_object_list(payload, src=0, group=group)
+    info = payload[0]
+    if info is None:
+        return
+    if rank == 0:
+        assert exc is not None
+        raise exc
+    # Rebuild a matching client-facing error on non-zero ranks so the runner's
+    # per-request try/except records the same 4xx status as rank 0. The exact
+    # subclass need not survive the wire; the message and status suffice.
+    message = f"[rank 0] {info['type']}: {info['message']}"
+    raise H3InputError(message)
+
+
+def _broadcast_tensor(
+    tensor: torch.Tensor | None,
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    group, rank, world_size = _dit_rank_world()
+    if world_size == 1:
+        if tensor is None:
+            raise ValueError("source tensor is required for single-rank execution")
+        return tensor.to(device=device, dtype=dtype)
+
+    shape = torch.zeros(5, dtype=torch.long, device=device)
+    if rank == 0:
+        if tensor is None:
+            raise ValueError("rank 0 must provide a tensor to broadcast")
+        shape[0] = tensor.ndim
+        shape[1 : tensor.ndim + 1] = torch.tensor(
+            tensor.shape,
+            device=device,
+        )
+    dist.broadcast(shape, src=0, group=group)
+    ndim = int(shape[0].item())
+    tensor_shape = tuple(int(v) for v in shape[1 : ndim + 1].tolist())
+    if rank == 0:
+        output = tensor.to(device=device, dtype=dtype).contiguous()
+    else:
+        output = torch.empty(tensor_shape, device=device, dtype=dtype)
+    dist.broadcast(output, src=0, group=group)
+    return output
+
+
+class MiniMaxH3Pipeline(nn.Module):
+    def __init__(self, config: H3Config):
+        super().__init__()
+        self.config = config
+        self.partition = config.partition
+        self.device = torch.device("cuda", torch.accelerator.current_device_index())
+        self.model_root = resolve_model_root(config)
+        path = self.model_root / ("FL2VA" if self.partition == "fl2va" else "Ref2VA")
+        shared = self.model_root / "FL2VA"
+        if not shared.is_dir():
+            shared = path
+        release = json.loads((path / "model_index.json").read_text())["_minimax_h3"]
+        if release["partition"].lower() != self.partition:
+            raise H3InputError("checkpoint partition does not match deployment")
+        self.supported_tasks = frozenset(
+            release.get(
+                "tasks", ["ref2va"] if self.partition == "ref2va" else ["t2va", "fl2va"]
+            )
+        )
+        shifts = release.get("sigma_shift_scales", {})
+        self.default_video_shift = float(shifts.get("video", 12.0))
+        self.default_audio_shift = float(shifts.get("audio", 3.0))
+        self._base_schedule_by_partition = {
+            self.partition: _read_base_schedule(release)
+        }
+        transformer_path = path / "transformer"
+        quant = None
+        overrides = None
+        if config.transformer_path:
+            transformer_path = resolve_comfy_checkpoint_path(config.transformer_path)
+            checkpoint = inspect_comfy_checkpoint(
+                transformer_path, expected_partition=self.partition
+            )
+            overrides = checkpoint.arch_overrides
+            quant = DiffusionInt8ConvRotConfig(layer_configs=checkpoint.layer_configs)
+        architecture = json.loads((path / "transformer/config.json").read_text())
+        token = attention_backend.set(config.attention_backend)
+        try:
+            self.transformer = MiniMaxH3DiTModel(
+                architecture, quant_config=quant, arch_overrides=overrides
+            )
+        finally:
+            attention_backend.reset(token)
+        loaded = self.transformer.load_weights(
+            iter_checkpoint_weights(transformer_path)
+        )
+        required = set(dict(self.transformer.named_parameters()))
+        required.update(dict(self.transformer.named_buffers()))
+        missing = required - loaded
+        if missing:
+            raise RuntimeError(f"H3 DiT checkpoint missing tensors: {sorted(missing)}")
+        for layer in self.transformer.modules():
+            method = getattr(layer, "quant_method", None)
+            if method is not None:
+                method.process_weights_after_loading(layer)
+        self.transformer.post_load_weights()
+        self._dit_stager = PinnedModuleStager(self.transformer, self.device)
+        self._weight_cache = FP16WeightCache(
+            self.transformer,
+            budget_gib=config.fp16_weight_cache_gib,
+            layers=config.fp16_cache_layers,
+        )
+        self.text_encoder_group = get_tp_group()
+        self.text_encoder_tp_size = self.text_encoder_group.world_size
+        self._dit_rank = self.text_encoder_group.rank_in_group
+        self.tokenizer = Qwen2TokenizerFast.from_pretrained(
+            str(shared / "tokenizer"), local_files_only=True
+        )
+        self.processor = Qwen3VLProcessor.from_pretrained(
+            str(shared / "processor"), local_files_only=True
+        )
+        self.text_encoder = MiniMaxH3Qwen3VLEncoder(
+            str(shared / "text_encoder"),
+            device=self.device,
+            load_model=True,
+            encoder_group=self.text_encoder_group,
+        )
+        self.text_encoder.load_weights(iter_checkpoint_weights(shared / "text_encoder"))
+        self._encoder_stager = PinnedModuleStager(self.text_encoder, self.device)
+        self.video_vae = MiniMaxH3VideoVAE(
+            str(shared / "video_vae"),
+            device=self.device,
+            load_device=torch.device("cpu"),
+        )
+        self.video_vae.set_parallel_size(config.tensor_parallel_size)
+        self.audio_vae = MiniMaxH3AudioVAE(
+            str(shared / "audio_vae"),
+            device=self.device,
+            load_device=torch.device("cpu"),
+        )
+        self.stage_durations = {}
+        self.actual_dit_calls = 0
+        self.eval()
+
+    def _transformer_for_task(self, task):
+        return self.transformer
+
+    def _resolve_sigma_positions(self, task, sampling):
+        schedule = self._base_schedule_for_task(task)
+        if schedule is None:
+            return None, sampling.num_inference_steps
+        if sampling.num_inference_steps != schedule.num_inference_steps:
+            raise H3InputError("checkpoint pins its own inference-step count")
+        return schedule.base_schedule, schedule.num_inference_steps
+
+    def _encode_text_hidden(self, input_ids, vision_kwargs):
+        with self._component_on_device(self.text_encoder):
+            return self.text_encoder.encode_ids(input_ids, **vision_kwargs)
+
+    @contextmanager
+    def _component_on_device(self, component):
+        stager = self._encoder_stager if component is self.text_encoder else None
+        if stager is not None:
+            stager.load()
+        else:
+            component.load_to_device()
+        try:
+            yield
+        finally:
+            if stager is not None:
+                stager.offload()
+            else:
+                component.offload_to_cpu()
+
+    @contextmanager
+    def _resident_dit_layers_on_device(self, *, enabled=True):
+        started = time.perf_counter()
+        self._dit_stager.load()
+        try:
+            self._weight_cache.prepare()
+            torch.accelerator.synchronize()
+            self.stage_durations["dit_staging_and_weight_cache"] = (
+                time.perf_counter() - started
+            )
+            yield
+        finally:
+            self._weight_cache.clear()
+            self._dit_stager.offload()
+
+    def progress_bar(self, *, total):
+        self.actual_dit_calls = total
+        return tqdm(total=total, desc="H3 denoise", disable=self._dit_rank != 0)
+
+    @torch.inference_mode()
+    def forward(self, request: H3Request):
+        self.stage_durations = {}
+        started = time.perf_counter()
+        context = self._prepare_request_inputs(
+            prompt=request.prompt,
+            multi_modal_data=request.media,
+            sampling=request.sampling,
+        )
+        torch.accelerator.synchronize()
+        self.stage_durations["encode"] = time.perf_counter() - started
+        started = time.perf_counter()
+        video_latent, audio_latent = self.diffuse(**self._denoise_kwargs(context))
+        torch.accelerator.synchronize()
+        self.stage_durations["denoise_including_staging"] = (
+            time.perf_counter() - started
+        )
+        started = time.perf_counter()
+        video, audio = self.decode(
+            video_latent, audio_latent, height=context["height"], width=context["width"]
+        )
+        torch.accelerator.synchronize()
+        self.stage_durations["vae"] = time.perf_counter() - started
+        return _prepare_minimax_h3_video_output(video), audio
+
+    def _base_schedule_for_task(self, task: str) -> DMD2SigmaSchedule | None:
+        """Return the distilled schedule of the partition that serves ``task``."""
+        partition = "ref2va" if task == "ref2va" else "fl2va"
+        return self._base_schedule_by_partition.get(partition)
+
+    def _resolve_task(
+        self,
+        requested: str | None,
+        multi_modal_data: dict[str, Any],
+    ) -> str:
+        if requested is None:
+            # A Ref2VA-only startup has no FL2VA transformer; preserve its
+            # historical implicit default even for image-only references.
+            if self.partition == "ref2va" or (
+                multi_modal_data.get("video") is not None
+                or multi_modal_data.get("audio") is not None
+            ):
+                requested = "ref2va"
+            elif multi_modal_data.get("image") is not None:
+                requested = "fl2va"
+            else:
+                requested = "t2va"
+        task = str(requested).lower()
+        if task not in self.supported_tasks:
+            raise H3InputError(
+                f"checkpoint partition {self.partition!r} supports "
+                f"{sorted(self.supported_tasks)}, got task={task!r}"
+            )
+        return task
+
+    def _resolve_shape(
+        self,
+        task: str,
+        sampling: Any,
+        image: Image.Image | None,
+    ) -> tuple[int, int, int, int, int]:
+        fps = int(sampling.fps or MINIMAX_H3_FPS)
+        if fps != MINIMAX_H3_FPS:
+            raise H3InputError(f"MiniMax H3 output fps is fixed at {MINIMAX_H3_FPS}")
+        extra = sampling.extra_args or {}
+        target = extra.get("target")
+        if target is not None and not isinstance(target, Mapping):
+            raise H3InputError("MiniMax H3 extra_args['target'] must be an object")
+        target = target if isinstance(target, Mapping) else {}
+        duration = target.get(
+            "duration_seconds", extra.get("duration_seconds", extra.get("duration"))
+        )
+        if duration is not None:
+            if isinstance(duration, bool):
+                raise H3InputError(
+                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"{duration!r}"
+                )
+            try:
+                duration = float(duration)
+            except (TypeError, ValueError) as exc:
+                raise H3InputError(
+                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"{duration!r}"
+                ) from exc
+            if (
+                not math.isfinite(duration)
+                or not MINIMAX_H3_MIN_OUTPUT_SECONDS
+                <= duration
+                <= MINIMAX_H3_MAX_OUTPUT_SECONDS
+            ):
+                raise H3InputError(
+                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"{duration}"
+                )
+            requested_frames = int(round(duration * fps))
+        elif int(sampling.num_frames or 1) > 1:
+            requested_frames = int(sampling.num_frames)
+        else:
+            requested_frames = 124 if task == "ref2va" else 209
+            duration = requested_frames / fps
+        if (
+            not MINIMAX_H3_MIN_OUTPUT_SECONDS
+            <= requested_frames / fps
+            <= MINIMAX_H3_MAX_OUTPUT_SECONDS
+        ):
+            raise H3InputError(
+                f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                f"{requested_frames / fps:.3f}"
+            )
+        num_frames = minimax_h3_align_frame_count(requested_frames)
+
+        height = sampling.height
+        width = sampling.width
+        aspect_ratio = target.get("aspect_ratio", extra.get("aspect_ratio"))
+        raw_short_edge = target.get(
+            "short_edge", extra.get("short_edge", MINIMAX_H3_OUTPUT_SHORT_EDGE)
+        )
+        if isinstance(raw_short_edge, bool) or not isinstance(
+            raw_short_edge, (int, np.integer)
+        ):
+            raise H3InputError(
+                f"MiniMax H3 target.short_edge must be {MINIMAX_H3_OUTPUT_SHORT_EDGE}, "
+                f"got {raw_short_edge!r}"
+            )
+        short_edge = int(raw_short_edge)
+
+        aspect_ratio = _resolve_minimax_h3_aspect_ratio(
+            task,
+            aspect_ratio,
+            image,
+        )
+        if not 0.25 <= aspect_ratio <= 4.0:
+            raise H3InputError(
+                f"MiniMax H3 canvas aspect ratio must be in [1:4, 4:1], got "
+                f"{aspect_ratio}"
+            )
+
+        if height is None or width is None:
+            height, width = _resolve_output_canvas(aspect_ratio, short_edge)
+        height = int(height) // 32 * 32
+        width = int(width) // 32 * 32
+        if min(height, width) <= 0:
+            raise H3InputError(f"invalid MiniMax H3 canvas {width}x{height}")
+        if width > 4 * height or height > 4 * width:
+            raise H3InputError("MiniMax H3 canvas aspect ratio must be in [1:4, 4:1]")
+
+        latent_t = MINIMAX_H3_SHAPE_PLANNER.video_latent_t(num_frames)
+        audio_t = MINIMAX_H3_SHAPE_PLANNER.audio_latent_t(num_frames / fps)
+        return height, width, num_frames, latent_t, audio_t
+
+    def encode_prompt(
+        self,
+        *,
+        task: str,
+        prompt: str,
+        image: Image.Image | None = None,
+        images: list[Image.Image] | None = None,
+        prepared_videos: list[dict[str, Any]] | None = None,
+        condition_labels: list[tuple[str, int]] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        _, rank, _ = _dit_rank_world()
+        hidden = None
+        tags = None
+        ids = None
+        vision_kwargs: dict[str, torch.Tensor] = {}
+        images = (
+            list(images)
+            if images is not None
+            else ([image] if image is not None else [])
+        )
+        if rank == 0:
+            if task == "t2va":
+                ids = minimax_h3_text_only_ids(self.tokenizer, prompt)
+                tags = torch.ones(ids.shape[0], dtype=torch.long)
+                vision_kwargs = {}
+            else:
+                image_token_counts: list[int] = []
+                if images:
+                    vision = self.processor.image_processor(
+                        images=images,
+                        return_tensors="pt",
+                    )
+                    image_grid = vision["image_grid_thw"]
+                    merge = int(self.processor.image_processor.merge_size) ** 2
+                    image_token_counts = [
+                        int(grid.prod().item()) // merge for grid in image_grid
+                    ]
+                    vision_kwargs.update(
+                        {
+                            "pixel_values": vision["pixel_values"],
+                            "image_grid_thw": image_grid,
+                        }
+                    )
+
+                video_block_counts: list[list[int]] = []
+                video_block_timestamps: list[list[float]] = []
+                if prepared_videos:
+                    videos = []
+                    sampled_videos = []
+                    for index, item in enumerate(prepared_videos):
+                        sampled = sample_reference_video_frames(item["prepared_path"])
+                        videos.append(np.stack(sampled["frames"]))
+                        sampled_videos.append(sampled)
+                    vision = self.processor.video_processor(
+                        videos=videos,
+                        do_sample_frames=False,
+                        return_tensors="pt",
+                    )
+                    video_grid = vision["video_grid_thw"]
+                    merge = int(self.processor.image_processor.merge_size) ** 2
+                    for index, sampled in enumerate(sampled_videos):
+                        blocks = int(video_grid[index, 0])
+                        per_block = (
+                            int(video_grid[index, 1])
+                            * int(video_grid[index, 2])
+                            // merge
+                        )
+                        timestamps = sampled["block_timestamps"]
+                        if len(timestamps) != blocks:
+                            raise ValueError(
+                                f"video block count mismatch: processor={blocks}, "
+                                f"timestamps={len(timestamps)}"
+                            )
+                        video_block_counts.append([per_block] * blocks)
+                        video_block_timestamps.append(timestamps)
+                    vision_kwargs.update(
+                        {
+                            "pixel_values_videos": vision["pixel_values_videos"],
+                            "video_grid_thw": video_grid,
+                        }
+                    )
+
+                if not images and not prepared_videos:
+                    raise H3InputError(f"{task} requires an image or video condition")
+                if condition_labels is None:
+                    condition_labels = []
+                    for image_index in range(1, len(images) + 1):
+                        condition_labels.append(("image", image_index))
+                    audio_index = 0
+                    for video_index, item in enumerate(prepared_videos or (), start=1):
+                        if item["input_has_audio"]:
+                            audio_index += 1
+                            condition_labels.append(("audio", audio_index))
+                        condition_labels.append(("video", video_index))
+
+                if task == "fl2va":
+                    if prepared_videos:
+                        raise H3InputError("fl2va does not accept video conditions")
+                    ids, tags = minimax_h3_multi_image_presentation(
+                        self.tokenizer,
+                        prompt=prompt,
+                        image_token_counts=image_token_counts,
+                    )
+                elif prepared_videos:
+                    ids, tags = minimax_h3_ref2va_video_presentation(
+                        self.tokenizer,
+                        prompt=prompt,
+                        condition_labels=condition_labels,
+                        image_token_count=image_token_counts or None,
+                        video_block_token_counts=video_block_counts,
+                        video_block_timestamps=video_block_timestamps,
+                    )
+                else:
+                    ids, tags = minimax_h3_ref2va_presentation(
+                        self.tokenizer,
+                        prompt=prompt,
+                        condition_labels=condition_labels,
+                        image_token_count=image_token_counts or None,
+                    )
+
+            logger.info(
+                "MiniMax H3 %s Qwen presentation: %d tokens%s",
+                task,
+                int(ids.shape[0]),
+                (
+                    f", {len(images)} reference images"
+                    + (
+                        f", {len(prepared_videos)} reference videos"
+                        if prepared_videos
+                        else ""
+                    )
+                    if images
+                    else (
+                        f", {len(prepared_videos)} reference videos"
+                        if prepared_videos
+                        else ""
+                    )
+                ),
+            )
+
+        if rank < self.text_encoder_tp_size:
+            # Distribute the encode inputs from the DiT main rank to the other
+            # encoder TP ranks, then run the distributed encode on all of them.
+            ids = self._distribute_encode_inputs(ids, vision_kwargs)
+            hidden = self._encode_text_hidden(ids, vision_kwargs)
+
+        hidden = _broadcast_tensor(
+            hidden,
+            dtype=torch.float16,
+            device=self.device,
+        )
+        tags = _broadcast_tensor(
+            tags,
+            dtype=torch.long,
+            device=self.device,
+        )
+        return hidden, tags
+
+    def _encoder_group_broadcast_tensor(
+        self,
+        tensor: torch.Tensor | None,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Broadcast a tensor from encoder rank 0 over the encoder TP group."""
+        group = self.text_encoder_group
+        if group.world_size == 1:
+            if tensor is None:
+                raise ValueError("source tensor is required for single-rank execution")
+            return tensor.to(device=device, dtype=dtype)
+
+        shape = torch.zeros(8, dtype=torch.long, device=device)
+        if group.rank_in_group == 0:
+            if tensor is None:
+                raise ValueError("encoder rank 0 must provide a tensor to broadcast")
+            shape[0] = tensor.ndim
+            shape[1 : tensor.ndim + 1] = torch.tensor(tensor.shape, device=device)
+        torch.distributed.broadcast(shape, src=group.ranks[0], group=group.device_group)
+        ndim = int(shape[0].item())
+        tensor_shape = tuple(int(value) for value in shape[1 : ndim + 1].tolist())
+        if group.rank_in_group == 0:
+            output = tensor.to(device=device, dtype=dtype).contiguous()
+        else:
+            output = torch.empty(tensor_shape, device=device, dtype=dtype)
+        torch.distributed.broadcast(
+            output, src=group.ranks[0], group=group.device_group
+        )
+        return output
+
+    def _distribute_encode_inputs(
+        self,
+        ids: torch.Tensor | None,
+        vision_kwargs: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """Fan out encode inputs from encoder rank 0 to the encoder TP ranks.
+
+        Mutates ``vision_kwargs`` in place so every encoder rank ends up with
+        the same vision tensors, and returns the broadcast ``input_ids``.
+        """
+        keys = (
+            "pixel_values",
+            "image_grid_thw",
+            "pixel_values_videos",
+            "video_grid_thw",
+        )
+        key_dtypes = {
+            "pixel_values": torch.float16,
+            "pixel_values_videos": torch.float16,
+            "image_grid_thw": torch.long,
+            "video_grid_thw": torch.long,
+        }
+        group = self.text_encoder_group
+        device = self.device
+        if group.world_size == 1:
+            if ids is None:
+                raise ValueError("encoder rank 0 must produce input ids")
+            return ids.to(device=device, dtype=torch.long)
+
+        mask = torch.zeros(len(keys), dtype=torch.long, device=device)
+        if group.rank_in_group == 0:
+            for index, key in enumerate(keys):
+                mask[index] = 1 if key in vision_kwargs else 0
+        torch.distributed.broadcast(mask, src=group.ranks[0], group=group.device_group)
+
+        if group.rank_in_group == 0:
+            ids = self._encoder_group_broadcast_tensor(
+                ids, dtype=torch.long, device=device
+            )
+        else:
+            ids = self._encoder_group_broadcast_tensor(
+                None, dtype=torch.long, device=device
+            )
+        for index, key in enumerate(keys):
+            if mask[index].item() == 0:
+                continue
+            source = vision_kwargs.get(key) if group.rank_in_group == 0 else None
+            vision_kwargs[key] = self._encoder_group_broadcast_tensor(
+                source,
+                dtype=key_dtypes[key],
+                device=device,
+            )
+        return ids
+
+    def _prepare_reference_videos(
+        self,
+        values: Any,
+        *,
+        target_frame_count: int,
+        workdir: str,
+        start_time_seconds: Any = None,
+    ) -> list[dict[str, Any]] | None:
+        _, rank, _ = _dit_rank_world()
+        if rank != 0:
+            return None
+        return prepare_reference_videos(
+            values,
+            target_frame_count=target_frame_count,
+            workdir=workdir,
+            start_time_seconds=start_time_seconds,
+        )
+
+    def _encode_visual_conditions(
+        self,
+        images: list[Image.Image],
+        prepared_videos: list[dict[str, Any]] | None,
+        *,
+        video_count: int,
+    ) -> tuple[torch.Tensor | None, list[tuple[int, int, int]]]:
+        rows: list[torch.Tensor] = []
+        shapes: list[tuple[int, int, int]] = []
+        _, rank, _ = _dit_rank_world()
+        # Keep image and video references in one residency window when both
+        # appear in a request; otherwise the video branch would reload the VAE.
+        needs_video_vae = video_count > 0 or (rank == 0 and bool(images))
+        video_vae_context = (
+            self._component_on_device(self.video_vae)
+            if needs_video_vae
+            else nullcontext()
+        )
+        with video_vae_context:
+            if images:
+                image_rows = None
+                if rank == 0:
+                    image_rows = torch.cat(
+                        [self.video_vae.encode_image(image) for image in images]
+                    )
+                rows.append(
+                    _broadcast_tensor(
+                        image_rows,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+                )
+                shapes.extend(
+                    (1, image.height // 16, image.width // 16) for image in images
+                )
+            if video_count:
+                video_rows, video_shapes = self._encode_video_conditions_resident(
+                    prepared_videos,
+                    count=video_count,
+                )
+                rows.append(video_rows)
+                shapes.extend(video_shapes)
+        return (torch.cat(rows) if rows else None), shapes
+
+    def _encode_audio_conditions_resident(
+        self,
+        audios: list[tuple[torch.Tensor, int]],
+        *,
+        max_duration_seconds: float | None = None,
+    ) -> tuple[torch.Tensor | None, list[int]]:
+        if not audios:
+            return None, []
+        if max_duration_seconds is not None:
+            max_duration_seconds = float(max_duration_seconds)
+            if max_duration_seconds <= 0:
+                raise ValueError("max_duration_seconds must be positive")
+        _, rank, _ = _dit_rank_world()
+        rows = None
+        lengths = torch.zeros(len(audios), dtype=torch.long, device=self.device)
+        if rank == 0:
+            bounded_audios = []
+            for waveform, sample_rate in audios:
+                if max_duration_seconds is not None:
+                    max_samples = int(round(max_duration_seconds * int(sample_rate)))
+                    waveform = waveform[..., :max_samples]
+                bounded_audios.append((waveform, sample_rate))
+            encoded = [
+                self.audio_vae.encode_waveform(*audio) for audio in bounded_audios
+            ]
+            rows = torch.cat([item[0] for item in encoded])
+            lengths = torch.tensor(
+                [int(item[1]) for item in encoded],
+                dtype=torch.long,
+                device=self.device,
+            )
+        group, _, world_size = _dit_rank_world()
+        if world_size > 1:
+            dist.broadcast(lengths, src=0, group=group)
+        return (
+            _broadcast_tensor(rows, dtype=torch.float32, device=self.device),
+            [int(value) for value in lengths.tolist()],
+        )
+
+    def _encode_video_conditions_resident(
+        self,
+        prepared_videos: list[dict[str, Any]] | None,
+        *,
+        count: int,
+    ) -> tuple[torch.Tensor, list[tuple[int, int, int]]]:
+        group, rank, world_size = _dit_rank_world()
+        distributed_encode = self.video_vae.is_distributed_enabled()
+        if distributed_encode:
+            # Native tiled encode uses collectives, so every VPP rank must
+            # enter each reference encode in the same input order.
+            prepared_videos_list = [prepared_videos]
+            dist.broadcast_object_list(
+                prepared_videos_list,
+                src=0,
+                group=group,
+                device=self.device,
+            )
+            prepared_videos = prepared_videos_list[0]
+
+        rows = None
+        shapes = torch.zeros((count, 3), dtype=torch.long, device=self.device)
+        if rank == 0 or distributed_encode:
+            if prepared_videos is None or len(prepared_videos) != count:
+                raise ValueError("reference-video preparation is incomplete")
+            encoded = [
+                self.video_vae.encode_video(load_video_frames(item["prepared_path"]))
+                for item in prepared_videos
+            ]
+            rows = torch.cat([item[0] for item in encoded])
+            shapes = torch.tensor(
+                [item[1] for item in encoded],
+                dtype=torch.long,
+                device=self.device,
+            )
+        if distributed_encode:
+            return (
+                rows.to(device=self.device, dtype=torch.float32),
+                [tuple(int(value) for value in item) for item in shapes.tolist()],
+            )
+
+        if world_size > 1:
+            dist.broadcast(shapes, src=0, group=group)
+        return (
+            _broadcast_tensor(rows, dtype=torch.float32, device=self.device),
+            [tuple(int(value) for value in item) for item in shapes.tolist()],
+        )
+
+    def _encode_video_audio_conditions_resident(
+        self,
+        prepared_videos: list[dict[str, Any]] | None,
+        *,
+        has_audio: list[bool],
+    ) -> tuple[torch.Tensor | None, list[int]]:
+        _, rank, _ = _dit_rank_world()
+        count = sum(has_audio)
+        if count == 0:
+            return None, []
+        rows = None
+        lengths = torch.zeros(count, dtype=torch.long, device=self.device)
+        if rank == 0:
+            if prepared_videos is None:
+                raise ValueError("rank 0 reference-video preparation is incomplete")
+            encoded = [
+                self.audio_vae.encode_waveform(
+                    *load_video_audio(
+                        item["original_path"],
+                        start_time_seconds=float(item.get("start_time_seconds", 0.0)),
+                        duration_seconds=item.get(
+                            "audio_duration_seconds",
+                            item.get("duration_seconds"),
+                        ),
+                    )
+                )
+                for item in prepared_videos
+                if item["input_has_audio"]
+            ]
+            rows = torch.cat([item[0] for item in encoded])
+            lengths = torch.tensor(
+                [item[1] for item in encoded],
+                dtype=torch.long,
+                device=self.device,
+            )
+        group, _, world_size = _dit_rank_world()
+        if world_size > 1:
+            dist.broadcast(lengths, src=0, group=group)
+        return (
+            _broadcast_tensor(rows, dtype=torch.float32, device=self.device),
+            [int(value) for value in lengths.tolist()],
+        )
+
+    def _encode_reference_audio_conditions(
+        self,
+        prepared_videos: list[dict[str, Any]] | None,
+        *,
+        has_audio: list[bool],
+        standalone_audios: list[tuple[torch.Tensor, int]],
+        max_duration_seconds: float,
+    ) -> tuple[torch.Tensor | None, list[int], torch.Tensor | None, list[int]]:
+        # Embedded and standalone audio are consecutive direct Audio-VAE
+        # calls. Keep the component resident across both paths.
+        needs_audio_vae = any(has_audio) or bool(standalone_audios)
+        audio_vae_context = (
+            self._component_on_device(self.audio_vae)
+            if needs_audio_vae
+            else nullcontext()
+        )
+        with audio_vae_context:
+            embedded_condition, embedded_lengths = (
+                self._encode_video_audio_conditions_resident(
+                    prepared_videos,
+                    has_audio=has_audio,
+                )
+            )
+            external_condition, external_lengths = (
+                self._encode_audio_conditions_resident(
+                    standalone_audios,
+                    max_duration_seconds=max_duration_seconds,
+                )
+            )
+        return (
+            embedded_condition,
+            embedded_lengths,
+            external_condition,
+            external_lengths,
+        )
+
+    def _initial_noise(
+        self,
+        *,
+        seed: int,
+        latent_t: int,
+        latent_h: int,
+        latent_w: int,
+        audio_t: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        video_generator = torch.Generator(device="cpu").manual_seed(seed)
+        video = torch.randn(
+            1,
+            24,
+            latent_t,
+            latent_h,
+            latent_w,
+            generator=video_generator,
+            dtype=torch.float32,
+        )
+        video_rows = minimax_h3_patchify_video_latent(
+            video,
+            patch_size=(1, 2, 2),
+        )
+        audio_generator = torch.Generator(device="cpu").manual_seed(seed)
+        audio_rows = torch.randn(
+            audio_t * 2,
+            32,
+            generator=audio_generator,
+            dtype=torch.float32,
+        )
+        return video_rows, audio_rows
+
+    def _build_denoise_inputs(
+        self,
+        *,
+        task: str,
+        text_embeddings: torch.Tensor,
+        text_tags: torch.Tensor,
+        seed: int,
+        latent_t: int,
+        latent_h: int,
+        latent_w: int,
+        audio_t: int,
+        num_frames: int,
+        num_steps: int,
+        video_shift: float,
+        audio_shift: float,
+        base_schedule: Sequence[float] | None,
+        visual_condition: torch.Tensor | None,
+        visual_condition_shape: tuple[int, int, int] | None,
+        audio_condition: torch.Tensor | None,
+        ref_audio_t: int | None,
+        ref_blocks: list[dict[str, Any]] | None = None,
+        visual_condition_shapes: list[tuple[int, int, int]] | None = None,
+        audio_condition_lengths: list[int] | None = None,
+        keyframe_frame_indices: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Build the packed layout, initial rows, anchors, and sigma schedules.
+
+        Shared by request-mode :meth:`diffuse` and step-mode
+        :meth:`prepare_encode` so both paths start from identical state.
+        """
+        initial_video, initial_audio = self._initial_noise(
+            seed=seed,
+            latent_t=latent_t,
+            latent_h=latent_h,
+            latent_w=latent_w,
+            audio_t=audio_t,
+        )
+        if task == "ref2va":
+            if ref_blocks is None:
+                if visual_condition_shape is None or ref_audio_t is None:
+                    raise ValueError("ref2va condition metadata is missing")
+                _, ref_h, ref_w = visual_condition_shape
+                ref_blocks = [
+                    {"kind": "image", "latent_h": ref_h, "latent_w": ref_w},
+                    {"kind": "audio", "ref_audio_t": ref_audio_t},
+                ]
+            packed = minimax_h3_packed_sequence_ref2va_blocks(
+                text_len=int(text_embeddings.shape[0]),
+                latent_t=latent_t,
+                latent_h=latent_h,
+                latent_w=latent_w,
+                audio_t=audio_t,
+                ref_blocks=ref_blocks,
+            )
+        else:
+            packed = minimax_h3_packed_sequence(
+                text_len=int(text_embeddings.shape[0]),
+                latent_t=latent_t,
+                latent_h=latent_h,
+                latent_w=latent_w,
+                audio_t=audio_t,
+                include_keyframe_cond=task == "fl2va",
+                keyframe_frame_indices=keyframe_frame_indices
+                if task == "fl2va"
+                else None,
+                frame_count=num_frames if task == "fl2va" else None,
+            )
+
+        tags = packed["token_tags"].clone()
+        tags[packed["text_pos"]] = text_tags.cpu()
+        branch = MiniMaxH3DenoiseBranch(
+            packed=packed,
+            text_embeddings=text_embeddings,
+            token_tags=tags,
+            device=self.device,
+        )
+
+        visual_anchor = visual_condition
+        if visual_anchor is not None:
+            condition_shapes = visual_condition_shapes
+            if condition_shapes is None and visual_condition_shape is not None:
+                condition_shapes = [visual_condition_shape]
+            if not condition_shapes:
+                raise ValueError("visual condition shape is missing")
+            visual_anchor = minimax_h3_imgvid_cond_noise_aug_rows(
+                visual_anchor,
+                condition_shapes=condition_shapes,
+                target_latent_t=latent_t,
+                imgvid_cond_num_frames=len(condition_shapes),
+                seed=seed,
+                noise_aug=MINIMAX_H3_IMGVID_COND_TIMESTEP,
+            )
+            full_video = torch.zeros(
+                branch.img_pos.shape[0],
+                96,
+                dtype=torch.float32,
+            )
+            full_video[branch.update_mask] = initial_video
+            initial_video = full_video
+
+        audio_anchor = audio_condition
+        if audio_anchor is not None:
+            condition_audio_t = audio_condition_lengths
+            if condition_audio_t is None and ref_audio_t is not None:
+                condition_audio_t = [ref_audio_t]
+            if not condition_audio_t:
+                raise ValueError("reference audio length is missing")
+            audio_anchor = minimax_h3_audio_cond_noise_aug_rows(
+                audio_anchor,
+                condition_audio_t=condition_audio_t,
+                seed=seed,
+                noise_aug=MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+            )
+            full_audio = torch.zeros(
+                branch.audio_pos.shape[0],
+                32,
+                dtype=torch.float32,
+            )
+            full_audio[branch.audio_update_mask] = initial_audio
+            initial_audio = full_audio
+
+        video_sigmas = minimax_h3_time_shift_sigmas(
+            num_steps=num_steps,
+            shift_scale=video_shift,
+            base_schedule=base_schedule,
+        )
+        audio_sigmas = minimax_h3_time_shift_sigmas(
+            num_steps=num_steps,
+            shift_scale=audio_shift,
+            base_schedule=base_schedule,
+        )
+        return {
+            "branch": branch,
+            # The request-mode loop moves these onto the device itself; step mode
+            # keeps them resident across steps, so normalize once for both.
+            "video_rows": initial_video.to(device=self.device, dtype=torch.float32),
+            "audio_rows": initial_audio.to(device=self.device, dtype=torch.float32),
+            "cond_anchor": (
+                None
+                if visual_anchor is None
+                else visual_anchor.to(device=self.device, dtype=torch.float32)
+            ),
+            "audio_anchor": (
+                None
+                if audio_anchor is None
+                else audio_anchor.to(device=self.device, dtype=torch.float32)
+            ),
+            "sigmas_video": video_sigmas,
+            "sigmas_audio": audio_sigmas,
+        }
+
+    def _unpack_denoised_rows(
+        self,
+        branch: MiniMaxH3DenoiseBranch,
+        video_rows: torch.Tensor,
+        audio_rows: torch.Tensor,
+        *,
+        latent_t: int,
+        latent_h: int,
+        latent_w: int,
+        audio_t: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Select the target rows and unpack them back into VAE latents."""
+        target_video = video_rows[branch.update_mask_dev]
+        video_latent = minimax_h3_unpatchify_video_tokens(
+            target_video,
+            latent_shape=(
+                latent_t,
+                latent_h // 2,
+                latent_w // 2,
+                24,
+            ),
+            patch_size=(1, 2, 2),
+        )
+        target_audio = audio_rows[branch.audio_update_mask_dev]
+        audio_latent = minimax_h3_unpack_audio_tokens(
+            target_audio,
+            audio_t=audio_t * 2,
+            audio_channel=2,
+        )
+        return video_latent, audio_latent
+
+    def diffuse(
+        self,
+        *,
+        task: str,
+        text_embeddings: torch.Tensor,
+        text_tags: torch.Tensor,
+        seed: int,
+        latent_t: int,
+        latent_h: int,
+        latent_w: int,
+        audio_t: int,
+        num_frames: int,
+        num_steps: int,
+        video_shift: float,
+        audio_shift: float,
+        base_schedule: Sequence[float] | None,
+        visual_condition: torch.Tensor | None,
+        visual_condition_shape: tuple[int, int, int] | None,
+        audio_condition: torch.Tensor | None,
+        ref_audio_t: int | None,
+        ref_blocks: list[dict[str, Any]] | None = None,
+        visual_condition_shapes: list[tuple[int, int, int]] | None = None,
+        audio_condition_lengths: list[int] | None = None,
+        keyframe_frame_indices: list[int] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        inputs = self._build_denoise_inputs(
+            task=task,
+            text_embeddings=text_embeddings,
+            text_tags=text_tags,
+            seed=seed,
+            latent_t=latent_t,
+            latent_h=latent_h,
+            latent_w=latent_w,
+            audio_t=audio_t,
+            num_frames=num_frames,
+            num_steps=num_steps,
+            video_shift=video_shift,
+            audio_shift=audio_shift,
+            base_schedule=base_schedule,
+            visual_condition=visual_condition,
+            visual_condition_shape=visual_condition_shape,
+            audio_condition=audio_condition,
+            ref_audio_t=ref_audio_t,
+            ref_blocks=ref_blocks,
+            visual_condition_shapes=visual_condition_shapes,
+            audio_condition_lengths=audio_condition_lengths,
+            keyframe_frame_indices=keyframe_frame_indices,
+        )
+        branch = inputs["branch"]
+        transformer = self._transformer_for_task(task)
+        counter = DenoiseWorkCounter(
+            transformer,
+            used_length=branch.used_len,
+            video_outputs=int(branch.update_mask.sum()),
+            audio_outputs=int(branch.audio_update_mask.sum()),
+        )
+        with self._resident_dit_layers_on_device(enabled=True):
+            torch.accelerator.synchronize()
+            dist.barrier()
+            torch.accelerator.synchronize()
+            started = time.perf_counter()
+            with self.progress_bar(total=len(inputs["sigmas_video"]) - 1) as progress:
+                video_rows, audio_rows = minimax_h3_denoise_loop(
+                    model=transformer,
+                    positive=branch,
+                    initial_video_rows=inputs["video_rows"],
+                    initial_audio_rows=inputs["audio_rows"],
+                    keyframe_cond_rows=inputs["cond_anchor"],
+                    audio_ref_rows=inputs["audio_anchor"],
+                    sigmas_video=inputs["sigmas_video"],
+                    sigmas_audio=inputs["sigmas_audio"],
+                    device=self.device,
+                    imgvid_cond_noise_aug_for_inference=(
+                        MINIMAX_H3_IMGVID_COND_TIMESTEP
+                    ),
+                    audio_cond_noise_aug_for_inference=(
+                        MINIMAX_H3_AUDIO_REF_COND_TIMESTEP
+                    ),
+                    on_step=lambda step, video, audio: progress.update(),
+                )
+            torch.accelerator.synchronize()
+            dist.barrier()
+            torch.accelerator.synchronize()
+            self.stage_durations["denoise"] = time.perf_counter() - started
+            self.useful_denoise_flops = counter.flops
+            self.denoise_flops_by_layer = counter.by_layer
+            counter.close()
+
+        return self._unpack_denoised_rows(
+            branch,
+            video_rows,
+            audio_rows,
+            latent_t=latent_t,
+            latent_h=latent_h,
+            latent_w=latent_w,
+            audio_t=audio_t,
+        )
+
+    def decode(
+        self,
+        video_latent: torch.Tensor,
+        audio_latent: torch.Tensor,
+        *,
+        height: int,
+        width: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        with (
+            self._component_on_device(self.video_vae),
+            torch.autocast(
+                device_type=self.device.type,
+                dtype=torch.float16,
+                enabled=True,
+            ),
+        ):
+            video = self.video_vae.decode_latent(video_latent)
+        video = video[..., :height, :width].contiguous()
+        with self._component_on_device(self.audio_vae):
+            audio = self.audio_vae.decode_latent(audio_latent)
+        return video, audio
+
+    def _prepare_request_inputs(
+        self,
+        *,
+        prompt: str,
+        multi_modal_data: dict[str, Any],
+        sampling: Any,
+        text_conditioning: MiniMaxH3TextConditioning | None = None,
+        prepared_reference_videos: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve the task and output shape, then run every request-level encode.
+
+        Shared by request-mode :meth:`forward` and step-mode
+        :meth:`prepare_encode`; the returned mapping feeds :meth:`diffuse` and
+        :meth:`_build_denoise_inputs` unchanged.
+        """
+        quality = sampling.quality
+        logger.debug("MiniMax H3 request quality=%s", quality)
+        extra = sampling.extra_args or {}
+        task = self._resolve_task(extra.get("task"), multi_modal_data)
+
+        raw_image = multi_modal_data.get("image")
+        raw_videos = multi_modal_data.get("video")
+        raw_audio = multi_modal_data.get("audio")
+        images = _load_images(raw_image) if raw_image is not None else []
+        video_values = (
+            list(raw_videos) if isinstance(raw_videos, (list, tuple)) else raw_videos
+        )
+        audio_values = (
+            list(raw_audio) if isinstance(raw_audio, (list, tuple)) else raw_audio
+        )
+
+        if task == "t2va" and (
+            images or raw_videos is not None or raw_audio is not None
+        ):
+            raise H3InputError("t2va does not accept image, video, or audio conditions")
+        if task == "fl2va":
+            if not images:
+                raise H3InputError("fl2va requires multi_modal_data.image")
+            if len(images) > 2:
+                raise H3InputError("fl2va accepts at most first and last images")
+            if raw_videos is not None or raw_audio is not None:
+                raise H3InputError("fl2va accepts image keyframes only")
+        if task == "ref2va":
+            video_count = (
+                len(video_values)
+                if isinstance(video_values, (list, tuple))
+                else int(video_values is not None)
+            )
+            audio_is_waveform_pair = (
+                isinstance(raw_audio, (list, tuple))
+                and len(raw_audio) == 2
+                and isinstance(raw_audio[1], (int, np.integer))
+            )
+            audio_count = (
+                len(audio_values)
+                if isinstance(audio_values, (list, tuple))
+                and not audio_is_waveform_pair
+                else int(raw_audio is not None)
+            )
+            _validate_ref2va_reference_counts(len(images), video_count, audio_count)
+        elif raw_videos is not None:
+            raise H3InputError(f"{task} does not accept a video condition")
+
+        image = images[0] if images else None
+        height, width, num_frames, latent_t, audio_t = self._resolve_shape(
+            task, sampling, image
+        )
+        if task == "fl2va":
+            for item in images:
+                _validate_reference_image(item)
+            prepared_images = [
+                item.resize((width, height), Image.Resampling.LANCZOS)
+                for item in images
+            ]
+            keyframe_frame_indices = _resolve_fl2va_keyframe_indices(extra, len(images))
+        elif task == "ref2va":
+            prepared_images = []
+            for item in images:
+                ref_width, ref_height = _reference_image_shape(item)
+                prepared_images.append(
+                    item.resize((ref_width, ref_height), Image.Resampling.LANCZOS)
+                )
+            keyframe_frame_indices = None
+        else:
+            prepared_images = []
+            keyframe_frame_indices = None
+
+        visual_condition = None
+        visual_shape = None
+        visual_shapes = None
+        audio_condition = None
+        ref_audio_t = None
+        audio_lengths = None
+        ref_blocks = None
+        with tempfile.TemporaryDirectory(prefix="minimax_h3_ref2va_") as workdir:
+            prepared_videos = None
+            has_audio: list[bool] = []
+            video_count = 0
+            if raw_videos is not None:
+                video_count = (
+                    len(raw_videos) if isinstance(raw_videos, (list, tuple)) else 1
+                )
+                # File-based reference-video prep runs only on rank 0; other
+                # ranks return None without touching disk. If rank 0 raises
+                # (e.g. invalid file, unsupported codec) it must not exit
+                # ``prepare_encode`` before the downstream broadcasts below --
+                # non-zero ranks would then deadlock on them forever. Capture
+                # the exception here and let every rank agree on the outcome
+                # before starting any subsequent collective.
+                prep_error: Exception | None = None
+                try:
+                    _, rank, _ = _dit_rank_world()
+                    if prepared_reference_videos is not None:
+                        if rank == 0:
+                            prepared_videos = _reuse_prepared_reference_videos(
+                                prepared_reference_videos,
+                                expected_count=video_count,
+                            )
+                    else:
+                        prepared_videos = self._prepare_reference_videos(
+                            raw_videos,
+                            target_frame_count=num_frames,
+                            workdir=workdir,
+                            start_time_seconds=extra.get("start_time_seconds"),
+                        )
+                except Exception as exc:
+                    prep_error = exc
+                _broadcast_rank0_exception(prep_error)
+                has_audio_tensor = torch.zeros(
+                    video_count,
+                    dtype=torch.long,
+                    device=self.device,
+                )
+                _, rank, world_size = _dit_rank_world()
+                if rank == 0:
+                    has_audio_tensor = torch.tensor(
+                        [
+                            int(item["input_has_audio"])
+                            for item in prepared_videos or []
+                        ],
+                        dtype=torch.long,
+                        device=self.device,
+                    )
+                if world_size > 1:
+                    dist.broadcast(
+                        has_audio_tensor,
+                        src=0,
+                        group=get_world_group().device_group,
+                    )
+                has_audio = [bool(value) for value in has_audio_tensor.tolist()]
+
+            if raw_audio is not None:
+                validate_reference_audio_files(raw_audio)
+            standalone_audios = _load_audios(raw_audio) if raw_audio is not None else []
+            validate_reference_audio_waveforms(standalone_audios)
+            condition_labels: list[tuple[str, int]] = []
+            for image_index in range(1, len(prepared_images) + 1):
+                condition_labels.append(("image", image_index))
+            audio_index = 0
+            for video_index, item in enumerate(prepared_videos or (), start=1):
+                if item["input_has_audio"]:
+                    audio_index += 1
+                    condition_labels.append(("audio", audio_index))
+                condition_labels.append(("video", video_index))
+            for _ in standalone_audios:
+                audio_index += 1
+                condition_labels.append(("audio", audio_index))
+
+            if text_conditioning is not None:
+                text_embeddings = text_conditioning.hidden_states.to(
+                    device=self.device,
+                    dtype=torch.float16,
+                )
+                text_tags = text_conditioning.token_tags.to(
+                    device=self.device,
+                    dtype=torch.long,
+                )
+            elif getattr(self, "text_encoder", None) is not None:
+                text_embeddings, text_tags = self.encode_prompt(
+                    task=task,
+                    prompt=prompt,
+                    images=prepared_images,
+                    prepared_videos=prepared_videos,
+                    condition_labels=condition_labels if task == "ref2va" else None,
+                )
+            else:
+                raise H3InputError(
+                    "MiniMax H3 diffusion stage requires text_encoder_output when "
+                    "text_encoder is not loaded"
+                )
+
+            # ``prepared_videos`` is intentionally ``None`` on non-zero DiT
+            # ranks; the distributed video encoder broadcasts the prepared
+            # metadata inside ``_encode_visual_conditions``.  Use the global
+            # video count here so video + standalone-audio Ref2VA requests do
+            # not look like audio-only requests on those ranks.
+            if video_count or prepared_images:
+                visual_condition, visual_shapes = self._encode_visual_conditions(
+                    prepared_images,
+                    prepared_videos,
+                    video_count=video_count,
+                )
+                (
+                    embedded_audio_condition,
+                    embedded_audio_lengths,
+                    external_audio_condition,
+                    external_audio_lengths,
+                ) = self._encode_reference_audio_conditions(
+                    prepared_videos,
+                    has_audio=has_audio,
+                    standalone_audios=standalone_audios,
+                    max_duration_seconds=float(num_frames)
+                    / float(sampling.fps or MINIMAX_H3_FPS),
+                )
+                audio_parts = [
+                    item
+                    for item in (embedded_audio_condition, external_audio_condition)
+                    if item is not None
+                ]
+                audio_condition = torch.cat(audio_parts) if audio_parts else None
+                audio_lengths = embedded_audio_lengths + external_audio_lengths
+                ref_blocks = []
+                image_shapes = visual_shapes[: len(prepared_images)]
+                video_shapes = visual_shapes[len(prepared_images) :]
+                for shape in image_shapes:
+                    ref_blocks.append(
+                        {
+                            "kind": "image",
+                            "latent_h": shape[1],
+                            "latent_w": shape[2],
+                        }
+                    )
+                audio_iterator = iter(embedded_audio_lengths)
+                for shape, contributes_audio in zip(
+                    video_shapes, has_audio, strict=True
+                ):
+                    ref_audio = next(audio_iterator) if contributes_audio else 0
+                    ref_blocks.append(
+                        {
+                            "kind": "video_audio" if ref_audio else "video",
+                            "ref_audio_t": ref_audio,
+                            "latent_t": shape[0],
+                            "latent_h": shape[1],
+                            "latent_w": shape[2],
+                        }
+                    )
+                for ref_audio_t in external_audio_lengths:
+                    ref_blocks.append({"kind": "audio", "ref_audio_t": ref_audio_t})
+            elif standalone_audios:
+                raise H3InputError(
+                    "standalone audio references require a Ref2VA visual reference"
+                )
+
+            if visual_shapes and len(visual_shapes) == 1:
+                visual_shape = visual_shapes[0]
+            if audio_lengths:
+                if any(length < 80 or length > 600 for length in audio_lengths):
+                    raise H3InputError(
+                        "MiniMax H3 audio references must each be between 2 and 15 "
+                        "seconds"
+                    )
+                if sum(audio_lengths) > 600:
+                    raise H3InputError(
+                        "MiniMax H3 audio references must be at most 15 seconds in "
+                        "total"
+                    )
+                if len(audio_lengths) == 1:
+                    ref_audio_t = audio_lengths[0]
+
+        seed = int(sampling.seed if sampling.seed is not None else 42)
+        base_schedule, num_steps = self._resolve_sigma_positions(task, sampling)
+        video_shift = float(extra.get("flow_shift", self.default_video_shift))
+        audio_shift = float(extra.get("audio_flow_shift", self.default_audio_shift))
+        num_outputs = _resolve_minimax_h3_num_outputs(sampling.num_outputs_per_prompt)
+        return {
+            "task": task,
+            "height": height,
+            "width": width,
+            "num_frames": num_frames,
+            "latent_t": latent_t,
+            "latent_h": height // 16,
+            "latent_w": width // 16,
+            "audio_t": audio_t,
+            "text_embeddings": text_embeddings,
+            "text_tags": text_tags,
+            "visual_condition": visual_condition,
+            "visual_condition_shape": visual_shape,
+            "audio_condition": audio_condition,
+            "ref_audio_t": ref_audio_t,
+            "ref_blocks": ref_blocks,
+            "visual_condition_shapes": visual_shapes,
+            "audio_condition_lengths": audio_lengths,
+            "keyframe_frame_indices": keyframe_frame_indices,
+            "seed": seed,
+            "num_steps": num_steps,
+            "video_shift": video_shift,
+            "audio_shift": audio_shift,
+            "base_schedule": base_schedule,
+            "num_outputs": num_outputs,
+        }
+
+    @staticmethod
+    def _denoise_kwargs(context: dict[str, Any]) -> dict[str, Any]:
+        """Select the denoise-input arguments from a prepared request context."""
+        return {key: context[key] for key in _MINIMAX_H3_DENOISE_INPUT_KEYS}

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -560,12 +560,12 @@ class MiniMaxH3Pipeline(nn.Module):
             self._dit_stager.offload()
 
     def progress_bar(self, *, total):
-        self.actual_dit_calls = total
         return tqdm(total=total, desc="H3 denoise", disable=self._dit_rank != 0)
 
     @torch.inference_mode()
     def forward(self, request: H3Request):
         self.stage_durations = {}
+        self.actual_dit_calls = 0
         started = time.perf_counter()
         context = self._prepare_request_inputs(
             prompt=request.prompt,
@@ -1490,6 +1490,7 @@ class MiniMaxH3Pipeline(nn.Module):
             torch.accelerator.synchronize()
             self.stage_durations["denoise"] = time.perf_counter() - started
             self.useful_denoise_flops = counter.flops
+            self.actual_dit_calls = counter.calls
             self.denoise_flops_by_layer = counter.by_layer
             counter.close()
 

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -690,11 +690,16 @@ class MiniMaxH3Pipeline(nn.Module):
             )
         short_edge = int(raw_short_edge)
 
-        aspect_ratio = _resolve_minimax_h3_aspect_ratio(
-            task,
-            aspect_ratio,
-            image,
-        )
+        if height is not None and width is not None and aspect_ratio is None:
+            # Native requests supply the final canvas, including the aligned
+            # 1344x768 shape whose ratio is slightly different from 16:9.
+            aspect_ratio = width / height
+        else:
+            aspect_ratio = _resolve_minimax_h3_aspect_ratio(
+                task,
+                aspect_ratio,
+                image,
+            )
         if not 0.25 <= aspect_ratio <= 4.0:
             raise H3InputError(
                 f"MiniMax H3 canvas aspect ratio must be in [1:4, 4:1], got "

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -33,7 +33,15 @@ from .condition_noise import (
     minimax_h3_imgvid_cond_noise_aug_rows,
 )
 from .conditioning import MiniMaxH3TextConditioning
-from .config import H3Config, H3InputError, H3Request
+from .config import (
+    MAX_OUTPUT_FRAMES,
+    MAX_OUTPUT_SECONDS,
+    MIN_OUTPUT_FRAMES,
+    MIN_OUTPUT_SECONDS,
+    H3Config,
+    H3InputError,
+    H3Request,
+)
 from .denoise_loop import MiniMaxH3DenoiseBranch, minimax_h3_denoise_loop
 from .encoder import MiniMaxH3Qwen3VLEncoder
 from .packed_sequence import (
@@ -125,12 +133,6 @@ MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES = 30 * 1024 * 1024
 
 
 MINIMAX_H3_REFERENCE_IMAGE_FORMATS = frozenset({"jpeg", "png", "webp", "heic", "heif"})
-
-
-MINIMAX_H3_MIN_OUTPUT_SECONDS = 4.0
-
-
-MINIMAX_H3_MAX_OUTPUT_SECONDS = 15.0
 
 
 _MINIMAX_H3_DENOISE_INPUT_KEYS = (
@@ -638,24 +640,22 @@ class MiniMaxH3Pipeline(nn.Module):
         if duration is not None:
             if isinstance(duration, bool):
                 raise H3InputError(
-                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"MiniMax H3 output duration must be in [22/24, 15] seconds, got "
                     f"{duration!r}"
                 )
             try:
                 duration = float(duration)
             except (TypeError, ValueError) as exc:
                 raise H3InputError(
-                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"MiniMax H3 output duration must be in [22/24, 15] seconds, got "
                     f"{duration!r}"
                 ) from exc
             if (
                 not math.isfinite(duration)
-                or not MINIMAX_H3_MIN_OUTPUT_SECONDS
-                <= duration
-                <= MINIMAX_H3_MAX_OUTPUT_SECONDS
+                or not MIN_OUTPUT_SECONDS <= duration <= MAX_OUTPUT_SECONDS
             ):
                 raise H3InputError(
-                    f"MiniMax H3 output duration must be in [4, 15] seconds, got "
+                    f"MiniMax H3 output duration must be in [22/24, 15] seconds, got "
                     f"{duration}"
                 )
             requested_frames = int(round(duration * fps))
@@ -664,14 +664,9 @@ class MiniMaxH3Pipeline(nn.Module):
         else:
             requested_frames = 124 if task == "ref2va" else 209
             duration = requested_frames / fps
-        if (
-            not MINIMAX_H3_MIN_OUTPUT_SECONDS
-            <= requested_frames / fps
-            <= MINIMAX_H3_MAX_OUTPUT_SECONDS
-        ):
+        if not MIN_OUTPUT_FRAMES <= requested_frames <= MAX_OUTPUT_FRAMES:
             raise H3InputError(
-                f"MiniMax H3 output duration must be in [4, 15] seconds, got "
-                f"{requested_frames / fps:.3f}"
+                f"MiniMax H3 requires between 22 and 362 frames, got {requested_frames}"
             )
         num_frames = minimax_h3_align_frame_count(requested_frames)
 

--- a/vllm/model_executor/models/minimax_h3/preprocessing.py
+++ b/vllm/model_executor/models/minimax_h3/preprocessing.py
@@ -1,0 +1,531 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared MiniMax H3 media normalization and Qwen presentation building.
+
+Builds the positive presentation token stream:
+- fl2va: '<Picture 1>: ' label + vision block (<|vision_start|> +
+  N*<|image_pad|> + <|vision_end|>) + prompt text.
+- t2va: prompt text only (no vision block).
+Prompt text passes through verbatim (no stripping or rewriting).
+
+All presentation variants are emitted through the shared ``_Presentation``
+accumulator so ids and AdaLN token tags cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from .config import H3InputError
+
+VISION_START = "<|vision_start|>"
+VISION_END = "<|vision_end|>"
+IMAGE_PAD = "<|image_pad|>"
+VIDEO_PAD = "<|video_pad|>"
+
+_TEXT_TAG = 1
+_VIDEO_TAG = 0
+
+MINIMAX_H3_OUTPUT_SHORT_EDGE = 768
+MINIMAX_H3_OUTPUT_MAX_PIXELS = 768 * 1344
+MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE = 2048
+MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE = 32
+MINIMAX_H3_SUPPORTED_ASPECT_RATIOS = {
+    "21:9": 21.0 / 9.0,
+    "16:9": 16.0 / 9.0,
+    "4:3": 4.0 / 3.0,
+    "1:1": 1.0,
+    "3:4": 3.0 / 4.0,
+    "9:16": 9.0 / 16.0,
+}
+MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES = 30 * 1024 * 1024
+MINIMAX_H3_REFERENCE_IMAGE_FORMATS = frozenset({"jpeg", "png", "webp", "heic", "heif"})
+
+
+def _align_multiple(value: float, multiple: int = 32) -> int:
+    return max(multiple, int(round(float(value) / multiple)) * multiple)
+
+
+def load_minimax_h3_images(value: Any) -> list[Image.Image]:
+    """Normalize one or more H3 image inputs to RGB PIL images."""
+    if isinstance(value, (list, tuple)):
+        if not value:
+            raise H3InputError("MiniMax H3 image input must not be empty")
+        images: list[Image.Image] = []
+        for item in value:
+            loaded = load_minimax_h3_images(item)
+            if len(loaded) != 1:
+                raise H3InputError(f"MiniMax H3 expected one image, got {len(loaded)}")
+            images.extend(loaded)
+        return images
+    if isinstance(value, (str, os.PathLike)):
+        if os.path.getsize(value) > MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES:
+            raise H3InputError(
+                "MiniMax H3 reference image exceeds the 30 MiB size limit"
+            )
+        with Image.open(value) as image:
+            image_format = str(image.format or "").lower()
+            if image_format and image_format not in MINIMAX_H3_REFERENCE_IMAGE_FORMATS:
+                raise H3InputError(
+                    f"MiniMax H3 reference image must use JPG, JPEG, PNG, WEBP, HEIC, "
+                    f"or HEIF, got {image.format}"
+                )
+            return [image.convert("RGB")]
+    if isinstance(value, Image.Image):
+        return [value.convert("RGB")]
+    if isinstance(value, torch.Tensor):
+        tensor = value.detach().float().cpu()
+        if tensor.ndim == 4 and tensor.shape[0] == 1:
+            tensor = tensor[0]
+        if tensor.ndim != 3:
+            raise H3InputError(
+                f"image tensor must be [C,H,W], got {tuple(tensor.shape)}"
+            )
+        if tensor.shape[0] in (1, 3, 4):
+            tensor = tensor.permute(1, 2, 0)
+        array = tensor.numpy()
+        if array.max(initial=0) <= 1.0:
+            array = array * 255.0
+        return [Image.fromarray(array.clip(0, 255).astype(np.uint8)).convert("RGB")]
+    raise H3InputError(f"unsupported MiniMax H3 image input {type(value)!r}")
+
+
+def resolve_minimax_h3_aspect_ratio(
+    task: str,
+    value: Any,
+    image: Image.Image | None,
+) -> float:
+    """Resolve H3's task-specific output aspect-ratio policy."""
+    if task == "fl2va":
+        if image is None:
+            raise H3InputError(
+                "fl2va requires an input image to resolve its aspect ratio"
+            )
+        return float(image.width) / float(image.height)
+
+    if value is None:
+        if task == "t2va":
+            raise H3InputError("t2va requires an explicit aspect_ratio")
+        return MINIMAX_H3_SUPPORTED_ASPECT_RATIOS["16:9"]
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"adaptive", "auto"}:
+            if task == "t2va":
+                raise H3InputError(
+                    "t2va requires an explicit named aspect_ratio, not adaptive"
+                )
+            return MINIMAX_H3_SUPPORTED_ASPECT_RATIOS["16:9"]
+        if normalized in MINIMAX_H3_SUPPORTED_ASPECT_RATIOS:
+            return MINIMAX_H3_SUPPORTED_ASPECT_RATIOS[normalized]
+        try:
+            numeric_value = float(normalized)
+        except (TypeError, ValueError) as exc:
+            supported = ", ".join(MINIMAX_H3_SUPPORTED_ASPECT_RATIOS)
+            raise H3InputError(
+                f"MiniMax H3 aspect_ratio must be one of {supported}, got {value!r}"
+            ) from exc
+    elif isinstance(value, (int, float, np.integer, np.floating)) and not isinstance(
+        value, bool
+    ):
+        numeric_value = float(value)
+    else:
+        raise H3InputError(
+            f"MiniMax H3 aspect_ratio must be a string ratio, got {value!r}"
+        )
+
+    if not math.isfinite(numeric_value) or not any(
+        math.isclose(numeric_value, ratio, rel_tol=0.0, abs_tol=1e-6)
+        for ratio in MINIMAX_H3_SUPPORTED_ASPECT_RATIOS.values()
+    ):
+        supported = ", ".join(MINIMAX_H3_SUPPORTED_ASPECT_RATIOS)
+        raise H3InputError(
+            f"MiniMax H3 aspect_ratio must be one of {supported}, got {value!r}"
+        )
+    return numeric_value
+
+
+def resolve_minimax_h3_reference_image_shape(image: Image.Image) -> tuple[int, int]:
+    """Resize an H3 reference image to the official 2048-short-edge canvas."""
+    width, height = image.size
+    ratio = width / height
+    if not 0.4 <= ratio <= 2.5:
+        raise H3InputError(
+            f"reference image aspect ratio must be in [0.4, 2.5], got {width}x{height}"
+        )
+    if min(width, height) < 256 or max(width, height) > 5760:
+        raise H3InputError(
+            f"reference image dimensions must be in [256, 5760] pixels, got "
+            f"{width}x{height}"
+        )
+    scale = MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE / min(width, height)
+    return (
+        _align_multiple(width * scale, MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE),
+        _align_multiple(height * scale, MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE),
+    )
+
+
+def resolve_minimax_h3_output_canvas(
+    aspect_ratio: float, short_edge: int
+) -> tuple[int, int]:
+    """Resolve the official H3 ratio/area policy to a 32-pixel canvas."""
+    if not math.isfinite(float(aspect_ratio)) or float(aspect_ratio) <= 0:
+        raise H3InputError(
+            f"MiniMax H3 canvas aspect ratio must be positive, got {aspect_ratio!r}"
+        )
+    if short_edge != MINIMAX_H3_OUTPUT_SHORT_EDGE:
+        raise H3InputError(
+            f"MiniMax H3 target.short_edge must be {MINIMAX_H3_OUTPUT_SHORT_EDGE}, got "
+            f"{short_edge}"
+        )
+    if aspect_ratio >= 1.0:
+        width = float(short_edge) * aspect_ratio
+        height = float(short_edge)
+    else:
+        width = float(short_edge)
+        height = float(short_edge) / aspect_ratio
+    area = width * height
+    if area > MINIMAX_H3_OUTPUT_MAX_PIXELS:
+        scale = (MINIMAX_H3_OUTPUT_MAX_PIXELS / area) ** 0.5
+        width *= scale
+        height *= scale
+    return _align_multiple(height, 32), _align_multiple(width, 32)
+
+
+def _text_ids(tokenizer: Any, text: str) -> list[int]:
+    return list(tokenizer(text, add_special_tokens=False)["input_ids"])
+
+
+def _vision_block_ids(tokenizer: Any, pad_token: str, count: int) -> list[int]:
+    return (
+        [tokenizer.convert_tokens_to_ids(VISION_START)]
+        + [tokenizer.convert_tokens_to_ids(pad_token)] * int(count)
+        + [tokenizer.convert_tokens_to_ids(VISION_END)]
+    )
+
+
+class _Presentation:
+    """Accumulates aligned (ids, token_tags) presentation segments."""
+
+    def __init__(self) -> None:
+        self.ids: list[int] = []
+        self.tags: list[int] = []
+
+    def text(self, token_ids: list[int]) -> None:
+        self.ids += token_ids
+        self.tags += [_TEXT_TAG] * len(token_ids)
+
+    def vision(self, token_ids: list[int]) -> None:
+        self.ids += token_ids
+        self.tags += [_VIDEO_TAG] * len(token_ids)
+
+    def build(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            torch.tensor(self.ids, dtype=torch.long),
+            torch.tensor(self.tags, dtype=torch.long),
+        )
+
+
+def _timestamped_video_blocks(
+    presentation: _Presentation,
+    tokenizer: Any,
+    *,
+    counts: Sequence[int],
+    timestamps: Sequence[float],
+    context: str,
+) -> None:
+    """Emit per-temporal-block ``<{t:.1f} seconds>`` text + VIDEO vision."""
+
+    counts = [int(value) for value in counts]
+    timestamps = [float(value) for value in timestamps]
+    if not counts or len(counts) != len(timestamps):
+        raise ValueError(f"{context}video block token counts and timestamps must align")
+    for count, timestamp in zip(counts, timestamps):
+        if count <= 0:
+            raise ValueError(f"{context}video block token count must be positive")
+        presentation.text(_text_ids(tokenizer, f"<{timestamp:.1f} seconds>"))
+        presentation.vision(_vision_block_ids(tokenizer, VIDEO_PAD, count))
+
+
+def minimax_h3_text_only_ids(tokenizer: Any, prompt: str) -> torch.Tensor:
+    """t2va presentation: verbatim prompt, no special tokens."""
+    if not prompt:
+        raise ValueError("prompt must be non-empty")
+    return torch.tensor(_text_ids(tokenizer, prompt), dtype=torch.long)
+
+
+def _multi_image_presentation(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    image_token_counts: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not image_token_counts:
+        raise ValueError("image_token_counts must be non-empty")
+    presentation = _Presentation()
+    for index, count in enumerate(image_token_counts, start=1):
+        if int(count) <= 0:
+            raise ValueError("image_token_count must be positive")
+        presentation.text(_text_ids(tokenizer, f"<Picture {index}>: "))
+        presentation.vision(_vision_block_ids(tokenizer, IMAGE_PAD, count))
+    presentation.text(_text_ids(tokenizer, prompt))
+    return presentation.build()
+
+
+def minimax_h3_multi_image_presentation(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    image_token_counts: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return aligned FL2VA presentation token IDs and role IDs."""
+    return _multi_image_presentation(
+        tokenizer,
+        prompt=prompt,
+        image_token_counts=image_token_counts,
+    )
+
+
+def minimax_h3_ref2va_presentation(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    condition_labels: list[tuple[str, int]],
+    image_token_count: int | list[int] | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """ref2va positive presentation:
+
+    per condition in request order — image i: ``<Picture i>: `` label followed
+    by the vision block; audio j: ``<Audio j>: `` label only (audio content
+    never enters Qwen) — then the verbatim prompt. Returns (ids, token_tags)
+    with the vision block tagged VIDEO(0) and everything else TEXT(1).
+
+    condition_labels: [("image", 1), ("audio", 1), ...] with 1-based ordinals
+    per type.
+    """
+    return minimax_h3_ref2va_video_presentation(
+        tokenizer,
+        prompt=prompt,
+        condition_labels=condition_labels,
+        image_token_count=image_token_count,
+        video_block_token_counts=None,
+        video_block_timestamps=None,
+    )
+
+
+def _as_int_list(value: int | Sequence[int] | None, *, name: str) -> list[int]:
+    if value is None:
+        return []
+    if isinstance(value, int):
+        return [int(value)]
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{name} must be an int or a sequence of ints")
+    return [int(item) for item in value]
+
+
+def _as_nested_int_list(
+    value: Sequence[int] | Sequence[Sequence[int]] | None,
+    *,
+    name: str,
+) -> list[list[int]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence")
+    if len(value) == 0:
+        return []
+    first = value[0]
+    if isinstance(first, Sequence) and not isinstance(first, (str, bytes)):
+        out: list[list[int]] = []
+        for group in value:
+            if not isinstance(group, Sequence) or isinstance(group, (str, bytes)):
+                raise ValueError(f"{name} must not mix nested and flat entries")
+            out.append([int(item) for item in group])
+        return out
+    return [[int(item) for item in value]]
+
+
+def _as_nested_float_list(
+    value: Sequence[float] | Sequence[Sequence[float]] | None,
+    *,
+    name: str,
+) -> list[list[float]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence")
+    if len(value) == 0:
+        return []
+    first = value[0]
+    if isinstance(first, Sequence) and not isinstance(first, (str, bytes)):
+        out: list[list[float]] = []
+        for group in value:
+            if not isinstance(group, Sequence) or isinstance(group, (str, bytes)):
+                raise ValueError(f"{name} must not mix nested and flat entries")
+            out.append([float(item) for item in group])
+        return out
+    return [[float(item) for item in value]]
+
+
+def minimax_h3_ref2va_video_presentation(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    condition_labels: list[tuple[str, int]],
+    image_token_count: int | list[int] | None,
+    video_block_token_counts: list[int] | list[list[int]] | None,
+    video_block_timestamps: list[float] | list[list[float]] | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """ref2va (optionally with video refs) positive presentation:
+
+    per condition in request order —
+    - image i:  ``<Picture i>: `` label + one image vision block;
+    - audio j:  ``<Audio j>: `` label only (audio content never enters Qwen);
+    - video k:  ``<Video k>: `` label, then per temporal block a timestamp
+      text ``<{t:.1f} seconds>`` followed by a VIDEO vision block
+      (<|vision_start|> + <|video_pad|> x n + <|vision_end|>). Timestamps are
+      the mean of each merged frame pair (Qwen3VL temporal merge 2; odd frame
+      counts repeat the last frame), emitting the
+      ``<0.2 seconds>`` ..
+      ``<4.0 seconds>`` sequence — note Python bankers-rounding at .1f.
+    then the verbatim prompt. Vision blocks are tagged VIDEO(0), everything
+    else TEXT(1).
+    """
+    if not prompt:
+        raise ValueError("prompt must be non-empty")
+    presentation = _Presentation()
+    image_token_counts = _as_int_list(image_token_count, name="image_token_count")
+    video_counts_by_ref = _as_nested_int_list(
+        video_block_token_counts,
+        name="video_block_token_counts",
+    )
+    video_timestamps_by_ref = _as_nested_float_list(
+        video_block_timestamps,
+        name="video_block_timestamps",
+    )
+    if len(video_counts_by_ref) != len(video_timestamps_by_ref):
+        raise ValueError("video block token counts and timestamps must align")
+    image_seen = 0
+    video_seen = 0
+    for cond_type, ordinal in condition_labels:
+        if cond_type == "image":
+            image_seen += 1
+            if image_seen > len(image_token_counts):
+                raise ValueError("image_token_count required for an image reference")
+            count = int(image_token_counts[image_seen - 1])
+            if count <= 0:
+                raise ValueError("image_token_count required for an image reference")
+            presentation.text(_text_ids(tokenizer, f"<Picture {ordinal}>: "))
+            presentation.vision(_vision_block_ids(tokenizer, IMAGE_PAD, count))
+        elif cond_type == "audio":
+            presentation.text(_text_ids(tokenizer, f"<Audio {ordinal}>: "))
+        elif cond_type == "video":
+            video_seen += 1
+            if video_seen > len(video_counts_by_ref):
+                raise ValueError(
+                    "video reference requires block token counts and timestamps"
+                )
+            counts = video_counts_by_ref[video_seen - 1]
+            timestamps = video_timestamps_by_ref[video_seen - 1]
+            if not counts or not timestamps:
+                raise ValueError(
+                    "video reference requires block token counts and timestamps"
+                )
+            presentation.text(_text_ids(tokenizer, f"<Video {ordinal}>: "))
+            _timestamped_video_blocks(
+                presentation,
+                tokenizer,
+                counts=counts,
+                timestamps=timestamps,
+                context="",
+            )
+        else:
+            raise ValueError(f"unsupported ref2va condition type {cond_type!r}")
+    if image_seen != len(image_token_counts):
+        raise ValueError("unused image_token_count entries")
+    if video_seen != len(video_counts_by_ref):
+        raise ValueError("unused video block token count entries")
+    presentation.text(_text_ids(tokenizer, prompt))
+    return presentation.build()
+
+
+def build_minimax_h3_presentation(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    task: str,
+    condition_labels: list[tuple[str, int]],
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    video_timestamps: Sequence[Sequence[float]] | None,
+    merge_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the token IDs and role IDs shared by fused and split H3."""
+    if task == "t2va":
+        ids = minimax_h3_text_only_ids(tokenizer, prompt)
+        return ids, torch.ones_like(ids)
+
+    merge_length = int(merge_size) ** 2
+    image_counts = (
+        [int(grid.prod().item()) // merge_length for grid in image_grid_thw]
+        if image_grid_thw is not None
+        else []
+    )
+    if task == "fl2va":
+        return minimax_h3_multi_image_presentation(
+            tokenizer,
+            prompt=prompt,
+            image_token_counts=image_counts,
+        )
+
+    video_counts: list[list[int]] = []
+    if video_grid_thw is not None:
+        for grid in video_grid_thw:
+            block_count = int(grid[0].item())
+            tokens_per_block = int(grid[1:].prod().item()) // merge_length
+            video_counts.append([tokens_per_block] * block_count)
+    timestamps = (
+        [[float(value) for value in group] for group in video_timestamps]
+        if video_timestamps is not None
+        else []
+    )
+    if video_counts:
+        return minimax_h3_ref2va_video_presentation(
+            tokenizer,
+            prompt=prompt,
+            condition_labels=condition_labels,
+            image_token_count=image_counts or None,
+            video_block_token_counts=video_counts,
+            video_block_timestamps=timestamps,
+        )
+    return minimax_h3_ref2va_presentation(
+        tokenizer,
+        prompt=prompt,
+        condition_labels=condition_labels,
+        image_token_count=image_counts or None,
+    )
+
+
+__all__ = [
+    "IMAGE_PAD",
+    "MINIMAX_H3_OUTPUT_SHORT_EDGE",
+    "VIDEO_PAD",
+    "VISION_END",
+    "VISION_START",
+    "build_minimax_h3_presentation",
+    "load_minimax_h3_images",
+    "minimax_h3_multi_image_presentation",
+    "minimax_h3_ref2va_presentation",
+    "minimax_h3_ref2va_video_presentation",
+    "minimax_h3_text_only_ids",
+    "resolve_minimax_h3_aspect_ratio",
+    "resolve_minimax_h3_output_canvas",
+    "resolve_minimax_h3_reference_image_shape",
+]

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -58,6 +58,49 @@ logger = init_logger(__name__)
 _FORMAT = "int8_tensorwise"
 
 
+def fp16_gemm_input(x):
+    """Scale wide-range activations by exact powers of two before FP16 GEMM.
+
+    Leave headroom for the 256-channel rotation's worst-case amplification.
+    Row scaling is restored in FP32 after the projection.
+    """
+    flat = x.reshape(-1, x.shape[-1]).contiguous()
+    if flat.dtype == torch.float16:
+        return flat, None
+    if flat.dtype != torch.float32:
+        raise ValueError("H3 GEMM activations must be FP16 or FP32")
+    maximum = flat.abs().amax(-1, keepdim=True)
+    _, exponent = torch.frexp(maximum)
+    scale = torch.ldexp(torch.ones_like(maximum), (exponent - 11).clamp_min(0))
+    return (flat / scale).half(), scale
+
+
+class FP32OutputLinearMethod(UnquantizedLinearMethod):
+    """Keep wide-range projection outputs in FP32 with FP16 Tensor Core inputs."""
+
+    def process_weights_after_loading(self, layer):
+        layer.weight.data = layer.weight.data.contiguous()
+
+    def apply(self, layer, x, bias=None):
+        if x.is_cuda:
+            from .cuda_ops import w8a16_extension
+
+            values, scale = fp16_gemm_input(x)
+            output = w8a16_extension().gemm(values, layer.weight, True)
+            if scale is not None:
+                output = output * scale
+            output = output.reshape(*x.shape[:-1], layer.weight.shape[0])
+        else:
+            output = torch.nn.functional.linear(x.float(), layer.weight.float())
+        return output if bias is None else output + bias.float()
+
+
+def preserve_fp32_output(layer):
+    layer.h3_output_fp32 = True
+    if isinstance(layer.quant_method, UnquantizedLinearMethod):
+        layer.quant_method = FP32OutputLinearMethod()
+
+
 @dataclass(frozen=True)
 class Int8ConvRotLayerConfig:
     """Validated per-linear metadata decoded from ``.comfy_quant``."""
@@ -308,14 +351,14 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
     def apply(
         self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None
     ) -> torch.Tensor:
-        if x.dtype != torch.float16:
-            raise ValueError("H3 W8A16 requires FP16 activations")
+        if x.dtype not in (torch.float16, torch.float32):
+            raise ValueError("H3 W8A16 requires FP16 or FP32 activations")
         if x.is_cuda:
             from .cuda_ops import w8a16_extension
 
             ops = w8a16_extension()
             shape = x.shape
-            x = x.reshape(-1, shape[-1]).contiguous()
+            x, scale = fp16_gemm_input(x)
             if self.layer_config.convrot:
                 if self.layer_config.convrot_groupsize != 256:
                     raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
@@ -323,9 +366,24 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             weight = getattr(layer, "h3_fp16_weight", None)
             if weight is None:
                 weight = ops.dequantize(layer.weight, layer.weight_scale)
-            output = ops.gemm(x, weight).reshape(*shape[:-1], layer.weight.shape[0])
+            output = ops.gemm(
+                x, weight, getattr(layer, "h3_output_fp32", False) or scale is not None
+            )
+            if scale is not None:
+                output = output * scale
+            output = output.reshape(*shape[:-1], layer.weight.shape[0])
             return output if bias is None else output + bias
+        original_shape = x.shape
+        x, scale = fp16_gemm_input(x)
         if self.layer_config.convrot:
             x = convrot_reference(x, self.layer_config.convrot_groupsize)
         weight = dequantize_int8_reference(layer.weight, layer.weight_scale)
-        return torch.nn.functional.linear(x, weight, bias)
+        if getattr(layer, "h3_output_fp32", False) or scale is not None:
+            output = torch.nn.functional.linear(x.float(), weight.float())
+            if scale is not None:
+                output = output * scale
+            if bias is not None:
+                output = output + bias.float()
+        else:
+            output = torch.nn.functional.linear(x, weight, bias)
+        return output.reshape(*original_shape[:-1], layer.weight.shape[0])

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""ComfyUI tensor-wise INT8 ConvRot checkpoint support.
+
+The on-disk format stores an already rotated, row-wise quantized weight and a
+per-output-row scale.  At runtime the activation must receive the matching
+Hadamard rotation before FP16 matrix multiplication; treating these weights as
+ordinary INT8 silently produces incorrect output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch.nn import Module
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
+from vllm.model_executor.parameter import (
+    ChannelQuantScaleParameter,
+    ModelWeightParameter,
+)
+
+from .ops import convrot_reference, dequantize_int8_reference
+
+
+def create_weight_parameter(
+    output_size_per_partition, input_size_per_partition, weight_loader, params_dtype
+):
+    return ModelWeightParameter(
+        data=torch.empty(
+            output_size_per_partition, input_size_per_partition, dtype=params_dtype
+        ),
+        input_dim=1,
+        output_dim=0,
+        weight_loader=weight_loader,
+    )
+
+
+logger = init_logger(__name__)
+
+_FORMAT = "int8_tensorwise"
+
+
+@dataclass(frozen=True)
+class Int8ConvRotLayerConfig:
+    """Validated per-linear metadata decoded from ``.comfy_quant``."""
+
+    convrot: bool
+    convrot_groupsize: int = 256
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> Int8ConvRotLayerConfig:
+        fmt = value.get("format")
+        if fmt != _FORMAT:
+            raise ValueError(
+                f"Unsupported Comfy quant format {fmt!r}; expected {_FORMAT!r}."
+            )
+        convrot = value.get("convrot", False)
+        if not isinstance(convrot, bool):
+            raise ValueError(f"Comfy ConvRot flag must be boolean, got {convrot!r}.")
+        group_size = value.get("convrot_groupsize", 256)
+        if not isinstance(group_size, int) or group_size < 4:
+            raise ValueError(
+                f"Comfy ConvRot group size must be an integer >= 4, got {group_size!r}."
+            )
+        # comfy-kitchen's regular Hadamard is defined for powers of four.
+        value_left = group_size
+        while value_left > 1 and value_left % 4 == 0:
+            value_left //= 4
+        if value_left != 1:
+            raise ValueError(
+                f"Comfy ConvRot group size must be a power of four, got {group_size}."
+            )
+        return cls(convrot=convrot, convrot_groupsize=group_size)
+
+
+class DiffusionInt8ConvRotConfig(QuantizationConfig):
+    """Offline ComfyUI W8A16 ConvRot configuration.
+
+    Quantized layers are explicit because a Comfy checkpoint can mix INT8
+    linears with BF16/FP16 linears.  The MiniMax-H3 pipeline fills this mapping
+    from each layer's ``.comfy_quant`` tensor before constructing the model.
+    """
+
+    def __init__(
+        self,
+        layer_configs: Mapping[str, Mapping[str, Any] | Int8ConvRotLayerConfig]
+        | None = None,
+        quantized_layers: list[str] | None = None,
+        convrot_groupsize: int = 256,
+        ignored_layers: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.ignored_layers = ignored_layers or []
+        self.layer_configs: dict[str, Int8ConvRotLayerConfig] = {}
+        self.is_checkpoint_quantized = True
+        self.is_checkpoint_int8_convrot_serialized = True
+
+        if layer_configs:
+            self.configure_layers(layer_configs)
+        if quantized_layers:
+            default = Int8ConvRotLayerConfig.from_mapping(
+                {
+                    "format": _FORMAT,
+                    "convrot": True,
+                    "convrot_groupsize": convrot_groupsize,
+                }
+            )
+            for prefix in quantized_layers:
+                self.layer_configs.setdefault(prefix, default)
+        self._validate_checkpoint_layers_are_quantized(self.layer_configs)
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "int8_convrot"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> DiffusionInt8ConvRotConfig:
+        return cls(
+            layer_configs=config.get("layer_configs"),
+            quantized_layers=config.get("quantized_layers"),
+            convrot_groupsize=config.get("convrot_groupsize", 256),
+            ignored_layers=config.get("ignored_layers"),
+        )
+
+    def configure_layers(
+        self,
+        layer_configs: Mapping[str, Mapping[str, Any] | Int8ConvRotLayerConfig],
+    ) -> None:
+        """Install checkpoint-derived metadata before model construction."""
+        parsed: dict[str, Int8ConvRotLayerConfig] = {}
+        for prefix, value in layer_configs.items():
+            if not prefix or prefix.endswith(
+                (".weight", ".weight_scale", ".comfy_quant")
+            ):
+                raise ValueError(
+                    f"ConvRot layer metadata must use a module prefix, got {prefix!r}."
+                )
+            parsed[prefix] = (
+                value
+                if isinstance(value, Int8ConvRotLayerConfig)
+                else Int8ConvRotLayerConfig.from_mapping(value)
+            )
+        self._validate_checkpoint_layers_are_quantized(parsed)
+        if self.layer_configs and self.layer_configs != parsed:
+            raise ValueError(
+                "ConvRot layer metadata was already configured with different "
+                "checkpoint values."
+            )
+        self.layer_configs = parsed
+
+    def _validate_checkpoint_layers_are_quantized(
+        self,
+        layer_configs: Mapping[str, Int8ConvRotLayerConfig],
+    ) -> None:
+        conflicts = sorted(
+            prefix
+            for prefix in layer_configs
+            if is_layer_skipped(prefix, self.ignored_layers)
+        )
+        if conflicts:
+            raise ValueError(
+                "Checkpoint-marked INT8 ConvRot layers cannot also be ignored: "
+                f"{conflicts[:5]}. Remove them from ignored_layers."
+            )
+
+    def validate_model_bindings(self, model: Module) -> None:
+        """Require every checkpoint marker to bind an executable ConvRot layer."""
+        expected = set(self.layer_configs)
+        bound = {
+            method.prefix
+            for module in model.modules()
+            if isinstance(
+                method := getattr(module, "quant_method", None),
+                Int8ConvRotLinearMethod,
+            )
+            and method.quant_config is self
+        }
+        if bound != expected:
+            missing = sorted(expected - bound)
+            unexpected = sorted(bound - expected)
+            raise ValueError(
+                "MiniMax-H3 ConvRot checkpoint metadata does not match executable "
+                "quantized layers: "
+                f"unbound markers={missing[:5]}, unexpected bindings={unexpected[:5]}."
+            )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> QuantizeMethodBase | None:
+        if not isinstance(layer, LinearBase):
+            return None
+        if is_layer_skipped(prefix, self.ignored_layers):
+            return UnquantizedLinearMethod()
+        layer_config = self.layer_configs.get(prefix)
+        if layer_config is None:
+            return UnquantizedLinearMethod()
+        return Int8ConvRotLinearMethod(self, layer_config, prefix=prefix)
+
+
+class Int8ConvRotLinearMethod(LinearMethodBase):
+    """Execute signed INT8 weights after FP16 dequantization."""
+
+    def __init__(
+        self,
+        quant_config: DiffusionInt8ConvRotConfig,
+        layer_config: Int8ConvRotLayerConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        self.quant_config = quant_config
+        self.layer_config = layer_config
+        self.prefix = prefix
+        self._cuda_impl: Callable[..., torch.Tensor] | None = None
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        group_size = self.layer_config.convrot_groupsize
+        if self.layer_config.convrot and input_size_per_partition % group_size:
+            raise ValueError(
+                f"{self.prefix} has TP-local input width {input_size_per_partition}, "
+                f"which is not aligned to its ConvRot group size {group_size}. "
+                "Choose a tensor-parallel degree whose row-parallel shards preserve "
+                "group boundaries."
+            )
+
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        weight = create_weight_parameter(
+            output_size_per_partition=output_size_per_partition,
+            input_size_per_partition=input_size_per_partition,
+            weight_loader=weight_loader,
+            params_dtype=torch.int8,
+        )
+        layer.register_parameter("weight", weight)
+        scale = ChannelQuantScaleParameter(
+            data=torch.empty((output_size_per_partition, 1), dtype=torch.float32),
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", scale)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if layer.weight.dtype != torch.int8 or layer.weight.dim() != 2:
+            raise ValueError(
+                f"{self.prefix} expected a 2-D INT8 weight, got "
+                f"{tuple(layer.weight.shape)} {layer.weight.dtype}."
+            )
+        scale = layer.weight_scale
+        if scale.dtype != torch.float32 or scale.numel() != layer.weight.shape[0]:
+            raise ValueError(
+                f"{self.prefix} expected one FP32 scale per output row; got "
+                f"{tuple(scale.shape)} {scale.dtype} for weight "
+                f"{tuple(layer.weight.shape)}."
+            )
+        if not torch.isfinite(scale).all() or not torch.all(scale > 0):
+            raise ValueError(
+                f"{self.prefix} contains non-finite or non-positive INT8 weight scales."
+            )
+        layer.weight.data = layer.weight.data.contiguous()
+        layer.weight_scale.data = scale.data.reshape(-1).contiguous()
+
+    def apply(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        if x.dtype != torch.float16:
+            raise ValueError("H3 W8A16 requires FP16 activations")
+        if x.is_cuda:
+            from .cuda_ops import w8a16_extension
+
+            ops = w8a16_extension()
+            shape = x.shape
+            x = x.reshape(-1, shape[-1]).contiguous()
+            if self.layer_config.convrot:
+                if self.layer_config.convrot_groupsize != 256:
+                    raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
+                x = ops.rotate(x)
+            weight = getattr(layer, "h3_fp16_weight", None)
+            if weight is None:
+                weight = ops.dequantize(layer.weight, layer.weight_scale)
+            output = ops.gemm(x, weight).reshape(*shape[:-1], layer.weight.shape[0])
+            return output if bias is None else output + bias
+        if self.layer_config.convrot:
+            x = convrot_reference(x, self.layer_config.convrot_groupsize)
+        weight = dequantize_int8_reference(layer.weight, layer.weight_scale)
+        return torch.nn.functional.linear(x, weight, bias)

--- a/vllm/model_executor/models/minimax_h3/reference_video.py
+++ b/vllm/model_executor/models/minimax_h3/reference_video.py
@@ -1,0 +1,784 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MiniMax H3 Ref2VA reference-video preparation."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from .config import H3InputError
+
+MINIMAX_H3_PREPARED_REFERENCE_VIDEOS_KEY = "minimax_h3_prepared_reference_videos"
+
+
+def serialize_prepared_reference_videos(
+    items: list[dict[str, Any]], artifact_dir: str
+) -> str:
+    fields = (
+        "original_path",
+        "prepared_path",
+        "input_has_audio",
+        "width",
+        "height",
+        "start_time_seconds",
+        "duration_seconds",
+        "audio_duration_seconds",
+    )
+    return json.dumps(
+        {
+            "artifact_dir": artifact_dir,
+            "videos": [{field: item[field] for field in fields} for item in items],
+        },
+        separators=(",", ":"),
+    )
+
+
+def deserialize_prepared_reference_videos(
+    value: str,
+) -> tuple[str, list[dict[str, Any]]]:
+    try:
+        payload = json.loads(value)
+        artifact_dir = payload["artifact_dir"]
+        videos = payload["videos"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "invalid MiniMax H3 prepared-reference-video descriptor"
+        ) from exc
+    if not isinstance(artifact_dir, str) or not isinstance(videos, list):
+        raise ValueError("invalid MiniMax H3 prepared-reference-video descriptor")
+    required = {
+        "original_path",
+        "prepared_path",
+        "input_has_audio",
+        "width",
+        "height",
+        "start_time_seconds",
+        "duration_seconds",
+        "audio_duration_seconds",
+    }
+    if any(not isinstance(item, dict) or set(item) != required for item in videos):
+        raise ValueError("invalid MiniMax H3 prepared-reference-video descriptor")
+    return artifact_dir, videos
+
+
+MINIMAX_H3_FPS = 24.0
+MINIMAX_H3_QWEN_VIDEO_SAMPLE_FPS = 2.0
+MINIMAX_H3_QWEN_TEMPORAL_PATCH = 2
+MINIMAX_H3_BASE_SHORT_EDGE = 768
+MINIMAX_H3_MAX_PIXELS = 768 * 1344
+MINIMAX_H3_CANVAS_MULTIPLE = 32
+MINIMAX_H3_MIN_REFERENCE_DIMENSION = 256
+MINIMAX_H3_MAX_REFERENCE_DIMENSION = 5760
+MINIMAX_H3_MIN_REFERENCE_FPS = 23.976
+MINIMAX_H3_MAX_REFERENCE_FPS = 60.0
+MINIMAX_H3_MIN_REFERENCE_DURATION = 2.0
+MINIMAX_H3_MAX_REFERENCE_DURATION = 15.0
+MINIMAX_H3_MAX_REFERENCE_TOTAL_DURATION = 15.0
+# ffprobe reports container durations at a finer precision than the official
+# example's rounded values. Trim only this small probe-rounding excess.
+MINIMAX_H3_REFERENCE_DURATION_EPSILON = 1e-2
+MINIMAX_H3_MAX_VIDEO_BYTES = 50 * 1024 * 1024
+MINIMAX_H3_MAX_AUDIO_BYTES = 15 * 1024 * 1024
+MINIMAX_H3_VIDEO_FORMATS = frozenset({"mp4", "mov"})
+MINIMAX_H3_VIDEO_CODECS = frozenset({"h264", "h265", "hevc"})
+MINIMAX_H3_AUDIO_FORMATS = frozenset({"wav", "mp3"})
+MINIMAX_H3_AUDIO_CODECS = frozenset({"aac", "mp3"})
+
+
+def _nearest_multiple(value: float, multiple: int) -> int:
+    return max(multiple, int(round(float(value) / multiple)) * multiple)
+
+
+def _probe_video(path: str) -> dict[str, Any]:
+    show_entries = (
+        "stream=codec_type,codec_name,width,height,r_frame_rate,nb_read_frames,nb_frames,duration,"
+        "sample_aspect_ratio:format=format_name,size,duration"
+    )
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        show_entries,
+        "-of",
+        "json",
+        path,
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    probe = json.loads(result.stdout)
+    streams = probe.get("streams") or []
+    video_streams = [
+        stream for stream in streams if stream.get("codec_type") == "video"
+    ]
+    if not video_streams:
+        raise H3InputError(f"media has no video stream: {path}")
+    stream = video_streams[0]
+    raw_count = stream.get("nb_read_frames") or stream.get("nb_frames")
+    if raw_count in (None, "", "N/A"):
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-count_frames", *command[3:]],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        probe = json.loads(result.stdout)
+        streams = probe.get("streams") or []
+        video_streams = [
+            stream for stream in streams if stream.get("codec_type") == "video"
+        ]
+        if not video_streams:
+            raise H3InputError(f"media has no video stream: {path}")
+        stream = video_streams[0]
+        raw_count = stream.get("nb_read_frames") or stream.get("nb_frames")
+    try:
+        numerator, denominator = str(stream["r_frame_rate"]).split("/", 1)
+        fps = float(numerator) / float(denominator)
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as exc:
+        raise H3InputError(f"cannot determine video FPS: {path}") from exc
+    if not math.isfinite(fps) or fps <= 0:
+        raise H3InputError(f"cannot determine video FPS: {path}")
+    if raw_count in (None, "", "N/A"):
+        raise H3InputError(f"cannot determine video frame count: {path}")
+    raw_duration = stream.get("duration")
+    if raw_duration in (None, "", "N/A"):
+        raw_duration = probe.get("format", {}).get("duration")
+    duration = (
+        float(raw_duration)
+        if raw_duration not in (None, "", "N/A")
+        else int(raw_count) / fps
+    )
+    format_info = probe.get("format") or {}
+    format_names = tuple(
+        name.strip().lower()
+        for name in str(format_info.get("format_name", "")).split(",")
+        if name.strip()
+    )
+    raw_size = format_info.get("size")
+    file_size = (
+        int(raw_size) if raw_size not in (None, "", "N/A") else os.path.getsize(path)
+    )
+    audio_codecs = tuple(
+        str(stream.get("codec_name", "")).lower()
+        for stream in streams
+        if stream.get("codec_type") == "audio" and stream.get("codec_name")
+    )
+    return {
+        "width": int(stream["width"]),
+        "height": int(stream["height"]),
+        "fps": fps,
+        "frame_count": int(raw_count),
+        "duration": duration,
+        "format_names": format_names,
+        "video_codec": str(stream.get("codec_name", "")).lower(),
+        "audio_codecs": audio_codecs,
+        "file_size": file_size,
+    }
+
+
+def _validate_reference_video_metadata(
+    meta: dict[str, Any], *, index: int, source: str
+) -> None:
+    width = int(meta["width"])
+    height = int(meta["height"])
+    if (
+        min(width, height) < MINIMAX_H3_MIN_REFERENCE_DIMENSION
+        or max(width, height) > MINIMAX_H3_MAX_REFERENCE_DIMENSION
+    ):
+        raise H3InputError(
+            f"reference video {index} dimensions must be in [256, 5760] pixels, got "
+            f"{width}x{height}"
+        )
+    ratio = width / height
+    if not 0.4 <= ratio <= 2.5:
+        raise H3InputError(
+            f"reference video {index} aspect ratio must be in [0.4, 2.5], got "
+            f"{width}x{height}"
+        )
+
+    fps = float(meta["fps"])
+    if not MINIMAX_H3_MIN_REFERENCE_FPS <= fps <= MINIMAX_H3_MAX_REFERENCE_FPS:
+        raise H3InputError(
+            f"reference video {index} FPS must be in [23.976, 60], got {fps:.3f}"
+        )
+    duration = float(meta["duration"])
+    if (
+        not math.isfinite(duration)
+        or not MINIMAX_H3_MIN_REFERENCE_DURATION
+        <= duration
+        <= MINIMAX_H3_MAX_REFERENCE_DURATION
+    ):
+        raise H3InputError(
+            f"reference video {index} duration must be in [2, 15] seconds, got "
+            f"{duration:.3f}"
+        )
+
+    raw_file_size = meta.get("file_size")
+    file_size = (
+        int(raw_file_size) if raw_file_size is not None else os.path.getsize(source)
+    )
+    if file_size > MINIMAX_H3_MAX_VIDEO_BYTES:
+        raise H3InputError(f"reference video {index} exceeds the 50 MiB size limit")
+    format_names = set(meta.get("format_names", ()))
+    if not format_names.intersection(MINIMAX_H3_VIDEO_FORMATS):
+        formats = ", ".join(sorted(format_names)) or "unknown"
+        raise H3InputError(
+            f"reference video {index} must use an MP4 or MOV container, got {formats}"
+        )
+    video_codec = str(meta.get("video_codec", "")).lower()
+    if video_codec not in MINIMAX_H3_VIDEO_CODECS:
+        raise H3InputError(
+            f"reference video {index} must use H.264 or H.265 video, got "
+            f"{video_codec or 'unknown'}"
+        )
+    audio_codecs = tuple(str(codec).lower() for codec in meta.get("audio_codecs", ()))
+    invalid_audio = [
+        codec for codec in audio_codecs if codec not in MINIMAX_H3_AUDIO_CODECS
+    ]
+    if invalid_audio:
+        raise H3InputError(
+            f"reference video {index} must use AAC or MP3 audio when audio is present, "
+            f"got {invalid_audio[0]}"
+        )
+
+
+def _audio_items(values: Any) -> list[Any]:
+    if isinstance(values, (str, os.PathLike)):
+        return [values]
+    if (
+        isinstance(values, tuple)
+        and len(values) == 2
+        and isinstance(values[1], (int, np.integer))
+    ):
+        return [values]
+    if isinstance(values, (list, tuple)):
+        return list(values)
+    return [values]
+
+
+def _probe_audio(path: str) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type,codec_name,duration:format=format_name,size,duration",
+            "-of",
+            "json",
+            path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    probe = json.loads(result.stdout)
+    streams = [
+        stream
+        for stream in probe.get("streams", [])
+        if stream.get("codec_type") == "audio"
+    ]
+    if not streams:
+        raise H3InputError(f"media has no audio stream: {path}")
+    stream = streams[0]
+    raw_duration = stream.get("duration")
+    if raw_duration in (None, "", "N/A"):
+        raw_duration = (probe.get("format") or {}).get("duration")
+    if raw_duration in (None, "", "N/A"):
+        raise H3InputError(f"cannot determine audio duration: {path}")
+    format_info = probe.get("format") or {}
+    format_names = tuple(
+        name.strip().lower()
+        for name in str(format_info.get("format_name", "")).split(",")
+        if name.strip()
+    )
+    raw_size = format_info.get("size")
+    file_size = (
+        int(raw_size) if raw_size not in (None, "", "N/A") else os.path.getsize(path)
+    )
+    return {
+        "duration": float(raw_duration),
+        "format_names": format_names,
+        "codec": str(stream.get("codec_name", "")).lower(),
+        "file_size": file_size,
+    }
+
+
+def validate_reference_audio_files(values: Any) -> None:
+    """Validate path-backed standalone audio references against the H3 spec."""
+    total_duration = 0.0
+    for index, value in enumerate(_audio_items(values)):
+        if not isinstance(value, (str, os.PathLike)):
+            continue
+        source = str(value)
+        meta = _probe_audio(source)
+        file_size = int(meta["file_size"])
+        if file_size > MINIMAX_H3_MAX_AUDIO_BYTES:
+            raise H3InputError(f"reference audio {index} exceeds the 15 MiB size limit")
+        if not set(meta["format_names"]).intersection(MINIMAX_H3_AUDIO_FORMATS):
+            formats = ", ".join(meta["format_names"]) or "unknown"
+            raise H3InputError(
+                f"reference audio {index} must be WAV or MP3, got {formats}"
+            )
+        codec = str(meta["codec"]).lower()
+        if codec not in MINIMAX_H3_AUDIO_CODECS and not codec.startswith("pcm_"):
+            raise H3InputError(
+                f"reference audio {index} must use MP3 or PCM audio, got "
+                f"{codec or 'unknown'}"
+            )
+        duration = float(meta["duration"])
+        if (
+            not math.isfinite(duration)
+            or not MINIMAX_H3_MIN_REFERENCE_DURATION
+            <= duration
+            <= MINIMAX_H3_MAX_REFERENCE_DURATION
+        ):
+            raise H3InputError(
+                f"reference audio {index} duration must be in [2, 15] seconds, got "
+                f"{duration:.3f}"
+            )
+        total_duration += duration
+    if total_duration > MINIMAX_H3_MAX_REFERENCE_TOTAL_DURATION:
+        raise H3InputError("reference audio must be at most 15 seconds in total")
+
+
+def validate_reference_audio_waveforms(values: list[tuple[torch.Tensor, int]]) -> None:
+    """Validate in-memory standalone audio references using sample counts."""
+    total_duration = 0.0
+    for index, (waveform, sample_rate) in enumerate(values):
+        if int(sample_rate) <= 0:
+            raise H3InputError(f"reference audio {index} has an invalid sample rate")
+        samples = int(waveform.shape[-1])
+        duration = samples / int(sample_rate)
+        if (
+            not MINIMAX_H3_MIN_REFERENCE_DURATION
+            <= duration
+            <= MINIMAX_H3_MAX_REFERENCE_DURATION
+        ):
+            raise H3InputError(
+                f"reference audio {index} duration must be in [2, 15] seconds, got "
+                f"{duration:.3f}"
+            )
+        total_duration += duration
+    if total_duration > MINIMAX_H3_MAX_REFERENCE_TOTAL_DURATION:
+        raise H3InputError("reference audio must be at most 15 seconds in total")
+
+
+def _reference_video_shape(width: int, height: int) -> tuple[int, int]:
+    if (
+        min(width, height) < MINIMAX_H3_MIN_REFERENCE_DIMENSION
+        or max(width, height) > MINIMAX_H3_MAX_REFERENCE_DIMENSION
+    ):
+        raise H3InputError(
+            f"reference video dimensions must be in [256, 5760] pixels, got "
+            f"{width}x{height}"
+        )
+    ratio = float(width) / float(height)
+    if not 0.4 <= ratio <= 2.5:
+        raise H3InputError(
+            f"reference video aspect ratio must be in [0.4, 2.5], got {width}x{height}"
+        )
+    if ratio >= 1.0:
+        target_width = MINIMAX_H3_BASE_SHORT_EDGE * ratio
+        target_height = float(MINIMAX_H3_BASE_SHORT_EDGE)
+    else:
+        target_width = float(MINIMAX_H3_BASE_SHORT_EDGE)
+        target_height = MINIMAX_H3_BASE_SHORT_EDGE / ratio
+    area = target_width * target_height
+    if area > MINIMAX_H3_MAX_PIXELS:
+        scale = math.sqrt(MINIMAX_H3_MAX_PIXELS / area)
+        target_width *= scale
+        target_height *= scale
+    return (
+        _nearest_multiple(target_width, MINIMAX_H3_CANVAS_MULTIPLE),
+        _nearest_multiple(target_height, MINIMAX_H3_CANVAS_MULTIPLE),
+    )
+
+
+def _transcode_reference_video(
+    source: str,
+    *,
+    target_width: int,
+    target_height: int,
+    target_frame_count: int,
+    workdir: str,
+    start_time_seconds: float = 0.0,
+    duration_seconds: float | None = None,
+) -> str:
+    output = str(Path(workdir) / "prepared.mp4")
+    duration_args = (
+        ["-t", f"{float(duration_seconds):.6f}"] if duration_seconds is not None else []
+    )
+    frame_count_args = (
+        ["-frames:v", str(int(target_frame_count))] if target_frame_count > 0 else []
+    )
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-ss",
+            f"{float(start_time_seconds):.6f}",
+            "-i",
+            source,
+            "-map",
+            "0:v:0",
+            "-an",
+            "-vf",
+            (
+                f"fps={MINIMAX_H3_FPS:g},scale={target_width}:{target_height}:flags=lanczos,setsar=1"
+            ),
+            *duration_args,
+            *frame_count_args,
+            "-metadata:s:v:0",
+            "rotate=0",
+            # Keep the transformed RGB pixels lossless. The same prepared
+            # stream is decoded by Qwen3VL and the video VAE; a yuv420p
+            # intermediate would make the two consumers see different
+            # pixels from the model-card reference recipe.
+            "-c:v",
+            "libx264rgb",
+            "-crf",
+            "0",
+            "-preset",
+            "veryfast",
+            "-pix_fmt",
+            "rgb24",
+            output,
+        ],
+        check=True,
+    )
+    return output
+
+
+def prepare_reference_videos(
+    values: Any,
+    *,
+    target_frame_count: int,
+    workdir: str,
+    start_time_seconds: Any = None,
+) -> list[dict[str, Any]]:
+    if isinstance(values, (str, os.PathLike)):
+        values = [values]
+    if not isinstance(values, (list, tuple)) or not values:
+        raise H3InputError(
+            "MiniMax H3 Ref2VA video input must be a path or a non-empty list of paths"
+        )
+    if isinstance(start_time_seconds, (list, tuple)):
+        start_times = list(start_time_seconds)
+    else:
+        start_times = [start_time_seconds] * len(values)
+    if len(start_times) != len(values):
+        raise H3InputError(
+            "start_time_seconds must contain one value per reference video"
+        )
+
+    prepared: list[dict[str, Any]] = []
+    total_duration = 0.0
+    for index, value in enumerate(values):
+        item_start = start_times[index]
+        if isinstance(value, dict):
+            item_start = value.get("start_time_seconds", item_start)
+            value = value.get("path", value.get("video_path", value.get("video_url")))
+        if not isinstance(value, (str, os.PathLike)):
+            raise H3InputError(
+                f"MiniMax H3 Ref2VA video references require file paths, got item "
+                f"{index}: {type(value)!r}"
+            )
+        source = str(value)
+        meta = _probe_video(source)
+        _validate_reference_video_metadata(meta, index=index, source=source)
+        start = 0.0 if item_start is None else float(item_start)
+        if not math.isfinite(start) or start < 0 or start >= float(meta["duration"]):
+            raise H3InputError(
+                f"reference video {index} start_time_seconds is outside the source "
+                f"duration"
+            )
+        duration = float(meta["duration"]) - start
+        if duration < MINIMAX_H3_MIN_REFERENCE_DURATION:
+            raise H3InputError(
+                f"reference video {index} must provide at least 2 seconds after "
+                f"start_time_seconds, got {duration:.3f}"
+            )
+        remaining_duration = MINIMAX_H3_MAX_REFERENCE_TOTAL_DURATION - total_duration
+        if duration > remaining_duration:
+            if duration - remaining_duration > MINIMAX_H3_REFERENCE_DURATION_EPSILON:
+                raise H3InputError(
+                    "reference videos must be at most 15 seconds in total"
+                )
+            duration = remaining_duration
+            if duration < MINIMAX_H3_MIN_REFERENCE_DURATION:
+                raise H3InputError(
+                    "reference videos must be at most 15 seconds in total"
+                )
+        total_duration += duration
+        width, height = _reference_video_shape(meta["width"], meta["height"])
+        item_workdir = Path(workdir) / f"video_{index}"
+        item_workdir.mkdir(parents=True)
+        prepared_path = _transcode_reference_video(
+            source,
+            target_width=width,
+            target_height=height,
+            target_frame_count=target_frame_count,
+            workdir=str(item_workdir),
+            start_time_seconds=start,
+            duration_seconds=duration,
+        )
+        prepared.append(
+            {
+                "original_path": source,
+                "prepared_path": prepared_path,
+                "input_has_audio": bool(meta.get("audio_codecs")),
+                "width": width,
+                "height": height,
+                "start_time_seconds": start,
+                "duration_seconds": duration,
+                # Reference video frames and their soundtrack are conditioned
+                # only for the generated temporal extent. Keep the source
+                # segment duration for metadata/validation, and expose the
+                # bounded duration separately for audio extraction.
+                "audio_duration_seconds": min(
+                    duration,
+                    float(target_frame_count) / MINIMAX_H3_FPS
+                    if target_frame_count > 0
+                    else duration,
+                ),
+            }
+        )
+    return prepared
+
+
+def load_video_frames(path: str) -> np.ndarray:
+    try:
+        import decord
+    except ImportError:
+        meta = _probe_video(path)
+        return _decode_video_frames_ffmpeg(
+            path,
+            frame_count=int(meta["frame_count"]),
+            width=int(meta["width"]),
+            height=int(meta["height"]),
+        )
+
+    reader = decord.VideoReader(path)
+    if len(reader) <= 0:
+        raise H3InputError(f"video has no frames: {path}")
+    frames = reader.get_batch(list(range(len(reader))))
+    return frames.asnumpy() if hasattr(frames, "asnumpy") else np.asarray(frames)
+
+
+def _decode_video_frames_ffmpeg(
+    path: str,
+    *,
+    frame_count: int,
+    width: int,
+    height: int,
+    indices: list[int] | None = None,
+) -> np.ndarray:
+    frame_count = int(frame_count)
+    width = int(width)
+    height = int(height)
+    if frame_count <= 0:
+        raise H3InputError(f"video has no frames: {path}")
+    if width <= 0 or height <= 0:
+        raise H3InputError(f"video has invalid dimensions {width}x{height}: {path}")
+    if indices is not None and (
+        not indices or any(index < 0 or index >= frame_count for index in indices)
+    ):
+        raise H3InputError(f"invalid frame indices for {path}: {indices}")
+
+    output_frame_count = frame_count if indices is None else len(indices)
+    command = [
+        "ffmpeg",
+        "-loglevel",
+        "error",
+        "-threads",
+        "0",
+        "-i",
+        path,
+        "-map",
+        "0:v:0",
+        "-an",
+    ]
+    if indices is not None:
+        select = "+".join(f"eq(n\\,{index})" for index in indices)
+        command.extend(["-vf", f"select={select}"])
+    command.extend(
+        [
+            "-vsync",
+            "0",
+            "-frames:v",
+            str(output_frame_count),
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "pipe:1",
+        ]
+    )
+    result = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+    )
+    frame_size = width * height * 3
+    expected_size = output_frame_count * frame_size
+    if len(result.stdout) != expected_size:
+        raise H3InputError(
+            f"decoded {len(result.stdout)} bytes from {path}, expected {expected_size}"
+        )
+    return np.frombuffer(result.stdout, dtype=np.uint8).reshape(
+        output_frame_count,
+        height,
+        width,
+        3,
+    )
+
+
+def sample_reference_video_frames(prepared_path: str) -> dict[str, Any]:
+    meta = _probe_video(prepared_path)
+    ratio = MINIMAX_H3_FPS / MINIMAX_H3_QWEN_VIDEO_SAMPLE_FPS
+    indices: list[int] = []
+    cursor = 0.0
+    while True:
+        frame_index = int(round(cursor))
+        if frame_index >= meta["frame_count"]:
+            break
+        if not indices or frame_index > indices[-1]:
+            indices.append(frame_index)
+        cursor += ratio
+    if not indices:
+        raise H3InputError(f"no frames sampled from {prepared_path}")
+
+    # The preparation step emits a lossless RGB stream. Decode only the sampled
+    # frames in one ffmpeg process so Qwen3VL sees the exact prepared pixels
+    # without decoding the entire high-bitrate stream into host memory.
+    decoded_frames = _decode_video_frames_ffmpeg(
+        prepared_path,
+        frame_count=int(meta["frame_count"]),
+        indices=indices,
+        width=meta["width"],
+        height=meta["height"],
+    )
+    frames = [np.asarray(frame) for frame in decoded_frames]
+
+    timestamps = [
+        index / MINIMAX_H3_QWEN_VIDEO_SAMPLE_FPS for index in range(len(indices))
+    ]
+    timestamps += [timestamps[-1]] * (
+        (-len(timestamps)) % MINIMAX_H3_QWEN_TEMPORAL_PATCH
+    )
+    block_timestamps = [
+        (timestamps[index] + timestamps[index + MINIMAX_H3_QWEN_TEMPORAL_PATCH - 1]) / 2
+        for index in range(
+            0,
+            len(timestamps),
+            MINIMAX_H3_QWEN_TEMPORAL_PATCH,
+        )
+    ]
+    return {
+        "frames": frames,
+        "block_timestamps": block_timestamps,
+    }
+
+
+def _soundfile_to_waveform(path: str) -> tuple[torch.Tensor, int]:
+    import soundfile as sf
+
+    data, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    # soundfile is (samples, channels); torchaudio.load is (channels, samples).
+    waveform = torch.from_numpy(data).t().contiguous()
+    return waveform, int(sample_rate)
+
+
+def load_audio_file(path: str) -> tuple[torch.Tensor, int]:
+    """Load an audio file as ``(waveform[C, T] float32, sample_rate)``.
+
+    torchaudio 2.6+ routes ``load`` through TorchCodec, whose wheels do not load
+    on aarch64 with a CPU-only torch (they link CUDA libraries that are absent).
+    Fall back to soundfile; if the container is not libsndfile-readable (e.g.
+    mp3/m4a/mp4), demux to wav with ffmpeg first so any ffmpeg-supported input
+    works at its native sample rate.
+    """
+    try:
+        import torchaudio
+
+        return torchaudio.load(path)
+    except (ImportError, RuntimeError, OSError):
+        pass
+    try:
+        return _soundfile_to_waveform(path)
+    except Exception:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="minimax_h3_audio_") as tmpdir:
+            wav = str(Path(tmpdir) / "audio.wav")
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-i",
+                    path,
+                    "-vn",
+                    "-f",
+                    "wav",
+                    wav,
+                ],
+                check=True,
+            )
+            return _soundfile_to_waveform(wav)
+
+
+def load_video_audio(
+    path: str,
+    *,
+    start_time_seconds: float = 0.0,
+    duration_seconds: float | None = None,
+) -> tuple[torch.Tensor, int]:
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="minimax_h3_video_audio_") as tmpdir:
+        output = str(Path(tmpdir) / "audio.wav")
+        command = [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-ss",
+            f"{float(start_time_seconds):.6f}",
+            "-i",
+            path,
+            "-vn",
+            "-ac",
+            "2",
+            "-ar",
+            "44100",
+            "-f",
+            "wav",
+        ]
+        if duration_seconds is not None:
+            command.extend(["-t", f"{float(duration_seconds):.6f}"])
+        command.append(output)
+        subprocess.run(command, check=True)
+        return load_audio_file(output)
+
+
+__all__ = [
+    "load_audio_file",
+    "load_video_audio",
+    "load_video_frames",
+    "prepare_reference_videos",
+    "sample_reference_video_frames",
+    "validate_reference_audio_files",
+    "validate_reference_audio_waveforms",
+]

--- a/vllm/model_executor/models/minimax_h3/residency.py
+++ b/vllm/model_executor/models/minimax_h3/residency.py
@@ -190,7 +190,8 @@ class PinnedModuleStager:
             grouped[storage_key][1].append(binding)
 
         groups: list[_StorageGroup] = []
-        for source, bindings in grouped.values():
+        while grouped:
+            _, (source, bindings) = grouped.popitem()
             storage = source.untyped_storage()
             storage_view = torch.empty(0, dtype=torch.uint8, device=source.device).set_(
                 storage,
@@ -206,6 +207,11 @@ class PinnedModuleStager:
             if pin_memory and not master.is_pinned():
                 master = master.pin_memory()
             groups.append(_StorageGroup(master=master, bindings=bindings))
+            # Release each pageable allocation as soon as its pinned master is
+            # ready. Keeping both full copies until the entire encoder is
+            # pinned can transiently double TP4 host memory.
+            for binding in bindings:
+                set_tensor_storage(binding.target, cls._view(master, binding))
         return groups
 
     @staticmethod

--- a/vllm/model_executor/models/minimax_h3/residency.py
+++ b/vllm/model_executor/models/minimax_h3/residency.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""On-demand module staging backed by immutable pinned CPU storage."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from itertools import chain
+from typing import Any
+
+import torch
+from torch import nn
+from torch.distributed.tensor import DTensor
+
+from vllm.logger import init_logger
+
+
+def is_dtensor(t):
+    return isinstance(t, DTensor)
+
+
+def set_tensor_storage(target, value):
+    if is_dtensor(target):
+        target._local_tensor = value
+    else:
+        target.data = value
+
+
+logger = init_logger(__name__)
+
+
+class BoundedAllocatorCache:
+    """Retain reusable allocator blocks without monopolizing device memory.
+
+    Component offload normally calls ``empty_cache`` after every stage. That
+    makes the next stage return to the device allocator even though PyTorch's
+    cached blocks are immediately reusable. This policy keeps the cache while
+    both of these bounds hold:
+
+    * cached-but-unallocated memory is at most 25% of device capacity; and
+    * at least 5% of device capacity is physically free.
+
+    Missing memory telemetry is handled conservatively by releasing the cache.
+    Failure paths can force release; normal executor shutdown keeps its own
+    unconditional device-cache cleanup because this policy is not global.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        *,
+        max_cached_fraction: float = 0.25,
+        min_free_fraction: float = 0.05,
+    ) -> None:
+        if not 0.0 <= max_cached_fraction <= 1.0:
+            raise ValueError(
+                f"max_cached_fraction must be in [0, 1], got {max_cached_fraction}"
+            )
+        if not 0.0 <= min_free_fraction <= 1.0:
+            raise ValueError(
+                f"min_free_fraction must be in [0, 1], got {min_free_fraction}"
+            )
+        self.device = device
+        self.max_cached_fraction = max_cached_fraction
+        self.min_free_fraction = min_free_fraction
+
+    def _should_release(self) -> bool:
+        reserved = int(torch.accelerator.memory_reserved(self.device))
+        allocated = int(torch.accelerator.memory_allocated(self.device))
+        free, total = torch.accelerator.get_memory_info(self.device)
+        cached = max(0, reserved - allocated)
+        return cached > int(total * self.max_cached_fraction) or free < int(
+            total * self.min_free_fraction
+        )
+
+    def release_if_needed(self, *, force: bool = False) -> bool:
+        """Release cached blocks when a bound is crossed or release is forced."""
+        if not force:
+            try:
+                if not self._should_release():
+                    return False
+            except Exception as exc:
+                # Preserve the pre-retention behavior on platforms that do not
+                # expose allocator telemetry through torch.accelerator.
+                logger.debug(
+                    "Allocator cache telemetry unavailable; releasing cache: %s", exc
+                )
+        torch.accelerator.empty_cache()
+        return True
+
+
+@dataclass(frozen=True)
+class _TensorBinding:
+    target: torch.Tensor
+    dtype: torch.dtype
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    storage_offset: int
+
+
+@dataclass
+class _StorageGroup:
+    master: torch.Tensor
+    bindings: list[_TensorBinding]
+
+
+class PinnedModuleStager:
+    """Stage immutable module groups without copying device weights to CPU.
+
+    ``nn.Module.to("cpu")`` performs a device-to-host copy for every parameter
+    after each forward. In inference the weights are immutable, so retain one
+    pinned CPU master instead. ``load`` materializes device storage from that
+    master; ``offload`` only rebinds Parameters and buffers to the master.
+
+    A module iterable is treated as one staging group. It uses one copy stream
+    and one reusable completion event. Tensors sharing storage keep their
+    shapes, strides, offsets, dtypes, and aliases across every transition.
+    """
+
+    def __init__(
+        self,
+        module: nn.Module | Iterable[nn.Module],
+        device: torch.device,
+        *,
+        pin_memory: bool = True,
+        copy_stream: Any | None = None,
+        cache_retention: BoundedAllocatorCache | None = None,
+    ) -> None:
+        modules = (module,) if isinstance(module, nn.Module) else tuple(module)
+        if not modules or not all(isinstance(item, nn.Module) for item in modules):
+            raise ValueError("PinnedModuleStager requires at least one nn.Module")
+
+        self.device = device
+        self.copy_stream = (
+            copy_stream if copy_stream is not None else torch.cuda.Stream()
+        )
+        self._ready_event = torch.cuda.Event()
+        self.cache_retention = cache_retention
+        self.loaded = False
+        self._groups = self._snapshot_groups(modules, pin_memory=pin_memory)
+        self._device_storages: list[torch.Tensor] = []
+        self._restore_masters()
+
+    @staticmethod
+    def _local_tensor(target: torch.Tensor) -> torch.Tensor:
+        return target.to_local() if is_dtensor(target) else target
+
+    @classmethod
+    def _snapshot_groups(
+        cls,
+        modules: tuple[nn.Module, ...],
+        *,
+        pin_memory: bool,
+    ) -> list[_StorageGroup]:
+        targets: list[torch.Tensor] = []
+        seen_targets: set[int] = set()
+        for target in chain.from_iterable(
+            chain(item.parameters(), item.buffers()) for item in modules
+        ):
+            if id(target) not in seen_targets:
+                seen_targets.add(id(target))
+                targets.append(target)
+
+        grouped: dict[tuple[Any, ...], tuple[torch.Tensor, list[_TensorBinding]]] = {}
+        for target in targets:
+            local = cls._local_tensor(target)
+            if local.is_meta:
+                raise ValueError("PinnedModuleStager cannot snapshot a meta tensor")
+            storage = local.untyped_storage()
+            if storage.nbytes() == 0:
+                storage_key: tuple[Any, ...] = ("empty", id(target))
+            else:
+                storage_key = (
+                    local.device.type,
+                    local.device.index,
+                    storage.data_ptr(),
+                    storage.nbytes(),
+                )
+            binding = _TensorBinding(
+                target=target,
+                dtype=local.dtype,
+                shape=tuple(local.shape),
+                stride=tuple(local.stride()),
+                storage_offset=local.storage_offset(),
+            )
+            if storage_key not in grouped:
+                grouped[storage_key] = (local, [])
+            grouped[storage_key][1].append(binding)
+
+        groups: list[_StorageGroup] = []
+        for source, bindings in grouped.values():
+            storage = source.untyped_storage()
+            storage_view = torch.empty(0, dtype=torch.uint8, device=source.device).set_(
+                storage,
+                0,
+                (storage.nbytes(),),
+                (1,),
+            )
+            master = (
+                storage_view.detach()
+                if storage_view.device.type == "cpu"
+                else storage_view.to("cpu")
+            )
+            if pin_memory and not master.is_pinned():
+                master = master.pin_memory()
+            groups.append(_StorageGroup(master=master, bindings=bindings))
+        return groups
+
+    @staticmethod
+    def _view(backing: torch.Tensor, binding: _TensorBinding) -> torch.Tensor:
+        return torch.empty(0, dtype=binding.dtype, device=backing.device).set_(
+            backing.untyped_storage(),
+            binding.storage_offset,
+            binding.shape,
+            binding.stride,
+        )
+
+    def _bind(self, storages: list[torch.Tensor]) -> None:
+        for storage, group in zip(storages, self._groups):
+            for binding in group.bindings:
+                set_tensor_storage(binding.target, self._view(storage, binding))
+
+    def _restore_masters(self) -> None:
+        self._bind([group.master for group in self._groups])
+
+    def set_cache_retention(
+        self, cache_retention: BoundedAllocatorCache | None
+    ) -> None:
+        self.cache_retention = cache_retention
+
+    def _release_cache(self, *, force: bool = False) -> None:
+        if self.cache_retention is None:
+            torch.accelerator.empty_cache()
+        else:
+            self.cache_retention.release_if_needed(force=force)
+
+    def _load_once(self) -> None:
+        device_storages = [
+            torch.empty_like(group.master, device=self.device) for group in self._groups
+        ]
+        compute_stream = torch.cuda.current_stream()
+        self.copy_stream.wait_stream(compute_stream)
+        with torch.cuda.stream(self.copy_stream):
+            for device_storage, group in zip(device_storages, self._groups):
+                device_storage.copy_(
+                    group.master, non_blocking=group.master.is_pinned()
+                )
+            self._ready_event.record(self.copy_stream)
+
+        self._bind(device_storages)
+        compute_stream.wait_event(self._ready_event)
+        self._device_storages = device_storages
+        self.loaded = True
+
+    def _cleanup_failed_load(self) -> None:
+        try:
+            torch.accelerator.synchronize()
+        except Exception:
+            logger.debug(
+                "Device synchronization failed while cleaning up module staging",
+                exc_info=True,
+            )
+        self._restore_masters()
+        self._device_storages.clear()
+        self.loaded = False
+        self._release_cache(force=True)
+
+    def load(self) -> None:
+        if self.loaded:
+            return
+        try:
+            self._load_once()
+        except torch.OutOfMemoryError:
+            # A retained cache is normally reusable by this process, but an
+            # explicit flush gives external memory pressure one bounded retry.
+            self._cleanup_failed_load()
+            try:
+                self._load_once()
+            except BaseException:
+                self._cleanup_failed_load()
+                raise
+        except BaseException:
+            self._cleanup_failed_load()
+            raise
+
+    def offload(self) -> None:
+        if not self.loaded:
+            return
+
+        # The module has completed on the compute stream. Synchronize once at
+        # the stage boundary, then discard device storage without any D2H copy.
+        try:
+            torch.accelerator.synchronize()
+            self._restore_masters()
+        except BaseException:
+            self._device_storages.clear()
+            self.loaded = False
+            self._release_cache(force=True)
+            raise
+        self._device_storages.clear()
+        self.loaded = False
+        self._release_cache()
+
+
+__all__ = ["BoundedAllocatorCache", "PinnedModuleStager"]

--- a/vllm/model_executor/models/minimax_h3/scheduling_minimax_h3_euler_ancestral.py
+++ b/vllm/model_executor/models/minimax_h3/scheduling_minimax_h3_euler_ancestral.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+
+
+def _require_finite_tensor(tensor: torch.Tensor, name: str) -> None:
+    if not bool(torch.isfinite(tensor).all().item()):
+        raise ValueError(f"{name} must be finite")
+
+
+def _validate_unit_timestep(timestep: torch.Tensor, name: str) -> None:
+    if not isinstance(timestep, torch.Tensor):
+        raise ValueError(f"{name} must be a torch.Tensor")
+    if not torch.is_floating_point(timestep):
+        raise ValueError(f"{name} must be a floating point tensor")
+    _require_finite_tensor(timestep, name)
+    out_of_range = (timestep < 0) | (timestep > 1)
+    if bool(out_of_range.any().item()):
+        raise ValueError(f"{name} must be in [0, 1]")
+
+
+def _validate_sigma(value: float, name: str) -> float:
+    sigma = float(value)
+    if not math.isfinite(sigma):
+        raise ValueError(f"{name} must be finite")
+    if sigma < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return sigma
+
+
+def _validate_timestep_sigma_pair(
+    timestep: torch.Tensor,
+    sigma_curr: float,
+    name: str,
+) -> float:
+    _validate_unit_timestep(timestep, f"{name}_timestep")
+    sigma = _validate_sigma(sigma_curr, f"{name}_sigma_curr")
+    expected = 1.0 - timestep.detach().to(dtype=torch.float32)
+    actual = torch.full_like(expected, sigma)
+    if not torch.allclose(actual, expected, rtol=1e-5, atol=1e-5):
+        raise ValueError(f"{name}_sigma_curr must equal 1 - {name}_timestep")
+    return sigma
+
+
+def minimax_h3_rf_v_to_x0(
+    xt: torch.Tensor,
+    v: torch.Tensor,
+    timestep: torch.Tensor,
+) -> torch.Tensor:
+    if xt.shape != v.shape:
+        raise ValueError(f"xt and v shapes must match, got {xt.shape} vs {v.shape}")
+    if not torch.is_floating_point(xt):
+        raise ValueError("xt must be a floating point tensor")
+    if not torch.is_floating_point(v):
+        raise ValueError("v must be a floating point tensor")
+    _require_finite_tensor(xt, "xt")
+    _require_finite_tensor(v, "v")
+    _validate_unit_timestep(timestep, "timestep")
+    cond_t = timestep.to(device=xt.device, dtype=xt.dtype)
+    while cond_t.ndim < xt.ndim:
+        cond_t = cond_t.unsqueeze(-1)
+    sigma_t = 1 - cond_t
+    x0 = xt + sigma_t * v
+    _require_finite_tensor(x0, "x0")
+    return x0
+
+
+def minimax_h3_euler_eta0_step(
+    state: torch.Tensor,
+    denoised: torch.Tensor,
+    *,
+    sigma_curr: float,
+    sigma_next: float,
+) -> torch.Tensor:
+    if state.shape != denoised.shape:
+        raise ValueError(
+            f"state and denoised shapes must match, got {state.shape} vs "
+            f"{denoised.shape}"
+        )
+    if not torch.is_floating_point(state):
+        raise ValueError("state must be a floating point tensor")
+    if not torch.is_floating_point(denoised):
+        raise ValueError("denoised must be a floating point tensor")
+    _require_finite_tensor(state, "state")
+    _require_finite_tensor(denoised, "denoised")
+    sigma_curr = _validate_sigma(sigma_curr, "sigma_curr")
+    sigma_next = _validate_sigma(sigma_next, "sigma_next")
+    if sigma_curr == 0.0:
+        if sigma_next != 0.0:
+            raise ValueError("sigma_next must be 0 when sigma_curr is 0")
+        return state
+    compute_dtype = torch.float32
+    if state.dtype not in (torch.float16, torch.bfloat16):
+        compute_dtype = state.dtype
+    sigma_curr_t = state.new_tensor(sigma_curr, dtype=compute_dtype)
+    sigma_next_t = state.new_tensor(sigma_next, dtype=compute_dtype)
+    sigma_ratio = sigma_next_t / sigma_curr_t
+    out = sigma_ratio * state.to(dtype=compute_dtype) + (
+        1.0 - sigma_ratio
+    ) * denoised.to(dtype=compute_dtype)
+    out = out.to(dtype=state.dtype)
+    _require_finite_tensor(out, "euler_eta0_step output")
+    return out
+
+
+class MiniMaxH3EulerAncestralEta0SchedulerAdapter:
+    def __init__(self, **config: Any) -> None:
+        if config:
+            raise ValueError(
+                f"{type(self).__name__} does not accept config fields: {sorted(config)}"
+            )
+
+    def set_shift(self, _flow_shift: float) -> None:
+        """Ignore flow shift, matching the previous loader-specific path."""
+
+    def step_denoising(
+        self,
+        *,
+        input_visual_latent: torch.Tensor,
+        input_audio_latent: torch.Tensor,
+        timestep: torch.Tensor,
+        noise_pred_visual: torch.Tensor,
+        noise_pred_audio: torch.Tensor,
+        sigma_curr: float,
+        sigma_next: float,
+        video_timestep: torch.Tensor | None = None,
+        audio_timestep: torch.Tensor | None = None,
+        video_sigma_curr: float | None = None,
+        video_sigma_next: float | None = None,
+        audio_sigma_curr: float | None = None,
+        audio_sigma_next: float | None = None,
+    ) -> dict[str, torch.Tensor]:
+        visual_timestep = timestep if video_timestep is None else video_timestep
+        audio_timestep = timestep if audio_timestep is None else audio_timestep
+        visual_sigma_curr = sigma_curr if video_sigma_curr is None else video_sigma_curr
+        visual_sigma_next = sigma_next if video_sigma_next is None else video_sigma_next
+        audio_sigma_curr = sigma_curr if audio_sigma_curr is None else audio_sigma_curr
+        audio_sigma_next = sigma_next if audio_sigma_next is None else audio_sigma_next
+        visual_sigma_curr = _validate_timestep_sigma_pair(
+            visual_timestep,
+            visual_sigma_curr,
+            "video",
+        )
+        audio_sigma_curr = _validate_timestep_sigma_pair(
+            audio_timestep,
+            audio_sigma_curr,
+            "audio",
+        )
+
+        denoised_visual = minimax_h3_rf_v_to_x0(
+            input_visual_latent,
+            noise_pred_visual,
+            visual_timestep,
+        )
+        denoised_audio = minimax_h3_rf_v_to_x0(
+            input_audio_latent,
+            noise_pred_audio,
+            audio_timestep,
+        )
+        return {
+            "output_visual_latent": minimax_h3_euler_eta0_step(
+                input_visual_latent,
+                denoised_visual,
+                sigma_curr=visual_sigma_curr,
+                sigma_next=visual_sigma_next,
+            ),
+            "output_audio_latent": minimax_h3_euler_eta0_step(
+                input_audio_latent,
+                denoised_audio,
+                sigma_curr=audio_sigma_curr,
+                sigma_next=audio_sigma_next,
+            ),
+        }
+
+
+EntryClass = MiniMaxH3EulerAncestralEta0SchedulerAdapter
+
+__all__ = [
+    "MiniMaxH3EulerAncestralEta0SchedulerAdapter",
+    "minimax_h3_euler_eta0_step",
+    "minimax_h3_rf_v_to_x0",
+]

--- a/vllm/model_executor/models/minimax_h3/sigma_schedule.py
+++ b/vllm/model_executor/models/minimax_h3/sigma_schedule.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+BASE_SCHEDULE_KEY = "base_schedule"
+
+
+@dataclass(frozen=True)
+class DMD2SigmaSchedule:
+    """Continuous rectified-flow positions pinned by a distilled checkpoint.
+
+    A DMD2 student only ever sees the few noise levels it was trained on, so a
+    distilled release ships the exact positions instead of letting the server
+    derive a uniform schedule from ``num_inference_steps``.
+
+    This is deliberately distinct from
+    ``vllm_omni.diffusion.models.dmd2.DMD2Config.denoising_timesteps``, which
+    carries integer scheduler timesteps for scheduler-backed pipelines. Here the
+    entries are continuous positions in ``[0, 1]`` that still need a per-modality
+    time shift applied, which is what lets one schedule drive several coupled
+    modalities at different shift scales.
+    """
+
+    base_schedule: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        values = self.base_schedule
+        if len(values) < 2:
+            raise ValueError("DMD2 base_schedule needs at least 2 entries")
+        # Ordering comparisons are all false against NaN, so non-finite entries
+        # have to be rejected before the monotonicity check rather than after it.
+        if any(not math.isfinite(value) for value in values):
+            raise ValueError("DMD2 base_schedule entries must be finite")
+        # A student whose training capped the noise level (``max_timestep_ratio``)
+        # starts just below 1.0 rather than at it, so the opening position is
+        # bounded rather than pinned; the terminal one is always clean latents.
+        if not 0.0 < values[0] <= 1.0 or values[-1] != 0.0:
+            raise ValueError(
+                "DMD2 base_schedule must start in (0.0, 1.0] and end at 0.0"
+            )
+        if any(curr <= nxt for curr, nxt in zip(values, values[1:], strict=False)):
+            raise ValueError("DMD2 base_schedule must be strictly decreasing")
+
+    @classmethod
+    def from_positions(cls, base_schedule: Sequence[float]) -> DMD2SigmaSchedule:
+        return cls(base_schedule=tuple(float(value) for value in base_schedule))
+
+    @classmethod
+    def from_metadata(
+        cls,
+        metadata: Mapping[str, Any],
+        *,
+        key: str = BASE_SCHEDULE_KEY,
+    ) -> DMD2SigmaSchedule | None:
+        """Read a schedule from checkpoint metadata.
+
+        An absent key means the release is not distilled and keeps the legacy
+        uniform schedule. An explicitly empty value is a malformed contract and
+        is rejected rather than silently falling back.
+        """
+        raw = metadata.get(key)
+        if raw is None:
+            return None
+        return cls.from_positions(raw)
+
+    @property
+    def num_inference_steps(self) -> int:
+        """Denoising steps, i.e. one per interval between sigma boundaries."""
+        return len(self.base_schedule) - 1
+
+    def shifted_sigmas(self, shift_scale: float) -> list[float]:
+        """Apply the rectified-flow time shift for one modality."""
+        if shift_scale <= 0:
+            raise ValueError("DMD2 shift_scale must be > 0")
+        shift = float(shift_scale)
+        return [shift * u / (1 + (shift - 1) * u) for u in self.base_schedule]
+
+
+__all__ = [
+    "BASE_SCHEDULE_KEY",
+    "DMD2SigmaSchedule",
+]

--- a/vllm/model_executor/models/minimax_h3/time_request.py
+++ b/vllm/model_executor/models/minimax_h3/time_request.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .sigma_schedule import DMD2SigmaSchedule
+
+
+def _align_frame_count(frame_count: int) -> int:
+    """Snap ``frame_count`` up to the MiniMax H3 17n+5 frame boundary."""
+    if frame_count <= 0:
+        return 1
+    current = int(frame_count)
+    while current % 17 != 5:
+        current += 1
+    return current
+
+
+def _video_latent_t(frame_count: int) -> int:
+    if frame_count <= 5:
+        return 2
+    return ((int(frame_count) - 5) // 17) * 5 + 2
+
+
+def _frame_count_from_video_latent_t(out_t: int) -> int:
+    if out_t == 1:
+        return 1
+    if out_t < 2 or (out_t - 2) % 5 != 0:
+        raise ValueError("MiniMax H3 video latent T must be 1 or match 5n+2")
+    return 17 * ((int(out_t) - 2) // 5) + 5
+
+
+def _audio_latent_t(duration_seconds: float) -> int:
+    # Rounding happens at the 40 Hz audio latent boundary.
+    return int(round(float(duration_seconds) * 40.0))
+
+
+def _time_shift_sigmas(
+    *,
+    num_steps: int = 50,
+    shift_scale: float = 6.0,
+    base_schedule: Sequence[float] | None = None,
+) -> list[float]:
+    """Build a shifted sigma schedule.
+
+    ``base_schedule`` supplies the rectified-flow positions explicitly and takes
+    precedence over ``num_steps``. Distilled checkpoints need it because their
+    few-step schedule is not the uniform one ``num_steps`` produces; validation
+    and the shift itself live in the shared :class:`DMD2SigmaSchedule`.
+    """
+    if shift_scale <= 0:
+        raise ValueError("MiniMax H3 shift_scale must be > 0")
+
+    if base_schedule is not None:
+        return DMD2SigmaSchedule.from_positions(base_schedule).shifted_sigmas(
+            shift_scale
+        )
+
+    import torch
+
+    if num_steps <= 0:
+        raise ValueError("MiniMax H3 num_steps must be > 0")
+
+    # The rectified-flow sigma range is fixed at [1.0, 0.0].
+    base = torch.linspace(
+        1.0,
+        0.0,
+        int(num_steps),
+        device="cpu",
+        dtype=torch.float32,
+    )
+    shifted = float(shift_scale) * base / (1 + (float(shift_scale) - 1) * base)
+    shifted, _ = torch.unique_consecutive(shifted, return_counts=True)
+    # A one-point request is still exactly one point.  Normal serving uses
+    # multiple points, but preserving the requested cardinality keeps
+    # ``num_inference_steps`` the sole schedule-size control.
+    if num_steps > 1 and shifted[-1].item() > 0.0:
+        shifted = torch.cat([shifted, torch.tensor([0.0], dtype=shifted.dtype)])
+    return [float(value) for value in shifted.tolist()]
+
+
+class MiniMaxH3ShapePlanner:
+    """Compute MiniMax H3 frame, latent-shape, and time-shift values."""
+
+    def align_frame_count(self, frame_count: int) -> int:
+        return _align_frame_count(frame_count)
+
+    def video_latent_t(self, frame_count: int) -> int:
+        return _video_latent_t(frame_count)
+
+    def frame_count_from_video_latent_t(self, out_t: int) -> int:
+        return _frame_count_from_video_latent_t(out_t)
+
+    def audio_latent_t(self, duration_seconds: float) -> int:
+        return _audio_latent_t(duration_seconds)
+
+    def time_shift_sigmas(
+        self,
+        *,
+        num_steps: int = 50,
+        shift_scale: float = 6.0,
+        base_schedule: Sequence[float] | None = None,
+    ) -> list[float]:
+        return _time_shift_sigmas(
+            num_steps=num_steps,
+            shift_scale=shift_scale,
+            base_schedule=base_schedule,
+        )
+
+
+MINIMAX_H3_SHAPE_PLANNER = MiniMaxH3ShapePlanner()
+
+
+def minimax_h3_align_frame_count(frame_count: int) -> int:
+    return MINIMAX_H3_SHAPE_PLANNER.align_frame_count(frame_count)
+
+
+def minimax_h3_frame_count_from_video_latent_t(out_t: int) -> int:
+    return MINIMAX_H3_SHAPE_PLANNER.frame_count_from_video_latent_t(out_t)
+
+
+def minimax_h3_time_shift_sigmas(
+    *,
+    num_steps: int = 50,
+    shift_scale: float = 6.0,
+    base_schedule: Sequence[float] | None = None,
+) -> list[float]:
+    return MINIMAX_H3_SHAPE_PLANNER.time_shift_sigmas(
+        num_steps=num_steps,
+        shift_scale=shift_scale,
+        base_schedule=base_schedule,
+    )

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -41,6 +41,7 @@ from .modulation import (
     rms_norm_indexed_scale_shift,
 )
 from .ops import RMSNorm, RotaryEmbedding, fused_qk_norm_rope
+from .quantization import preserve_fp32_output
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (
@@ -129,6 +130,8 @@ MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
         "video_patch_proj.bias",
         "audio_patch_proj.weight",
         "audio_patch_proj.bias",
+        "condition_proj.weight",
+        "condition_proj.bias",
         "time_embedder.proj_in.weight",
         "time_embedder.proj_in.bias",
         "time_embedder.proj_out.weight",
@@ -394,6 +397,7 @@ class MiniMaxH3Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.out_proj",
         )
+        preserve_fp32_output(self.out_proj)
         self.attention = Attention(
             num_heads=self.num_heads,
             num_kv_heads=self.num_kv_heads,
@@ -623,10 +627,14 @@ class MiniMaxH3MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.fc2",
         )
+        preserve_fp32_output(self.fc2)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden, _ = self.fc1(x)
-        hidden = self.act_fn(hidden)
+        # Real H3 gated products exceed FP16 even when both factors are finite.
+        # The following row projection rescales these FP32 activations into
+        # FP16 Tensor Core range and restores their scale in its FP32 output.
+        hidden = self.act_fn(hidden.float())
         out, _ = self.fc2(hidden)
         return out
 
@@ -719,13 +727,13 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
         num_requests: int = 1,
     ) -> torch.Tensor:
         x = x + self.attn(
-            self.norm1(x),
+            self.norm1(x).to(_COMPUTE_DTYPE),
             rope_table=None,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
             num_requests=num_requests,
         )
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.mlp(self.norm2(x).to(_COMPUTE_DTYPE))
         return x
 
 
@@ -838,6 +846,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             scale_msa,
             combined_indices,
             self.norm1.variance_epsilon,
+            output_dtype=_COMPUTE_DTYPE,
         )
         h = self.attn(
             h,
@@ -858,6 +867,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             scale_mlp,
             combined_indices,
             self.norm2.variance_epsilon,
+            output_dtype=_COMPUTE_DTYPE,
         )
         residual = x
         h = self.mlp(h)
@@ -1043,8 +1053,8 @@ class MiniMaxH3DiTModel(nn.Module):
             arch.hidden_size,
             bias=True,
             gather_output=True,
-            params_dtype=_COMPUTE_DTYPE,
-            quant_config=quant_config,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
             prefix="condition_proj",
         )
         if arch.adaln_curve_grid is None:
@@ -1331,7 +1341,10 @@ class MiniMaxH3DiTModel(nn.Module):
         audio_rows = audio_rows.index_select(0, audio_global_pos).to(_FP32_DTYPE)
         audio_embed, _ = self.audio_patch_proj(audio_rows)
 
-        text_rows = text_embeddings_selected.to(device=device, dtype=_COMPUTE_DTYPE)
+        # Actual H3 text projections exceed FP16's range before the refiner's
+        # final normalization. Preserve projection and residuals in FP32;
+        # normalized refiner attention and MLP inputs still use FP16 GEMMs.
+        text_rows = text_embeddings_selected.to(device=device, dtype=_FP32_DTYPE)
         text_embed, _ = self.condition_proj(text_rows)
         text_embed = self.token_refiner(
             text_embed,
@@ -1345,22 +1358,22 @@ class MiniMaxH3DiTModel(nn.Module):
         embeddings = torch.zeros(
             (local_len, self.hidden_size),
             device=device,
-            dtype=_COMPUTE_DTYPE,
+            dtype=_FP32_DTYPE,
         )
         embeddings.index_add_(
             0,
             text_local_pos,
-            text_embed.to(_COMPUTE_DTYPE)[: text_local_pos.shape[0]],
+            text_embed.to(_FP32_DTYPE)[: text_local_pos.shape[0]],
         )
         embeddings.index_add_(
             0,
             img_local_pos,
-            video_embed.to(_COMPUTE_DTYPE)[: img_local_pos.shape[0]],
+            video_embed[: img_local_pos.shape[0]],
         )
         embeddings.index_add_(
             0,
             audio_local_pos,
-            audio_embed.to(_COMPUTE_DTYPE)[: audio_local_pos.shape[0]],
+            audio_embed[: audio_local_pos.shape[0]],
         )
 
         t_emb = self._embed_timesteps(unique_timesteps)

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -1,0 +1,1558 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Native MiniMax H3 DiT using vLLM tensor-parallel linear layers.
+
+Port provenance and numerical changes are recorded in UPSTREAM.md.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.parameter import ChannelQuantScaleParameter
+
+from .attention import (
+    Attention,
+    AttentionMetadata,
+    PackedPaddingMetadata,
+    VideoTokenLayout,
+)
+from .modulation import (
+    indexed_gate,
+    indexed_gate_rms_norm_scale_shift,
+    indexed_scale_shift_,
+    rms_norm_indexed_scale_shift,
+)
+from .ops import RMSNorm, RotaryEmbedding, fused_qk_norm_rope
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import (
+        QuantizationConfig,
+    )
+
+
+logger = init_logger(__name__)
+
+
+# Packed multi-request forwards require the attention backend to actually
+# consume cu_seqlens as a block-diagonal plan (not a padding-mask rebuild that
+# spans the full packed row). The pipeline gates on this capability before
+# packing, and ``_run_packed_attention`` re-checks it per forward; a name-only
+# gate would let FLASH_ATTN's NPU/XPU code paths through even though those
+# variants would silently attend across request boundaries.
+def _attention_isolates_packed_requests(attention_layer: Any) -> bool:
+    """True if this attention layer keeps N-document packed boundaries.
+
+    Requires a backend advertising ``supports_multi_doc_packed_varlen`` *and*
+    that the layer is not running under ring sequence parallelism (the ring
+    kernel dispatches through its own attention that ignores the packed
+    cu_seqlens regardless of the configured backend).
+    """
+    backend = getattr(attention_layer, "attn_backend", None)
+    if backend is None or not backend.supports_multi_doc_packed_varlen():
+        return False
+    return not getattr(attention_layer, "use_ring", False)
+
+
+@dataclass
+class MiniMaxH3DiTArchConfig:
+    num_layers: int = 50
+    token_refiner_num_layers: int = 2
+    hidden_size: int = 5376
+    num_attention_heads: int = 56
+    attention_head_dim: int = 128
+    ffn_hidden_size: int = 14336
+    latents_dim: int = 24
+    audio_latents_dim: int = 32
+    patch_size: tuple[int, int, int] = (1, 2, 2)
+    text_dim: int = 5120
+    timestep_input_dim: int = 256
+    time_embed_hidden_size: int = 5376
+    time_embed_dim: int = 2688
+    # ComfyUI's AdaLN-pruned checkpoints replace the dense time embedder with
+    # a small shared interpolation table and project its low-rank coordinates.
+    adaln_curve_grid: int | None = None
+    adaln_curve_dim: int = 8
+    adaln_out_features: int = 18 * 5376
+    final_adaln_out_features: int = 2 * 5376
+    rope_inv_freq_len: int = 16
+    norm_eps: float = 1e-5
+    qk_norm_eps: float = 1e-5
+    final_norm_eps: float = 1e-5
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any]) -> MiniMaxH3DiTArchConfig:
+        fields = cls.__dataclass_fields__
+        values = {name: config[name] for name in fields if name in config}
+        if "patch_size" in values:
+            values["patch_size"] = tuple(values["patch_size"])
+        arch = cls(**values)
+        if len(arch.patch_size) != 3:
+            raise ValueError(
+                f"patch_size must contain three values, got {arch.patch_size!r}"
+            )
+        return arch
+
+    @property
+    def adaln_input_dim(self) -> int:
+        return (
+            self.adaln_curve_dim
+            if self.adaln_curve_grid is not None
+            else self.time_embed_dim
+        )
+
+
+_ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
+_COMPUTE_DTYPE = torch.float16
+_FP32_DTYPE = torch.float32
+
+MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
+    {
+        "video_patch_proj.weight",
+        "video_patch_proj.bias",
+        "audio_patch_proj.weight",
+        "audio_patch_proj.bias",
+        "time_embedder.proj_in.weight",
+        "time_embedder.proj_in.bias",
+        "time_embedder.proj_out.weight",
+        "time_embedder.proj_out.bias",
+        "final_layer.video_out.weight",
+        "final_layer.video_out.bias",
+        "final_layer.audio_out.weight",
+        "final_layer.audio_out.bias",
+    }
+)
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq", "adaln_t_table"})
+
+# AdaLN modality count: token tags carry -1 for padding and 0/1/2 for
+# video/text/audio tokens (padding is clamped to 0 before the embedding
+# lookup and masked out afterwards).
+MINIMAX_H3_ADALN_MODALITY_NUM = 3
+_LOCAL_SP_PREPARE_HOOK = "sp_input---local_sp_prepare"
+
+# Opt-in fp16-range protection for the NPU ascend_laser_attention kernel
+# (consumed only via the "laser_input_scale" extra key; other backends and
+# platforms ignore it). The kernel stores unscaled QK^T in an fp16 GM
+# workspace, and H3's outlier activations (per-element amax in the hundreds)
+# push dot products past fp16 max 65504, turning whole 128-row blocks NaN.
+# 256 is a power of two, so pre-dividing q/k/v and the compensating
+# kernel-scale/output multiplies are exact in floating point.
+MINIMAX_H3_LASER_INPUT_SCALE = 256.0
+
+
+def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
+    if key not in kwargs or kwargs[key] is None:
+        raise ValueError(f"MiniMaxH3DiTModel.forward requires kwarg {key!r}")
+    return kwargs[key]
+
+
+# The exhaustive keyword contract of MiniMaxH3DiTModel.forward. Anything not
+# listed here is rejected with a TypeError before any tensor work starts.
+_FORWARD_SUPPORTED_KWARGS = frozenset(
+    {
+        "x",
+        "audio_x",
+        "img_position_ids",
+        "unique_timesteps",
+        "inverse_indices",
+        "update_mask",
+        "update_audio_mask",
+        "token_tags",
+        "skip_mask_out_condition",
+        "prompt_embeds",
+        "img_pos_info",
+        "audio_pos_info",
+        "text_pos_info",
+        "img_pos_for_infer_output_info",
+        "packed_seq_params",
+        "refiner_packed_seq_params",
+        "video_token_layout",
+        "rope_table",
+    }
+)
+
+
+def _reorder_grouped_qkv_to_qkv(
+    weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    heads_per_group: int,
+    head_dim: int,
+) -> torch.Tensor:
+    per_group = (heads_per_group + 2) * head_dim
+    expected_out = num_query_groups * per_group
+    if weight.shape[0] != expected_out:
+        raise ValueError(
+            "qkv weight has incompatible output dim for grouped checkpoint layout: "
+            f"got {tuple(weight.shape)}, expected first dim {expected_out}."
+        )
+
+    rest_shape = weight.shape[1:]
+    grouped = weight.reshape(num_query_groups, per_group, *rest_shape)
+    q, k, v = torch.split(
+        grouped,
+        [heads_per_group * head_dim, head_dim, head_dim],
+        dim=1,
+    )
+    return torch.cat(
+        [
+            q.reshape(num_query_groups * heads_per_group * head_dim, *rest_shape),
+            k.reshape(num_query_groups * head_dim, *rest_shape),
+            v.reshape(num_query_groups * head_dim, *rest_shape),
+        ],
+        dim=0,
+    )
+
+
+def _norm(size: int, *, eps: float, dtype: torch.dtype = _COMPUTE_DTYPE) -> RMSNorm:
+    # RMSNorm uses fp32 accumulation with bf16 inputs and outputs.
+    # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
+    # reduction, matching that accumulation semantic.
+    return RMSNorm(size, eps=eps, dtype=dtype)
+
+
+def _sequence_parallel_local_span(seq_len, *, hooks_applied):
+    if hooks_applied:
+        raise ValueError("Native H3 uses tensor parallelism only")
+    return 0, seq_len
+
+
+class MiniMaxH3Rope(nn.Module):
+    """3D rope over (t, h, w); rotates 96 of 128 head dims (rotary_percent 0.75).
+
+    Frequency layout concatenates temporal, height, and width embeddings twice,
+    with 16 frequencies per axis (inv_freq = base^-(arange(0,32,2)/32)).
+    """
+
+    def __init__(self, inv_freq_len: int) -> None:
+        super().__init__()
+        self.register_buffer(
+            "inv_freq",
+            torch.empty(inv_freq_len, dtype=_FP32_DTYPE),
+            persistent=True,
+        )
+
+    def forward(self, img_position_ids: torch.Tensor) -> torch.Tensor:
+        """img_position_ids: [1, S, 3] (t, h, w) -> freqs [S, rot_dim=96]."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                f"img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        pos = img_position_ids[0].to(_FP32_DTYPE)  # [S, 3]
+        per_axis = pos.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)  # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)  # each [S, 16]
+        half = torch.cat((t_f, h_f, w_f), dim=-1)  # [S, 48]
+        return torch.cat((half, half), dim=-1)  # [S, 96]
+
+
+def _build_rope_table(freqs: torch.Tensor) -> torch.Tensor:
+    """Materialize H3's packed ``[cos(freqs[:48]), sin(freqs[:48])]`` table."""
+    half = freqs.shape[-1] // 2
+    return torch.cat(
+        (torch.cos(freqs[..., :half]), torch.sin(freqs[..., :half])),
+        dim=-1,
+    ).to(_COMPUTE_DTYPE)
+
+
+class MiniMaxH3TimeEmbedder(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.frequency_embedding_size = arch.timestep_input_dim
+        self.proj_in = ColumnParallelLinear(
+            arch.timestep_input_dim,
+            arch.time_embed_hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_in",
+        )
+        self.proj_out = RowParallelLinear(
+            arch.time_embed_hidden_size,
+            arch.time_embed_dim,
+            bias=True,
+            input_is_parallel=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_out",
+        )
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """t: [M] -> [M, time_embed_dim] fp32.
+
+        The sinusoidal embedding stays fp32 throughout and concatenates cosine
+        values before sine values.
+        """
+        half = self.frequency_embedding_size // 2
+        freqs = torch.exp(
+            -math.log(10000.0)
+            * torch.arange(half, dtype=_FP32_DTYPE, device=t.device)
+            / half
+        )
+        args = t.to(_FP32_DTYPE)[:, None] * freqs[None]
+        t_freq = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        hidden, _ = self.proj_in(t_freq)
+        hidden = nn.functional.silu(hidden)
+        out, _ = self.proj_out(hidden)
+        return out
+
+
+def _sdpa_varlen_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Segment-wise SDPA equivalent of the non-causal varlen FA call.
+
+    Mirrors the generic attention layer's semantics: FA is the fast path,
+    SDPA is the correctness fallback when the platform resolves another
+    backend. Segments are delimited by ``cu_seqlens`` exactly like the
+    varlen kernel, so attention never crosses packed-document boundaries.
+    """
+    out = torch.empty_like(q)
+    bounds = cu_seqlens.tolist()
+    for start, stop in zip(bounds[:-1], bounds[1:]):
+        if stop == start:
+            continue
+        seg_q = q[start:stop].transpose(0, 1).unsqueeze(0)
+        seg_k = k[start:stop].transpose(0, 1).unsqueeze(0)
+        seg_v = v[start:stop].transpose(0, 1).unsqueeze(0)
+        seg_out = torch.nn.functional.scaled_dot_product_attention(
+            seg_q,
+            seg_k,
+            seg_v,
+            scale=softmax_scale,
+        )
+        out[start:stop] = seg_out.squeeze(0).transpose(0, 1)
+    return out
+
+
+class MiniMaxH3Attention(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        role: str = "self",
+        role_category: str | None = None,
+        skip_sequence_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+        self.total_num_heads = arch.num_attention_heads
+        self.head_dim = arch.attention_head_dim
+        inner_dim = self.total_num_heads * self.head_dim
+        self.softmax_scale = self.head_dim**-0.5
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size=arch.hidden_size,
+            head_size=self.head_dim,
+            total_num_heads=self.total_num_heads,
+            total_num_kv_heads=self.total_num_heads,
+            bias=False,
+            params_dtype=_COMPUTE_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+            return_bias=True,
+        )
+        self.num_heads = self.qkv_proj.num_heads
+        self.num_kv_heads = self.qkv_proj.num_kv_heads
+        self.rot_dim = 6 * arch.rope_inv_freq_len
+        self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        self.rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
+        self.out_proj = RowParallelLinear(
+            inner_dim,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_COMPUTE_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+        self.attention = Attention(
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            softmax_scale=self.softmax_scale,
+            causal=False,
+            # Packed rows reach the impl as [B, S, N, D].
+            qkv_layout="BSND",
+            role=role,
+            role_category=role_category,
+            skip_sequence_parallel=skip_sequence_parallel,
+            prefix=prefix,
+        )
+
+    def _apply_rope(self, x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+        """Rotate the first rot_dim head dims; pass the rest through.
+
+        x: [T, heads, head_dim]; freqs: [T, rot_dim]. In the unfused path, cos/sin
+        are cast to the activation dtype before the elementwise math.
+        """
+        rot_dim = self.rot_dim
+        x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+        cos = torch.cos(freqs).to(x.dtype)  # [T, rot_dim]
+        sin = torch.sin(freqs).to(x.dtype)
+        x_rot = self.rope(x_rot, cos, sin)
+        return torch.cat((x_rot, x_pass), dim=-1)
+
+    @torch.compiler.disable
+    def _run_packed_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        packed_total: int,
+        num_requests: int = 1,
+        video_layout: VideoTokenLayout | None = None,
+    ) -> torch.Tensor:
+        """Run packed attention as a small eager island.
+
+        The scalar packed-layout metadata and backend-specific attention
+        kernels are intentionally opaque to Dynamo. Keeping this boundary
+        narrow lets regional compile fuse projections, norms, RoPE, and the
+        surrounding DiT block without repeated graph breaks.
+        """
+        # max_seqlen is already the longest packed document length. Do not read
+        # the CUDA cu_seqlens scalars here: this function runs once per layer
+        # and .item() would serialize every attention launch. ``num_requests``
+        # is carried as a Python int for the same reason.
+        if not 0 < max_seqlen <= packed_total:
+            raise ValueError(
+                f"max_seqlen must be within the packed sequence, got {max_seqlen} for "
+                f"length {packed_total}"
+            )
+        attn_mask = None
+        mask_free_packed_padding = False
+        if num_requests > 1:
+            # A step-mode batch packs one document per request, so its valid
+            # rows are block-diagonal rather than a prefix: neither a KV prefix
+            # length nor a 1-D key mask can describe them. Such a layout is
+            # only correct on a backend that actually attends by cu_seqlens as
+            # a block-diagonal plan. Check the capability (not the backend
+            # name): FLASH_ATTN's NPU/XPU variants would otherwise silently
+            # fall back to a padding-mask rebuild that spans the whole packed
+            # row and attend across request boundaries.
+            if not _attention_isolates_packed_requests(self.attention):
+                backend_name = self.attention.attn_backend.get_name()
+                raise ValueError(
+                    f"MiniMax H3 packed a {num_requests}-request batch, but the "
+                    f"resolved "
+                    f"attention ({backend_name}, "
+                    f"use_ring={getattr(self.attention, 'use_ring', False)}) "
+                    "does not isolate multi-document packed cu_seqlens. Run one "
+                    "request "
+                    "per forward on this backend."
+                )
+            used = packed_total
+        else:
+            used = min(max_seqlen, packed_total)
+            # Ring attention can dispatch to a different implementation from the
+            # configured backend, so the no-mask fast paths are local-only.
+            # supports_prefix_kv_slicing: backend slices K/V itself (cuDNN).
+            # supports_packed_mask_free: backend consumes the packed metadata
+            # without ever reading attn_mask (CUDA packed varlen, NPU
+            # npu_attn_varlen opt-in with its own fallback rebuild).
+            use_ring = getattr(self.attention, "use_ring", False)
+            mask_free_packed_padding = (
+                not use_ring and self.attention.attn_backend.supports_packed_mask_free()
+            )
+            no_mask = not use_ring and (
+                self.attention.attn_backend.supports_prefix_kv_slicing
+                or mask_free_packed_padding
+            )
+            if used < packed_total and not no_mask:
+                attn_mask = torch.arange(packed_total, device=q.device)[None] < used
+        metadata = AttentionMetadata(
+            attn_mask=attn_mask,
+            packed_padding=(
+                PackedPaddingMetadata(
+                    q_length=used,
+                    kv_length=used,
+                    cu_seqlens_q=cu_seqlens[:2],
+                    cu_seqlens_k=cu_seqlens[:2],
+                )
+                if mask_free_packed_padding
+                else None
+            ),
+            extra={
+                "cu_seqlens_q": cu_seqlens,
+                "cu_seqlens_k": cu_seqlens,
+                "max_seqlen_q": max_seqlen,
+                "max_seqlen_k": max_seqlen,
+                "valid_kv_length": used,
+                # Opt the NPU flash backend into the packed varlen path so the
+                # quadratic full_qk mask is never materialized. Ring attention
+                # is excluded: it keeps the aligned padding rows for its
+                # fixed-size P2P buffers and still needs the mask.
+                "npu_attn_varlen": not getattr(self.attention, "use_ring", False),
+                # fp16-range protection for the ascend_laser_attention kernel
+                # (see MINIMAX_H3_LASER_INPUT_SCALE). Ignored by every other
+                # backend/path.
+                "laser_input_scale": MINIMAX_H3_LASER_INPUT_SCALE,
+            },
+            video_layout=video_layout,
+        )
+        return self.attention(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            metadata,
+        ).squeeze(0)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        rope_table: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        packed_total: int | None = None,
+        num_requests: int = 1,
+        sp_seq_lens: list[int] | None = None,
+        video_layout: VideoTokenLayout | None = None,
+    ) -> torch.Tensor:
+        """x: [T, hidden] packed thd rows -> [T, hidden].
+
+        Operation order: fused qkv projection -> per-head q/k RMSNorm -> RoPE
+        on q/k -> variable-length non-causal flash attention -> output projection.
+
+        With Ulysses sequence parallelism, x holds this rank's row shard;
+        qkv/norm/RoPE run locally, an all-to-all trades sequence for heads.
+        Each rank attends the full sequence with heads/world_size local heads,
+        so cu_seqlens retains global packed-document semantics. The inverse
+        all-to-all restores the row shard before the output projection.
+        """
+        total = x.shape[0]
+        qkv, _ = self.qkv_proj(x)
+        q_size = self.num_heads * self.head_dim
+        kv_size = self.num_kv_heads * self.head_dim
+        q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+        q = q.view(total, self.num_heads, self.head_dim)
+        k = k.view(total, self.num_kv_heads, self.head_dim)
+        v = v.view(total, self.num_kv_heads, self.head_dim)
+        if rope_table is None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+        else:
+            q, k = fused_qk_norm_rope(
+                q,
+                k,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                rope_table,
+                self.q_norm.variance_epsilon,
+            )
+
+        # Each request contributes a document for its rows plus one for any
+        # nonempty alignment padding. Local/Ulysses backends unpad it, while
+        # Ring keeps aligned rows for fixed-size P2P buffers.
+        out = self._run_packed_attention(
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            # Before Ulysses, q contains only this rank's row shard. The
+            # backend receives the global sequence after all-to-all, so carry
+            # its Python length explicitly instead of inferring it from q.
+            packed_total=packed_total if packed_total is not None else q.shape[0],
+            num_requests=num_requests,
+            video_layout=video_layout,
+        )
+        out = out.reshape(total, self.num_heads * self.head_dim)
+        out, _ = self.out_proj(out)
+        return out
+
+
+class MiniMaxH3MLP(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.fc1 = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [arch.ffn_hidden_size, arch.ffn_hidden_size],
+            bias=False,
+            gather_output=False,
+            params_dtype=_COMPUTE_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+        )
+        self.act_fn = SiluAndMul()
+        # Chunk the fused fc1 output as [gate, up], then compute
+        # silu(gate) * up.
+        self.fc2 = RowParallelLinear(
+            arch.ffn_hidden_size,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_COMPUTE_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc2",
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden, _ = self.fc1(x)
+        hidden = self.act_fn(hidden)
+        out, _ = self.fc2(hidden)
+        return out
+
+
+class MiniMaxH3AdalnProj(nn.Module):
+    """SiLU + zero-init linear over unique condition embeddings.
+
+    Per block, three modalities each produce six H-wide vectors:
+    [M, t_dim] -> [M, 3*6H] -> view(M*3, 6H) -> chunk(6).
+    The final layer uses one modality and produces two H-wide vectors:
+    [M, t_dim] -> [M, 2H] -> chunk(2).
+    """
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        out_features: int,
+        quant_config: QuantizationConfig | None,
+        *,
+        expand_ratio: int,
+        modality_num: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        if out_features != expand_ratio * arch.hidden_size * modality_num:
+            raise ValueError(
+                f"adaln out_features mismatch: {out_features} != "
+                f"{expand_ratio}*{arch.hidden_size}*{modality_num}"
+            )
+        self.expand_ratio = expand_ratio
+        self.modality_num = modality_num
+        self.hidden_size = arch.hidden_size
+        self.apply_silu = arch.adaln_curve_grid is None
+        self.input_dtype = _COMPUTE_DTYPE if self.apply_silu else _FP32_DTYPE
+        self.linear = ColumnParallelLinear(
+            arch.adaln_input_dim,
+            out_features,
+            bias=True,
+            gather_output=True,
+            params_dtype=self.input_dtype,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear",
+        )
+
+    def forward(self, t_emb: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """t_emb: [M, t_dim] -> expand_ratio tensors of [M*modality_num, H]."""
+        x = nn.functional.silu(t_emb) if self.apply_silu else t_emb
+        x, _ = self.linear(x.to(self.input_dtype))
+        m = x.shape[0]
+        x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
+        return tuple(x.chunk(self.expand_ratio, dim=-1))
+
+
+class MiniMaxH3TokenRefinerBlock(nn.Module):
+    """Standard pre-norm transformer block without AdaLN or RoPE."""
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        # Text refinement runs on replicated rows before ``sp_prepare``.
+        # Applying Ulysses here would all-to-all an unsharded sequence while
+        # retaining the original packed ``cu_seqlens`` metadata.
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+            role="minimax_h3.token_refiner",
+            role_category="self",
+            skip_sequence_parallel=True,
+        )
+        self.mlp = MiniMaxH3MLP(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        num_requests: int = 1,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            rope_table=None,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            num_requests=num_requests,
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class MiniMaxH3TokenRefiner(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3TokenRefinerBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"{prefix}.blocks.{i}",
+                )
+                for i in range(arch.token_refiner_num_layers)
+            ]
+        )
+        self.final_norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        num_requests: int = 1,
+    ) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(
+                x,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                num_requests=num_requests,
+            )
+        return self.final_norm(x)
+
+
+class MiniMaxH3DiTBlock(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        # The prefix also carries the block index that block-sparse attention
+        # backends match against their skip_layers selector.
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.mlp = MiniMaxH3MLP(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.adaln_out_features,
+            quant_config,
+            expand_ratio=6,
+            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+            prefix=f"{prefix}.adaln_proj",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        t_emb: torch.Tensor,
+        combined_indices: torch.Tensor,
+        rope_table: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        packed_total: int,
+        num_requests: int = 1,
+        sp_seq_lens: list[int] | None = None,
+        video_layout: VideoTokenLayout | None = None,
+    ) -> torch.Tensor:
+        """x: [T, H]; t_emb: [M, t_dim]; combined_indices: [T]
+        (= inverse_indices * modality_num + token_tags.clamp(min=0)).
+
+        Each block computes AdaLN parameters once, then applies
+        norm1 -> scale/shift -> attention -> gated residual, followed by
+        norm2 -> scale/shift -> MLP -> gated residual.
+        """
+        (
+            shift_msa,
+            scale_msa,
+            gate_msa,
+            shift_mlp,
+            scale_mlp,
+            gate_mlp,
+        ) = self.adaln_proj(t_emb)
+
+        residual = x
+        h = rms_norm_indexed_scale_shift(
+            x,
+            self.norm1.weight,
+            shift_msa,
+            scale_msa,
+            combined_indices,
+            self.norm1.variance_epsilon,
+        )
+        h = self.attn(
+            h,
+            rope_table=rope_table,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            packed_total=packed_total,
+            num_requests=num_requests,
+            sp_seq_lens=sp_seq_lens,
+            video_layout=video_layout,
+        )
+        x, h = indexed_gate_rms_norm_scale_shift(
+            residual,
+            gate_msa,
+            h,
+            self.norm2.weight,
+            shift_mlp,
+            scale_mlp,
+            combined_indices,
+            self.norm2.variance_epsilon,
+        )
+        residual = x
+        h = self.mlp(h)
+        return indexed_gate(residual, gate_mlp, h, combined_indices)
+
+
+class MiniMaxH3FinalLayer(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        video_patch_dim = (
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2]
+        )
+        self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.final_adaln_out_features,
+            quant_config,
+            expand_ratio=2,
+            modality_num=1,
+            prefix=f"{prefix}.adaln_proj",
+        )
+        self.video_out = ColumnParallelLinear(
+            arch.hidden_size,
+            video_patch_dim,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.video_out",
+        )
+        self.audio_out = ColumnParallelLinear(
+            arch.hidden_size,
+            arch.audio_latents_dim,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.audio_out",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        t_emb: torch.Tensor,
+        inverse_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """x: [T, H] -> (video_logits [T, 96] fp32, audio_logits [T, 32] fp32).
+
+        Apply single-modality shift/scale AdaLN to the final normalized
+        activations, cast to fp32, then apply both output heads to all rows.
+        """
+        shift, scale = self.adaln_proj(t_emb)
+        h = self.norm(x)
+        # Comfy's out-of-place affine naturally promotes the normalized BF16
+        # activations when an AdaLN-curve checkpoint supplies FP32 modulation.
+        # Our fused affine writes in-place, so promote its destination first or
+        # the FP32 shift/scale contribution is silently rounded back to BF16.
+        # Dense checkpoints keep BF16 AdaLN inputs and retain the existing path.
+        if self.adaln_proj.input_dtype == _FP32_DTYPE:
+            h = h.to(_FP32_DTYPE)
+        h = indexed_scale_shift_(h, shift, scale, inverse_indices)
+        # Preserve full precision through both final output projections.
+        h = h.to(_FP32_DTYPE)
+        video, _ = self.video_out(h)
+        audio, _ = self.audio_out(h)
+        return video, audio
+
+
+class MiniMaxH3SPPrepare(nn.Module):
+    """Explicit boundary for sharding packed rows and their metadata together."""
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rope_table: torch.Tensor,
+        combined_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return hidden_states, rope_table, combined_indices
+
+
+class MiniMaxH3SPGather(nn.Module):
+    """Explicit boundary for restoring packed rows after the block stack."""
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
+
+class MiniMaxH3DiTModel(nn.Module):
+    packed_modules_mapping = {}
+
+    def _validate_tp_config(
+        self, *, arch: MiniMaxH3DiTArchConfig, tp_size: int
+    ) -> None:
+        if tp_size < 1:
+            raise ValueError(f"tensor_parallel_size must be positive, got {tp_size}")
+        if arch.num_attention_heads % tp_size:
+            raise ValueError(
+                "num_attention_heads must be divisible by tensor_parallel_size: "
+                f"{arch.num_attention_heads} % {tp_size} != 0"
+            )
+        if arch.ffn_hidden_size % tp_size:
+            raise ValueError(
+                f"ffn_hidden_size must be divisible by tensor_parallel_size: "
+                f"{arch.ffn_hidden_size} % {tp_size} != 0"
+            )
+        if arch.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if arch.hidden_size <= 0:
+            raise ValueError("hidden_size must be positive.")
+        if arch.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if arch.ffn_hidden_size <= 0:
+            raise ValueError("ffn_hidden_size must be positive.")
+
+    def __init__(
+        self,
+        config: Mapping[str, Any],
+        quant_config: QuantizationConfig | None = None,
+        arch_overrides: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        config_mapping = dict(config)
+        if arch_overrides:
+            config_mapping.update(arch_overrides)
+        arch = MiniMaxH3DiTArchConfig.from_mapping(config_mapping)
+        if arch.adaln_curve_grid is not None:
+            if arch.adaln_curve_grid < 2:
+                raise ValueError(
+                    f"adaln_curve_grid must be >= 2, got {arch.adaln_curve_grid}"
+                )
+            if arch.adaln_curve_dim <= 0:
+                raise ValueError(
+                    f"adaln_curve_dim must be positive, got {arch.adaln_curve_dim}"
+                )
+        self.arch = arch
+        # Comfy's serialized INT8 ConvRot checkpoint already stores fused QKV
+        # rows in runtime [Q-all, K-all, V-all] order.  Dense and online
+        # quantized MiniMax checkpoints retain the original grouped layout and
+        # still need the transform in load_weights().
+        self._qkv_checkpoint_is_runtime_layout = bool(
+            getattr(quant_config, "is_checkpoint_int8_convrot_serialized", False)
+        )
+        self.hidden_size = arch.hidden_size
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.latents_dim
+        self._validate_tp_config(
+            arch=arch,
+            tp_size=get_tensor_model_parallel_world_size(),
+        )
+        self.video_patch_proj = ColumnParallelLinear(
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2],
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="video_patch_proj",
+        )
+        self.audio_patch_proj = ColumnParallelLinear(
+            arch.audio_latents_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="audio_patch_proj",
+        )
+        self.condition_proj = ColumnParallelLinear(
+            arch.text_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_COMPUTE_DTYPE,
+            quant_config=quant_config,
+            prefix="condition_proj",
+        )
+        if arch.adaln_curve_grid is None:
+            self.time_embedder: MiniMaxH3TimeEmbedder | None = MiniMaxH3TimeEmbedder(
+                arch,
+                prefix="time_embedder",
+            )
+        else:
+            self.time_embedder = None
+            self.register_buffer(
+                "adaln_t_table",
+                torch.empty(
+                    arch.adaln_curve_grid,
+                    arch.adaln_curve_dim,
+                    dtype=_FP32_DTYPE,
+                ),
+            )
+        self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
+        self.token_refiner = MiniMaxH3TokenRefiner(
+            arch,
+            quant_config,
+            prefix="token_refiner",
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3DiTBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"blocks.{i}",
+                )
+                for i in range(arch.num_layers)
+            ]
+        )
+        self.sp_prepare = MiniMaxH3SPPrepare()
+        self.local_sp_prepare = MiniMaxH3SPPrepare()
+        self.sp_gather = MiniMaxH3SPGather()
+        self.final_layer = MiniMaxH3FinalLayer(
+            arch,
+            quant_config,
+            prefix="final_layer",
+        )
+        self._mark_missing_params_required()
+        validate_bindings = getattr(quant_config, "validate_model_bindings", None)
+        if callable(validate_bindings):
+            validate_bindings(self)
+
+    def _mark_missing_params_required(self) -> None:
+        for _, param in self.named_parameters():
+            param.missing_param_init = "error"
+
+    def _rope_local_span(self, seq_len: int) -> tuple[int, int]:
+        """Return the sequence-parallel rows owned by this DiT rank."""
+        local_sp_registry = getattr(self.local_sp_prepare, "_hook_registry", None)
+        hooks_applied = local_sp_registry is not None
+        if local_sp_registry is not None:
+            local_sp_hook = local_sp_registry.get_hook(_LOCAL_SP_PREPARE_HOOK)
+            hooks_applied = local_sp_hook is not None
+        return _sequence_parallel_local_span(
+            seq_len,
+            hooks_applied=hooks_applied,
+        )
+
+    def prepare_rope_table(
+        self,
+        img_position_ids: torch.Tensor,
+        *,
+        seq_len: int,
+    ) -> torch.Tensor:
+        """Build the static local RoPE table once for one denoise branch.
+
+        A MiniMax-H3 denoise branch reuses its packed position IDs at every
+        scheduler step. The returned table is local to the current sequence-
+        parallel rank, and therefore must be built by the model that will
+        consume it rather than cached globally across requests or ranks.
+        """
+        local_start, local_len = self._rope_local_span(seq_len)
+        rope_position_ids = img_position_ids.narrow(1, local_start, local_len)
+        return _build_rope_table(
+            self.rope(rope_position_ids).to(img_position_ids.device)
+        )
+
+    def _validate_prepared_rope_table(
+        self,
+        rope_table: torch.Tensor,
+        *,
+        local_len: int,
+        device: torch.device,
+    ) -> None:
+        expected_width = 6 * self.arch.rope_inv_freq_len
+        if rope_table.dim() != 2 or tuple(rope_table.shape) != (
+            local_len,
+            expected_width,
+        ):
+            raise ValueError(
+                "rope_table must be [local_seq_len, rotary_dim] for the current "
+                f"sequence-parallel rank, got {list(rope_table.shape)}; expected "
+                f"[{local_len}, {expected_width}]."
+            )
+        if rope_table.device != device:
+            raise ValueError(
+                f"rope_table device {rope_table.device} must match x device {device}."
+            )
+        if rope_table.dtype != _COMPUTE_DTYPE:
+            raise ValueError(
+                f"rope_table must be {_COMPUTE_DTYPE}, got {rope_table.dtype}."
+            )
+
+    def post_load_weights(self) -> None:
+        for name, param in self.named_parameters():
+            if name in MINIMAX_H3_FP32_PARAM_NAMES and param.dtype != _FP32_DTYPE:
+                raise ValueError(
+                    f"{name} must stay fp32 after load, got {param.dtype}."
+                )
+            if (
+                self.arch.adaln_curve_grid is not None
+                and ".adaln_proj.linear." in name
+                and param.dtype != _FP32_DTYPE
+            ):
+                raise ValueError(
+                    f"{name} must stay fp32 for an AdaLN-curve checkpoint, got "
+                    f"{param.dtype}."
+                )
+        for name, buffer in self.named_buffers():
+            if name in MINIMAX_H3_FP32_BUFFER_NAMES and buffer.dtype != _FP32_DTYPE:
+                raise ValueError(
+                    f"{name} must stay fp32 after load, got {buffer.dtype}."
+                )
+
+    def validate_restored_host_weights(self) -> None:
+        """Validate mixed-precision invariants after lease-backed restore."""
+        self.post_load_weights()
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        """Load exact H3 checkpoint names with logical TP-aware loaders."""
+        params = dict(self.named_parameters())
+        params.update(dict(self.named_buffers()))
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if name.endswith(".comfy_quant"):
+                # Marker JSON was validated before construction.  It is a
+                # checkpoint protocol tensor, not executable model state.
+                loaded.add(name)
+                continue
+            param = params.get(name)
+            if param is None:
+                logger.warning(
+                    "Skipping MiniMax H3 weight not present in model: %s", name
+                )
+                continue
+            # Comfy serializes row scales as either [N] or [N, 1]. Normalize
+            # only our channel-scale parameter; other quantizers may attach a
+            # different meaning and loader contract to a 1-D weight_scale.
+            if (
+                isinstance(param, ChannelQuantScaleParameter)
+                and loaded_weight.dim() == 1
+                and param.dim() == 2
+                and param.shape[1] == 1
+            ):
+                loaded_weight = loaded_weight.unsqueeze(1)
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            is_channel_scale = isinstance(param, ChannelQuantScaleParameter)
+            if name.endswith(".attn.qkv_proj.weight") or (
+                name.endswith(".attn.qkv_proj.weight_scale") and is_channel_scale
+            ):
+                if not getattr(self, "_qkv_checkpoint_is_runtime_layout", False):
+                    # Transform checkpoint layout before entering vLLM's loader
+                    # so online FP8 can keep ``online_process_loader`` outermost.
+                    loaded_weight = _reorder_grouped_qkv_to_qkv(
+                        loaded_weight,
+                        num_query_groups=self.arch.num_attention_heads,
+                        heads_per_group=1,
+                        head_dim=self.arch.attention_head_dim,
+                    )
+                weight_loader(param, loaded_weight)
+            elif name.endswith(".mlp.fc1.weight") or (
+                name.endswith(".mlp.fc1.weight_scale") and is_channel_scale
+            ):
+                if loaded_weight.shape[0] % 2:
+                    raise ValueError(
+                        "MiniMax H3 fc1 checkpoint rows must split evenly into "
+                        f"gate/up matrices, got {tuple(loaded_weight.shape)}"
+                    )
+                gate, up = loaded_weight.chunk(2, dim=0)
+                weight_loader(param, gate, 0)
+                weight_loader(param, up, 1)
+            else:
+                weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
+
+    def _embed_timesteps(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
+        if self.arch.adaln_curve_grid is None:
+            if self.time_embedder is None:
+                raise RuntimeError(
+                    "MiniMax-H3 dense AdaLN model is missing its time embedder."
+                )
+            return self.time_embedder(unique_timesteps)
+
+        table = self.adaln_t_table
+        positions = unique_timesteps.to(_FP32_DTYPE).clamp(0.0, 1.0) * (
+            table.shape[0] - 1
+        )
+        lower = positions.floor().to(torch.long).clamp(max=table.shape[0] - 2)
+        fraction = (positions - lower).unsqueeze(1)
+        return torch.lerp(table[lower], table[lower + 1], fraction)
+
+    @staticmethod
+    def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
+        if isinstance(pos_info, dict):
+            ids = pos_info.get("position_ids")
+        else:
+            ids = getattr(pos_info, "position_ids", None)
+        if ids is None:
+            raise ValueError(f"{key}.position_ids is required")
+        return ids.view(-1).to(torch.long)
+
+    @staticmethod
+    def _psp_field(psp: Any, key: str, field: str) -> Any:
+        value = psp.get(field) if isinstance(psp, dict) else getattr(psp, field, None)
+        if value is None:
+            raise ValueError(f"{key}.{field} is required")
+        return value
+
+    @staticmethod
+    def _psp_optional(psp: Any, field: str, default: Any) -> Any:
+        value = psp.get(field) if isinstance(psp, dict) else getattr(psp, field, None)
+        return default if value is None else value
+
+    def _embed(
+        self,
+        *,
+        x: torch.Tensor,
+        audio_x: torch.Tensor,
+        text_embeddings_selected: torch.Tensor,
+        unique_timesteps: torch.Tensor,
+        img_pos: torch.Tensor,
+        audio_pos: torch.Tensor,
+        text_pos: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        seq_len: int,
+        device: torch.device,
+        local_span: tuple[int, int],
+        num_requests: int = 1,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build this rank's packed multimodal embedding rows.
+
+        Returns (decoder_input [S_local, H] bf16, t_emb [M, t_dim] fp32).
+
+        ``num_requests`` defaults to a single packed request so callers that
+        pre-date the continuous-batching change (e.g. TeaCache's extractor
+        contract) do not silently miss the kwarg. ``forward()`` reads the real
+        value from ``packed_seq_params["num_requests"]``.
+        """
+        local_start, local_len = local_span
+        local_end = local_start + local_len
+        local_only = local_len != seq_len
+        if local_only:
+            img_mask = (img_pos >= local_start) & (img_pos < local_end)
+            audio_mask = (audio_pos >= local_start) & (audio_pos < local_end)
+            text_mask = (text_pos >= local_start) & (text_pos < local_end)
+            img_global_pos = img_pos[img_mask]
+            audio_global_pos = audio_pos[audio_mask]
+            img_local_pos = img_global_pos - local_start
+            audio_local_pos = audio_global_pos - local_start
+            text_local_pos = text_pos[text_mask] - local_start
+            text_local_indices = torch.nonzero(text_mask, as_tuple=False).view(-1)
+        else:
+            img_global_pos = img_pos
+            audio_global_pos = audio_pos
+            img_local_pos = img_pos
+            audio_local_pos = audio_pos
+            text_local_pos = text_pos
+            text_local_indices = None
+
+        # Latent embedders stay fp32 in and out; their outputs are cast to the
+        # bf16 sequence dtype only during indexed scattering.
+        x_rows = x.view(-1, x.shape[-1]).index_select(0, img_global_pos).to(_FP32_DTYPE)
+        video_embed, _ = self.video_patch_proj(x_rows)
+        audio_rows = audio_x.view(-1, audio_x.shape[-1])
+        audio_rows = audio_rows.index_select(0, audio_global_pos).to(_FP32_DTYPE)
+        audio_embed, _ = self.audio_patch_proj(audio_rows)
+
+        text_rows = text_embeddings_selected.to(device=device, dtype=_COMPUTE_DTYPE)
+        text_embed, _ = self.condition_proj(text_rows)
+        text_embed = self.token_refiner(
+            text_embed,
+            cu_seqlens=refiner_cu_seqlens,
+            max_seqlen=refiner_max_seqlen,
+            num_requests=num_requests,
+        )
+        if text_local_indices is not None:
+            text_embed = text_embed.index_select(0, text_local_indices)
+
+        embeddings = torch.zeros(
+            (local_len, self.hidden_size),
+            device=device,
+            dtype=_COMPUTE_DTYPE,
+        )
+        embeddings.index_add_(
+            0,
+            text_local_pos,
+            text_embed.to(_COMPUTE_DTYPE)[: text_local_pos.shape[0]],
+        )
+        embeddings.index_add_(
+            0,
+            img_local_pos,
+            video_embed.to(_COMPUTE_DTYPE)[: img_local_pos.shape[0]],
+        )
+        embeddings.index_add_(
+            0,
+            audio_local_pos,
+            audio_embed.to(_COMPUTE_DTYPE)[: audio_local_pos.shape[0]],
+        )
+
+        t_emb = self._embed_timesteps(unique_timesteps)
+        return embeddings, t_emb
+
+    def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        """Packed inference forward.
+
+        Keyword names follow the checkpoint's serving contract.
+        Returns `(video_logits, audio_logits)` from rows selected by
+        `img_pos_for_infer_output_info` and `audio_pos_info`, with condition
+        rows zeroed by update masks.
+        """
+        # Strict keyword contract: refuse any kwarg forward does not consume.
+        unexpected = sorted(set(kwargs) - _FORWARD_SUPPORTED_KWARGS)
+        if unexpected:
+            raise TypeError(
+                "MiniMaxH3DiTModel.forward received unexpected kwargs: "
+                f"{unexpected}; supported kwargs: "
+                f"{sorted(_FORWARD_SUPPORTED_KWARGS)}"
+            )
+
+        x = _required_kwarg(kwargs, "x")
+        audio_x = _required_kwarg(kwargs, "audio_x")
+        img_position_ids = _required_kwarg(kwargs, "img_position_ids")
+        unique_timesteps = _required_kwarg(kwargs, "unique_timesteps")
+        inverse_indices = (
+            _required_kwarg(kwargs, "inverse_indices").view(-1).to(torch.long)
+        )
+        update_mask = _required_kwarg(kwargs, "update_mask")
+        token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
+        skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
+        text_selected = _required_kwarg(kwargs, "prompt_embeds")
+
+        img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
+        audio_pos = self._pos_ids(
+            _required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info"
+        )
+        text_pos = self._pos_ids(
+            _required_kwarg(kwargs, "text_pos_info"),
+            "text_pos_info",
+        )
+        infer_out_pos = self._pos_ids(
+            _required_kwarg(kwargs, "img_pos_for_infer_output_info"),
+            "img_pos_for_infer_output_info",
+        )
+
+        psp = _required_kwarg(kwargs, "packed_seq_params")
+        cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(
+            torch.int32
+        )
+        max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
+        # How many requests share this packed sequence. Carried as a host int so
+        # attention never reads cu_seqlens scalars off the device; a producer
+        # that omits it is packing a single request.
+        num_requests = int(self._psp_optional(psp, "num_requests", 1))
+        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
+        refiner_cu = self._psp_field(
+            refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q"
+        ).to(torch.int32)
+        refiner_max = int(
+            self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q")
+        )
+        video_layout = kwargs.get("video_token_layout")
+
+        if x.dim() != 3 or x.shape[0] != 1:
+            raise ValueError(f"x must be [1, S, C], got {list(x.shape)}")
+        seq_len = int(x.shape[1])
+        if token_tags.shape[0] != seq_len:
+            raise ValueError(
+                f"token_tags must cover the full packed sequence ({seq_len}), got "
+                f"{token_tags.shape[0]}."
+            )
+        if inverse_indices.shape[0] != seq_len:
+            raise ValueError(
+                f"inverse_indices must be [{seq_len}], got "
+                f"{list(inverse_indices.shape)}"
+            )
+        device = x.device
+        local_span = self._rope_local_span(seq_len)
+        local_start, local_len = local_span
+        rope_table = kwargs.get("rope_table")
+        if rope_table is None:
+            rope_position_ids = img_position_ids.narrow(1, local_start, local_len)
+            rope_table = _build_rope_table(self.rope(rope_position_ids).to(device))
+        else:
+            self._validate_prepared_rope_table(
+                rope_table,
+                local_len=local_len,
+                device=device,
+            )
+
+        decoder_input, t_emb = self._embed(
+            x=x,
+            audio_x=audio_x,
+            text_embeddings_selected=text_selected,
+            unique_timesteps=unique_timesteps.view(-1).to(device),
+            img_pos=img_pos.to(device),
+            audio_pos=audio_pos.to(device),
+            text_pos=text_pos.to(device),
+            refiner_cu_seqlens=refiner_cu.to(device),
+            refiner_max_seqlen=refiner_max,
+            num_requests=num_requests,
+            seq_len=seq_len,
+            device=device,
+            local_span=local_span,
+        )
+
+        combined_indices = (
+            inverse_indices * MINIMAX_H3_ADALN_MODALITY_NUM + token_tags.clamp(min=0)
+        ).to(device)
+        inverse_indices = inverse_indices.to(device)
+
+        hidden = decoder_input
+        cu_seqlens = cu_seqlens.to(device)
+        block_rope = rope_table
+        block_combined = combined_indices
+
+        if local_len == seq_len:
+            hidden, block_rope, block_combined = self.sp_prepare(
+                hidden,
+                block_rope,
+                block_combined,
+            )
+        else:
+            hidden, block_rope, block_combined = self.local_sp_prepare(
+                hidden,
+                block_rope,
+                block_combined,
+            )
+        for block in self.blocks:
+            hidden = block(
+                hidden,
+                t_emb=t_emb,
+                combined_indices=block_combined,
+                rope_table=block_rope,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                packed_total=seq_len,
+                num_requests=num_requests,
+                video_layout=video_layout,
+            )
+        if local_len == seq_len:
+            hidden = self.sp_gather(hidden)
+            video_logits, audio_logits = self.final_layer(
+                hidden,
+                t_emb=t_emb,
+                inverse_indices=inverse_indices,
+            )
+        else:
+            local_inverse_indices = inverse_indices.narrow(
+                0,
+                local_start,
+                local_len,
+            )
+            video_logits, audio_logits = self.final_layer(
+                hidden,
+                t_emb=t_emb,
+                inverse_indices=local_inverse_indices,
+            )
+            compact_logits = torch.cat((video_logits, audio_logits), dim=-1)
+            compact_logits = self.sp_gather(compact_logits)
+            video_width = self.arch.latents_dim * math.prod(self.arch.patch_size)
+            video_logits = compact_logits[..., :video_width]
+            audio_logits = compact_logits[..., video_width:]
+
+        # Select target and condition rows at inference-output positions, then
+        # zero the condition rows.
+        video_logits = video_logits.index_select(0, infer_out_pos.to(device))
+        audio_logits = audio_logits.index_select(0, audio_pos.to(device))
+        if not skip_mask_out_condition:
+            update_mask = update_mask.view(-1).to(device)
+            if update_mask.shape[0] != video_logits.shape[0]:
+                raise ValueError(
+                    f"update_mask length mismatch: {update_mask.shape[0]} != "
+                    f"{video_logits.shape[0]}"
+                )
+            video_logits = video_logits * update_mask.unsqueeze(-1)
+            # Audio has no condition rows in the supported tasks, so its
+            # derived update mask is all ones. Honor an explicit mask when
+            # provided.
+            update_audio_mask = kwargs.get("update_audio_mask")
+            if update_audio_mask is not None:
+                audio_logits = audio_logits * update_audio_mask.view(-1).unsqueeze(-1)
+        return video_logits, audio_logits
+
+
+EntryClass = MiniMaxH3DiTModel
+
+__all__ = [
+    "MINIMAX_H3_FP32_BUFFER_NAMES",
+    "MINIMAX_H3_FP32_PARAM_NAMES",
+    "MiniMaxH3DiTModel",
+    "_reorder_grouped_qkv_to_qkv",
+]

--- a/vllm/model_executor/models/minimax_h3/vae.py
+++ b/vllm/model_executor/models/minimax_h3/vae.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""MiniMax H3 remote-code VAE adapters and exact latent contracts."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from PIL import Image
+from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+from vllm.distributed import get_world_group
+from vllm.logger import init_logger
+
+from .packed_tokens import minimax_h3_patchify_video_latent
+from .residency import BoundedAllocatorCache, PinnedModuleStager
+
+MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
+MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
+MINIMAX_H3_AUDIO_CHANNELS = 2
+
+
+logger = init_logger(__name__)
+
+
+@contextmanager
+def _minimax_h3_keyframe_encode_context(
+    device: torch.device,
+) -> Iterator[None]:
+    if device.type != "cuda":
+        yield
+        return
+
+    # The official keyframe latent uses cuDNN's TF32 convolution path. The
+    # default non-deterministic algorithm can select numerically different
+    # reductions on H100s, and the difference is amplified by the denoiser.
+    # Pin both the algorithm and math mode for this sensitive encode only.
+    with torch.backends.cudnn.flags(
+        enabled=True,
+        benchmark=False,
+        deterministic=True,
+        allow_tf32=True,
+    ):
+        yield
+
+
+def _load_component_config(component_path: str) -> dict[str, Any]:
+    config_path = Path(component_path) / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    channels = int(config["latent_channels"])
+    for key in ("latents_mean", "latents_std"):
+        values = config.get(key)
+        if not isinstance(values, list) or len(values) != channels:
+            raise ValueError(f"{config_path}: {key} must contain {channels} values")
+    return config
+
+
+def _load_remote_component(
+    component_path: str,
+    config: dict[str, Any],
+) -> nn.Module:
+    auto_map = config.get("auto_map") or {}
+    class_reference = auto_map.get("AutoModel")
+    if not isinstance(class_reference, str):
+        raise ValueError(f"{component_path}/config.json must define auto_map.AutoModel")
+    component_cls = get_class_from_dynamic_module(
+        class_reference,
+        component_path,
+    )
+    # Build on the host regardless of the ambient default device. Online
+    # quantization wraps pipeline construction in a `with torch.device(<accel>)`
+    # block for the DiT's quantized linears, and the checkpoint's own VAE code
+    # builds constants with ops that have no accelerator kernel (BigVGAN's
+    # anti-aliasing filters call torch.kaiser_window). Callers place the module
+    # explicitly right after this returns, so nothing depends on the context.
+    with torch.device("cpu"):
+        return component_cls.from_pretrained(component_path)
+
+
+class _AudioVAEDeterminismContext(AbstractContextManager):
+    def __enter__(self):
+        backends = torch.backends
+        self._saved = (
+            backends.cuda.matmul.allow_tf32,
+            backends.cudnn.allow_tf32,
+            backends.cudnn.benchmark,
+            backends.cudnn.deterministic,
+            backends.cudnn.enabled,
+            backends.cuda.flash_sdp_enabled(),
+            backends.cuda.mem_efficient_sdp_enabled(),
+            backends.cuda.math_sdp_enabled(),
+        )
+        backends.cuda.matmul.allow_tf32 = False
+        backends.cudnn.allow_tf32 = False
+        backends.cudnn.benchmark = False
+        backends.cudnn.deterministic = True
+        backends.cudnn.enabled = False
+        backends.cuda.enable_flash_sdp(False)
+        backends.cuda.enable_mem_efficient_sdp(False)
+        backends.cuda.enable_math_sdp(True)
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        backends = torch.backends
+        (
+            backends.cuda.matmul.allow_tf32,
+            backends.cudnn.allow_tf32,
+            backends.cudnn.benchmark,
+            backends.cudnn.deterministic,
+            backends.cudnn.enabled,
+            flash,
+            memory_efficient,
+            math_sdp,
+        ) = self._saved
+        backends.cuda.enable_flash_sdp(flash)
+        backends.cuda.enable_mem_efficient_sdp(memory_efficient)
+        backends.cuda.enable_math_sdp(math_sdp)
+        return False
+
+
+class MiniMaxH3VideoVAE(nn.Module):
+    """Adapter around the checkpoint's native parallel-tiled video VAE."""
+
+    def __init__(
+        self,
+        component_path: str,
+        *,
+        device: torch.device,
+        load_device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        self._device_target = device
+        self.config_dict = _load_component_config(component_path)
+        self.remote = _load_remote_component(
+            component_path,
+            self.config_dict,
+        )
+        # Match the reference loader contract before installing inference-only
+        # decoder fast paths. Keyframe encoding remains FP32; decoder Linear
+        # weights may be materialized in FP16 because reference decode casts
+        # those same tensors through CUDA autocast on every tile.
+        initial_device = load_device or device
+        self.remote.eval().to(device=initial_device, dtype=torch.float32)
+        self._stager = None
+        if initial_device.type == "cpu" and device.type not in ("cpu", "meta"):
+            self._stager = PinnedModuleStager(
+                self.remote,
+                device,
+                pin_memory=True,
+            )
+        self.model = self.remote.model
+        self.use_tiling = True
+        self.use_slicing = False
+        self.parallel_size = 1
+        self.device_module = torch.get_device_module()
+
+    def load_to_device(self) -> None:
+        if self._stager is not None:
+            self._stager.load()
+        else:
+            self.remote.to(self._device_target)
+
+    def set_omni_component_cache(self, cache: BoundedAllocatorCache | None) -> None:
+        self._omni_component_cache = cache
+        if self._stager is not None:
+            self._stager.set_cache_retention(cache)
+
+    def offload_to_cpu(self) -> None:
+        if self._stager is not None:
+            self._stager.offload()
+        else:
+            self.remote.to("cpu")
+            cache = getattr(self, "_omni_component_cache", None)
+            if cache is None:
+                torch.accelerator.empty_cache()
+            else:
+                cache.release_if_needed()
+
+    def set_parallel_size(
+        self,
+        parallel_size: int,
+        mode: str = "tile",
+    ) -> None:
+        if mode != "tile":
+            raise ValueError(
+                f"MiniMax H3 VAE supports its native tile parallel mode only, got "
+                f"{mode!r}"
+            )
+        group = get_world_group().device_group
+        world_size = dist.get_world_size(group)
+        rank = dist.get_rank(group)
+        parallel_size = int(parallel_size)
+        if parallel_size not in (1, world_size):
+            raise ValueError(
+                "MiniMax H3 native VAE patch parallelism currently requires "
+                "vae_patch_parallel_size=1 or the full DiT group size "
+                f"({world_size}), got {parallel_size}"
+            )
+        self.parallel_size = parallel_size
+        enabled = parallel_size > 1
+
+        state = self._native_parallel_state()
+        state.clear()
+        state.update(
+            group_size=parallel_size,
+            group_rank=rank if enabled else 0,
+            local_process_group=group if enabled else None,
+            sp_size=parallel_size,
+            sp_rank=rank if enabled else 0,
+            sp_enabled=enabled,
+            sp_process_group=group if enabled else None,
+            tp_size=1,
+            tp_rank=0,
+        )
+        self.model.parallel_tiling = enabled
+
+    def _native_parallel_state(self) -> dict[str, Any]:
+        """Return the checkpoint's own mutable parallel-state dict."""
+
+        package = self.remote.__class__.__module__.rsplit(".", 1)[0]
+        parallel_module = importlib.import_module(f"{package}.parallel")
+        return parallel_module.get_parallel_state()
+
+    def _decoder_tile_count(self, latent: torch.Tensor) -> int:
+        """Number of decoder tiles the checkpoint will split ``latent`` into.
+
+        Mirrors the checkpoint's ``decode_tiled``: the grid is computed from the
+        pixel-space dimensions, so it is a pure function of the latent shape and
+        resolves identically on every rank.
+        """
+
+        ratio = int(self.model.vae_ratio)
+        rows, _, _ = self.model.split_tiles(int(latent.shape[-2]) * ratio, True)
+        cols, _, _ = self.model.split_tiles(int(latent.shape[-1]) * ratio, True)
+        return len(rows) * len(cols)
+
+    @contextmanager
+    def _rank_local_tiling(self) -> Iterator[None]:
+        """Run one decode with tiling kept on this rank, then restore the group.
+
+        Used only when there are fewer tiles than ranks. Every rank then decodes
+        every tile, which is slower than sharing the work but is correct and
+        involves no collective.
+        """
+
+        state = self._native_parallel_state()
+        saved_state = dict(state)
+        saved_tiling = self.model.parallel_tiling
+        state.update(
+            group_size=1,
+            group_rank=0,
+            local_process_group=None,
+            sp_size=1,
+            sp_rank=0,
+            sp_enabled=False,
+            sp_process_group=None,
+            tp_size=1,
+            tp_rank=0,
+        )
+        self.model.parallel_tiling = False
+        try:
+            yield
+        finally:
+            state.clear()
+            state.update(saved_state)
+            self.model.parallel_tiling = saved_tiling
+
+    def is_distributed_enabled(self) -> bool:
+        return self.parallel_size > 1 and dist.is_initialized()
+
+    @torch.inference_mode()
+    def encode_image(self, image: Image.Image) -> torch.Tensor:
+        previous_parallel = self.model.parallel_tiling
+        self.model.parallel_tiling = False
+        parameter = next(self.parameters())
+        previous_dtype = parameter.dtype
+        if previous_dtype != torch.float32:
+            self.to(torch.float32)
+        devices = [parameter.device] if parameter.device.type != "cpu" else []
+        try:
+            with torch.random.fork_rng(
+                devices=devices, device_type=parameter.device.type
+            ):
+                torch.default_generator.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
+                for device in devices:
+                    with self.device_module.device(device):
+                        self.device_module.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
+                with _minimax_h3_keyframe_encode_context(parameter.device):
+                    latent = self.model.encode_images(
+                        image,
+                        use_fp16_latent=True,
+                    )[0]
+        finally:
+            self.model.parallel_tiling = previous_parallel
+            if previous_dtype != torch.float32:
+                self.to(previous_dtype)
+
+        # Match the reference contract exactly: normalization and patchify
+        # happen on CPU in FP32 after the sampled encode. The condition noise
+        # path is sensitive enough that doing these elementwise operations on
+        # CUDA can noticeably change the final conditioned video.
+        latent = latent.float().cpu()
+        if latent.ndim == 4:
+            latent = latent[None]
+        channels = int(self.config_dict["latent_channels"])
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+        ).view(1, channels, 1, 1, 1)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+        ).view(1, channels, 1, 1, 1)
+        return minimax_h3_patchify_video_latent(
+            (latent - mean) / std,
+            patch_size=(1, 2, 2),
+        ).float()
+
+    @torch.inference_mode()
+    def encode_video(
+        self,
+        frames: Any,
+    ) -> tuple[torch.Tensor, tuple[int, int, int]]:
+        parameter = next(self.parameters())
+        previous_dtype = parameter.dtype
+        if previous_dtype != torch.float32:
+            self.to(torch.float32)
+        devices = [parameter.device] if parameter.device.type != "cpu" else []
+        try:
+            with torch.random.fork_rng(
+                devices=devices, device_type=parameter.device.type
+            ):
+                torch.default_generator.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
+                for device in devices:
+                    with self.device_module.device(device):
+                        self.device_module.manual_seed(MINIMAX_H3_KEYFRAME_ENCODE_SEED)
+                latent = self.model.encode_videos(
+                    frames,
+                    use_fp16_latent=True,
+                )[0]
+        finally:
+            if previous_dtype != torch.float32:
+                self.to(previous_dtype)
+
+        latent = latent.float().cpu()
+        if latent.ndim == 4:
+            latent = latent[None]
+        channels = int(self.config_dict["latent_channels"])
+        if latent.ndim != 5 or int(latent.shape[1]) != channels:
+            raise ValueError(
+                f"unexpected reference video latent shape {tuple(latent.shape)}"
+            )
+        shape = (
+            int(latent.shape[2]),
+            int(latent.shape[3]),
+            int(latent.shape[4]),
+        )
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+        ).view(1, channels, 1, 1, 1)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+        ).view(1, channels, 1, 1, 1)
+        rows = minimax_h3_patchify_video_latent(
+            (latent - mean) / std,
+            patch_size=(1, 2, 2),
+        ).float()
+        return rows, shape
+
+    @torch.inference_mode()
+    def decode_latent(self, latent: torch.Tensor) -> torch.Tensor:
+        channels = int(self.config_dict["latent_channels"])
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1, 1, 1)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1, 1, 1)
+        # The checkpoint hands rank r the tiles ``range(r, num_tiles, sp_size)``
+        # and then rejects an empty share inside the gather. A rank with no
+        # tiles raises and leaves the collective while the others block in it
+        # forever, so too few tiles hangs the whole stage rather than failing
+        # it. Tile count depends only on the latent shape, so every rank takes
+        # this branch together.
+        num_tiles = self._decoder_tile_count(latent)
+        if self.parallel_size > 1 and num_tiles < self.parallel_size:
+            logger.warning_once(
+                "MiniMax-H3 VAE decode splits into %d tile(s) but the tile group has "
+                "%d ranks; decoding rank-locally for this shape instead, which is "
+                "slower but avoids ranks without tiles hanging the collective.",
+                num_tiles,
+                self.parallel_size,
+            )
+            tiling_context: AbstractContextManager = self._rank_local_tiling()
+        else:
+            tiling_context = nullcontext()
+
+        with tiling_context:
+            decoded = self.model.decode_base(latent * std + mean)
+        frames = self.model.processor.revert_tensor(decoded)
+        if frames.ndim == 4:
+            frames = frames.unsqueeze(0).transpose(1, 2)
+        if frames.ndim != 5:
+            raise ValueError(f"unexpected decoded video shape {tuple(frames.shape)}")
+        return frames.float()
+
+
+class MiniMaxH3AudioVAE(nn.Module):
+    def __init__(
+        self,
+        component_path: str,
+        *,
+        device: torch.device,
+        load_device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        self._device_target = device
+        self.config_dict = _load_component_config(component_path)
+        self.remote = _load_remote_component(
+            component_path,
+            self.config_dict,
+        )
+        # The checkpoint's audio VAE contract is FP32 for both reference
+        # encoding and waveform decoding.
+        initial_device = load_device or device
+        self.remote.eval().to(device=initial_device, dtype=torch.float32)
+        self._stager = None
+        if initial_device.type == "cpu" and device.type not in ("cpu", "meta"):
+            self._stager = PinnedModuleStager(
+                self.remote,
+                device,
+                pin_memory=True,
+            )
+        self.model = self.remote.model
+        self.sample_rate = int(self.config_dict["sample_rate"])
+
+    def load_to_device(self) -> None:
+        if self._stager is not None:
+            self._stager.load()
+        else:
+            self.remote.to(self._device_target)
+
+    def set_omni_component_cache(self, cache: BoundedAllocatorCache | None) -> None:
+        self._omni_component_cache = cache
+        if self._stager is not None:
+            self._stager.set_cache_retention(cache)
+
+    def offload_to_cpu(self) -> None:
+        if self._stager is not None:
+            self._stager.offload()
+        else:
+            self.remote.to("cpu")
+            cache = getattr(self, "_omni_component_cache", None)
+            if cache is None:
+                torch.accelerator.empty_cache()
+            else:
+                cache.release_if_needed()
+
+    @torch.inference_mode()
+    def encode_waveform(
+        self,
+        waveform: torch.Tensor,
+        sample_rate: int,
+    ) -> tuple[torch.Tensor, int]:
+        import torchaudio
+
+        waveform = waveform.float()
+        if waveform.ndim == 1:
+            waveform = waveform[None]
+        if int(sample_rate) != MINIMAX_H3_AUDIO_SAMPLE_RATE:
+            waveform = torchaudio.transforms.Resample(
+                int(sample_rate),
+                MINIMAX_H3_AUDIO_SAMPLE_RATE,
+            )(waveform)
+        if waveform.shape[0] < MINIMAX_H3_AUDIO_CHANNELS:
+            waveform = waveform.repeat(
+                MINIMAX_H3_AUDIO_CHANNELS,
+                1,
+            )
+        waveform = waveform[:MINIMAX_H3_AUDIO_CHANNELS]
+        device = next(self.model.parameters()).device
+        waveform = waveform.to(device)
+
+        with _AudioVAEDeterminismContext():
+            audio = self.model.preprocess(
+                waveform.unsqueeze(1),
+                MINIMAX_H3_AUDIO_SAMPLE_RATE,
+            )
+            latent = self.model.encoder(audio)
+            if bool(getattr(self.model, "attn_proj", False)):
+                latent = self.model.pre_block(latent.transpose(1, 2)).transpose(1, 2)
+            latent = self.model.mean_proj(latent).float().cpu()
+
+        channels = int(self.config_dict["latent_channels"])
+        if latent.shape[-1] != channels:
+            if latent.shape[1] != channels:
+                raise ValueError(
+                    f"cannot canonicalize audio latent {tuple(latent.shape)}"
+                )
+            latent = latent.transpose(1, 2).contiguous()
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+        ).view(1, 1, channels)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+        ).view(1, 1, channels)
+        rows = ((latent - mean) / std).reshape(-1, channels)
+        return rows.float(), int(latent.shape[1])
+
+    @torch.inference_mode()
+    def decode_latent(self, latent: torch.Tensor) -> torch.Tensor:
+        channels = int(self.config_dict["latent_channels"])
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1)
+        waveform = self.remote.decode(latent * std + mean)
+        if waveform.ndim != 3 or waveform.shape[1] != 1:
+            raise ValueError(f"unexpected decoded audio shape {tuple(waveform.shape)}")
+        return waveform.permute(1, 0, 2).contiguous().float()
+
+
+__all__ = ["MiniMaxH3AudioVAE", "MiniMaxH3VideoVAE"]

--- a/vllm/model_executor/models/minimax_h3/validation.py
+++ b/vllm/model_executor/models/minimax_h3/validation.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validate client metadata before it reaches distributed H3 workers."""
+
+from os import PathLike
+from pathlib import Path
+from types import SimpleNamespace
+
+from .config import H3Config, H3InputError, H3Request
+
+
+def validate_request(config: H3Config, request: H3Request) -> None:
+    # Reuse the pipeline's reference contract, without constructing a model or
+    # touching CUDA. Media encoding remains in the distributed worker stage.
+    from .pipeline import (
+        MiniMaxH3Pipeline,
+        _resolve_fl2va_keyframe_indices,
+        _validate_ref2va_reference_counts,
+        _validate_reference_image,
+    )
+    from .preprocessing import load_minimax_h3_images
+
+    supported = {"t2va", "fl2va"} if config.partition == "fl2va" else {"ref2va"}
+    deployment = SimpleNamespace(partition=config.partition, supported_tasks=supported)
+    task = MiniMaxH3Pipeline._resolve_task(
+        deployment, request.sampling.extra_args.get("task"), request.media
+    )
+    references = {}
+    for key in ("image", "video", "audio"):
+        value = request.media.get(key)
+        values = (
+            []
+            if value is None
+            else (list(value) if isinstance(value, (list, tuple)) else [value])
+        )
+        if value is not None and not values:
+            raise H3InputError(f"{key} references must not be empty")
+        if key == "audio" and len(values) == 2 and isinstance(values[1], int):
+            values = [value]  # A waveform/sample-rate pair is one reference.
+        for item in values:
+            if isinstance(item, (str, PathLike)) and not Path(item).is_file():
+                raise H3InputError(f"{key} reference does not exist: {item}")
+        references[key] = values
+
+    counts = [len(references[key]) for key in ("image", "video", "audio")]
+    if task == "ref2va":
+        _validate_ref2va_reference_counts(*counts)
+    elif task == "t2va" and any(counts):
+        raise H3InputError("t2va does not accept reference media")
+    elif task == "fl2va":
+        if not 1 <= counts[0] <= 2 or counts[1] or counts[2]:
+            raise H3InputError("fl2va accepts one or two image keyframes only")
+        _resolve_fl2va_keyframe_indices(request.sampling.extra_args, counts[0])
+    if task != "fl2va" and request.sampling.extra_args.get("frame_indices") is not None:
+        raise H3InputError("keyframe indices require image keyframes")
+    images = []
+    try:
+        if references["image"]:
+            images = load_minimax_h3_images(references["image"])
+            for image in images:
+                _validate_reference_image(image)
+    except (OSError, ValueError) as exc:
+        raise H3InputError(f"invalid reference image: {exc}") from exc
+    MiniMaxH3Pipeline._resolve_shape(
+        deployment, task, request.sampling, images[0] if images else None
+    )

--- a/vllm/model_executor/models/minimax_h3/weight_cache.py
+++ b/vllm/model_executor/models/minimax_h3/weight_cache.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Budgeted cache of explicitly selected, rotated FP16 H3 weights."""
+
+import torch
+
+
+class FP16WeightCache:
+    def __init__(self, model, *, budget_gib, layers):
+        self.layers = []
+        self.bytes = 0
+        modules = dict(model.named_modules())
+        for name in layers:
+            if name not in modules:
+                raise ValueError(f"unknown H3 cache layer {name}")
+            layer = modules[name]
+            if layer.weight.dtype != torch.int8 or not hasattr(layer, "weight_scale"):
+                raise ValueError(f"FP16 cache requires a quantized layer: {name}")
+            self.bytes += layer.weight.numel() * 2
+            self.layers.append(layer)
+        if self.bytes > int(budget_gib * 1024**3):
+            raise ValueError("fixed H3 FP16 cache list exceeds its memory budget")
+
+    def prepare(self):
+        from .cuda_ops import w8a16_extension
+
+        try:
+            for layer in self.layers:
+                free, _ = torch.accelerator.get_memory_info(layer.weight.device)
+                required = layer.weight.numel() * 2
+                if (
+                    required >= free
+                    or torch.accelerator.memory_allocated() + required > 30 * 1024**3
+                ):
+                    raise RuntimeError(
+                        "H3 FP16 weight cache exceeds available GPU memory"
+                    )
+                # The weight stays in ConvRot coordinates; activations still
+                # receive the original rotation on every invocation.
+                layer.h3_fp16_weight = w8a16_extension().dequantize(
+                    layer.weight, layer.weight_scale
+                )
+        except BaseException:
+            self.clear()
+            raise
+
+    def clear(self):
+        for layer in self.layers:
+            if hasattr(layer, "h3_fp16_weight"):
+                del layer.h3_fp16_weight

--- a/vllm/model_executor/models/minimax_h3/weights.py
+++ b/vllm/model_executor/models/minimax_h3/weights.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Revision-pinned H3 resolution and bounded-memory checkpoint iteration."""
+
+import hashlib
+import json
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+
+from .config import H3Config
+
+
+def resolve_model_root(config: H3Config) -> Path:
+    path = Path(config.model).expanduser()
+    if path.is_dir():
+        return path.absolute()
+    partition = "FL2VA" if config.partition == "fl2va" else "Ref2VA"
+    patterns = [f"{partition}/model_index.json", f"{partition}/transformer/**"]
+    patterns += [
+        f"FL2VA/{name}/**"
+        for name in ("text_encoder", "tokenizer", "processor", "video_vae", "audio_vae")
+    ]
+    ignored = (
+        [f"{partition}/transformer/*.safetensors"] if config.transformer_path else None
+    )
+    return Path(
+        snapshot_download(
+            config.model,
+            revision=config.revision,
+            allow_patterns=patterns,
+            ignore_patterns=ignored,
+        )
+    )
+
+
+def iter_checkpoint_weights(path: str | Path):
+    path = Path(path)
+    files = [path] if path.is_file() else sorted(path.glob("*.safetensors"))
+    if not files:
+        raise FileNotFoundError(f"no safetensors checkpoint at {path}")
+    seen = set()
+    for file in files:
+        with safe_open(file, framework="pt", device="cpu") as checkpoint:
+            for name in checkpoint.keys():  # noqa: SIM118 (safe_open is not iterable)
+                if name in seen:
+                    raise ValueError(f"duplicate checkpoint tensor {name}")
+                seen.add(name)
+                yield name, checkpoint.get_tensor(name)
+
+
+def write_checkpoint_manifest(root: str | Path, output: str | Path, *, revision: str):
+    root = Path(root)
+    records = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or ".cache" in path.parts:
+            continue
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+                digest.update(chunk)
+        records.append(
+            {
+                "path": str(path.relative_to(root)),
+                "bytes": path.stat().st_size,
+                "sha256": digest.hexdigest(),
+            }
+        )
+    Path(output).write_text(
+        json.dumps({"revision": revision, "files": records}, indent=2)
+    )

--- a/vllm/video/__init__.py
+++ b/vllm/video/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native audio/video generation and serving."""

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Persistent, serial TP worker group shared by offline and HTTP video APIs."""
+
+from __future__ import annotations
+
+import contextlib
+import multiprocessing as mp
+import os
+import socket
+import threading
+import time
+import traceback
+from dataclasses import asdict
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import cast
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+
+
+def select_gpu_group(tp: int) -> tuple[int, ...]:
+    import pynvml as nvml
+
+    nvml.nvmlInit()
+    try:
+        for start in (0, 4):
+            indices = tuple(range(start, start + tp))
+            if indices[-1] >= nvml.nvmlDeviceGetCount():
+                continue
+            available = True
+            for index in indices:
+                handle = nvml.nvmlDeviceGetHandleByIndex(index)
+                processes = nvml.nvmlDeviceGetComputeRunningProcesses(handle)
+                # Ignore a small desktop CUDA allocation; never displace jobs.
+                if any(p.usedGpuMemory > 256 * 1024**2 for p in processes):
+                    available = False
+                if nvml.nvmlDeviceGetMemoryInfo(handle).free < 30 * 1024**3:
+                    available = False
+            if available:
+                return indices
+        raise RuntimeError("Neither configured GPU group has enough free memory")
+    finally:
+        nvml.nvmlShutdown()
+
+
+def _worker(rank, config, gpu_ids, endpoint, connection):
+    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
+    from datetime import timedelta
+
+    import torch
+
+    from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from vllm.model_executor.models.minimax_h3.pipeline import MiniMaxH3Pipeline
+
+    torch.set_num_threads(4)
+    torch.accelerator.set_device_index(rank)
+    # Explicitly disallow reduced-precision GEMM reductions for FP16 islands.
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+    current = VllmConfig(
+        parallel_config=ParallelConfig(tensor_parallel_size=config.tensor_parallel_size)
+    )
+    try:
+        with set_current_vllm_config(current):
+            init_distributed_environment(
+                config.tensor_parallel_size,
+                rank,
+                endpoint,
+                rank,
+                "nccl",
+                timeout=timedelta(minutes=30),
+            )
+            initialize_model_parallel(config.tensor_parallel_size)
+            started = time.perf_counter()
+            pipeline = MiniMaxH3Pipeline(config)
+            connection.send(
+                {
+                    "ready": True,
+                    "rank": rank,
+                    "startup_seconds": time.perf_counter() - started,
+                }
+            )
+            while True:
+                command = connection.recv()
+                if command is None:
+                    break
+                request, output_dir = command
+                torch.accelerator.reset_peak_memory_stats()
+                video, audio = pipeline(request)
+                result = {
+                    "rank": rank,
+                    "stage_seconds": pipeline.stage_durations,
+                    "dit_calls": pipeline.actual_dit_calls,
+                    "useful_denoise_flops": pipeline.useful_denoise_flops,
+                    "denoise_flops_by_layer": pipeline.denoise_flops_by_layer,
+                    "peak_allocated_bytes": torch.accelerator.max_memory_allocated(),
+                }
+                if rank == 0:
+                    from .media import export_video
+
+                    started = time.perf_counter()
+                    result.update(
+                        export_video(video, audio, output_dir, fps=request.sampling.fps)
+                    )
+                    result["stage_seconds"]["packaging"] = time.perf_counter() - started
+                    from vllm.model_executor.models.minimax_h3.time_request import (
+                        minimax_h3_align_frame_count,
+                    )
+
+                    from .quality import inspect_video
+
+                    started = time.perf_counter()
+                    duration = request.sampling.extra_args.get("duration_seconds")
+                    frames = (
+                        round(duration * request.sampling.fps)
+                        if duration is not None
+                        else request.sampling.num_frames
+                    )
+                    result["quality"] = inspect_video(
+                        result["video"],
+                        expected_frames=minimax_h3_align_frame_count(frames),
+                        expected_width=request.sampling.width,
+                        expected_height=request.sampling.height,
+                        expected_fps=request.sampling.fps,
+                    )
+                    result["stage_seconds"]["quality_validation"] = (
+                        time.perf_counter() - started
+                    )
+                connection.send(result)
+                del video, audio
+    except BaseException:
+        connection.send({"error": traceback.format_exc(), "rank": rank})
+    finally:
+        cleanup_dist_env_and_memory()
+        connection.close()
+
+
+class H3Engine:
+    def __init__(self, config: H3Config):
+        self.config = config
+        self.gpu_ids = select_gpu_group(config.tensor_parallel_size)
+        self._lock = threading.Lock()
+        self._closed = False
+        self.workers = []
+        self.connections = []
+        self.startup = []
+        context = mp.get_context("spawn")
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        endpoint = f"tcp://127.0.0.1:{port}"
+        try:
+            for rank in range(config.tensor_parallel_size):
+                parent, child = context.Pipe()
+                worker = context.Process(
+                    target=_worker, args=(rank, config, self.gpu_ids, endpoint, child)
+                )
+                worker.start()
+                child.close()
+                self.workers.append(worker)
+                self.connections.append(parent)
+            self.startup = self._receive_all(timeout=7200)
+        except BaseException:
+            self.close()
+            raise
+
+    def _receive_all(self, *, timeout):
+        from multiprocessing.connection import wait
+
+        pending = set(self.connections)
+        results = []
+        deadline = time.monotonic() + timeout
+        while pending:
+            if time.monotonic() >= deadline:
+                raise TimeoutError("H3 distributed worker timed out")
+            for ready_connection in wait(pending, timeout=1):
+                connection = cast(Connection, ready_connection)
+                message = connection.recv()
+                if "error" in message:
+                    raise RuntimeError(message["error"])
+                results.append(message)
+                pending.remove(connection)
+            for worker, connection in zip(self.workers, self.connections):
+                if connection in pending and not worker.is_alive():
+                    raise RuntimeError(
+                        f"H3 worker {worker.pid} exited ({worker.exitcode})"
+                    )
+        return sorted(results, key=lambda result: result["rank"])
+
+    def generate(self, request: H3Request, output_dir: str | Path):
+        import json
+
+        from .metrics import NVMLMonitor
+
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("H3 engine is closed")
+            output_dir = Path(output_dir).absolute()
+            output_dir.mkdir(parents=True, exist_ok=True)
+            started = time.perf_counter()
+            try:
+                for connection in self.connections:
+                    connection.send((request, str(output_dir)))
+                with NVMLMonitor(self.gpu_ids, output_dir / "nvml.jsonl"):
+                    ranks = self._receive_all(timeout=24 * 3600)
+            except BaseException:
+                # A failing rank invalidates the whole communicator. Release
+                # only owned workers instead of reusing a partially alive group.
+                self.close()
+                raise
+            result = {
+                "config": asdict(self.config),
+                "request": asdict(request),
+                "gpus": self.gpu_ids,
+                "ranks": ranks,
+                "startup": self.startup,
+                "end_to_end_seconds": time.perf_counter() - started,
+            }
+            (output_dir / "run.json").write_text(
+                json.dumps(result, indent=2, ensure_ascii=False)
+            )
+            return result
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        for connection in self.connections:
+            with contextlib.suppress(BrokenPipeError, EOFError, OSError):
+                connection.send(None)
+        for worker in self.workers:
+            worker.join(timeout=3)
+            if worker.is_alive():
+                worker.terminate()
+                worker.join(timeout=3)
+            if worker.is_alive():
+                worker.kill()
+                worker.join()
+        for connection in self.connections:
+            connection.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -18,30 +18,8 @@ from typing import cast
 
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 
-
-def select_gpu_group(tp: int) -> tuple[int, ...]:
-    import pynvml as nvml
-
-    nvml.nvmlInit()
-    try:
-        for start in (0, 4):
-            indices = tuple(range(start, start + tp))
-            if indices[-1] >= nvml.nvmlDeviceGetCount():
-                continue
-            available = True
-            for index in indices:
-                handle = nvml.nvmlDeviceGetHandleByIndex(index)
-                processes = nvml.nvmlDeviceGetComputeRunningProcesses(handle)
-                # Ignore a small desktop CUDA allocation; never displace jobs.
-                if any(p.usedGpuMemory > 256 * 1024**2 for p in processes):
-                    available = False
-                if nvml.nvmlDeviceGetMemoryInfo(handle).free < 30 * 1024**3:
-                    available = False
-            if available:
-                return indices
-        raise RuntimeError("Neither configured GPU group has enough free memory")
-    finally:
-        nvml.nvmlShutdown()
+from .gpu import acquire_gpu_group
+from .gpu import select_gpu_group as select_gpu_group
 
 
 def _worker(rank, config, gpu_ids, endpoint, connection):
@@ -143,18 +121,20 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
 class H3Engine:
     def __init__(self, config: H3Config):
         self.config = config
-        self.gpu_ids = select_gpu_group(config.tensor_parallel_size)
+        self._gpu_lease = None
         self._lock = threading.Lock()
         self._closed = False
         self.workers = []
         self.connections = []
         self.startup = []
         context = mp.get_context("spawn")
-        with socket.socket() as sock:
-            sock.bind(("127.0.0.1", 0))
-            port = sock.getsockname()[1]
-        endpoint = f"tcp://127.0.0.1:{port}"
         try:
+            self._gpu_lease = acquire_gpu_group(config.tensor_parallel_size)
+            self.gpu_ids = self._gpu_lease.gpu_ids
+            with socket.socket() as sock:
+                sock.bind(("127.0.0.1", 0))
+                port = sock.getsockname()[1]
+            endpoint = f"tcp://127.0.0.1:{port}"
             for rank in range(config.tensor_parallel_size):
                 parent, child = context.Pipe()
                 worker = context.Process(
@@ -247,6 +227,9 @@ class H3Engine:
                 worker.join()
         for connection in self.connections:
             connection.close()
+        if self._gpu_lease is not None:
+            self._gpu_lease.close()
+            self._gpu_lease = None
 
     def __enter__(self):
         return self

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -195,7 +195,11 @@ class H3Engine:
     def generate(self, request: H3Request, output_dir: str | Path):
         import json
 
+        from vllm.model_executor.models.minimax_h3.validation import validate_request
+
         from .metrics import NVMLMonitor
+
+        validate_request(self.config, request)
 
         with self._lock:
             if self._closed:

--- a/vllm/video/gpu.py
+++ b/vllm/video/gpu.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Coordinate H3 with other cooperating V100 jobs before workers allocate memory."""
+
+import fcntl
+import os
+from pathlib import Path
+
+LOCK_ROOT = Path("/tmp")
+
+
+def _available_gpu_groups(tp: int) -> list[tuple[int, ...]]:
+    import pynvml as nvml
+
+    groups = []
+    nvml.nvmlInit()
+    try:
+        for start in (0, 4):
+            indices = tuple(range(start, start + tp))
+            if indices[-1] >= nvml.nvmlDeviceGetCount():
+                continue
+            available = True
+            for index in indices:
+                handle = nvml.nvmlDeviceGetHandleByIndex(index)
+                processes = nvml.nvmlDeviceGetComputeRunningProcesses(handle)
+                # Ignore a small desktop CUDA allocation; never displace jobs.
+                if any(p.usedGpuMemory > 256 * 1024**2 for p in processes):
+                    available = False
+                if nvml.nvmlDeviceGetMemoryInfo(handle).free < 30 * 1024**3:
+                    available = False
+            if available:
+                groups.append(indices)
+        return groups
+    finally:
+        nvml.nvmlShutdown()
+
+
+def select_gpu_group(tp: int) -> tuple[int, ...]:
+    """Read-only capacity probe; launchers should hold acquire_gpu_group instead."""
+    groups = _available_gpu_groups(tp)
+    if groups:
+        return groups[0]
+    raise RuntimeError("Neither configured GPU group has enough free memory")
+
+
+class GPUGroupLease:
+    def __init__(self, gpu_ids: tuple[int, ...]):
+        self.gpu_ids = gpu_ids
+        self._files = []
+        names = [*(f"gpu{i}" for i in gpu_ids), "gpus" + "".join(map(str, gpu_ids))]
+        try:
+            for name in names:
+                file = (LOCK_ROOT / f"1cat-vllm-v100-{name}.lock").open("a+")
+                self._files.append(file)
+                fcntl.flock(file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self):
+        for file in self._files:
+            file.close()
+        self._files.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+def acquire_gpu_group(tp: int) -> GPUGroupLease:
+    for indices in _available_gpu_groups(tp):
+        try:
+            lease = GPUGroupLease(indices)
+        except BlockingIOError:
+            continue
+        try:
+            # Recheck after locking: a capacity probe alone races other loaders.
+            if indices not in _available_gpu_groups(tp):
+                lease.close()
+                continue
+            for file in lease._files:
+                file.seek(0)
+                file.truncate()
+                file.write(f"pid={os.getpid()} task=native-h3 gpus={indices}\n")
+                file.flush()
+            return lease
+        except BaseException:
+            lease.close()
+            raise
+    raise RuntimeError("No free, unleased H3 GPU group; existing jobs remain active")

--- a/vllm/video/media.py
+++ b/vllm/video/media.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Export H3 video and its synchronous 32 kHz audio."""
+
+import subprocess
+from pathlib import Path
+
+import imageio_ffmpeg
+import numpy as np
+import soundfile as sf
+
+
+def export_video(video, audio, output_dir, *, fps=24):
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    # Pipeline video is B,T,H,W,C, audio is B,C,samples.
+    video = video.detach().cpu()
+    audio = audio.detach().float().cpu()
+    if video.ndim != 5 or video.shape[0] != 1 or video.shape[-1] != 3:
+        raise ValueError(f"unexpected H3 video shape {tuple(video.shape)}")
+    if audio.ndim != 3 or audio.shape[0] != 1 or audio.shape[1] not in (1, 2):
+        raise ValueError(f"unexpected H3 audio shape {tuple(audio.shape)}")
+    if not np.isfinite(audio.numpy()).all():
+        raise ValueError("H3 produced non-finite audio")
+    waveform = audio[0].numpy().T
+    wav = root / "audio.wav"
+    sf.write(wav, waveform, 32000, subtype="FLOAT")
+    _, frames, height, width, _ = video.shape
+    output = root / "video.mp4"
+    command = [
+        imageio_ffmpeg.get_ffmpeg_exe(),
+        "-y",
+        "-v",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "-s",
+        f"{width}x{height}",
+        "-r",
+        str(fps),
+        "-i",
+        "pipe:0",
+        "-i",
+        str(wav),
+        "-map",
+        "0:v",
+        "-map",
+        "1:a",
+        "-c:v",
+        "libx264",
+        "-crf",
+        "18",
+        "-preset",
+        "medium",
+        "-pix_fmt",
+        "yuv420p",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "320k",
+        "-movflags",
+        "+faststart",
+        str(output),
+    ]
+    with (root / "encode.log").open("wb") as log:
+        process = subprocess.Popen(command, stdin=subprocess.PIPE, stderr=log)
+        try:
+            assert process.stdin is not None
+            for frame in video[0]:
+                process.stdin.write(frame.contiguous().numpy().tobytes())
+            process.stdin.close()
+            if process.wait() != 0:
+                raise RuntimeError(
+                    f"ffmpeg video export failed; see {root / 'encode.log'}"
+                )
+        except BaseException:
+            process.kill()
+            process.wait()
+            raise
+    return {
+        "video": str(output),
+        "audio": str(wav),
+        "frames": frames,
+        "width": width,
+        "height": height,
+        "fps": fps,
+    }

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -25,8 +25,14 @@ class DenoiseWorkCounter:
         from vllm.model_executor.models.minimax_h3.attention import Attention
 
         self.flops = 0
+        self.calls = 0
         self.by_layer: dict[str, int] = {}
         self.handles = []
+
+        def completed_call(module, inputs, output):
+            self.calls += 1
+
+        self.handles.append(model.register_forward_hook(completed_call))
         for name, module in model.named_modules():
             if isinstance(module, LinearBase):
 

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -83,6 +83,7 @@ class NVMLMonitor:
 
         try:
             nvml.nvmlInit()
+            get_processes = nvml.nvmlDeviceGetComputeRunningProcesses
             handles = [
                 (index, nvml.nvmlDeviceGetHandleByIndex(index))
                 for index in self.gpu_ids
@@ -118,6 +119,13 @@ class NVMLMonitor:
                             "throttle_reasons": lambda handle=handle: (
                                 nvml.nvmlDeviceGetCurrentClocksThrottleReasons(handle)
                             ),
+                            "compute_processes": lambda handle=handle: [
+                                {
+                                    "pid": process.pid,
+                                    "memory_used_bytes": process.usedGpuMemory,
+                                }
+                                for process in get_processes(handle)
+                            ],
                         }
                         for key, query in queries.items():
                             try:

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Useful model work accounting and independent NVML sampling."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import statistics
+import threading
+import time
+from pathlib import Path
+
+
+class DenoiseWorkCounter:
+    """Count actual TP-local matrix shapes, excluding structural padding.
+
+    Hooks apply only to the DiT. Rotation, dequantization, cache preparation,
+    padding and redundant output projections contribute no numerator.
+    """
+
+    def __init__(self, model, *, used_length, video_outputs, audio_outputs):
+        from vllm.model_executor.layers.linear import LinearBase
+        from vllm.model_executor.models.minimax_h3.attention import Attention
+
+        self.flops = 0
+        self.by_layer: dict[str, int] = {}
+        self.handles = []
+        for name, module in model.named_modules():
+            if isinstance(module, LinearBase):
+
+                def linear_hook(layer, inputs, output, name=name):
+                    rows = inputs[0].numel() // inputs[0].shape[-1]
+                    effective = min(rows, used_length)
+                    if name == "final_layer.video_out":
+                        effective = min(rows, video_outputs)
+                    elif name == "final_layer.audio_out":
+                        effective = min(rows, audio_outputs)
+                    n, k = layer.weight.shape
+                    count = 2 * effective * n * k
+                    self.flops += count
+                    self.by_layer[name] = self.by_layer.get(name, 0) + count
+
+                self.handles.append(module.register_forward_hook(linear_hook))
+            elif isinstance(module, Attention):
+
+                def attention_hook(layer, inputs, output, name=name):
+                    q, k, v, metadata = inputs
+                    used = metadata.extra.get("valid_kv_length", q.shape[1])
+                    count = 4 * q.shape[0] * q.shape[2] * used * used * q.shape[3]
+                    self.flops += count
+                    self.by_layer[name] = self.by_layer.get(name, 0) + count
+
+                self.handles.append(module.register_forward_hook(attention_hook))
+
+    def close(self):
+        for handle in self.handles:
+            handle.remove()
+
+
+class NVMLMonitor:
+    def __init__(self, gpu_ids, path, interval=1.0):
+        self.gpu_ids = gpu_ids
+        self.path = Path(path)
+        self.interval = interval
+        self.stop = threading.Event()
+        self.thread = None
+
+    def __enter__(self):
+        self.thread = threading.Thread(target=self._sample, daemon=True)
+        self.thread.start()
+        return self
+
+    def _sample(self):
+        import pynvml as nvml
+
+        try:
+            nvml.nvmlInit()
+            handles = [
+                (index, nvml.nvmlDeviceGetHandleByIndex(index))
+                for index in self.gpu_ids
+            ]
+            with self.path.open("w") as stream:
+                while not self.stop.is_set():
+                    for index, handle in handles:
+                        record = {"timestamp": time.time(), "gpu": index}
+                        queries = {
+                            "memory_used_bytes": lambda handle=handle: (
+                                nvml.nvmlDeviceGetMemoryInfo(handle).used
+                            ),
+                            "gpu_util_percent": lambda handle=handle: (
+                                nvml.nvmlDeviceGetUtilizationRates(handle).gpu
+                            ),
+                            "memory_util_percent": lambda handle=handle: (
+                                nvml.nvmlDeviceGetUtilizationRates(handle).memory
+                            ),
+                            "power_watts": lambda handle=handle: (
+                                nvml.nvmlDeviceGetPowerUsage(handle) / 1000
+                            ),
+                            "sm_clock_mhz": lambda handle=handle: (
+                                nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_SM)
+                            ),
+                            "memory_clock_mhz": lambda handle=handle: (
+                                nvml.nvmlDeviceGetClockInfo(handle, nvml.NVML_CLOCK_MEM)
+                            ),
+                            "temperature_c": lambda handle=handle: (
+                                nvml.nvmlDeviceGetTemperature(
+                                    handle, nvml.NVML_TEMPERATURE_GPU
+                                )
+                            ),
+                            "throttle_reasons": lambda handle=handle: (
+                                nvml.nvmlDeviceGetCurrentClocksThrottleReasons(handle)
+                            ),
+                        }
+                        for key, query in queries.items():
+                            try:
+                                record[key] = query()
+                            except nvml.NVMLError as exc:
+                                record[key] = None
+                                record.setdefault("unavailable", {})[key] = str(exc)
+                        stream.write(json.dumps(record) + "\n")
+                    stream.flush()
+                    self.stop.wait(self.interval)
+        except Exception as exc:
+            self.path.with_suffix(".error.txt").write_text(str(exc))
+        finally:
+            with contextlib.suppress(Exception):
+                nvml.nvmlShutdown()
+
+    def __exit__(self, *_):
+        self.stop.set()
+        if self.thread is not None:
+            self.thread.join(timeout=5)
+
+
+def evaluate_performance(runs):
+    """Evaluate three unprofiled post-warmup runs; never use utilization as FLOPs."""
+    if len(runs) != 3 or any(len(run["ranks"]) != 4 for run in runs):
+        raise ValueError("acceptance requires three four-rank measurements")
+    seconds = [
+        max(rank["stage_seconds"]["denoise"] for rank in run["ranks"]) for run in runs
+    ]
+    if any(not math.isfinite(value) or value <= 0 for value in seconds):
+        raise ValueError("invalid denoise duration")
+    medians = []
+    for rank in range(4):
+        values = [
+            run["ranks"][rank]["useful_denoise_flops"] / duration / 1e12
+            for run, duration in zip(runs, seconds)
+        ]
+        medians.append(statistics.median(values))
+    cv = statistics.pstdev(seconds) / statistics.mean(seconds)
+    return {
+        "rank_median_tflops": medians,
+        "denoise_seconds": seconds,
+        "denoise_cv": cv,
+        "performance_passed": all(value > 80 for value in medians) and cv <= 0.05,
+    }

--- a/vllm/video/quality.py
+++ b/vllm/video/quality.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Deterministic media checks; human video-quality review remains a separate gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import av
+import numpy as np
+from PIL import Image
+
+
+def inspect_video(
+    path,
+    *,
+    expected_frames=243,
+    expected_width=1344,
+    expected_height=768,
+    expected_fps=24,
+):
+    path = Path(path)
+    frame_means = []
+    differences = []
+    black_frames = []
+    previous = None
+    sizes = set()
+    screenshots = []
+    folder = path.parent / "frames"
+    folder.mkdir(exist_ok=True)
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        fps = float(stream.average_rate)
+        for index, frame in enumerate(container.decode(stream)):
+            rgb = frame.to_ndarray(format="rgb24")
+            sizes.add((frame.width, frame.height))
+            sampled = rgb[::8, ::8].astype(np.float32)
+            mean = float(sampled.mean())
+            frame_means.append(mean)
+            if mean < 1 and float(sampled.std()) < 1:
+                black_frames.append(index)
+            if previous is not None:
+                differences.append(float(np.abs(sampled - previous).mean()))
+            previous = sampled
+            if index % (expected_fps * 2) == 0 or index == expected_frames - 1:
+                output = folder / f"frame-{index:04d}.png"
+                Image.fromarray(rgb).save(output)
+                screenshots.append(str(output))
+    samples = 0
+    audio_rates = set()
+    audio_energy = 0.0
+    audio_finite = True
+    with av.open(str(path)) as container:
+        if container.streams.audio:
+            for frame in container.decode(audio=0):
+                array = frame.to_ndarray().astype(np.float64)
+                audio_finite = audio_finite and bool(np.isfinite(array).all())
+                audio_energy += float(np.square(array).sum())
+                samples += frame.samples
+                audio_rates.add(frame.sample_rate)
+    longest_static = current_static = 0
+    for difference in differences:
+        current_static = current_static + 1 if difference < 0.02 else 0
+        longest_static = max(longest_static, current_static)
+    audio_duration = (
+        samples / next(iter(audio_rates)) if len(audio_rates) == 1 else None
+    )
+    checks = {
+        "frame_count": len(frame_means) == expected_frames,
+        "dimensions": sizes == {(expected_width, expected_height)},
+        "fps": abs(fps - expected_fps) < 0.001,
+        "audio_present_finite_nonzero": samples > 0
+        and audio_finite
+        and audio_energy > 0,
+        "audio_duration": audio_duration is not None
+        and abs(audio_duration - expected_frames / expected_fps) < 0.15,
+        "no_black_frames": not black_frames,
+        "no_prolonged_static_run": longest_static < expected_fps,
+    }
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    result = {
+        "checks": checks,
+        "automatic_passed": all(checks.values()),
+        "frames": len(frame_means),
+        "sizes": sorted(sizes),
+        "fps": fps,
+        "audio_duration_seconds": audio_duration,
+        "black_frames": black_frames,
+        "longest_static_run": longest_static,
+        "frame_mean": frame_means,
+        "adjacent_frame_difference": differences,
+        "screenshots": screenshots,
+        "sha256": digest.hexdigest(),
+        "human_review": {
+            "status": "pending",
+            "scores": {
+                key: None
+                for key in (
+                    "prompt_following",
+                    "subject_consistency",
+                    "temporal_continuity",
+                    "detail",
+                    "audio",
+                )
+            },
+        },
+    }
+    (path.parent / "quality.json").write_text(json.dumps(result, indent=2))
+    return result

--- a/vllm/video/server.py
+++ b/vllm/video/server.py
@@ -137,6 +137,11 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
             raise HTTPException(503, "video engine unavailable")
         try:
             request = body.request()
+            from vllm.model_executor.models.minimax_h3.validation import (
+                validate_request,
+            )
+
+            await asyncio.to_thread(validate_request, config, request)
         except ValueError as exc:
             raise HTTPException(422, str(exc)) from exc
         if queue.full():

--- a/vllm/video/server.py
+++ b/vllm/video/server.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""One-partition, serial H3 video job service."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager, suppress
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, PlainTextResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from vllm.model_executor.models.minimax_h3.config import (
+    DEFAULT_PROMPT,
+    H3Config,
+    H3Request,
+    H3SamplingParams,
+)
+
+
+class VideoRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    prompt: str = DEFAULT_PROMPT
+    width: int = 1344
+    height: int = 768
+    num_frames: int = 243
+    duration: float | None = None
+    seed: int = 42
+    num_inference_steps: int = 50
+    image: list[str] = Field(default_factory=list)
+    video: list[str] = Field(default_factory=list)
+    audio: list[str] = Field(default_factory=list)
+    keyframe_indices: list[int] | None = None
+
+    def request(self):
+        extra: dict[str, Any] = {}
+        if self.duration is not None:
+            extra["duration_seconds"] = self.duration
+        if self.keyframe_indices is not None:
+            extra["frame_indices"] = self.keyframe_indices
+        return H3Request(
+            prompt=self.prompt,
+            sampling=H3SamplingParams(
+                width=self.width,
+                height=self.height,
+                num_frames=self.num_frames,
+                seed=self.seed,
+                num_inference_steps=self.num_inference_steps,
+                extra_args=extra,
+            ),
+            media={
+                key: getattr(self, key)
+                for key in ("image", "video", "audio")
+                if getattr(self, key)
+            },
+        )
+
+
+def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None):
+    from .engine import H3Engine
+
+    factory = engine_factory or H3Engine
+    root = Path(output_dir).absolute()
+    jobs: dict[str, dict[str, Any]] = {}
+    queue: asyncio.Queue[tuple[str, H3Request]] = asyncio.Queue(maxsize=32)
+    state: dict[str, Any] = {
+        "engine": None,
+        "ready": False,
+        "completed": 0,
+        "failed": 0,
+    }
+
+    async def process():
+        while True:
+            identity, request = await queue.get()
+            job = jobs[identity]
+            job.update(status="in_progress", started_at=time.time())
+            try:
+                result = await asyncio.to_thread(
+                    state["engine"].generate, request, root / identity
+                )
+                job.update(
+                    status="completed",
+                    completed_at=time.time(),
+                    result=result,
+                    content_url=f"/v1/videos/{identity}/content",
+                )
+                state["completed"] += 1
+            except Exception as exc:
+                job.update(status="failed", error=str(exc), completed_at=time.time())
+                state["failed"] += 1
+                state["ready"] = not state["engine"]._closed
+            finally:
+                queue.task_done()
+
+    @asynccontextmanager
+    async def lifespan(app):
+        root.mkdir(parents=True, exist_ok=True)
+        state["engine"] = await asyncio.to_thread(factory, config)
+        state["ready"] = True
+        task = asyncio.create_task(process())
+        try:
+            yield
+        finally:
+            state["ready"] = False
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            await asyncio.to_thread(state["engine"].close)
+
+    app = FastAPI(title="1Cat H3 video API", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health():
+        if not state["ready"]:
+            raise HTTPException(503, "video engine unavailable")
+        return {"status": "ok", "partition": config.partition}
+
+    @app.get("/metrics", response_class=PlainTextResponse)
+    async def metrics():
+        return (
+            f"onecat_video_ready {int(state['ready'])}\n"
+            f"onecat_video_queue_depth {queue.qsize()}\n"
+            f"onecat_video_completed_total {state['completed']}\n"
+            f"onecat_video_failed_total {state['failed']}\n"
+        )
+
+    @app.post("/v1/videos", status_code=202)
+    async def create_video(body: VideoRequest):
+        if not state["ready"]:
+            raise HTTPException(503, "video engine unavailable")
+        try:
+            request = body.request()
+        except ValueError as exc:
+            raise HTTPException(422, str(exc)) from exc
+        if queue.full():
+            raise HTTPException(429, "video queue is full")
+        identity = "video_" + uuid.uuid4().hex
+        jobs[identity] = {
+            "id": identity,
+            "status": "queued",
+            "created_at": time.time(),
+            "partition": config.partition,
+            "request": asdict(request),
+        }
+        queue.put_nowait((identity, request))
+        return jobs[identity]
+
+    @app.get("/v1/videos/{identity}")
+    async def get_video(identity: str):
+        if identity not in jobs:
+            raise HTTPException(404, "video job not found")
+        return jobs[identity]
+
+    @app.get("/v1/videos/{identity}/content")
+    async def download_video(identity: str):
+        job = await get_video(identity)
+        if job["status"] != "completed":
+            raise HTTPException(409, "video is not completed")
+        return FileResponse(
+            root / identity / "video.mp4",
+            media_type="video/mp4",
+            filename=identity + ".mp4",
+        )
+
+    return app
+
+
+def serve(config, *, host, port, output_dir):
+    import uvicorn
+
+    uvicorn.run(create_app(config, output_dir), host=host, port=port)


### PR DESCRIPTION
## Purpose

Adds native MiniMax H3 checkpoint loading, generation and serial audio/video
serving to 1Cat without a separate vllm-omni runtime. CLI generate/serve share a
TP worker engine and support original BF16 checkpoints and Comfy signed INT8
ConvRot/AdaLN-pruned layouts, using FP16 matrix inputs and FP32-sensitive
intermediates on V100. The user-selected development default is now
FLASH_ATTN_V100; FLASHINFER_SM70 remains an explicit control/rollback.
Text encoding retains its causal Flash-V100 route.

The engine holds per-GPU/group leases until worker shutdown, validates requests
before dispatch, and records GPU compute PIDs. It does not automatically
terminate other jobs. Base: onecat/main@56f534e672657a6c7599afd6c0dcb2e2c211b2e3.
Omni/loader revisions and licenses are retained in the model's UPSTREAM.md.
This native integration has a different scope from upstream Omni; #558 supplies
the independent SM70 operators and #559 the acceptance tools.

## Test Plan

Validate checkpoint packing/sharding, TP4, numerical range, padding, serial API
jobs and media export. Use short 20-update clips for development and reserve the
full 243-frame workload for final quality and formal timing.

## Test Result

- Combined kernel checkout: 73 video-suite tests pass. Ten focused lease/service
  tests pass after changing the native default to FlashAttention-V100.
- Real TP4 text encoding and earlier original-BF16/INT8 FL2VA short generation
  pass their finite/rank checks. New D128 attention's original-weight and
  mixed-reference end-to-end coverage remain pending.

INT8 FL2VA development contract: GPU0-3, TP4 V100-SXM2-32GB, Torch2.10.0+cu128,
CUDA12.8, 1344x768, 39 frames/24FPS, seed42, 21 sigma positions/20 actual
updates, original modality shifts, no LoRA/approximate cache/step skipping,
FP16 weight cache off, and prompt-verified real cached text encoding.

The new FlashAttention-V100 path completes denoise in 77.342982 s (3.867149
s/update), or 44.784329 useful TFLOPS on each rank against the slowest complete
denoise time. The retained FlashInfer control with the same W8A16 preparation
takes 86.200372 s and achieves 40.182583 TFLOPS/card: an 11.4521% throughput
gain. This is one unprofiled development run after a one-call warmup, not the
formal primary warmup/three-run measurement.

Fresh VAE load/decode takes 35.935474/5.650908 s. Automatic media checks pass;
first/last frames show a red paper boat and yellow duck. Full human temporal
and audio review remains pending. Video/audio latent relative L2 differences
versus FlashInfer are 0.107541/0.018019; outputs are not bitwise equal and no
decoder result was reused. DiT-only peak allocation is 6.647851 GiB/card.

Raw evidence is retained in `/data/minimax-h3/native-h3-20260908/flashattention-mainline/`
and `outputs/quality39-int8-flashattn-fused-20steps/FLASH_ATTN_V100/` under the
same artifact root, including video/audio, latents, source/binary hashes,
per-rank CSV, NVML JSONL/plots and profiler data. CONTROL.md records failed paths.

**The 243-frame primary quality, human five-axis review, full backend/partition
matrix, extra seeds, release-wheel validation, and >80 TFLOPS/card acceptance
remain incomplete.**

Rollback: select `--attention-backend FLASHINFER_SM70`, or revert the feature
scope to remove video entrypoints. AI assistance: OpenAI Codex; a human must
review the changes before merge. Keep Draft.
