### PR TITLE
[Kernel] Reuse native H3 attention operands and fuse FP16 MLP preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,7 +762,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" AND SM70_TURBOMIND_ARCHS)
     SOURCES "csrc/sm70_turbomind/ops/h3_w8a16.cu"
     COMPILE_FLAGS ${VLLM_GPU_FLAGS}
     ARCHITECTURES "70"
-    LIBRARIES CUDA::cublas "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+    LIBRARIES CUDA::cublas CUDA::cublasLt "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
     WITH_SOABI)
   define_extension_target(
     _h3_flashinfer_C DESTINATION vllm LANGUAGE CUDA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,16 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" AND SM70_TURBOMIND_ARCHS)
     ARCHITECTURES "70"
     LIBRARIES "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
     WITH_SOABI)
+  define_extension_target(
+    _h3_flashattn_C DESTINATION vllm LANGUAGE CUDA
+    SOURCES "flash-attention-v100/kernel/h3/forward.cu"
+    INCLUDE_DIRECTORIES
+      "${CUTLASS_INCLUDE_DIR}"
+      "${cutlass_SOURCE_DIR}/examples/41_fused_multi_head_attention"
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES "70"
+    LIBRARIES "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+    WITH_SOABI)
 endif()
 
 if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,24 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" AND SM70_TURBOMIND_ARCHS)
     $<$<COMPILE_LANGUAGE:CUDA>:-UNDEBUG;-lineinfo>)
   target_link_libraries(_sm70_sampler_C PRIVATE
     "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
+
+  # Native H3 kernels use ordinary Torch/Python ABI and remain independent of
+  # the existing primary SM70 extension's registrations.
+  define_extension_target(
+    _h3_w8a16_C DESTINATION vllm LANGUAGE CUDA
+    SOURCES "csrc/sm70_turbomind/ops/h3_w8a16.cu"
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES "70"
+    LIBRARIES CUDA::cublas "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+    WITH_SOABI)
+  define_extension_target(
+    _h3_flashinfer_C DESTINATION vllm LANGUAGE CUDA
+    SOURCES "flashinfer-sm70/csrc/h3_noncausal_sm70.cu"
+    INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/flashinfer-sm70/include"
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES "70"
+    LIBRARIES "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+    WITH_SOABI)
 endif()
 
 if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include CMakeLists.txt
 recursive-include cmake *
 recursive-include csrc *
 recursive-include flash_qla *.py *.cu LICENSE
+recursive-include flash-attention-v100/kernel/h3 *.cu *.h *.md

--- a/csrc/sm70_turbomind/ops/h3_column_major_gemm.h
+++ b/csrc/sm70_turbomind/ops/h3_column_major_gemm.h
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#pragma once
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+#include <cublasLt.h>
+
+// Host descriptors only: no persistent weights and no device workspace.
+// The validated Volta algorithm uses FP16 operands and FP32 accumulation,
+// without split-K or intermediate reduced-precision reductions.
+class H3ColumnMajorGemmPlan {
+ public:
+  H3ColumnMajorGemmPlan(int device, int64_t m, int64_t n, int64_t k,
+                        bool output_fp32)
+      : device_(device), m_(m), n_(n), k_(k), output_fp32_(output_fp32) {
+    TORCH_CHECK(
+        m > 0 && n > 0 && k > 0 && m <= INT_MAX && n <= INT_MAX && k <= INT_MAX,
+        "H3 column-major GEMM dimension overflow");
+    const c10::cuda::CUDAGuard guard(device_);
+    const auto* properties = at::cuda::getCurrentDeviceProperties();
+    TORCH_CHECK(properties->major == 7 && properties->minor == 0,
+                "H3 column-major GEMM requires SM70");
+    cudaStreamCaptureStatus capture;
+    C10_CUDA_CHECK(
+        cudaStreamIsCapturing(at::cuda::getCurrentCUDAStream(), &capture));
+    TORCH_CHECK(capture == cudaStreamCaptureStatusNone,
+                "Warm up the H3 GEMM shape before CUDA graph capture");
+    try {
+      check(cublasLtMatmulDescCreate(&desc_, CUBLAS_COMPUTE_32F, CUDA_R_32F));
+      // W is physically column-major [N,K], X.T column-major [K,M].
+      check(cublasLtMatrixLayoutCreate(&weight_, CUDA_R_16F, n, k, n));
+      check(cublasLtMatrixLayoutCreate(&input_, CUDA_R_16F, k, m, k));
+      check(cublasLtMatrixLayoutCreate(
+          &output_, output_fp32 ? CUDA_R_32F : CUDA_R_16F, n, m, n));
+      check(cublasLtMatmulPreferenceCreate(&preference_));
+      size_t workspace_bytes = 0;
+      uint32_t reduction = CUBLASLT_REDUCTION_SCHEME_NONE;
+      check(cublasLtMatmulPreferenceSetAttribute(
+          preference_, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+          &workspace_bytes, sizeof(workspace_bytes)));
+      check(cublasLtMatmulPreferenceSetAttribute(
+          preference_, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, &reduction,
+          sizeof(reduction)));
+      cublasLtMatmulHeuristicResult_t choices[32];
+      int count = 0;
+      auto status = cublasLtMatmulAlgoGetHeuristic(
+          at::cuda::getCurrentCUDABlasLtHandle(), desc_, weight_, input_,
+          output_, output_, preference_, 32, choices, &count);
+      if (status == CUBLAS_STATUS_NOT_SUPPORTED) return;
+      check(status);
+      for (int i = 0; i < count; ++i) {
+        const auto& choice = choices[i];
+        if (choice.state != CUBLAS_STATUS_SUCCESS || choice.workspaceSize)
+          continue;
+        int id = 0, split = 0;
+        uint32_t tile = 0;
+        size_t written = 0;
+        check(cublasLtMatmulAlgoConfigGetAttribute(
+            &choice.algo, CUBLASLT_ALGO_CONFIG_ID, &id, sizeof(id), &written));
+        check(cublasLtMatmulAlgoConfigGetAttribute(
+            &choice.algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &tile, sizeof(tile),
+            &written));
+        check(cublasLtMatmulAlgoConfigGetAttribute(
+            &choice.algo, CUBLASLT_ALGO_CONFIG_SPLITK_NUM, &split,
+            sizeof(split), &written));
+        check(cublasLtMatmulAlgoConfigGetAttribute(
+            &choice.algo, CUBLASLT_ALGO_CONFIG_REDUCTION_SCHEME, &reduction,
+            sizeof(reduction), &written));
+        if (id == 21 && tile == 24 && split == 1 && reduction == 0) {
+          algorithm_ = choice.algo;
+          supported_ = true;
+          break;
+        }
+      }
+    } catch (...) {
+      release();
+      throw;
+    }
+  }
+
+  ~H3ColumnMajorGemmPlan() { release(); }
+  H3ColumnMajorGemmPlan(const H3ColumnMajorGemmPlan&) = delete;
+  H3ColumnMajorGemmPlan& operator=(const H3ColumnMajorGemmPlan&) = delete;
+  bool supported() const { return supported_; }
+
+  torch::Tensor run(torch::Tensor input, torch::Tensor weight) const {
+    TORCH_CHECK(supported_,
+                "No validated zero-workspace H3 cuBLASLt algorithm");
+    TORCH_CHECK(
+        input.is_cuda() && weight.device() == input.device() &&
+            input.get_device() == device_ && input.dim() == 2 &&
+            weight.dim() == 2 && input.is_contiguous() &&
+            input.scalar_type() == torch::kFloat16 &&
+            weight.scalar_type() == torch::kFloat16 && input.size(0) == m_ &&
+            input.size(1) == k_ && weight.size(0) == n_ &&
+            weight.size(1) == k_ && weight.stride(0) == 1 &&
+            weight.stride(1) == n_ &&
+            reinterpret_cast<uintptr_t>(input.data_ptr()) % 16 == 0 &&
+            reinterpret_cast<uintptr_t>(weight.data_ptr()) % 16 == 0,
+        "H3 column-major GEMM requires matching aligned FP16 CUDA matrices");
+    const c10::cuda::CUDAGuard guard(device_);
+    auto out = torch::empty(
+        {m_, n_}, input.options().dtype(output_fp32_ ? torch::kFloat32
+                                                     : torch::kFloat16));
+    float alpha = 1, beta = 0;
+    check(cublasLtMatmul(at::cuda::getCurrentCUDABlasLtHandle(), desc_, &alpha,
+                         weight.data_ptr(), weight_, input.data_ptr(), input_,
+                         &beta, out.data_ptr(), output_, out.data_ptr(),
+                         output_, &algorithm_, nullptr, 0,
+                         at::cuda::getCurrentCUDAStream()));
+    return out;
+  }
+
+ private:
+  static void check(cublasStatus_t status) {
+    TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS,
+                "H3 cuBLASLt failed: ", int(status));
+  }
+  void release() noexcept {
+    if (preference_) cublasLtMatmulPreferenceDestroy(preference_);
+    if (output_) cublasLtMatrixLayoutDestroy(output_);
+    if (input_) cublasLtMatrixLayoutDestroy(input_);
+    if (weight_) cublasLtMatrixLayoutDestroy(weight_);
+    if (desc_) cublasLtMatmulDescDestroy(desc_);
+  }
+  int device_;
+  int64_t m_, n_, k_;
+  bool output_fp32_, supported_ = false;
+  cublasLtMatmulDesc_t desc_{};
+  cublasLtMatrixLayout_t weight_{}, input_{}, output_{};
+  cublasLtMatmulPreference_t preference_{};
+  cublasLtMatmulAlgo_t algorithm_{};
+};

--- a/csrc/sm70_turbomind/ops/h3_w8a16.cu
+++ b/csrc/sm70_turbomind/ops/h3_w8a16.cu
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_fp16.h>
+#include <cublas_v2.h>
+
+namespace {
+__global__ void dequantize_rows(const int8_t* weights, const float* scales,
+                                half* output, int64_t count, int64_t width) {
+  for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
+       i += int64_t(gridDim.x) * blockDim.x) {
+    output[i] = __float2half_rn(float(weights[i]) * scales[i / width]);
+  }
+}
+
+__global__ void convrot256(const half* input, half* output, int64_t groups) {
+  __shared__ float values[256];
+  const int lane = threadIdx.x;
+  for (int64_t group = blockIdx.x; group < groups; group += gridDim.x) {
+    values[lane] = __half2float(input[group * 256 + lane]);
+    __syncthreads();
+#pragma unroll
+    for (int stride = 1; stride <= 64; stride *= 4) {
+      const int digit = (lane / stride) % 4;
+      const int base = lane - digit * stride;
+      float a = values[base], b = values[base + stride];
+      float c = values[base + 2 * stride], d = values[base + 3 * stride];
+      float value = digit == 0   ? a + b + c - d
+                    : digit == 1 ? a + b - c + d
+                    : digit == 2 ? a - b + c + d
+                                 : -a + b + c + d;
+      __syncthreads();
+      values[lane] = value;
+      __syncthreads();
+    }
+    output[group * 256 + lane] = __float2half_rn(values[lane] * (1.f / 16.f));
+    __syncthreads();
+  }
+}
+
+void validate_cuda(const torch::Tensor& value) {
+  TORCH_CHECK(value.is_cuda() && value.is_contiguous(),
+              "H3 requires contiguous CUDA tensors");
+  const auto* p = at::cuda::getDeviceProperties(value.get_device());
+  TORCH_CHECK(p->major == 7 && p->minor == 0,
+              "H3 SM70 operator requires Volta");
+}
+}  // namespace
+
+torch::Tensor h3_dequantize(torch::Tensor weight, torch::Tensor scale) {
+  validate_cuda(weight);
+  validate_cuda(scale);
+  TORCH_CHECK(weight.dim() == 2 && weight.scalar_type() == torch::kInt8,
+              "H3 weight must be a signed INT8 matrix");
+  TORCH_CHECK(scale.scalar_type() == torch::kFloat32 &&
+                  scale.numel() == weight.size(0) &&
+                  scale.device() == weight.device(),
+              "H3 requires same-device FP32 row scales");
+  const c10::cuda::CUDAGuard guard(weight.device());
+  auto output =
+      torch::empty(weight.sizes(), weight.options().dtype(torch::kFloat16));
+  if (weight.numel()) {
+    const int grid = std::min<int64_t>((weight.numel() + 255) / 256, 65535);
+    dequantize_rows<<<grid, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        weight.data_ptr<int8_t>(), scale.data_ptr<float>(),
+        reinterpret_cast<half*>(output.data_ptr<at::Half>()), weight.numel(),
+        weight.size(1));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+torch::Tensor h3_rotate(torch::Tensor input) {
+  validate_cuda(input);
+  TORCH_CHECK(input.scalar_type() == torch::kFloat16 && input.dim() >= 1 &&
+                  input.size(-1) % 256 == 0,
+              "H3 rotation requires FP16 groups of 256");
+  const c10::cuda::CUDAGuard guard(input.device());
+  auto output = torch::empty_like(input);
+  const int64_t groups = input.numel() / 256;
+  if (groups) {
+    convrot256<<<std::min<int64_t>(groups, 65535), 256, 0,
+                 at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+        reinterpret_cast<half*>(output.data_ptr<at::Half>()), groups);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight) {
+  validate_cuda(input);
+  validate_cuda(weight);
+  TORCH_CHECK(input.dim() == 2 && weight.dim() == 2 &&
+                  input.size(1) == weight.size(1) &&
+                  input.device() == weight.device() &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  weight.scalar_type() == torch::kFloat16,
+              "H3 GEMM requires matching FP16 [M,K] and [N,K] matrices");
+  const c10::cuda::CUDAGuard guard(input.device());
+  const int64_t m = input.size(0), n = weight.size(0), k = input.size(1);
+  TORCH_CHECK(m <= INT_MAX && n <= INT_MAX && k <= INT_MAX,
+              "GEMM dimension overflow");
+  auto output = torch::empty({m, n}, input.options());
+  if (!m || !n) return output;
+  // cuBLAS is an existing TurboMind SM70 dispatch option. Explicit 32F compute
+  // prevents reduced-precision accumulation; W8 decode is outside the GEMM.
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  cublasMath_t saved_math;
+  TORCH_CHECK(cublasGetMathMode(handle, &saved_math) == CUBLAS_STATUS_SUCCESS,
+              "cannot read cuBLAS math mode");
+  TORCH_CHECK(
+      cublasSetMathMode(
+          handle, static_cast<cublasMath_t>(
+                      CUBLAS_TENSOR_OP_MATH |
+                      CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION)) ==
+          CUBLAS_STATUS_SUCCESS,
+      "cannot enable FP32 GEMM reductions");
+  float alpha = 1.f, beta = 0.f;
+  auto status = cublasGemmEx(
+      handle, CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, &alpha, weight.data_ptr(),
+      CUDA_R_16F, k, input.data_ptr(), CUDA_R_16F, k, &beta, output.data_ptr(),
+      CUDA_R_16F, n, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+  auto restored = cublasSetMathMode(handle, saved_math);
+  TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS,
+              "H3 FP16 GEMM failed: ", int(status));
+  TORCH_CHECK(restored == CUBLAS_STATUS_SUCCESS,
+              "cannot restore cuBLAS math mode");
+  return output;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("dequantize", &h3_dequantize);
+  m.def("rotate", &h3_rotate);
+  m.def("gemm", &h3_fp16_gemm);
+}

--- a/csrc/sm70_turbomind/ops/h3_w8a16.cu
+++ b/csrc/sm70_turbomind/ops/h3_w8a16.cu
@@ -7,6 +7,8 @@
 #include <cuda_fp16.h>
 #include <cublas_v2.h>
 
+#include "h3_column_major_gemm.h"
+
 namespace {
 __global__ void prepare_fp16_rows(const float* input, half* output,
                                   float* scales, int64_t rows, int width) {
@@ -51,6 +53,15 @@ __global__ void dequantize_rows(const int8_t* weights, const float* scales,
   for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
        i += int64_t(gridDim.x) * blockDim.x) {
     output[i] = __float2half_rn(float(weights[i]) * scales[i / width]);
+  }
+}
+
+// Physical [K,N] storage retains logical [N,K] and output-channel scales.
+__global__ void dequantize_columns(const int8_t* weights, const float* scales,
+                                   half* output, int64_t count, int64_t rows) {
+  for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
+       i += int64_t(gridDim.x) * blockDim.x) {
+    output[i] = __float2half_rn(float(weights[i]) * scales[i % rows]);
   }
 }
 
@@ -136,7 +147,11 @@ std::tuple<torch::Tensor, torch::Tensor> h3_prepare_fp16(torch::Tensor input) {
 }
 
 torch::Tensor h3_dequantize(torch::Tensor weight, torch::Tensor scale) {
-  validate_cuda(weight);
+  TORCH_CHECK(
+      weight.is_cuda() && weight.dim() == 2 &&
+          (weight.is_contiguous() ||
+           (weight.stride(0) == 1 && weight.stride(1) == weight.size(0))),
+      "H3 INT8 weight requires dense row-major or column-major CUDA storage");
   validate_cuda(scale);
   TORCH_CHECK(weight.dim() == 2 && weight.scalar_type() == torch::kInt8,
               "H3 weight must be a signed INT8 matrix");
@@ -145,14 +160,25 @@ torch::Tensor h3_dequantize(torch::Tensor weight, torch::Tensor scale) {
                   scale.device() == weight.device(),
               "H3 requires same-device FP32 row scales");
   const c10::cuda::CUDAGuard guard(weight.device());
-  auto output =
-      torch::empty(weight.sizes(), weight.options().dtype(torch::kFloat16));
+  const bool columns = !weight.is_contiguous();
+  auto output = columns ? torch::empty({weight.size(1), weight.size(0)},
+                                       weight.options().dtype(torch::kFloat16))
+                              .t()
+                        : torch::empty(weight.sizes(),
+                                       weight.options().dtype(torch::kFloat16));
   if (weight.numel()) {
     const int grid = std::min<int64_t>((weight.numel() + 255) / 256, 65535);
-    dequantize_rows<<<grid, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-        weight.data_ptr<int8_t>(), scale.data_ptr<float>(),
-        reinterpret_cast<half*>(output.data_ptr<at::Half>()), weight.numel(),
-        weight.size(1));
+    if (columns) {
+      dequantize_columns<<<grid, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+          weight.data_ptr<int8_t>(), scale.data_ptr<float>(),
+          reinterpret_cast<half*>(output.data_ptr<at::Half>()), weight.numel(),
+          weight.size(0));
+    } else {
+      dequantize_rows<<<grid, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+          weight.data_ptr<int8_t>(), scale.data_ptr<float>(),
+          reinterpret_cast<half*>(output.data_ptr<at::Half>()), weight.numel(),
+          weight.size(1));
+    }
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   return output;
@@ -194,6 +220,7 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight,
       {m, n},
       input.options().dtype(output_fp32 ? torch::kFloat32 : torch::kFloat16));
   if (!m || !n) return output;
+  if (!k) return output.zero_();
   // cuBLAS is an existing TurboMind SM70 dispatch option. Explicit 32F compute
   // prevents reduced-precision accumulation; W8 decode is outside the GEMM.
   auto handle = at::cuda::getCurrentCUDABlasHandle();
@@ -222,6 +249,10 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight,
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  pybind11::class_<H3ColumnMajorGemmPlan>(m, "ColumnMajorGemmPlan")
+      .def(pybind11::init<int, int64_t, int64_t, int64_t, bool>())
+      .def_property_readonly("supported", &H3ColumnMajorGemmPlan::supported)
+      .def("run", &H3ColumnMajorGemmPlan::run);
   m.def("prepare_fp16", &h3_prepare_fp16);
   m.def("dequantize", &h3_dequantize);
   m.def("rotate", &h3_rotate);

--- a/csrc/sm70_turbomind/ops/h3_w8a16.cu
+++ b/csrc/sm70_turbomind/ops/h3_w8a16.cu
@@ -91,7 +91,8 @@ torch::Tensor h3_rotate(torch::Tensor input) {
   return output;
 }
 
-torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight) {
+torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight,
+                           bool output_fp32) {
   validate_cuda(input);
   validate_cuda(weight);
   TORCH_CHECK(input.dim() == 2 && weight.dim() == 2 &&
@@ -104,7 +105,9 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight) {
   const int64_t m = input.size(0), n = weight.size(0), k = input.size(1);
   TORCH_CHECK(m <= INT_MAX && n <= INT_MAX && k <= INT_MAX,
               "GEMM dimension overflow");
-  auto output = torch::empty({m, n}, input.options());
+  auto output = torch::empty(
+      {m, n},
+      input.options().dtype(output_fp32 ? torch::kFloat32 : torch::kFloat16));
   if (!m || !n) return output;
   // cuBLAS is an existing TurboMind SM70 dispatch option. Explicit 32F compute
   // prevents reduced-precision accumulation; W8 decode is outside the GEMM.
@@ -120,10 +123,11 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight) {
           CUBLAS_STATUS_SUCCESS,
       "cannot enable FP32 GEMM reductions");
   float alpha = 1.f, beta = 0.f;
-  auto status = cublasGemmEx(
-      handle, CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, &alpha, weight.data_ptr(),
-      CUDA_R_16F, k, input.data_ptr(), CUDA_R_16F, k, &beta, output.data_ptr(),
-      CUDA_R_16F, n, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+  auto status = cublasGemmEx(handle, CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, &alpha,
+                             weight.data_ptr(), CUDA_R_16F, k, input.data_ptr(),
+                             CUDA_R_16F, k, &beta, output.data_ptr(),
+                             output_fp32 ? CUDA_R_32F : CUDA_R_16F, n,
+                             CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
   auto restored = cublasSetMathMode(handle, saved_math);
   TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS,
               "H3 FP16 GEMM failed: ", int(status));
@@ -135,5 +139,6 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("dequantize", &h3_dequantize);
   m.def("rotate", &h3_rotate);
-  m.def("gemm", &h3_fp16_gemm);
+  m.def("gemm", &h3_fp16_gemm, pybind11::arg("input"), pybind11::arg("weight"),
+        pybind11::arg("output_fp32") = false);
 }

--- a/csrc/sm70_turbomind/ops/h3_w8a16.cu
+++ b/csrc/sm70_turbomind/ops/h3_w8a16.cu
@@ -8,6 +8,44 @@
 #include <cublas_v2.h>
 
 namespace {
+__global__ void prepare_fp16_rows(const float* input, half* output,
+                                  float* scales, int64_t rows, int width) {
+  __shared__ float warp_maxima[8];
+  __shared__ float row_scale;
+  const int tid = threadIdx.x, lane = tid % 32, warp = tid / 32;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    float maximum = 0.f;
+    for (int col = tid; col < width; col += blockDim.x) {
+      float value = fabsf(input[row * width + col]);
+      // Nonfinite inputs remain nonfinite after conversion. Like torch.frexp,
+      // use scale 1 when a row's maximum is nonfinite.
+      maximum = fmaxf(maximum, isnan(value) ? INFINITY : value);
+    }
+#pragma unroll
+    for (int delta = 16; delta; delta /= 2)
+      maximum = fmaxf(maximum, __shfl_down_sync(0xffffffff, maximum, delta));
+    if (lane == 0) warp_maxima[warp] = maximum;
+    __syncthreads();
+    if (warp == 0) {
+      maximum = lane < 8 ? warp_maxima[lane] : 0.f;
+#pragma unroll
+      for (int delta = 16; delta; delta /= 2)
+        maximum = fmaxf(maximum, __shfl_down_sync(0xffffffff, maximum, delta));
+      if (lane == 0) {
+        int exponent = 0;
+        if (isfinite(maximum)) frexpf(maximum, &exponent);
+        row_scale = ldexpf(1.f, max(exponent - 11, 0));
+        scales[row] = row_scale;
+      }
+    }
+    __syncthreads();
+    for (int col = tid; col < width; col += blockDim.x)
+      output[row * width + col] =
+          __float2half_rn(input[row * width + col] / row_scale);
+    __syncthreads();
+  }
+}
+
 __global__ void dequantize_rows(const int8_t* weights, const float* scales,
                                 half* output, int64_t count, int64_t width) {
   for (int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
@@ -16,28 +54,56 @@ __global__ void dequantize_rows(const int8_t* weights, const float* scales,
   }
 }
 
+__device__ __forceinline__ float convrot_butterfly(float a, float b, float c,
+                                                   float d, int digit) {
+  return digit == 0   ? a + b + c - d
+         : digit == 1 ? a + b - c + d
+         : digit == 2 ? a - b + c + d
+                      : -a + b + c + d;
+}
+
 __global__ void convrot256(const half* input, half* output, int64_t groups) {
-  __shared__ float values[256];
-  const int lane = threadIdx.x;
-  for (int64_t group = blockIdx.x; group < groups; group += gridDim.x) {
-    values[lane] = __half2float(input[group * 256 + lane]);
-    __syncthreads();
+  const int lane = threadIdx.x % 32;
+  // Each warp owns a full rotation group, with eight channels per lane.
+  // Keep the checkpoint's radix-four operation order and FP32 intermediates.
+  for (int64_t group =
+           int64_t(blockIdx.x) * (blockDim.x / 32) + threadIdx.x / 32;
+       group < groups; group += int64_t(gridDim.x) * (blockDim.x / 32)) {
+    float values[8], next[8];
 #pragma unroll
-    for (int stride = 1; stride <= 64; stride *= 4) {
+    for (int i = 0; i < 8; ++i)
+      values[i] = __half2float(input[group * 256 + lane + 32 * i]);
+#pragma unroll
+    for (int stride = 1; stride <= 4; stride *= 4) {
       const int digit = (lane / stride) % 4;
       const int base = lane - digit * stride;
-      float a = values[base], b = values[base + stride];
-      float c = values[base + 2 * stride], d = values[base + 3 * stride];
-      float value = digit == 0   ? a + b + c - d
-                    : digit == 1 ? a + b - c + d
-                    : digit == 2 ? a - b + c + d
-                                 : -a + b + c + d;
-      __syncthreads();
-      values[lane] = value;
-      __syncthreads();
+#pragma unroll
+      for (int i = 0; i < 8; ++i) {
+        float a = __shfl_sync(0xffffffff, values[i], base);
+        float b = __shfl_sync(0xffffffff, values[i], base + stride);
+        float c = __shfl_sync(0xffffffff, values[i], base + 2 * stride);
+        float d = __shfl_sync(0xffffffff, values[i], base + 3 * stride);
+        values[i] = convrot_butterfly(a, b, c, d, digit);
+      }
     }
-    output[group * 256 + lane] = __float2half_rn(values[lane] * (1.f / 16.f));
-    __syncthreads();
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int even = i & ~1, base = lane % 16;
+      const int digit = lane / 16 + 2 * (i % 2);
+      float a = __shfl_sync(0xffffffff, values[even], base);
+      float b = __shfl_sync(0xffffffff, values[even], base + 16);
+      float c = __shfl_sync(0xffffffff, values[even + 1], base);
+      float d = __shfl_sync(0xffffffff, values[even + 1], base + 16);
+      next[i] = convrot_butterfly(a, b, c, d, digit);
+    }
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int base = i % 2;
+      float value = convrot_butterfly(next[base], next[base + 2],
+                                      next[base + 4], next[base + 6], i / 2);
+      output[group * 256 + lane + 32 * i] =
+          __float2half_rn(value * (1.f / 16.f));
+    }
   }
 }
 
@@ -49,6 +115,25 @@ void validate_cuda(const torch::Tensor& value) {
               "H3 SM70 operator requires Volta");
 }
 }  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> h3_prepare_fp16(torch::Tensor input) {
+  validate_cuda(input);
+  TORCH_CHECK(input.dim() == 2 && input.scalar_type() == torch::kFloat32 &&
+                  input.size(1) > 0 && input.size(1) <= INT_MAX,
+              "H3 FP16 preparation requires a FP32 matrix with nonempty rows");
+  const c10::cuda::CUDAGuard guard(input.device());
+  auto output =
+      torch::empty(input.sizes(), input.options().dtype(torch::kFloat16));
+  auto scales = torch::empty({input.size(0), 1}, input.options());
+  if (input.size(0)) {
+    prepare_fp16_rows<<<std::min<int64_t>(input.size(0), 65535), 256, 0,
+                        at::cuda::getCurrentCUDAStream()>>>(
+        input.data_ptr<float>(), reinterpret_cast<half*>(output.data_ptr()),
+        scales.data_ptr<float>(), input.size(0), input.size(1));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return {output, scales};
+}
 
 torch::Tensor h3_dequantize(torch::Tensor weight, torch::Tensor scale) {
   validate_cuda(weight);
@@ -82,7 +167,7 @@ torch::Tensor h3_rotate(torch::Tensor input) {
   auto output = torch::empty_like(input);
   const int64_t groups = input.numel() / 256;
   if (groups) {
-    convrot256<<<std::min<int64_t>(groups, 65535), 256, 0,
+    convrot256<<<std::min<int64_t>((groups + 3) / 4, 65535), 128, 0,
                  at::cuda::getCurrentCUDAStream()>>>(
         reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
         reinterpret_cast<half*>(output.data_ptr<at::Half>()), groups);
@@ -137,6 +222,7 @@ torch::Tensor h3_fp16_gemm(torch::Tensor input, torch::Tensor weight,
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("prepare_fp16", &h3_prepare_fp16);
   m.def("dequantize", &h3_dequantize);
   m.def("rotate", &h3_rotate);
   m.def("gemm", &h3_fp16_gemm, pybind11::arg("input"), pybind11::arg("weight"),

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -472,3 +472,41 @@ Evidence: `transpose-candidates-warm.json`, `cooperative-long-results.json`,
 `cooperative-cmake-build.log`, `profiles/flashinfer-cooperative-short.*`, and
 `outputs/quality39-int8-cooperative-20steps/`. The prior accepted prefetch
 binary is retained as `flashinfer-prefetch-baseline.so`.
+
+## FlashInfer mainline: conversion and ConvRot follow-up
+
+The retained W8A16 change replaces block-wide ConvRot256 shared-memory
+butterflies with warp shuffles and register permutations. FP32 intermediates,
+radix-four addition order and the final FP16 rounding stay intact. A separate
+CUDA operator fuses FP32 row maximum, exact power-of-two scaling and FP16
+conversion before GEMM. CPU reference behavior remains available.
+
+On a synthetic `[12323,7168]` matrix, ConvRot decreases from 1.054720 to
+0.571392 ms and FP16 preparation from 2.870272 to 1.302528 ms. Both conversions
+and row scales are bitwise equal to their controls. These operator results
+are distinct from the real H3 layer dimensions and model timing below.
+
+The final W8A16 binary SHA256 is
+`c7eb5d619eb6a3a5e260acae04f17e7f88a172649717ad26478a5a9d6d6e9a1b`.
+The FlashInfer attention binary stays at the cooperative-prefetch revision
+above. The same 39-frame/20-update INT8 TP4 request completes denoise in
+86.200372 s (4.310019 s/update), or 40.182583 useful TFLOPS on each rank.
+Video/audio latents are bitwise equal to the previous result; decoder reuse
+is explicitly recorded. This single short run is still below the primary
+>80 TFLOPS/card gate. DiT-only peak remains 6.647851 GiB.
+
+Validation: 58 video tests pass, plus the subsequently added nonfinite-input
+test passes separately. CUDA12.8 memcheck, racecheck and synccheck each pass
+the eleven new rotation/scaling cases, including grid-stride boundaries.
+The standard CMake W8A16 component builds. Evidence is under
+`feeding-round2/` and `outputs/quality39-int8-fusedprep-20steps/`.
+
+Rejected attention controls at D128/N12323: expanding BK to 64 spills
+registers and takes 58.25 ms; limiting unrolling lowers that to 38.63 ms but
+still loses to the 34.99 ms baseline. BK32 without unrolling takes 40.46 ms.
+Halving BQ to 64 gives 41.07 ms (BK32) or 45.72 ms (BK64). Explicit P-fragment
+reuse gives no improvement; skipping unit output rescaling gives only about
+1% and is not retained. CUTLASS FMHA controls take about 30 ms, with different
+rounding, and are not installed or counted as FlashInfer results. An asymmetric
+QK/PV CUTLASS control compiles but remains unmeasured after the user's ComfyUI
+audit request. Preserve these controls rather than repeat them unchanged.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -510,3 +510,33 @@ reuse gives no improvement; skipping unit output rescaling gives only about
 rounding, and are not installed or counted as FlashInfer results. An asymmetric
 QK/PV CUTLASS control compiles but remains unmeasured after the user's ComfyUI
 audit request. Preserve these controls rather than repeat them unchanged.
+
+## Recovered ComfyUI V100 source audit
+
+The user identified unmounted local disks as the likely source location.
+Read-only inspection recovered a ComfyUI/Raylight tree containing
+`flash-attention-v100-1cat-0.0.5`. Its dense source SHA256 is
+`82e4a09dda874034bf0ca76482d670fe22676315e9143232f63c742dc475683f`.
+The recovered D128 route uses Q32/K176, 512 threads and WMMA. CUDA12.8 emits
+64 registers/thread with spills. The original files remain unmodified.
+
+An unaligned 65-token request hangs: a block barrier is inside a conditional
+that excludes invalid query-row threads. Padding Q alone avoids that hang
+but still produces NaNs with 65 valid K/V tokens. Do not use this recovered
+kernel directly for H3's unaligned lengths or infer quality from its timing.
+
+Fully aligned controls isolate the old kernel's performance. At B1/H14/D128,
+noncausal FP16 N12320, current FlashInfer takes 34.900993 ms versus recovered
+ComfyUI's 67.394562 ms; at N73568, 1224.818726 versus 2334.326904 ms. All
+outputs are finite and sampled-row FP32 references pass. Three alternating
+measurements after warmup observed 1530 MHz throughout. These aligned lengths
+differ from H3's actual 12323/73483 and are only operator controls. Their
+effective attention rates are approximately 31.2/31.7 TFLOPS for FlashInfer
+versus 16.1/16.6 for recovered ComfyUI, not full-model acceptance figures.
+
+The old Raylight documentation's large cold/hot speedup includes worker/model
+startup. Its archived logs also show PyTorch/xformers routes, while LTX TP
+can call ComfyUI's selected attention directly. A workflow's FLASH_ATTN label
+alone is insufficient route evidence. The audit does not justify replacing
+the current H3 FlashInfer mainline. Source snapshots, licenses, reproduction
+scripts, failures and results are retained in `comfy-audit/`.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -2,11 +2,66 @@
 
 Status: implementation in progress; no video quality or 80 TFLOPS acceptance yet.
 
-Current decision: the user selects FlashInfer-SM70 as the H3 denoiser mainline.
-Optimize complete denoise toward >80 useful TFLOPS on every participating GPU;
-keep Flash-V100 as an explicit control. Development uses 39-frame clips and
-20 actual updates for quality. The historical 60-TFLOPS D256/GQA Flash-V100
-architecture was audited, but its H3 adaptation is not the selected mainline.
+Current decision: the user selects FlashAttention-V100 as the H3 development
+mainline, superseding the earlier FlashInfer choice. Optimize complete denoise
+toward >80 useful TFLOPS on every participating GPU; keep FlashInfer as the
+measured control/rollback. Development uses 39-frame clips and 20 actual
+updates for quality. Preserve D128 MHA and its original scale when reusing
+the existing D256 TensorOp architecture; padding never increases useful FLOPs.
+
+## 2026-09-08 FlashAttention-V100 D128 native route
+
+The new `_h3_flashattn_C` extension selects a dedicated CUTLASS SM70 fused
+kernel under `FLASH_ATTN_V100`. Its QK tile is 64x64 and PV tile is 64x128;
+all 128 output channels remain in FP32 registers across online-softmax updates.
+It uses 128 threads, 232 registers without spills in the initial build, and
+26,128 bytes of shared memory. Each MHA head is independent. There is no D256
+head padding, global square score allocation, or FlashInfer delegation.
+The wrapper supports masked query/key tails, storage-offset/strided inputs and
+stream-local metadata. Provenance and BSD notices are in
+`flash-attention-v100/kernel/h3/UPSTREAM.md`. Standard CMake, setuptools and
+the source-only extension helper include the new operator.
+
+The existing v37 QK/PV implementation was separately adapted to D128 with
+FP32 scale and masked KV padding. At actual H3 N12323 it passes the sampled
+FP32 reference and takes 34.279 ms against a 34.993 ms FlashInfer control.
+The serial bounded-score prototype is slower than the fused path and is not
+installed. Fused Q32/K64 and Q128/K64 candidates also pass numerical checks
+but are slower than Q64/K64 in their respective matched comparisons.
+
+An unprofiled GPU0 B1/H14/D128 comparison at actual valid H3 lengths measures:
+
+| Tokens | New Flash-V100 | FlashInfer control | Generic Flash-V100 |
+| --- | ---: | ---: | ---: |
+| 12323 | 26.185728 ms | 35.336193 ms | 61.659138 ms |
+| 73483 | 942.884888 ms | 1229.690918 ms | 2245.138428 ms |
+
+Both lengths pass spread-out FP32 query references and whole-output finiteness.
+These are operator measurements, not full-denoise acceptance. Clocks were
+recorded, not locked: at the long length new Flash-V100 observed 1455-1462 MHz
+and the controls 1530 MHz. Useful operator throughput is 41.57/41.05 TFLOPS;
+the requested 80 TFLOPS/card model gate remains pending.
+
+Validation: 73 video-suite tests passed on the initial JIT binary, including
+14 new cases for tail masking, independent batches, rescaling, strided/offset
+storage, native dispatch, graph replay and rejected inputs. The final standard
+CMake binary SHA256 is
+`84a41632bbc8e99459a938b90ca5981ded5600f336ce72b1e10e294613bc986a`.
+Eight independent offset/tail/rescaling cases pass CUDA12.8 memcheck,
+racecheck and synccheck with zero reported errors/hazards and
+`CUDA_MODULE_LOADING=EAGER`. The broader pytest sanitizer harness reports
+`cuKernelGetFunction` error 400 despite passing numerical assertions; the
+instrumented graph/API issue remains open. It is not suppressed or counted
+as a clean all-tests sanitizer result. A temporary diagnostic named `profile.py`
+also shadowed Python's standard library; it was renamed `profile_native.py`.
+No production Python dependency was changed to address that harness error.
+
+Raw artifacts: `/data/minimax-h3/native-h3-20260908/flashattention-mainline/`.
+They include all prototype sources/build logs, `bench-results.json`, GPU
+ownership records, tests and sanitizer logs. The first ordinary-user NCU
+attempt lacked GPU counter permission; it produced no counters. Complete
+short-denoise measurements and the privileged profile are recorded below
+when completed. Use `FLASHINFER_SM70` as the measured rollback path.
 
 ## Fixed scope
 

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -385,3 +385,49 @@ Evidence: `profile_h3_steps.py`, `run_profile_h3_steps.py`,
 `profiles/h3-flashinfer-step-breakdown.json`, `query-owned-results.json`, and
 `flashv100-60t-route-audit.md`. GPU 0–3 priority preemption is authorized; the
 active development lease is recorded in `flashinfer-development-lease.json`.
+
+### FlashInfer V-layout and K/V-prefetch checkpoint
+
+Retained the 128x32 register-softmax layout and moved V into column-major
+shared storage for PV. Vectorized loads fetch the next K/V tile while the
+current PV tile computes; the next iteration joins before consuming it.
+Contiguous storage-offset views retain a scalar load path when their K/V
+pointers are not 16-byte aligned. The launch remains 512 threads, 128
+registers/thread, with no register spills.
+
+After warmup, three ABBA groups at each shape give these prototype operator
+medians (padding excluded from useful FLOPs):
+
+| Length | Previous kernel | Prefetch candidate |
+| --- | ---: | ---: |
+| 12323 | 53.202433 ms | 38.789122 ms |
+| 73483 | 1859.025452 ms | 1354.961914 ms |
+
+The final source also handles unaligned storage and passes all 47 video tests.
+CUDA 12.8 Compute Sanitizer memcheck and synccheck each pass all six new tail
+and unaligned-view cases with zero errors. The system sanitizer was incomplete
+and could not find its injection library; the verified CUDA 12.8 redistributable
+was used instead. The ordinary CMake H3 FlashInfer target builds successfully.
+
+The final binary SHA256 is
+`67d542efaaf9bf3fa4e360bfe4c32e9537832a239d0d12b5488460cf9bf464c1`.
+With this binary, the same seed-42/39-frame/20-update cached-text INT8 request
+completes denoise in 90.880784 s, versus 105.642574 s before: 4.544039 s/update
+and 38.113157 useful TFLOPS per rank. Both video and audio latents are bitwise
+identical to the earlier register-softmax result. Automatic export checks pass;
+the MP4 SHA256 is also identical:
+`db77e1ab34999a1727b962edc77d42780b203c4cd23a835e6e05540956c6a078`.
+DiT-only peak allocation remains 6.647851 GiB/rank. This is one short diagnostic,
+not primary quality or the three-run >80 TFLOPS qualification.
+
+Matched-shape NCU reports tensor-pipe activity rising from 16.976% to 22.950%,
+and long-scoreboard stalls falling from 28.329% to 0.531%. Shared load conflicts
+fall from 1.208 billion to 0.671 billion, while shared store conflicts rise to
+1.105 billion. The next experiment targets the transpose stores; no further
+speedup is assumed. NCU durations/counters remain separate from formal timing.
+
+Evidence: `prefetch-long-results.json`, `prefetch-final-tests.log`,
+`prefetch-memcheck-12.8.log`, `prefetch-synccheck.log`,
+`prefetch-cmake-build.log`, `profiles/flashinfer-prefetch-short.*`, and
+`outputs/quality39-int8-prefetch-20steps/`. The previous binary is retained as
+`flashinfer-register-baseline.so` for exact rollback/AB comparison.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -63,6 +63,55 @@ attempt lacked GPU counter permission; it produced no counters. Complete
 short-denoise measurements and the privileged profile are recorded below
 when completed. Use `FLASHINFER_SM70` as the measured rollback path.
 
+### Complete short-denoise and counter evidence
+
+GPU0-3 INT8 FL2VA, 1344x768, 39 frames, seed42 and 20 actual updates completes
+in **77.342982236 s** (3.867149112 s/update). Each rank performs
+3,463,753,579,661,312 useful FLOPs and achieves **44.784329224 TFLOPS** against
+the slowest rank's complete denoise time. The same retained W8A16 binary and
+cache-off settings were used; the prior FlashInfer checkpoint took 86.200372206 s
+and achieved 40.182582639 TFLOPS. The throughput gain is 11.4521%. This is one
+unprofiled development measurement after a one-call warmup, with cached,
+prompt-verified real text encoding; it is not the formal primary three-run gate.
+DiT peak allocation is 6.647851467 GiB/card, not whole-pipeline memory acceptance.
+
+The VAE was freshly loaded and decoded this candidate: load 35.935474 s,
+decode 5.650908 s. All automatic media checks pass. The 39-frame MP4 SHA256 is
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+First/last frames show one red paper boat and one yellow duck; complete temporal
+and audio review remains pending. Compared with FlashInfer, final video/audio
+latents have relative L2 differences 0.107541/0.018019. They are not bitwise equal,
+so no decode reuse or final quality equivalence is claimed.
+
+The privileged NCU run records the actual `h3_flash_v100_d128` kernel:
+Tensor pipe active 34.64%, 232 registers/thread, 26,128 bytes shared and maximum
+active-warps fraction 12.5%. Long/short-scoreboard stalls are 15.43%/12.91%.
+The profile used `--clock-control none` and is excluded from timing. Register
+pressure and memory-latency hiding remain concrete optimization targets;
+these counter percentages do not establish full-model throughput. NVML during
+denoise reports mean GPU utilization above 99% but only 44.78 useful TFLOPS/card.
+
+A post-profile register-limit probe requested three resident CTAs. It reduced
+registers from 232 to 168 but introduced a 232-byte stack with 260/356 bytes of
+spill stores/loads. Outputs remain bitwise equal to the new FlashAttention
+control, but the exact N12323 operator slows from 26.385 to 47.712 ms. It is
+rejected and retained as `reg3.cu`, `reg3-build.log` and `reg3-results.json`.
+Do not repeat a register-cap-only change as an occupancy optimization.
+
+The first two short-run launch attempts found another H3 task's GPU0-3 lease;
+no timing/model run started. That independently owned FlashInfer task completed
+before the FlashAttention run acquired the group. Its source and result were
+not used as this change's matched baseline. No other job was terminated.
+The initial privileged NCU wrapper hit Linux's protected `/tmp` lock-file
+policy; the working wrapper holds the GPU lease as the user and elevates only
+the profiling child. No global driver or power settings were changed.
+
+Artifacts: `flashattention-mainline/report.json`, `native-ncu-summary.json`,
+`native-ncu-privileged.ncu-rep`, `quality3.log`, and
+`outputs/quality39-int8-flashattn-fused-20steps/FLASH_ATTN_V100/` under the task
+artifact root. The output directory includes regenerated video/audio, latents,
+rank/phase CSV, NVML JSONL and plots. **80 TFLOPS/card remains unmet.**
+
 ## Fixed scope
 
 - Base: onecat/main 56f534e672657a6c7599afd6c0dcb2e2c211b2e3.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,89 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Attention-focused diagnosis and V prefetch: 69.06 seconds
+
+The user redirects the next optimization to GEMM/attention arithmetic and data
+movement, with **60 useful TFLOPS for D128 attention** as the next operator
+milestone. Preserve the under-50-second complete-denoise and >80 TFLOPS/card
+model targets; none of these targets has passed.
+
+A fresh two-update trace of the 69.92-second native baseline records 2.515795 s
+of GEMM service (94.413296 useful TFLOPS) and 2.580667 s of attention service
+(42.179368 useful TFLOPS) on the critical rank. These are service rates, not
+complete-model throughput. The actual B1/N12323/H14/D128 noncausal attention
+call has 1,088,506,166,272 useful FLOPs; 60 TFLOPS requires 18.141769 ms.
+
+NCU on the same baseline binary finds 234 registers/thread, 26,128 shared
+bytes/block, two resident blocks and 12.5% occupancy. Tensor pipe activity is
+36.99%; HBM throughput is only 1.51%, while the L1/shared data path reaches
+61.64%. SASS-correlated samples identify long-scoreboard consumers at the
+QK/V shared stores after global loads, and short-scoreboard consumers at QK
+HMMA instructions. This supports addressing operand movement and latency
+hiding *inside* attention. It does not establish an HBM bandwidth limit.
+
+The retained change loads the first V fragment before softmax and passes it
+to a small adaptation of the existing SM70 PV software pipeline. Residual
+masks, FP16 rounding, FP32 accumulation and math order are unchanged. It keeps
+234 registers without spills, the same shared footprint and zero persistent
+FP16 cache / zero Lt workspace. The native helper's paired operator median
+is 24.522753 versus 25.702400 ms (44.387601 versus 42.350370 TFLOPS); clocks
+vary, so this is a development microbenchmark, not formal model acceptance.
+
+The new binary's independent NCU run reduces long-scoreboard stalls per
+issued instruction from 0.646730 to 0.342021. Tensor pipe activity rises from
+36.99% to 37.91%; short-scoreboard stalls remain. Do not interpret that stall
+ratio change as an equivalent wall-time reduction. Remaining work should
+address QK's shared-load/HMMA dependencies and input reuse.
+
+The installed CMake build completes the unchanged 39-frame/20-update TP4
+workload in **69.062335 s**, or 3.453117 s/update and 50.154018 useful
+TFLOPS/card: a 1.23% reduction from 69.923404 s. All ranks retain exactly
+6.647851467 GiB peak Torch allocation. Video/audio latents are bitwise equal;
+reuse of the baseline decode is explicit, with MP4 SHA256
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+Automatic media checks inherit the identical baseline output; human scoring
+is pending. The artifact prototype's 68.980006 s is a separate build/run.
+Neither timing is end-to-end or the formal three-run 243-frame acceptance.
+
+Eighteen native GPU tests pass, including newly added 32/33/96/97-key residual
+boundaries, strided storage, poisoned padding, online rescaling and graph
+replay. The standard CMake FlashAttention component builds. Binary SHA256 is
+`540474cfad758d4328ad0e0f00c745be62d3d8caaebea1d4bc19b86354442b9f`.
+
+CUDA12.8 isolated memcheck, racecheck and synccheck each pass thirteen cases
+with zero errors/hazards. Full pytest under memcheck completed its seventeen
+selected tests but reported a CUDA `cuKernelGetFunction` invalid-handle API
+error during module loading, as in the earlier full-environment diagnostic.
+Retain that failed log; the isolated run loads the exact installed extension
+without importing the full vLLM runtime. Ordinary GPU graph replay is covered
+by pytest; the isolated sanitizer harness does not test graph capture.
+
+Rejected or paused probes, all outside production source:
+
+| Probe | Paired candidate / control | Decision |
+| --- | --- | --- |
+| Manual QK shared fill | 44.529663 / 24.239103 ms | Exact but slower; retain original pipeline |
+| QK internal K64 stage | 25.759745 / 25.328640 ms | Exact, no improvement |
+| PV internal K64 stage | 26.507263 / 24.967169 ms | Exact, slower |
+| QK first-tile persistence / next-K prefetch | 25.236481 / 25.414656 ms | Only 0.7%, registers 234 to 254; not retained |
+| Q64/K128 with a 32x64 QK warp | NaN at length 63 | Rejected; grouped version spills, direct indexing removes spills but does not fix numerics |
+
+The wider QK path needs its accumulator/shared-memory mapping and boundary
+behavior fixed before any timing can be admitted. Its split-32 conversion
+attempt also fails length 63; do not repeat these variants unchanged. Earlier
+Q128/K32 wide-PV variants corrupt the length-one output; their direct-store
+workaround spills and slows down. Manual PV fill and larger Q/K tiles remain
+rejected in the retained artifact records.
+
+Evidence is under `flashattention-warp50/`: `report.json`,
+`attention60-root-cause.json`, `native-steps.nsys-rep`, both NCU reports and
+SASS-correlated samples, candidate source/build logs, native tests and quality
+commands. Media, rank/phase CSVs and NVML curves are under
+`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
+Rollback is the kernel parent `8cacbb70219c` plus a rebuild of
+`_h3_flashattn_C`; keep the existing column-major INT8 path.
+
 ### Low-memory follow-up: 69.92 seconds, under-50 target incomplete
 
 The user requires no substantial memory increase. Keep the persistent FP16

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,89 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Feeding diagnosis and exact QK/RoPE fusion follow-up
+
+The current development target is **under 50 seconds for 20 actual updates**
+at the unchanged 1344x768, 39-frame, seed42, INT8 ConvRot, TP4 GPU0-3 workload,
+with output quality retained. The primary 243-frame >80 TFLOPS/card acceptance
+is separate and remains incomplete.
+
+Before QK/RoPE fusion, a four-rank Nsight Systems trace of the first two updates
+from the unchanged 20-update schedule gives the following exclusive GPU wall
+breakdown. The traced intervals include synchronized denoise boundaries; they
+are profiling evidence, not unprofiled acceptance timing.
+
+| Rank | Wall | Attention | GEMM | TP transfer + waiting | Other GPU work | No GPU activity |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0 | 7.744 s | 2.795 s | 2.716 s | 1.058 s | 1.125 s | 0.049 s |
+| 1 | 7.744 s | 2.612 s | 2.651 s | 1.332 s | 1.108 s | 0.041 s |
+| 2 | 7.744 s | 2.645 s | 2.641 s | 1.275 s | 1.128 s | 0.053 s |
+| 3 | 7.744 s | 2.641 s | 2.655 s | 1.268 s | 1.131 s | 0.049 s |
+
+Other GPU work includes normalization, conversion, ConvRot, INT8 decode and
+copies. Rank0 performs 108,850,886,402,048 attention FLOPs and
+237,524,454,107,136 linear FLOPs in these two updates. GEMM service throughput
+is 87.46 TFLOPS and attention service throughput is 38.94 TFLOPS; neither is
+complete-denoise throughput. Less than 1% is unoccupied GPU time. INT8 weight
+decode is only 0.063 s, so weight caching and host launch optimization are not
+the first targets. Faster ranks spend longer in NCCL: kernel duration includes
+waiting for rank0 and must not all be attributed to network transfer.
+
+With every other traced cost held constant, making attention take zero time
+would yield only 69.99 TFLOPS for this short shape. This is an Amdahl illustration,
+not a hardware limit or achieved result. The long primary shape has a different
+compute/communication balance. NCCL auto versus forced Simple at real FP32
+payloads gives approximately 5.44 ms for 264,993,792 bytes and 31 ms for
+1,580,178,432 bytes; forcing the protocol is not promoted.
+
+The retained fix fuses Q/K RMSNorm and 96-of-128-channel RoPE into two Triton
+launches, replacing 32 PyTorch kernels per DiT attention block. Normalization
+and both rotary products retain the reference FP16 rounding boundaries; FP32
+arithmetic fusion is disabled. Unsupported shapes and autograd keep the
+reference path. On N12323/H14, paired Q/K preparation drops from 3.44 ms to
+0.30 ms, with bitwise-equal outputs at normal and high input amplitudes.
+
+An unprofiled complete 20-update run now takes **74.411058897 s**, or
+**3.720552945 s/update** and **46.548908603 useful TFLOPS/card**. The prior
+77.342982236 s control uses the same attention/W8A16 binaries, prompt, seed,
+weights and cache-off settings. The speedup is 3.94%; this is one development
+measurement with a one-call warmup, not the formal three-run gate. DiT peak
+allocation remains 6.647851467 GiB/card. Both final video/audio latents are
+bitwise equal to the control. Fresh VAE decoding produces the identical MP4
+SHA256 `17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+Automatic media checks pass; human audiovisual quality review is still pending.
+
+Validation: 24 targeted tests pass, including 10 QK/RoPE cases for real length,
+strided projection views, FP32 weights, high-range/zero inputs, rotary tails,
+reference fallback and changed-input CUDA Graph replay. Three isolated
+offset/tail cases pass CUDA12.8 memcheck, racecheck and synccheck. The first
+model launcher failed during NCCL initialization with CUDA_MODULE_LOADING=EAGER,
+before model inference. The successful model run uses the prior LAZY mode;
+that single failure does not establish EAGER as its cause.
+
+Rejected attention probes, each against an interleaved unchanged control:
+direct fixed-D128 dispatch 27.189 vs 26.739 ms (209 registers); Q32/K128
+30.757 vs 27.088 ms (198 registers); Q64/K128 30.810 vs 26.655 ms
+(190 registers); warp-reduced max 27.237 vs 26.797 ms. All passed sampled
+FP32 references; none is installed. Lower register count alone did not improve
+throughput. Preserve these results instead of repeating unchanged tile sweeps.
+
+Artifacts: `/data/minimax-h3/native-h3-20260908/flashattention-feeding-round2/`,
+including `denoise-steps.nsys-rep`, its SQLite export, `breakdown.csv`,
+`module-kernels.json`, `rootcause.json`, `denoise-breakdown.png`, prototype
+sources/build logs, tests and sanitizers. The new media and NVML/phase reports
+are under `outputs/quality39-int8-flashattn-rope-20steps/FLASH_ATTN_V100/`.
+Reproduce the retained change with `run_rope_quality.py`; source and environment
+are recorded in the task handoff. Roll back only QK/RoPE fusion by using
+`qk_norm_rope_reference` at its dispatch point; attention and weights remain fixed.
+
+GPU0-3 jobs were preempted under the user's explicit priority authorization.
+One subsequent cleanup mistakenly targeted a GPU4-7 audit process before
+checking its GPU UUID. This was outside that scope. The incident and recovery
+are recorded in `preemption-followup.json`: the original supervisor relaunched
+the same audit configuration with an independent recovery output label.
+Always verify physical GPU UUIDs and process environment before any signal.
+
 The new `_h3_flashattn_C` extension selects a dedicated CUTLASS SM70 fused
 kernel under `FLASH_ATTN_V100`. Its QK tile is 64x64 and PV tile is 64x128;
 all 128 output channels remain in FP32 registers across online-softmax updates.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,78 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Low-memory follow-up: 69.92 seconds, under-50 target incomplete
+
+The user requires no substantial memory increase. Keep the persistent FP16
+weight cache at zero; the development guard allows at most 1 GiB/card above
+the prior 6.647851467 GiB denoise allocation peak. This allowance is a working
+interpretation of the memory request, not a new user-specified numeric limit.
+
+Two exact changes are now implemented:
+
+- Specialize the softmax bounds check once per complete 64-key tile. The tail
+  still uses valid-key masking; FP32 accumulation and exp2f are unchanged.
+- Repack DiT INT8 weights into column-major physical storage during loading.
+  Logical [N,K] coordinates, signed codes, channel scales and ConvRot remain
+  unchanged. Per-call FP16 decode keeps this layout. A bounded host descriptor
+  cache selects cuBLASLt algorithm 21 / tile 24 / split 1 / reduction 0 with
+  **zero device workspace**. Missing plans fall back to the original row-major
+  GEMM. No persistent FP16 cache is required. Roll back the layout and GEMM with
+  `--int8-weight-layout row`.
+
+| Fixed 39-frame / 20-update workload | Prior QK/RoPE baseline | Native low-memory route |
+| --- | ---: | ---: |
+| Complete synchronized denoise | 74.411059 s | 69.923404 s |
+| Seconds / actual update | 3.720553 | 3.496170 |
+| Effective useful TFLOPS / each rank | 46.548909 | 49.536398 |
+| Peak allocated / each rank | 6.647851 GiB | 6.647851 GiB |
+| Persistent FP16 cache / each rank | 0 | 0 |
+
+The native route reduces denoise time by 6.03%; **50 seconds is not achieved**.
+Video and audio latents are bitwise equal to the baseline, as are decoded
+PCM samples and the MP4 (SHA256
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`).
+A WAV container can differ while its PCM is identical. All automatic media
+checks pass; five-axis human scoring remains pending. Driver-reported peak
+used memory is 8.583496 GiB/card, which includes allocations outside Torch's
+allocator. NVML busy percentage is diagnostic and is not Tensor Core FLOPS.
+
+This is one unprofiled complete run after a one-invocation warmup, with cached
+prompt-verified text. It is not end-to-end timing or the primary 243-frame,
+three-measurement >80 TFLOPS/card acceptance. An artifact prototype measured
+69.868952 s with the same zero-cache policy; do not combine different builds
+into the formal three-run statistic.
+
+Validation: 86 targeted GPU/CPU tests pass, including all signed INT8 codes,
+scale/offset tails, all four padded-M12352 TP4 projections, forced fallback,
+layout idempotence and CUDA Graph replay. Isolated CUDA12.8 memcheck, racecheck
+and synccheck pass with zero errors/hazards for the new decode and Lt path.
+The standard CMake W8A16 and FlashAttention components build successfully.
+
+Evidence: `flashattention-lowmem50/report.json`, `production-binaries.json`,
+`production-quality-job.json` and
+`outputs/quality39-int8-flashattn-lowmem-native-20steps/FLASH_ATTN_V100/`.
+GPU logs are in the serialized queue's `flashattention-under50/` directory.
+
+Preserve failed or unselected experiments rather than repeat them unchanged:
+
+- A 9.63-GB/card FP16 cache plus Lt measured 69.456427 s; it fails the latest
+  memory policy and is not the forward configuration.
+- Alternative cuBLAS row-layout algorithms and larger CUTLASS GEMM tiles were
+  slower; some algorithm IDs also failed exact FP16-output checks.
+- Row-layout GEMM/TP overlap improved standalone row projections only modestly
+  and changed FP32 reduction rounding; it is not enabled.
+- Q32/K64 attention measured 28.025 ms versus 27.575 ms control. A persistent
+  shared-Q prototype measured 24.784 versus 25.083 ms with clock variation;
+  this does not establish a useful complete-model gain. Neither is enabled.
+- Head-major and sequence-padding copies add storage traffic with no clear
+  benefit. Approximate exp2 variants add no clear gain over the exact full-tile
+  specialization and are not enabled.
+
+Attention and serialized TP transfers remain the main opportunities alongside
+GEMM. The prior trace shows less than 1% GPU idle time; allocating more weight
+cache or only reducing Python launches cannot supply the remaining 19.9 seconds.
+
 ### Feeding diagnosis and exact QK/RoPE fusion follow-up
 
 The current development target is **under 50 seconds for 20 actual updates**

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -431,3 +431,44 @@ Evidence: `prefetch-long-results.json`, `prefetch-final-tests.log`,
 `prefetch-cmake-build.log`, `profiles/flashinfer-prefetch-short.*`, and
 `outputs/quality39-int8-prefetch-20steps/`. The previous binary is retained as
 `flashinfer-register-baseline.so` for exact rollback/AB comparison.
+
+### Selected cooperative V transpose
+
+The selected follow-up reuses the consumed probability tile as temporary
+row-major V storage, synchronizes, and writes the column-major V tile
+cooperatively. This removes the direct strided-store pattern without changing
+floating-point arithmetic. The final binary SHA256 is
+`339ceba5f296faba8c4a13a0ebed7788a5f2f795ab39d7a5c6c3d3353dbb0186`;
+compilation uses 127 registers/thread and reports no spills.
+
+At 12323 tokens with observed SM clocks at 1530 MHz throughout the timed
+comparison, medians are 38.209343 ms for direct prefetch stores, 34.983711 ms
+for cooperative transpose and 35.778271 ms for an additional XOR-swizzle
+candidate. Outputs are bitwise equal; reject the slower extra-swizzle variant.
+An earlier warmed long-shape bracket at 73483 tokens gives 1334.623779 versus
+1223.218689 ms for direct versus cooperative stores. These remain isolated
+operator results and are not used as model acceptance figures.
+
+The same complete 20-update INT8 short request takes 87.824099 s
+(4.391205 s/update), giving 39.439671 useful TFLOPS on every rank. Both final
+latent tensors are bitwise equal to the prior validated video/audio tensors.
+The diagnostic therefore reuses the unchanged decoder's prior output only
+after verifying both equalities and the MP4 hash. Its explicit mode is
+`short_clip_denoise_quality_with_reused_decode`; no fresh VAE or end-to-end
+service timing is claimed. The original register-softmax baseline was
+105.642574 s and 32.787478 TFLOPS/rank. The >80 gate remains unmet.
+
+All 47 video tests pass with the final binary. CUDA12.8 memcheck, racecheck and
+synccheck each pass all six tail/unaligned cases, with zero errors/hazards.
+The standard CMake component build passes. Final matched-shape NCU measures
+25.091% tensor-pipe activity, 0.580% long-scoreboard stalls, 0.872 billion
+shared-load conflicts and 0.101 billion shared-store conflicts. The remaining
+25% theoretical active-warp limit, shared-load stalls and matrix scheduling
+need further attention; the previous full-step trace also records nontrivial
+TP communication. Hardware counters are not full-model TFLOPS.
+
+Evidence: `transpose-candidates-warm.json`, `cooperative-long-results.json`,
+`cooperative-final-tests.log`, `cooperative-{memcheck,racecheck,synccheck}.log`,
+`cooperative-cmake-build.log`, `profiles/flashinfer-cooperative-short.*`, and
+`outputs/quality39-int8-cooperative-20steps/`. The prior accepted prefetch
+binary is retained as `flashinfer-prefetch-baseline.so`.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -193,3 +193,40 @@ Evidence under `/data/minimax-h3/native-h3-20260908/`:
 `original-checkpoint-manifest.json`, `comfy-checkpoint-manifest.json`,
 `profiles/flashv100-attention.summary.json`, and
 `profiles/w8a16-fp32-output.summary.json`.
+
+### Independent FlashInfer register accumulation
+
+The selected SM70 kernel keeps QK scores, online-softmax reductions and PV
+accumulators in registers. Only cross-warp row partials and probabilities use
+shared memory. A 128-query by 32-key tile uses 512 threads and 64 KiB shared
+memory. The explicit backend continues to execute its own Volta WMMA kernel.
+
+- Full FP32 checks at 17, 243, 1025 and 8192 tokens passed. Spread-out query
+  checks at 12323 and 73483 tokens passed without a square attention matrix.
+  Added regression coverage for batch indexing, 127/128/129 query boundaries,
+  short-video token count and changing softmax maxima across key tiles.
+- The final formatted implementation passes all 38 native video tests on GPU 0.
+- At 12323 tokens (39-frame canvas), candidate median attention time was
+  53.220 ms versus 61.108 ms for Flash-V100. At 73483 tokens the same isolated
+  comparison was 1.857 seconds versus 2.246 seconds. No full long video was run.
+- Cached-text TP4 INT8 denoise at 1344x768, 39 frames, seed 42 and three sigma
+  positions (two forwards), after a one-forward warmup: Flash-V100 11.29494 s,
+  FlashInfer candidate 10.55566 s. Each rank counted 346375340509184 useful
+  FLOPs, giving 30.6664 and 32.8142 useful TFLOPS respectively. All four ranks
+  matched bitwise within each backend and all latents were finite.
+  This is development timing, not the full-schedule >80 TFLOPS acceptance.
+- Rejected candidates: 128x64 requested too many launch resources; 32x64 was
+  slower; keeping only PV in registers was slower than also reducing softmax
+  in registers. Their code/binary and raw measurements remain in artifacts,
+  while the public extension retains only the selected implementation.
+- The first cached-text diagnostic attempted to export the raw BCTHW VAE
+  tensor. Its script omitted the pipeline's output conversion to BTHWC RGB8.
+  The native pipeline already performs that conversion; correct the diagnostic
+  and save latents before export to avoid repeating denoise on export failures.
+
+Artifacts: `attention-short-candidates.json`, `flashinfer-tested-candidates.cu`,
+`flashinfer-tested-candidates.so`, `flashinfer-register-formatted-build.log`,
+`kernel-register-native-tests.log`, `denoise-short-int8.log` and
+`outputs/dev39-int8/{FLASH_ATTN_V100,FLASHINFER_SM70}/` under the task artifact
+directory. Those output directories contain timing and NVML curves; the initial
+export failed and must not be presented as generated-video quality evidence.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -75,6 +75,10 @@ Preserve failed or unselected experiments rather than repeat them unchanged:
 - Q32/K64 attention measured 28.025 ms versus 27.575 ms control. A persistent
   shared-Q prototype measured 24.784 versus 25.083 ms with clock variation;
   this does not establish a useful complete-model gain. Neither is enabled.
+- Manually staging the full PV value tile took 87.811 versus 23.785 ms;
+  128-bit vector loads/stores reduced this to 31.587 versus 24.302 ms, still
+  slower. Both matched control values but are rejected; retain these prototypes
+  in `flashattention-lowmem50/attention-failed-paths.json`.
 - Head-major and sequence-padding copies add storage traffic with no clear
   benefit. Approximate exp2 variants add no clear gain over the exact full-tile
   specialization and are not enabled.

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,95 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Wide QK reuse and fused MLP preparation: 62.80 seconds
+
+The retained native implementation completes the unchanged 1344x768,
+39-frame/24-FPS, seed42, INT8 ConvRot FL2VA, TP4 GPU0-3 workload in
+**62.804019 s for 20 actual updates** (21 sigma positions), or
+**3.140201 s/update and 55.151783 useful model TFLOPS/card**. This is 9.06%
+less time than 69.062335 s. Peak denoise Torch allocation falls from
+6.647851467 to **6.566735744 GiB/card**; NVML peak device-used memory is
+8.419433594 GiB/card. Persistent FP16 cache and Lt workspace remain zero.
+This is one unprofiled development measurement after a one-call warmup with
+prompt-verified cached text, not end-to-end or formal repeated acceptance.
+
+Two changes address arithmetic operand reuse and intermediate data movement:
+
+- Q64/K128 uses four 32x64 QK warps, reusing each Q fragment across twice as
+  many keys. Direct batch/head indexing removes grouped pointer metadata and
+  register pressure. Softmax distributes rows by actual `WarpCount::kCount`.
+  The previous wide-QK failure incorrectly inferred eight warps from tile
+  area despite launching four, leaving rows 32..63 unnormalized. This fixes
+  the length-63 NaNs; the prior mapping-only diagnosis below is superseded.
+  Two original 32x32 accumulator subfragments retain the probability store
+  layout. Large sequences select K128; small refiners retain K64. The N12323,
+  H14 specialization and V-load/softmax overlap use 246 registers/thread,
+  34,304 shared bytes/block and no spills. There is no extra global workspace.
+- INT8 MLPs fuse FP32 SiLU/product evaluation with power-of-two FP16 input
+  preparation, avoiding the large FP32 intermediate write/read. A model-local
+  row-parallel subclass accepts the explicit scale, preserves module/FLOP
+  hooks and restores scale in FP32 before the ordinary TP sum. Releasing the
+  gate/up buffer before projection avoids retaining an extra allocation.
+  CPU, unquantized and FP32-input MLPs use the previous implementation.
+
+The installed native attention's independently loaded, paired control is
+**25.572351 ->20.110336 ms**, or **42.565744 ->54.126701 useful TFLOPS** at
+B1/N12323/H14/D128. The earlier 19.772415 ms /55.051756 TFLOPS artifact
+prototype is a separate build/run. A corrected Q128/K128 prototype passes
+numerics but only improves 20.046848 ->19.749887 ms against the new native
+path (1.48%); it is not enabled or treated as a full-model gain. The wider-M
+64x32 warp spills 40 bytes in each direction and is slower, so it is rejected.
+
+Quality provenance matters: changing K64 to K128 changes FP32 online reduction
+and FP16 probability rounding. The native attention-only run (64.284648 s)
+was freshly decoded; relative RMS changes against the previous video/audio
+latents are 10.5741% /1.8484%. All automatic media checks pass. Eight sampled
+frames show one red paper boat and one yellow duck, stable scene/color/count
+and no obvious geometric corruption; this is not a full audiovisual score.
+The subsequent SiLU fusion run (62.852804 s) and final buffer-release run
+(62.804019 s) are both bitwise equal to the attention-only latents, so their
+decode reuse is explicit. MP4 SHA256 is
+`97b9196c49a8e1bf61cb8368f4db7d7013e99bc107650945dbe92b4b59b0184a`.
+Human five-axis review remains pending; do not claim quality accepted.
+
+Validation: 103 targeted attention/activation/INT8/numerics tests pass. New
+coverage includes both key tiles, half-warp row boundaries, the CUDA grid-y
+limit, hot-shape graph replay with changed values, fused activation scaling
+and scale restoration before reduction. Long N73483 uses sampled FP32 rows,
+never a full square reference allocation. K64 is bitwise equal to the frozen
+V-prefetch primitive on all 16 checked lengths. Isolated CUDA12.8 memcheck,
+racecheck and synccheck each pass 25 attention cases without errors/hazards;
+graph replay is covered by ordinary pytest, not isolated sanitizer capture.
+The previous full-runtime sanitizer loader issue remains documented below.
+
+Two initial native control probes loaded both extensions under the same Python
+module name, causing import caching to reuse the candidate as control. Their
+timings and apparent bitwise failure are invalid. `native-verified-results.json`
+uses distinct qualified module names and checks both function schemas before
+comparison. Preserve the invalid logs; do not reuse them as evidence.
+
+Evidence: `flashattention-qk50/` contains source prototypes, exact job JSON,
+build/test/sanitizer logs, `report.json`, `REPORT.md`, `failed-paths.json`,
+NVML curves and the sampled contact sheet. Final media and raw rank/NVML data:
+`outputs/quality39-int8-flashattn-native-wide-silu-release-20steps/FLASH_ATTN_V100/`.
+The measured attention binary is
+`98b2e902208fae496b03ee5d66e9718931ccf056b4ae8d65eeb16d168c18f8a4`.
+After repository formatting, the rebuilt binary is
+`bdb3dcf0eea8c23f992536182a06d26f7b61c7bb6ddefa4b3c88590b81ad0005`;
+its entire cuobjdump SASS output is byte-for-byte identical to the measured
+binary (`formatted-build-comparison.json`). No new denoise timing is inferred
+from the rebuild.
+Rollback the combined change to kernel parent `f825756607db` and rebuild the
+FlashAttention extension; `key_tile=64` is also available for primitive
+numerical comparison. The existing `--int8-weight-layout row` independently
+rolls back the column-major GEMM path.
+
+**The under-50-second, attention-60-TFLOPS, formal per-card-80-TFLOPS and human
+quality gates remain incomplete.** Next work should continue the measured
+attention operand-reuse/shared-load/HMMA focus. Do not inflate useful FLOPs
+with padding, rotations or dequantization, or use NVML's 100% median GPU
+utilization as a Tensor Core saturation claim.
+
 ### Attention-focused diagnosis and V prefetch: 69.06 seconds
 
 The user redirects the next optimization to GEMM/attention arithmetic and data
@@ -77,11 +166,11 @@ Rejected or paused probes, all outside production source:
 | QK internal K64 stage | 25.759745 / 25.328640 ms | Exact, no improvement |
 | PV internal K64 stage | 26.507263 / 24.967169 ms | Exact, slower |
 | QK first-tile persistence / next-K prefetch | 25.236481 / 25.414656 ms | Only 0.7%, registers 234 to 254; not retained |
-| Q64/K128 with a 32x64 QK warp | NaN at length 63 | Rejected; grouped version spills, direct indexing removes spills but does not fix numerics |
+| Q64/K128 with a 32x64 QK warp | NaN at length 63 in the earlier probe | Superseded by the actual-warp-count fix above |
 
-The wider QK path needs its accumulator/shared-memory mapping and boundary
-behavior fixed before any timing can be admitted. Its split-32 conversion
-attempt also fails length 63; do not repeat these variants unchanged. Earlier
+At this earlier checkpoint, split-32 conversion still failed length 63.
+The newer investigation above identifies and fixes the separate softmax warp-count
+error; do not repeat the original variants unchanged. Earlier
 Q128/K32 wide-PV variants corrupt the length-one output; their direct-store
 workaround spills and slows down. Manual PV fill and larger Q/K tiles remain
 rejected in the retained artifact records.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -82,6 +82,14 @@ fixed layer list. Cached weights retain ConvRot coordinates. Cache/staging
 preparation is separately timed; dequantization remains inside denoise timing
 for uncached weights. Both original INT8 tensors and FP32 scales are retained.
 
+`--int8-weight-layout column` is the default for DiT INT8 projections. Loading
+reorders physical INT8 storage without changing logical weights or scales.
+Each invocation decodes transient FP16 weights and selects the validated SM70
+cuBLASLt plan with FP32 accumulation and zero workspace. This does not create
+a persistent FP16 cache. Unsupported plans use the original GEMM; warm up a
+shape before CUDA graph capture. Use `--int8-weight-layout row` to restore the
+original weight layout and GEMM route. Original BF16 checkpoints are unaffected.
+
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
 `nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
 replace the five-axis human quality review. Useful TFLOPS use actual local

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -90,6 +90,13 @@ a persistent FP16 cache. Unsupported plans use the original GEMM; warm up a
 shape before CUDA graph capture. Use `--int8-weight-layout row` to restore the
 original weight layout and GEMM route. Original BF16 checkpoints are unaffected.
 
+For INT8 MLPs, the native path combines FP32 SiLU/product evaluation and
+power-of-two FP16 input preparation in one kernel. The following projection
+restores the scale in FP32 before the normal TP reduction. This removes the
+large FP32 activation intermediate without lowering arithmetic precision or
+adding a persistent cache. CPU, unquantized and FP32-input paths keep their
+existing implementation.
+
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
 `nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
 replace the five-axis human quality review. Useful TFLOPS use actual local

--- a/flash-attention-v100/kernel/h3/UPSTREAM.md
+++ b/flash-attention-v100/kernel/h3/UPSTREAM.md
@@ -13,6 +13,14 @@ at revision `da5e086dab31d63815acafdac9a9c5893b1c69e2` (v4.4.2). Both retain
 their BSD-3-Clause notices. Unmodified helper headers are build dependencies
 from the same pinned CUTLASS source already fetched by 1Cat CMake.
 
+`prefetch_mma.h` adapts the SM70 PV main loop from that revision's
+`gemm/mma_from_smem.h`, retaining its BSD-3-Clause notice. It accepts the
+first V fragment loaded before softmax and keeps the remaining CUTLASS
+software pipeline and accumulation order. The first fragment uses the same
+residual mask as the original prologue, including 32-key V tile boundaries.
+Register allocation remains 234/thread without spills; shared memory stays
+26,128 bytes/block. There is no extra persistent device allocation.
+
 The adaptation separates the QK and PV tile widths. All 128 output channels
 remain in FP32 registers while each iteration consumes 64 keys. Rescaling the
 output uses the PV accumulator's lane/row mapping; reusing the QK mapping

--- a/flash-attention-v100/kernel/h3/UPSTREAM.md
+++ b/flash-attention-v100/kernel/h3/UPSTREAM.md
@@ -1,0 +1,27 @@
+# H3 D128 non-causal FlashAttention-V100
+
+This inference path uses SM70 CUTLASS TensorOp QK/PV with FP32 accumulation,
+online max/sum and output state. Each MHA head is a separate grouped problem;
+there is no GQA head packing, D256 padding or global square probability matrix.
+The QK tile is 64 x 64 and the PV tile is 64 x 128. The original D128 scale
+is passed in FP32. This is an independent FlashAttention-V100 operator and
+does not call the FlashInfer backend.
+
+`default_fmha.h` and `fmha.h` derive from NVIDIA CUTLASS
+`examples/41_fused_multi_head_attention/{default_fmha_grouped.h,fmha_grouped.h}`
+at revision `da5e086dab31d63815acafdac9a9c5893b1c69e2` (v4.4.2). Both retain
+their BSD-3-Clause notices. Unmodified helper headers are build dependencies
+from the same pinned CUTLASS source already fetched by 1Cat CMake.
+
+The adaptation separates the QK and PV tile widths. All 128 output channels
+remain in FP32 registers while each iteration consumes 64 keys. Rescaling the
+output uses the PV accumulator's lane/row mapping; reusing the QK mapping
+would corrupt the second half of the output. Query/key tails are predicated.
+The wrapper creates batch/head pointers on the active stream, supports graph
+replay, and copies an unaligned or strided input only when necessary.
+
+The existing v37 D256/GQA implementation inspired the large TensorOp route
+investigation. This fused operator is derived from CUTLASS FMHA, not a direct
+port of the v37 prefix/causal-tail dispatcher. Historical D256 throughput
+does not establish H3 performance. The separate v37-derived D128 experiment
+and its result are retained in the H3 migration control record.

--- a/flash-attention-v100/kernel/h3/UPSTREAM.md
+++ b/flash-attention-v100/kernel/h3/UPSTREAM.md
@@ -1,9 +1,9 @@
 # H3 D128 non-causal FlashAttention-V100
 
 This inference path uses SM70 CUTLASS TensorOp QK/PV with FP32 accumulation,
-online max/sum and output state. Each MHA head is a separate grouped problem;
+online max/sum and output state. Each MHA head has its own grid coordinate;
 there is no GQA head packing, D256 padding or global square probability matrix.
-The QK tile is 64 x 64 and the PV tile is 64 x 128. The original D128 scale
+The QK tile is 64 x 64 or 64 x 128 and the PV tile is 64 x 128. The original D128 scale
 is passed in FP32. This is an independent FlashAttention-V100 operator and
 does not call the FlashInfer backend.
 
@@ -18,15 +18,25 @@ from the same pinned CUTLASS source already fetched by 1Cat CMake.
 first V fragment loaded before softmax and keeps the remaining CUTLASS
 software pipeline and accumulation order. The first fragment uses the same
 residual mask as the original prologue, including 32-key V tile boundaries.
-Register allocation remains 234/thread without spills; shared memory stays
-26,128 bytes/block. There is no extra persistent device allocation.
+The large-key path uses four 32x64 QK warps. Softmax row distribution uses
+the actual warp count, rather than inferring eight warps from the tile area;
+the latter leaves rows 32..63 unnormalized and caused the old length-63 NaNs.
+Two original 32x32 accumulator subfragments preserve CUTLASS's probability
+store layout. The compiled N12323/H14 specialization uses 246 registers/thread
+without spills and 34,304 shared bytes/block. The generic K128 variant uses
+255 registers; K64 uses 210. There is no extra persistent device allocation.
 
 The adaptation separates the QK and PV tile widths. All 128 output channels
-remain in FP32 registers while each iteration consumes 64 keys. Rescaling the
+remain in FP32 registers while each iteration consumes 64 or 128 keys. Rescaling the
 output uses the PV accumulator's lane/row mapping; reusing the QK mapping
 would corrupt the second half of the output. Query/key tails are predicated.
-The wrapper creates batch/head pointers on the active stream, supports graph
-replay, and copies an unaligned or strided input only when necessary.
+The kernel computes batch/head offsets directly, avoiding grouped metadata
+allocation. The wrapper supports graph replay and copies an unaligned or
+strided input only when necessary. Auto dispatch selects 128 keys when both
+sequence lengths are at least 1024, otherwise 64; the extension's optional
+`key_tile=64` argument retains a primitive control path. Larger key tiles
+change online reduction and FP16 probability rounding, so their model outputs
+require a fresh quality check. They are not claimed bitwise equal to K64.
 
 The existing v37 D256/GQA implementation inspired the large TensorOp route
 investigation. This fused operator is derived from CUTLASS FMHA, not a direct

--- a/flash-attention-v100/kernel/h3/default_fmha.h
+++ b/flash-attention-v100/kernel/h3/default_fmha.h
@@ -1,0 +1,254 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+    \brief
+      Default kernel-level GEMM definitions combine threadblock-scoped matrix
+   multiply-add with the appropriate threadblock-scoped epilogue.
+
+      Note, CUTLASS epilogues universally target row-major outputs. Column-major
+   outputs are accommodated by exchanging A and B operands and assuming
+   transposed layouts. Partial specializations here choose
+   'device::GemmTransposed' to implement this functionality.
+
+*/
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+
+#include "cutlass/complex.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/numeric_types.h"
+
+#include "fmha.h"
+#include "gemm_kernel_utils.h"
+#include "gemm/custom_mma.h"
+#include "gemm/find_default_mma.h"
+#include "gemm/mma_from_smem.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass {
+namespace gemm {
+namespace kernel {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+    // The datatype of Q/K/V
+    typename scalar_t_,
+    // Architecture we are targeting (eg `cutlass::arch::Sm80`)
+    typename ArchTag_,
+    // If Q/K/V are correctly aligned in memory and we can run a fast kernel
+    bool isAligned_, int kQueriesPerBlock, int kKeysPerBlock,
+    int kMaxK = (int)cutlass::platform::numeric_limits<uint32_t>::max(),
+    GroupScheduleMode GroupScheduleMode_ = GroupScheduleMode::kDeviceOnly>
+struct H3FMHA {
+  using scalar_t = scalar_t_;
+  using accum_t = float;
+  using output_t = scalar_t;
+
+  // Accumulator between 2 iterations
+  // Using `accum_t` improves perf on f16 at the cost of
+  // numerical errors
+  using output_accum_t = accum_t;
+
+  using ArchTag = ArchTag_;
+  static bool const kIsAligned = isAligned_;
+  static bool const kSingleValueIteration = kMaxK <= 128;
+  static constexpr bool kIsHalf = cutlass::sizeof_bits<scalar_t>::value == 16;
+  static int const kWarpSize = 32;
+  static int const kNumWarpsPerBlock =
+      kQueriesPerBlock * kKeysPerBlock / (kWarpSize * kWarpSize);
+
+  struct MM0 {
+    /*
+      In this first matmul, we compute a block of `Q @ K.T`.
+      While the calculation result is still hot in registers, we update
+      `mi`, `m_prime`, `s_prime` in shared-memory, and then store this value
+      into a shared-memory ("AccumulatorSharedStorage") that is used later as
+      operand A for the second matmul (see MM1)
+    */
+
+    using GemmType = gemm_kernel_utils::DefaultGemmType<ArchTag, scalar_t>;
+    using OpClass = typename GemmType::OpClass;
+
+    using ElementA = scalar_t;
+    using ElementB = scalar_t;
+    using ElementC = scalar_t;
+    using ElementAccumulator = accum_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    using DefaultConfig =
+        typename cutlass::gemm::device::DefaultGemmConfiguration<
+            OpClass, ArchTag, ElementA, ElementB, ElementC, ElementAccumulator>;
+
+    static int const kAlignmentA =
+        kIsAligned ? DefaultConfig::kAlignmentA : GemmType::kMinimumAlignment;
+    static int const kAlignmentB =
+        kIsAligned ? DefaultConfig::kAlignmentB : GemmType::kMinimumAlignment;
+
+    using ThreadblockShape =
+        cutlass::gemm::GemmShape<kQueriesPerBlock, kKeysPerBlock,
+                                 GemmType::ThreadK>;
+    using WarpShape = cutlass::gemm::GemmShape<32, 32, GemmType::WarpK>;
+    using InstructionShape = typename GemmType::InstructionShape;
+
+    static int const kStages = DefaultConfig::kStages;
+    using Operator = typename GemmType::Operator;
+
+    using DefaultMma = typename cutlass::gemm::threadblock::FindDefaultMma<
+        ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB,
+        ElementAccumulator, LayoutC, OpClass, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape,
+        ArchTag::kMinComputeCapability >= 80 && kIsHalf
+            ? 4
+            : DefaultConfig::kStages,
+        Operator>::DefaultMma;
+
+    using MmaCore = typename DefaultMma::MmaCore;
+    using IteratorA = typename DefaultMma::IteratorA;
+    using IteratorB = typename DefaultMma::IteratorB;
+    using DefaultThreadblockMma = typename DefaultMma::ThreadblockMma;
+    using Mma = typename cutlass::platform::conditional<
+        kSingleValueIteration,
+        typename MakeCustomMma<DefaultThreadblockMma, kMaxK>::Mma,
+        DefaultThreadblockMma>::type;
+    using AccumLambdaIterator = typename DefaultMmaAccumLambdaIterator<
+        typename Mma::Operator::IteratorC, ElementAccumulator,
+        kWarpSize>::Iterator;
+
+    static_assert(MmaCore::WarpCount::kCount == kNumWarpsPerBlock, "");
+
+    // Epilogue to store to shared-memory in a format that we can use later for
+    // the second matmul
+    using B2bGemm = typename cutlass::gemm::threadblock::B2bGemm<
+        typename Mma::Operator::IteratorC, typename Mma::Operator, scalar_t,
+        WarpShape, ThreadblockShape>;
+    using AccumulatorSharedStorage = typename B2bGemm::AccumulatorSharedStorage;
+  };
+
+  struct MM1 {
+    /*
+      Second matmul: perform `attn @ V` where `attn` is the attention (not
+      normalized) and stored in shared memory
+    */
+
+    using GemmType = typename MM0::GemmType;
+    using OpClass = typename GemmType::OpClass;
+
+    using ElementA = scalar_t;
+    using ElementB = scalar_t;
+    using ElementC = output_accum_t;
+    using ElementAccumulator = accum_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    using DefaultConfig =
+        typename cutlass::gemm::device::DefaultGemmConfiguration<
+            OpClass, ArchTag, ElementA, ElementB, ElementC, ElementAccumulator>;
+
+    static int const kAlignmentA = DefaultConfig::kAlignmentA;
+    static int const kAlignmentB =
+        kIsAligned ? DefaultConfig::kAlignmentB : GemmType::kMinimumAlignment;
+
+    using ThreadblockShape =
+        cutlass::gemm::GemmShape<kQueriesPerBlock, 128, GemmType::ThreadK>;
+    using WarpShape = cutlass::gemm::GemmShape<32, 64, GemmType::WarpK>;
+    using InstructionShape = typename MM0::InstructionShape;
+
+    using EpilogueOutputOp = typename DefaultConfig::EpilogueOutputOp;
+
+    static int const kStages = DefaultConfig::kStages;
+    using Operator = typename GemmType::Operator;
+
+    using ThreadblockSwizzle = void;  // Swizzling is unused
+    static bool const kSplitKSerial = false;
+
+    using DefaultGemm = cutlass::gemm::kernel::DefaultGemm<
+        ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB,
+        ElementC, LayoutC, ElementAccumulator, OpClass, ArchTag,
+        ThreadblockShape, WarpShape, InstructionShape, EpilogueOutputOp,
+        ThreadblockSwizzle,
+        ArchTag::kMinComputeCapability >= 80 && kIsHalf
+            ? 4
+            : DefaultConfig::kStages,
+        kSplitKSerial, Operator>;
+
+    using WarpIteratorA = typename cutlass::gemm::threadblock::
+        DefaultWarpIteratorAFromSharedMemory<
+            typename DefaultGemm::Mma::Policy::Operator::Shape,  // WarpShape
+            typename DefaultGemm::Mma::Policy::Operator::InstructionShape,
+            typename DefaultGemm::Mma::Policy::Operator::IteratorA,
+            typename DefaultGemm::Mma::Policy>::WarpIterator;
+
+    using DefaultMmaFromSmem =
+        typename cutlass::gemm::threadblock::DefaultMmaFromSharedMemory<
+            typename DefaultGemm::Mma,
+            MM0::AccumulatorSharedStorage::Shape::kN,  // kMaxK
+            WarpIteratorA,
+            false>;  // kScaleOperandA
+
+    using Mma = typename DefaultMmaFromSmem::Mma;
+    using IteratorB = typename Mma::IteratorB;
+    using WarpCount = typename Mma::WarpCount;
+    static_assert(WarpCount::kCount == kNumWarpsPerBlock, "");
+
+    using DefaultEpilogue = typename DefaultGemm::Epilogue;
+    using OutputTileIterator =
+        typename cutlass::epilogue::threadblock::PredicatedTileIterator<
+            typename DefaultEpilogue::OutputTileIterator::ThreadMap, output_t>;
+    using OutputTileIteratorAccum =
+        typename cutlass::epilogue::threadblock::PredicatedTileIterator<
+            typename DefaultEpilogue::OutputTileIterator::ThreadMap,
+            output_accum_t>;
+  };
+
+  /// Define the kernel in terms of the default kernel
+  using FMHAKernel = kernel::H3FMHAKernel<MM0, MM1, scalar_t, accum_t, output_t,
+                                          output_accum_t, kSingleValueIteration,
+                                          GroupScheduleMode_>;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace kernel
+}  // namespace gemm
+}  // namespace cutlass
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/flash-attention-v100/kernel/h3/default_fmha.h
+++ b/flash-attention-v100/kernel/h3/default_fmha.h
@@ -74,6 +74,7 @@ template <
     int kMaxK = (int)cutlass::platform::numeric_limits<uint32_t>::max(),
     GroupScheduleMode GroupScheduleMode_ = GroupScheduleMode::kDeviceOnly>
 struct H3FMHA {
+  static_assert(kKeysPerBlock == 64 || kKeysPerBlock == 128);
   using scalar_t = scalar_t_;
   using accum_t = float;
   using output_t = scalar_t;
@@ -88,8 +89,7 @@ struct H3FMHA {
   static bool const kSingleValueIteration = kMaxK <= 128;
   static constexpr bool kIsHalf = cutlass::sizeof_bits<scalar_t>::value == 16;
   static int const kWarpSize = 32;
-  static int const kNumWarpsPerBlock =
-      kQueriesPerBlock * kKeysPerBlock / (kWarpSize * kWarpSize);
+  static int const kNumWarpsPerBlock = (kQueriesPerBlock / kWarpSize) * 2;
 
   struct MM0 {
     /*
@@ -124,7 +124,8 @@ struct H3FMHA {
     using ThreadblockShape =
         cutlass::gemm::GemmShape<kQueriesPerBlock, kKeysPerBlock,
                                  GemmType::ThreadK>;
-    using WarpShape = cutlass::gemm::GemmShape<32, 32, GemmType::WarpK>;
+    using WarpShape =
+        cutlass::gemm::GemmShape<32, kKeysPerBlock / 2, GemmType::WarpK>;
     using InstructionShape = typename GemmType::InstructionShape;
 
     static int const kStages = DefaultConfig::kStages;
@@ -155,9 +156,31 @@ struct H3FMHA {
 
     // Epilogue to store to shared-memory in a format that we can use later for
     // the second matmul
-    using B2bGemm = typename cutlass::gemm::threadblock::B2bGemm<
-        typename Mma::Operator::IteratorC, typename Mma::Operator, scalar_t,
-        WarpShape, ThreadblockShape>;
+    using SmallIteratorC =
+        cutlass::gemm::warp::MmaVoltaTensorOpAccumulatorTileIterator<
+            cutlass::MatrixShape<32, 32>, float, cutlass::layout::RowMajor,
+            cutlass::gemm::GemmShape<16, 16, 4>, cutlass::MatrixShape<1, 1>>;
+    using B2b32 = cutlass::gemm::threadblock::B2bGemm<
+        SmallIteratorC, typename Mma::Operator, scalar_t,
+        cutlass::gemm::GemmShape<32, 32, 32>, ThreadblockShape>;
+    struct B2bGemm {
+      using AccumulatorSharedStorage = typename B2b32::AccumulatorSharedStorage;
+      CUTLASS_DEVICE static void accumToSmem(
+          AccumulatorSharedStorage& storage,
+          typename Mma::FragmentC const& accum, int lane,
+          cutlass::MatrixCoord const& coords) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int tile = 0; tile < kKeysPerBlock / 64; ++tile) {
+          typename SmallIteratorC::Fragment part;
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < part.kElements; ++i)
+            part[i] = accum[tile * part.kElements + i];
+          B2b32::accumToSmem(
+              storage, part, lane,
+              {coords.row(), coords.column() * (kKeysPerBlock / 64) + tile});
+        }
+      }
+    };
     using AccumulatorSharedStorage = typename B2bGemm::AccumulatorSharedStorage;
   };
 

--- a/flash-attention-v100/kernel/h3/default_fmha.h
+++ b/flash-attention-v100/kernel/h3/default_fmha.h
@@ -54,7 +54,7 @@
 #include "gemm_kernel_utils.h"
 #include "gemm/custom_mma.h"
 #include "gemm/find_default_mma.h"
-#include "gemm/mma_from_smem.h"
+#include "prefetch_mma.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -224,7 +224,8 @@ struct H3FMHA {
             WarpIteratorA,
             false>;  // kScaleOperandA
 
-    using Mma = typename DefaultMmaFromSmem::Mma;
+    using Mma = cutlass::gemm::threadblock::H3PrefetchMma<
+        typename DefaultMmaFromSmem::Mma>;
     using IteratorB = typename Mma::IteratorB;
     using WarpCount = typename Mma::WarpCount;
     static_assert(WarpCount::kCount == kNumWarpsPerBlock, "");

--- a/flash-attention-v100/kernel/h3/fmha.h
+++ b/flash-attention-v100/kernel/h3/fmha.h
@@ -644,11 +644,19 @@ struct H3FMHAKernel {
 
         // Update `mi` from accum stored in registers
         // Also does accum[i] <- exp(accum[i] - mi)
-        iterative_softmax<typename MM0::Mma::Operator::IteratorC>(
-            accum_o, accum, mi, m_prime, s_prime, out_rescale,
-            shared_storage.addition_storage, lane_id(), thread_id(), warp_id(),
-            num_keys - iter_key_start, iter_key_start == 0,
-            iteratorC_tile_offset, kSupportsBias ? 1.0f : params.scale);
+        if (num_keys - iter_key_start >= kKeysPerBlock) {
+          iterative_softmax<typename MM0::Mma::Operator::IteratorC, true>(
+              accum_o, accum, mi, m_prime, s_prime, out_rescale,
+              shared_storage.addition_storage, lane_id(), thread_id(),
+              warp_id(), num_keys - iter_key_start, iter_key_start == 0,
+              iteratorC_tile_offset, kSupportsBias ? 1.0f : params.scale);
+        } else {
+          iterative_softmax<typename MM0::Mma::Operator::IteratorC, false>(
+              accum_o, accum, mi, m_prime, s_prime, out_rescale,
+              shared_storage.addition_storage, lane_id(), thread_id(),
+              warp_id(), num_keys - iter_key_start, iter_key_start == 0,
+              iteratorC_tile_offset, kSupportsBias ? 1.0f : params.scale);
+        }
 
         // Output results to shared-memory
         int warp_idx_mn_0 = warp_id() % (MM0::Mma::Base::WarpCount::kM *
@@ -822,7 +830,7 @@ struct H3FMHAKernel {
     }
   }
 
-  template <typename WarpIteratorC>
+  template <typename WarpIteratorC, bool FullKeys>
   CUTLASS_DEVICE static void iterative_softmax(
       typename MM1::Mma::FragmentC& frag_o,  // output so far
       typename WarpIteratorC::Fragment& frag,
@@ -870,7 +878,7 @@ struct H3FMHAKernel {
             max = -cutlass::platform::numeric_limits<accum_t>::infinity();
           },
           [&](int accum_m, int accum_n, int idx) {
-            if (accum_n < max_col) {
+            if (FullKeys || accum_n < max_col) {
               max = cutlass::fast_max(max, frag[idx]);
             }
           },
@@ -930,8 +938,9 @@ struct H3FMHAKernel {
       LambdaIterator::iterateRows(
           lane_offset, [&](int accum_m) { mi_row = mi[accum_m]; },
           [&](int accum_m, int accum_n, int idx) {
-            frag[idx] =
-                (accum_n < max_col) ? exp2f(frag[idx] - mi_row) : accum_t(0.0);
+            frag[idx] = (FullKeys || accum_n < max_col)
+                            ? exp2f(frag[idx] - mi_row)
+                            : accum_t(0.0);
           },
           [&](int accum_m) {});
       LambdaIterator::iterateRows(

--- a/flash-attention-v100/kernel/h3/fmha.h
+++ b/flash-attention-v100/kernel/h3/fmha.h
@@ -149,8 +149,7 @@ struct H3FMHAKernel {
   static int const kThreadsPerWarp = 32;
   static int const kThreadCount = kThreadsPerWarp * WarpCount::kCount;
 
-  static constexpr int kNumWarpsPerBlock =
-      kQueriesPerBlock * kKeysPerBlock / (kThreadsPerWarp * kThreadsPerWarp);
+  static constexpr int kNumWarpsPerBlock = WarpCount::kCount;
 
   using ProblemVisitor =
       FMHAGroupedProblemVisitor<ThreadblockShape, kGroupScheduleMode,
@@ -355,9 +354,6 @@ struct H3FMHAKernel {
     epilogue_shared_storage() {
       return epilogue;
     }
-
-    // ProblemVisitor shared storage can't be overlapped with others
-    typename ProblemVisitor::SharedStorage problem_visitor;
   };
 
   struct SharedStorageEpilogueInLoop : ScalingCoefs {
@@ -377,9 +373,6 @@ struct H3FMHAKernel {
     epilogue_shared_storage() {
       return after_mm0.epilogue;
     }
-
-    // ProblemVisitor shared storage can't be overlapped with others
-    typename ProblemVisitor::SharedStorage problem_visitor;
   };
 
   using SharedStorage = typename cutlass::platform::conditional<
@@ -447,31 +440,39 @@ struct H3FMHAKernel {
     return threadIdx.x % kThreadsPerWarp;
   }
 
+  struct DirectParams {
+    ElementQ* q;
+    ElementK* k;
+    ElementV* v;
+    ElementO* output;
+    int queries;
+    int keys;
+    int heads;
+    float scale;
+    static constexpr bool causal = false;
+  };
+
   /// Executes one GEMM
   CUTLASS_DEVICE
-  void operator()(Params const& params, SharedStorage& shared_storage) {
+  void operator()(DirectParams const& params, SharedStorage& shared_storage) {
     auto& m_prime = shared_storage.m_prime;
     auto& s_prime = shared_storage.s_prime;
     [[maybe_unused]] auto& si = shared_storage.after_mm0.si;
     auto& mi = shared_storage.mi;
     auto& out_rescale = shared_storage.out_rescale;
 
-    ProblemVisitor problem_visitor(params.problem_visitor,
-                                   shared_storage.problem_visitor, blockIdx.x);
-
-    // Outer 'persistent' loop to iterate over tiles
-    while (problem_visitor.next_tile()) {
-      GemmCoord problem_size0 = problem_visitor.problem_size0();
-      GemmCoord problem_size1 = problem_visitor.problem_size1();
-      const int32_t threadblock_idx =
-          int32_t(problem_visitor.threadblock_idx());
-
-      if (!TileParams::can_compute(threadblock_idx, problem_size0)) {
-        problem_visitor.advance(gridDim.x);
-        continue;
-      }
-
-      const int32_t problem_idx = problem_visitor.problem_index();
+    {
+      const int32_t threadblock_idx = blockIdx.x;
+      const int group = blockIdx.y;
+      const int64_t stride = int64_t(params.heads) * 128;
+      const int64_t q_offset =
+          int64_t(group / params.heads) * params.queries * stride +
+          (group % params.heads) * 128;
+      const int64_t kv_offset =
+          int64_t(group / params.heads) * params.keys * stride +
+          (group % params.heads) * 128;
+      const GemmCoord problem_size0(params.queries, params.keys, 128);
+      const GemmCoord problem_size1(params.queries, 128, params.keys);
 
       if (thread_id() < kQueriesPerBlock) {
         s_prime[thread_id()] = ElementAccumulator(0);
@@ -482,21 +483,17 @@ struct H3FMHAKernel {
             -cutlass::platform::numeric_limits<ElementAccumulator>::infinity();
       }
 
-      ElementO* ptr_O =
-          params.ptr_O[problem_idx] +
-          TileParams::query_start(threadblock_idx) * params.ldo[problem_idx];
-      ElementOAccum* ptr_O_accum =
-          params.ptr_O_accum[problem_idx] +
-          TileParams::query_start(threadblock_idx) * params.ldo[problem_idx];
+      ElementO* ptr_O = (params.output + q_offset) +
+                        TileParams::query_start(threadblock_idx) * stride;
+      static_assert(kKeepOutputInRF);
+      ElementOAccum* ptr_O_accum = nullptr;
       const int num_queries =
           TileParams::num_queries(threadblock_idx, problem_size0);
 
       auto createOutputIter = [&](int col) -> typename MM1::OutputTileIterator {
         using OutputTileIterator = typename MM1::OutputTileIterator;
         return OutputTileIterator(
-            typename OutputTileIterator::Params{
-                (int32_t)params.ldo[problem_idx]},
-            ptr_O,
+            typename OutputTileIterator::Params{(int32_t)stride}, ptr_O,
             typename OutputTileIterator::TensorCoord{num_queries,
                                                      problem_size1.n()},
             thread_id(), {0, col});
@@ -506,8 +503,7 @@ struct H3FMHAKernel {
           [&](int col) -> typename MM1::OutputTileIteratorAccum {
         using OutputTileIteratorAccum = typename MM1::OutputTileIteratorAccum;
         return OutputTileIteratorAccum(
-            typename OutputTileIteratorAccum::Params{
-                (int32_t)params.ldo[problem_idx]},
+            typename OutputTileIteratorAccum::Params{(int32_t)stride},
             ptr_O_accum,
             typename OutputTileIteratorAccum::TensorCoord{num_queries,
                                                           problem_size1.n()},
@@ -532,10 +528,8 @@ struct H3FMHAKernel {
 
         auto prologueV = [&](int blockN) {
           typename MM1::Mma::IteratorB iterator_V(
-              typename MM1::IteratorB::Params{
-                  typename MM1::LayoutB(params.ldv[problem_idx])},
-              params.ptr_V[problem_idx] +
-                  iter_key_start * params.ldv[problem_idx],
+              typename MM1::IteratorB::Params{typename MM1::LayoutB(stride)},
+              (params.v + kv_offset) + iter_key_start * stride,
               {problem_size_1_k, problem_size_1_n}, thread_id(),
               cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
 
@@ -556,21 +550,19 @@ struct H3FMHAKernel {
         // and stores that into `shared_storage.si`
         //
 
-        ElementQ* ptr_Q =
-            params.ptr_Q[problem_idx] +
-            TileParams::query_start(threadblock_idx) * params.ldq[problem_idx];
+        ElementQ* ptr_Q = (params.q + q_offset) +
+                          TileParams::query_start(threadblock_idx) * stride;
 
         // Construct iterators to A and B operands
         typename MM0::IteratorA iterator_A(
             typename MM0::IteratorA::Params(
-                typename MM0::MmaCore::LayoutA(params.ldq[problem_idx])),
+                typename MM0::MmaCore::LayoutA(stride)),
             ptr_Q, {problem_size_0_m, problem_size_0_k}, thread_id(), {0, 0});
 
         typename MM0::IteratorB iterator_B(
             typename MM0::IteratorB::Params(
-                typename MM0::MmaCore::LayoutB(params.ldk[problem_idx])),
-            params.ptr_K[problem_idx] +
-                iter_key_start * params.ldk[problem_idx],
+                typename MM0::MmaCore::LayoutB(stride)),
+            (params.k + kv_offset) + iter_key_start * stride,
             {problem_size_0_k, problem_size_0_n}, thread_id(), {0, 0});
 
         // Construct thread-scoped matrix multiply
@@ -645,10 +637,8 @@ struct H3FMHAKernel {
         typename MM1::Mma::FragmentB prefetched_v;
         {
           typename MM1::IteratorB early_v(
-              typename MM1::IteratorB::Params{
-                  typename MM1::LayoutB(params.ldv[problem_idx])},
-              params.ptr_V[problem_idx] +
-                  iter_key_start * params.ldv[problem_idx],
+              typename MM1::IteratorB::Params{typename MM1::LayoutB(stride)},
+              params.v + kv_offset + iter_key_start * stride,
               {problem_size_1_k, problem_size_1_n}, thread_id(), {0, 0});
           early_v.set_residual_tile(problem_size_1_k <= MM1::Mma::Shape::kK);
           prefetched_v.clear();
@@ -706,10 +696,8 @@ struct H3FMHAKernel {
           }
 
           typename MM1::Mma::IteratorB iterator_V(
-              typename MM1::IteratorB::Params{
-                  typename MM1::LayoutB(params.ldv[problem_idx])},
-              params.ptr_V[problem_idx] +
-                  iter_key_start * params.ldv[problem_idx],
+              typename MM1::IteratorB::Params{typename MM1::LayoutB(stride)},
+              (params.v + kv_offset) + iter_key_start * stride,
               {problem_size_1_k, problem_size_1_n}, thread_id(),
               cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
 
@@ -836,10 +824,7 @@ struct H3FMHAKernel {
         epilogue(rescale, dest_iter, accum_o);
       }
 
-      // Next tile
-      problem_visitor.advance(gridDim.x);
-      __syncthreads();  // Don't start the next iteration until all threads are
-                        // done using shared memory.
+      __syncthreads();  // Complete all shared-memory consumers before exit.
     }
   }
 

--- a/flash-attention-v100/kernel/h3/fmha.h
+++ b/flash-attention-v100/kernel/h3/fmha.h
@@ -642,6 +642,18 @@ struct H3FMHAKernel {
         //             }));
         //       }));
 
+        typename MM1::Mma::FragmentB prefetched_v;
+        {
+          typename MM1::IteratorB early_v(
+              typename MM1::IteratorB::Params{
+                  typename MM1::LayoutB(params.ldv[problem_idx])},
+              params.ptr_V[problem_idx] +
+                  iter_key_start * params.ldv[problem_idx],
+              {problem_size_1_k, problem_size_1_n}, thread_id(), {0, 0});
+          early_v.set_residual_tile(problem_size_1_k <= MM1::Mma::Shape::kK);
+          prefetched_v.clear();
+          early_v.load(prefetched_v);
+        }
         // Update `mi` from accum stored in registers
         // Also does accum[i] <- exp(accum[i] - mi)
         if (num_keys - iter_key_start >= kKeysPerBlock) {
@@ -714,7 +726,8 @@ struct H3FMHAKernel {
             accum_o.clear();
           }
 
-          mma_pv(gemm_k_iterations, accum_o, iterator_V, accum_o);
+          mma_pv(gemm_k_iterations, accum_o, iterator_V, accum_o,
+                 &prefetched_v);
           __syncthreads();
 
           if (kPreloadV && !kKeepOutputInRF && blockN + 1 < nBlockN) {

--- a/flash-attention-v100/kernel/h3/fmha.h
+++ b/flash-attention-v100/kernel/h3/fmha.h
@@ -1,0 +1,977 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+    \brief Grouped FMHA kernel
+*/
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/fast_math.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/matrix_coord.h"
+#include "cutlass/complex.h"
+#include "cutlass/semaphore.h"
+
+#include "cutlass/layout/matrix.h"
+#include "cutlass/trace.h"
+#include "cutlass/gemm/kernel/gemm_transpose_operands.h"
+
+#include "fmha_grouped_problem_visitor.h"
+#include "gemm_kernel_utils.h"
+#include "gemm/mma_accum_lambda_iterator.h"
+#include "epilogue/epilogue_rescale_output.h"
+
+namespace {
+static CUTLASS_DEVICE float atomicMaxFloat(float* addr, float value) {
+  // source: https://stackoverflow.com/a/51549250
+  return (value >= 0)
+             ? __int_as_float(atomicMax((int*)addr, __float_as_int(value)))
+             : __uint_as_float(
+                   atomicMin((unsigned int*)addr, __float_as_uint(value)));
+}
+}  // namespace
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass {
+namespace gemm {
+namespace kernel {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename MM0_,  ///! Structure for computing P = Q @ K
+          typename MM1_,  ///! Structure for computing O = P @ V
+          typename scalar_t_, typename accum_t_, typename output_t_,
+          typename output_accum_t_,
+          bool kKeepOutputInRF,  ///! Whether the intermediate output from MM0_
+                                 /// should be kept in the register file
+          GroupScheduleMode GroupScheduleMode_  ///! Type of scheduling to
+                                                /// perform
+          >
+struct H3FMHAKernel {
+ public:
+  using MM0 = MM0_;
+  using MM1 = MM1_;
+
+  using scalar_t = scalar_t_;
+  using accum_t = accum_t_;
+  using output_t = output_t_;
+  using output_accum_t = output_accum_t_;
+
+  static GroupScheduleMode const kGroupScheduleMode = GroupScheduleMode_;
+
+  static constexpr bool kNeedsOutputAccumulatorBuffer =
+      !kKeepOutputInRF &&
+      !cutlass::platform::is_same<output_accum_t, output_t>::value;
+
+  // Parameters to satisfy BaseGrouped
+  using ElementA = scalar_t;
+  using ElementB = scalar_t;
+  using ElementC = accum_t;
+  using LayoutA = typename MM0::LayoutA;
+  using LayoutB = typename MM0::ElementB;
+  using LayoutC = typename MM1::ElementC;
+  static ComplexTransform const kTransformA = ComplexTransform::kNone;
+  static ComplexTransform const kTransformB = ComplexTransform::kNone;
+  static int const kAlignmentA = MM0::kAlignmentA;
+  static int const kAlignmentB = MM0::kAlignmentB;
+  static int const kAlignmentC = 1;
+  using Mma = typename MM1::Mma;
+  using EpilogueOutputOp = typename MM1::EpilogueOutputOp;
+  using ThreadblockSwizzle = void;
+  using Operator = typename MM1::Operator;
+  using WarpShape = typename MM1::WarpShape;
+  using InstructionShape = typename MM1::InstructionShape;
+
+  using ElementQ = scalar_t;
+  using ElementK = scalar_t;
+  using ElementP = accum_t;
+  using ElementV = scalar_t;
+  using ElementO = output_t;
+  using ElementOAccum = output_accum_t;
+  using ElementAccumulator = accum_t;
+
+  using LayoutQ = typename MM0::LayoutA;
+  using LayoutK = typename MM0::LayoutB;
+  using LayoutP = typename MM0::LayoutC;
+  using LayoutV = typename MM1::LayoutB;
+  using LayoutO = typename MM1::LayoutC;
+
+  static bool const kPreloadV =
+      (MM1::Mma::ArchTag::kMinComputeCapability >= 80 &&
+       cutlass::sizeof_bits<ElementV>::value == 16);
+
+  static int const kAlignmentQ = MM0::kAlignmentA;
+  static int const kAlignmentK = MM0::kAlignmentB;
+  static int const kAlignmentV = 1;
+
+  using ThreadblockShape = typename MM0::ThreadblockShape;
+
+  static int const kQueriesPerBlock = ThreadblockShape::kM;
+  static int const kKeysPerBlock = ThreadblockShape::kN;
+
+  static constexpr bool kSupportsDropout = false;
+  static constexpr bool kSupportsBias = false;
+
+  /// Warp count (concept: GemmShape)
+  using WarpCount = typename MM1::WarpCount;
+  static int const kThreadsPerWarp = 32;
+  static int const kThreadCount = kThreadsPerWarp * WarpCount::kCount;
+
+  static constexpr int kNumWarpsPerBlock =
+      kQueriesPerBlock * kKeysPerBlock / (kThreadsPerWarp * kThreadsPerWarp);
+
+  using ProblemVisitor =
+      FMHAGroupedProblemVisitor<ThreadblockShape, kGroupScheduleMode,
+                                kThreadCount, kThreadCount>;
+
+  //
+  // Structures
+  //
+
+  /// Argument structure
+  struct Arguments {
+    //
+    // Data members
+    //
+
+    GemmCoord* problem_sizes0{nullptr};
+    GemmCoord* problem_sizes1{nullptr};
+
+    int problem_count{0};
+    int threadblock_count{0};
+
+    ElementQ** ptr_Q{nullptr};
+    ElementK** ptr_K{nullptr};
+    ElementP** ptr_P{nullptr};
+    ElementV** ptr_V{nullptr};
+    ElementO** ptr_O{nullptr};
+    ElementOAccum** ptr_O_accum{nullptr};
+
+    typename LayoutQ::Stride::LongIndex* ldq{nullptr};
+    typename LayoutK::Stride::LongIndex* ldk{nullptr};
+    typename LayoutP::Stride::LongIndex* ldv{nullptr};
+    typename LayoutO::Stride::LongIndex* ldo{nullptr};
+
+    // Whether causal masking is to be performed
+    bool causal{false};
+
+    // Scale
+    ElementAccumulator scale{0};
+
+    // Only used by device-level operator
+    GemmCoord* host_problem_sizes{nullptr};
+
+    //
+    // Methods
+    //
+
+    /// Default ctor
+    Arguments() = default;
+
+    /// Ctor
+    CUTLASS_HOST_DEVICE
+    Arguments(GemmCoord* problem_sizes0, GemmCoord* problem_sizes1,
+              int problem_count, int threadblock_count, ElementQ** ptr_Q,
+              ElementK** ptr_K, ElementP** ptr_P, ElementV** ptr_V,
+              ElementO** ptr_O, ElementOAccum** ptr_O_accum,
+              typename LayoutQ::Stride::LongIndex* ldq,
+              typename LayoutK::Stride::LongIndex* ldk,
+              typename LayoutP::Stride::LongIndex* ldp,
+              typename LayoutV::Stride::LongIndex* ldv,
+              typename LayoutO::Stride::LongIndex* ldo, bool causal,
+              ElementAccumulator scale, GemmCoord* host_problem_sizes = nullptr)
+        : problem_sizes0(problem_sizes0),
+          problem_sizes1(problem_sizes1),
+          problem_count(problem_count),
+          threadblock_count(threadblock_count),
+          ptr_Q(ptr_Q),
+          ptr_K(ptr_K),
+          ptr_P(ptr_P),
+          ptr_V(ptr_V),
+          ptr_O(ptr_O),
+          ptr_O_accum(kNeedsOutputAccumulatorBuffer ? ptr_O_accum
+                                                    : (accum_t**)ptr_O),
+          ldq(ldq),
+          ldk(ldk),
+          ldv(ldv),
+          ldo(ldo),
+          causal(causal),
+          scale(scale),
+          host_problem_sizes(host_problem_sizes) {}
+
+    bool __host__ check_supported() {
+      CHECK_ALIGNED_PTR(ptr_Q, kAlignmentQ);
+      CHECK_ALIGNED_PTR(ptr_K, kAlignmentK);
+      CHECK_ALIGNED_PTR(ptr_V, kAlignmentV);
+      XFORMERS_CHECK(ldq % kAlignmentQ == 0, "query is not correctly aligned");
+      XFORMERS_CHECK(ldk % kAlignmentK == 0, "key is not correctly aligned");
+      XFORMERS_CHECK(ldv % kAlignmentV == 0, "value is not correctly aligned");
+      return true;
+    }
+  };
+
+  //
+  // Structure for precomputing values in host memory and passing to kernels
+  //
+
+  /// Parameters structure
+  struct Params {
+    typename ProblemVisitor::Params problem_visitor;
+    int threadblock_count;
+
+    ElementQ** ptr_Q;
+    ElementK** ptr_K;
+    ElementP** ptr_P;
+    ElementV** ptr_V;
+    ElementO** ptr_O;
+    ElementOAccum** ptr_O_accum;
+
+    typename LayoutQ::Stride::LongIndex* ldq;
+    typename LayoutK::Stride::LongIndex* ldk;
+    typename LayoutP::Stride::LongIndex* ldv;
+    typename LayoutO::Stride::LongIndex* ldo;
+
+    ElementAccumulator scale;
+    bool causal;
+
+    //
+    // Methods
+    //
+
+    CUTLASS_HOST_DEVICE
+    Params()
+        : ptr_Q(nullptr),
+          ptr_K(nullptr),
+          ptr_P(nullptr),
+          ptr_V(nullptr),
+          ptr_O(nullptr),
+          ptr_O_accum(nullptr),
+          ldq(nullptr),
+          ldk(nullptr),
+          ldv(nullptr),
+          ldo(nullptr),
+          causal(false),
+          scale(0) {}
+
+    CUTLASS_HOST_DEVICE
+    Params(Arguments const& args, void* workspace = nullptr, int tile_count = 0)
+        : problem_visitor(args.problem_sizes0, args.problem_sizes1,
+                          args.problem_count, workspace, tile_count),
+          threadblock_count(args.threadblock_count),
+          ptr_Q(args.ptr_Q),
+          ptr_K(args.ptr_K),
+          ptr_P(args.ptr_P),
+          ptr_V(args.ptr_V),
+          ptr_O(args.ptr_O),
+          ptr_O_accum(kNeedsOutputAccumulatorBuffer ? args.ptr_O_accum
+                                                    : (accum_t**)args.ptr_O),
+          ldq(args.ldq),
+          ldk(args.ldk),
+          ldv(args.ldv),
+          ldo(args.ldo),
+          causal(args.causal),
+          scale(args.scale) {}
+
+    CUTLASS_HOST_DEVICE
+    void update(Arguments const& args, void* workspace = nullptr,
+                int tile_count = 0) {
+      problem_visitor = typename ProblemVisitor::Params(
+          args.problem_sizes0, args.problem_sizes1, args.problem_count,
+          workspace, tile_count);
+      threadblock_count = args.threadblock_count;
+      ptr_Q = args.ptr_Q;
+      ptr_K = args.ptr_K;
+      ptr_P = args.ptr_P;
+      ptr_V = args.ptr_V;
+      ptr_O = args.ptr_O;
+      ptr_O_accum = kNeedsOutputAccumulatorBuffer ? args.ptr_O_accum
+                                                  : (accum_t**)args.ptr_O;
+      ldq = args.ldq;
+      ldk = args.ldk;
+      ldv = args.ldv;
+      ldo = args.ldo;
+      causal = args.causal;
+      scale = args.scale;
+    }
+  };
+
+  // Shared storage - depends on kernel params
+  struct ScalingCoefs {
+    cutlass::Array<ElementAccumulator, kQueriesPerBlock> m_prime;
+    cutlass::Array<ElementAccumulator, kQueriesPerBlock> s_prime;
+    cutlass::Array<ElementAccumulator, kQueriesPerBlock> mi;
+    cutlass::Array<ElementAccumulator, kQueriesPerBlock> out_rescale;
+    cutlass::Array<ElementAccumulator,
+                   kQueriesPerBlock * MM0::MmaCore::WarpCount::kN>
+        addition_storage;
+  };
+
+  struct SharedStorageEpilogueAtEnd : ScalingCoefs {
+    struct SharedStorageAfterMM0 {
+      // Everything here might be overwritten during MM0
+      typename MM0::AccumulatorSharedStorage si;
+      typename MM1::Mma::SharedStorage mm1;
+    };
+
+    union {
+      typename MM0::Mma::SharedStorage mm0;
+      SharedStorageAfterMM0 after_mm0;
+      typename MM1::DefaultEpilogue::SharedStorage epilogue;
+    };
+
+    CUTLASS_DEVICE typename MM1::DefaultEpilogue::SharedStorage&
+    epilogue_shared_storage() {
+      return epilogue;
+    }
+
+    // ProblemVisitor shared storage can't be overlapped with others
+    typename ProblemVisitor::SharedStorage problem_visitor;
+  };
+
+  struct SharedStorageEpilogueInLoop : ScalingCoefs {
+    struct SharedStorageAfterMM0 {
+      // Everything here might be overwritten during MM0
+      typename MM0::AccumulatorSharedStorage si;
+      typename MM1::Mma::SharedStorage mm1;
+      typename MM1::DefaultEpilogue::SharedStorage epilogue;
+    };
+
+    union {
+      typename MM0::Mma::SharedStorage mm0;
+      SharedStorageAfterMM0 after_mm0;
+    };
+
+    CUTLASS_DEVICE typename MM1::DefaultEpilogue::SharedStorage&
+    epilogue_shared_storage() {
+      return after_mm0.epilogue;
+    }
+
+    // ProblemVisitor shared storage can't be overlapped with others
+    typename ProblemVisitor::SharedStorage problem_visitor;
+  };
+
+  using SharedStorage = typename cutlass::platform::conditional<
+      kKeepOutputInRF, SharedStorageEpilogueAtEnd,
+      SharedStorageEpilogueInLoop>::type;
+
+ private:
+  // Parameters to be used by an individual tile
+  struct TileParams {
+    CUTLASS_HOST_DEVICE
+    static int query_start(int threadblock_idx) {
+      return threadblock_idx * kQueriesPerBlock;
+    }
+
+    // Returns whether this threadblock computes within the number of queries,
+    // which is determined by the M dimension of problem 0
+    CUTLASS_HOST_DEVICE
+    static bool can_compute(int threadblock_idx,
+                            const GemmCoord& problem_size0) {
+      return query_start(threadblock_idx) < problem_size0.m();
+    }
+
+    CUTLASS_HOST_DEVICE
+    static int num_queries(int threadblock_idx,
+                           const GemmCoord& problem_size0) {
+      return problem_size0.m() - query_start(threadblock_idx);
+    }
+
+    CUTLASS_HOST_DEVICE
+    static int num_keys(int threadblock_idx, const GemmCoord& problem_size0,
+                        bool causal) {
+      int nk = problem_size0.n();
+      if (causal) {
+        nk = cutlass::fast_min(
+            int32_t(query_start(threadblock_idx) + kQueriesPerBlock), nk);
+      }
+      return nk;
+    }
+  };
+
+ public:
+  //
+  // Methods
+  //
+
+  CUTLASS_DEVICE
+  H3FMHAKernel() {}
+
+  /// Determines whether kernel satisfies alignment
+  static Status can_implement(cutlass::gemm::GemmCoord const& problem_size) {
+    return Status::kSuccess;
+  }
+
+  static Status can_implement(Arguments const& args) {
+    return Status::kSuccess;
+  }
+
+  static CUTLASS_DEVICE int16_t thread_id() { return threadIdx.x; }
+
+  static CUTLASS_DEVICE int8_t warp_id() {
+    return threadIdx.x / kThreadsPerWarp;
+  }
+
+  static CUTLASS_DEVICE int8_t lane_id() {
+    return threadIdx.x % kThreadsPerWarp;
+  }
+
+  /// Executes one GEMM
+  CUTLASS_DEVICE
+  void operator()(Params const& params, SharedStorage& shared_storage) {
+    auto& m_prime = shared_storage.m_prime;
+    auto& s_prime = shared_storage.s_prime;
+    [[maybe_unused]] auto& si = shared_storage.after_mm0.si;
+    auto& mi = shared_storage.mi;
+    auto& out_rescale = shared_storage.out_rescale;
+
+    ProblemVisitor problem_visitor(params.problem_visitor,
+                                   shared_storage.problem_visitor, blockIdx.x);
+
+    // Outer 'persistent' loop to iterate over tiles
+    while (problem_visitor.next_tile()) {
+      GemmCoord problem_size0 = problem_visitor.problem_size0();
+      GemmCoord problem_size1 = problem_visitor.problem_size1();
+      const int32_t threadblock_idx =
+          int32_t(problem_visitor.threadblock_idx());
+
+      if (!TileParams::can_compute(threadblock_idx, problem_size0)) {
+        problem_visitor.advance(gridDim.x);
+        continue;
+      }
+
+      const int32_t problem_idx = problem_visitor.problem_index();
+
+      if (thread_id() < kQueriesPerBlock) {
+        s_prime[thread_id()] = ElementAccumulator(0);
+        out_rescale[thread_id()] = accum_t(1.0);
+        m_prime[thread_id()] =
+            -cutlass::platform::numeric_limits<ElementAccumulator>::infinity();
+        mi[thread_id()] =
+            -cutlass::platform::numeric_limits<ElementAccumulator>::infinity();
+      }
+
+      ElementO* ptr_O =
+          params.ptr_O[problem_idx] +
+          TileParams::query_start(threadblock_idx) * params.ldo[problem_idx];
+      ElementOAccum* ptr_O_accum =
+          params.ptr_O_accum[problem_idx] +
+          TileParams::query_start(threadblock_idx) * params.ldo[problem_idx];
+      const int num_queries =
+          TileParams::num_queries(threadblock_idx, problem_size0);
+
+      auto createOutputIter = [&](int col) -> typename MM1::OutputTileIterator {
+        using OutputTileIterator = typename MM1::OutputTileIterator;
+        return OutputTileIterator(
+            typename OutputTileIterator::Params{
+                (int32_t)params.ldo[problem_idx]},
+            ptr_O,
+            typename OutputTileIterator::TensorCoord{num_queries,
+                                                     problem_size1.n()},
+            thread_id(), {0, col});
+      };
+
+      auto createOutputAccumIter =
+          [&](int col) -> typename MM1::OutputTileIteratorAccum {
+        using OutputTileIteratorAccum = typename MM1::OutputTileIteratorAccum;
+        return OutputTileIteratorAccum(
+            typename OutputTileIteratorAccum::Params{
+                (int32_t)params.ldo[problem_idx]},
+            ptr_O_accum,
+            typename OutputTileIteratorAccum::TensorCoord{num_queries,
+                                                          problem_size1.n()},
+            thread_id(), {0, col});
+      };
+
+      typename MM1::Mma::FragmentC accum_o;
+      accum_o.clear();
+
+      const int num_keys =
+          TileParams::num_keys(threadblock_idx, problem_size0, params.causal);
+
+      for (int32_t iter_key_start = 0; iter_key_start < num_keys;
+           iter_key_start += kKeysPerBlock) {
+        int32_t problem_size_0_m =
+            cutlass::fast_min((int32_t)kQueriesPerBlock, num_queries);
+        int32_t problem_size_0_n = cutlass::fast_min((int32_t)kKeysPerBlock,
+                                                     num_keys - iter_key_start);
+        int32_t const& problem_size_0_k = problem_size0.k();
+        int32_t const& problem_size_1_n = problem_size1.n();
+        int32_t const& problem_size_1_k = problem_size_0_n;
+
+        auto prologueV = [&](int blockN) {
+          typename MM1::Mma::IteratorB iterator_V(
+              typename MM1::IteratorB::Params{
+                  typename MM1::LayoutB(params.ldv[problem_idx])},
+              params.ptr_V[problem_idx] +
+                  iter_key_start * params.ldv[problem_idx],
+              {problem_size_1_k, problem_size_1_n}, thread_id(),
+              cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+
+          MM1::Mma::prologue(shared_storage.after_mm0.mm1, iterator_V,
+                             thread_id(), problem_size_1_k);
+        };
+
+        __syncthreads();  // Need to have shared memory initialized, and
+                          // `m_prime` updated from end of prev iter
+
+        //
+        // MATMUL: Q.K_t
+        //
+        // Computes the block-matrix product of:
+        // (a) query[query_start:query_end, :]
+        // with
+        // (b) key[iter_key_start:iter_key_start + kKeysPerBlock]
+        // and stores that into `shared_storage.si`
+        //
+
+        ElementQ* ptr_Q =
+            params.ptr_Q[problem_idx] +
+            TileParams::query_start(threadblock_idx) * params.ldq[problem_idx];
+
+        // Construct iterators to A and B operands
+        typename MM0::IteratorA iterator_A(
+            typename MM0::IteratorA::Params(
+                typename MM0::MmaCore::LayoutA(params.ldq[problem_idx])),
+            ptr_Q, {problem_size_0_m, problem_size_0_k}, thread_id(), {0, 0});
+
+        typename MM0::IteratorB iterator_B(
+            typename MM0::IteratorB::Params(
+                typename MM0::MmaCore::LayoutB(params.ldk[problem_idx])),
+            params.ptr_K[problem_idx] +
+                iter_key_start * params.ldk[problem_idx],
+            {problem_size_0_k, problem_size_0_n}, thread_id(), {0, 0});
+
+        // Construct thread-scoped matrix multiply
+        typename MM0::Mma mma(shared_storage.mm0, thread_id(), warp_id(),
+                              lane_id());
+
+        typename MM0::Mma::FragmentC accum;
+
+        accum.clear();
+
+        auto gemm_k_iterations =
+            (problem_size_0_k + MM0::Mma::Shape::kK - 1) / MM0::Mma::Shape::kK;
+
+        // Compute threadblock-scoped matrix multiply-add
+        mma(gemm_k_iterations, accum, iterator_A, iterator_B, accum);
+        __syncthreads();
+
+        if (kPreloadV) {
+          prologueV(0);
+        } else {
+          MM1::Mma::drain_cp_asyncs();
+        }
+
+        typename MM0::Mma::Operator::IteratorC::TensorCoord
+            iteratorC_tile_offset = {(warp_id() % MM0::Mma::WarpCount::kM),
+                                     (warp_id() / MM0::Mma::WarpCount::kM)};
+
+        // Mask out last if causal
+        if (params.causal && num_keys - iter_key_start <= kKeysPerBlock) {
+          auto lane_offset = MM0::AccumLambdaIterator::get_lane_offset(
+              lane_id(), warp_id(), iteratorC_tile_offset);
+          int32_t last_col;
+          MM0::AccumLambdaIterator::iterateRows(
+              lane_offset,
+              [&](int accum_m) {
+                last_col = TileParams::query_start(threadblock_idx) + accum_m -
+                           iter_key_start;
+              },
+              [&](int accum_m, int accum_n, int idx) {
+                if (accum_n > last_col) {
+                  accum[idx] =
+                      -cutlass::platform::numeric_limits<accum_t>::infinity();
+                }
+              },
+              [&](int accum_m) {});
+        }
+        // DISPATCH_BOOL(iter_key_start == 0, kIsFirst, ([&] {
+        //         DISPATCH_BOOL(
+        //             num_keys - iter_key_start >= kKeysPerBlock,
+        //             kFullColumns,
+        //             ([&] {
+        //               // Update `mi` from accum stored in registers
+        //               // Also does accum[i] <- exp(accum[i] - mi)
+        //               iterative_softmax<
+        //                   typename MM0::Mma::Operator::IteratorC,
+        //                   kFullColumns,
+        //                   kIsFirst>(
+        //                   accum_o,
+        //                   accum,
+        //                   mi,
+        //                   m_prime,
+        //                   s_prime,
+        //                   lane_id(),
+        //                   thread_id(),
+        //                   warp_id(),
+        //                   num_keys - iter_key_start,
+        //                   iteratorC_tile_offset,
+        //                   kSupportsBias ? 1.0f : params.scale);
+        //             }));
+        //       }));
+
+        // Update `mi` from accum stored in registers
+        // Also does accum[i] <- exp(accum[i] - mi)
+        iterative_softmax<typename MM0::Mma::Operator::IteratorC>(
+            accum_o, accum, mi, m_prime, s_prime, out_rescale,
+            shared_storage.addition_storage, lane_id(), thread_id(), warp_id(),
+            num_keys - iter_key_start, iter_key_start == 0,
+            iteratorC_tile_offset, kSupportsBias ? 1.0f : params.scale);
+
+        // Output results to shared-memory
+        int warp_idx_mn_0 = warp_id() % (MM0::Mma::Base::WarpCount::kM *
+                                         MM0::Mma::Base::WarpCount::kN);
+        auto output_tile_coords =
+            cutlass::MatrixCoord{warp_idx_mn_0 % MM0::Mma::Base::WarpCount::kM,
+                                 warp_idx_mn_0 / MM0::Mma::Base::WarpCount::kM};
+
+        MM0::B2bGemm::accumToSmem(shared_storage.after_mm0.si, accum, lane_id(),
+                                  output_tile_coords);
+
+        __syncthreads();
+
+        //
+        // MATMUL: Attn . V
+        // Run the matmul `attn @ V` for a block of attn and V.
+        // `attn` is read from shared memory (in `shared_storage_si`)
+        // `V` is read from global memory (with iterator_B)
+        //
+
+        const int64_t nBlockN =
+            kKeepOutputInRF ? 1
+                            : ceil_div((int64_t)problem_size_1_n,
+                                       int64_t(MM1::ThreadblockShape::kN));
+
+        // Iterate over the N dimension of GEMM1
+        for (int blockN = 0; blockN < nBlockN; ++blockN) {
+          int gemm_k_iterations = (problem_size_1_k + MM1::Mma::Shape::kK - 1) /
+                                  MM1::Mma::Shape::kK;
+
+          // Compute threadblock-scoped matrix multiply-add and store it in
+          // accum (in registers)
+          if (!kPreloadV) {
+            __syncthreads();  // we share shmem between mma and epilogue
+          }
+
+          typename MM1::Mma::IteratorB iterator_V(
+              typename MM1::IteratorB::Params{
+                  typename MM1::LayoutB(params.ldv[problem_idx])},
+              params.ptr_V[problem_idx] +
+                  iter_key_start * params.ldv[problem_idx],
+              {problem_size_1_k, problem_size_1_n}, thread_id(),
+              cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+
+          typename MM1::Mma mma_pv(
+              // operand A: Pij_dropped in shared memory
+              shared_storage.after_mm0.si.accum_ref(),
+              // operand B: shared memory staging area for Vj, which is loaded
+              // from global memory
+              shared_storage.after_mm0.mm1.operand_B_ref(), (int)thread_id(),
+              (int)warp_id(), (int)lane_id());
+
+          mma_pv.set_prologue_done(kPreloadV);
+          if (!kKeepOutputInRF) {
+            accum_o.clear();
+          }
+
+          mma_pv(gemm_k_iterations, accum_o, iterator_V, accum_o);
+          __syncthreads();
+
+          if (kPreloadV && !kKeepOutputInRF && blockN + 1 < nBlockN) {
+            prologueV(blockN + 1);
+          }
+
+          if (!kKeepOutputInRF) {
+            MM1::Mma::drain_cp_asyncs();
+            DISPATCH_BOOL(
+                iter_key_start == 0, kIsFirst, ([&] {
+                  DISPATCH_BOOL(
+                      (iter_key_start + kKeysPerBlock) >= num_keys, kIsLast,
+                      ([&] {
+                        using DefaultEpilogue = typename MM1::DefaultEpilogue;
+                        using DefaultOp =
+                            typename MM1::DefaultConfig::EpilogueOutputOp;
+                        using ElementCompute =
+                            typename DefaultOp::ElementCompute;
+                        using EpilogueOutputOp = typename cutlass::epilogue::
+                            thread::MemoryEfficientAttentionNormalize<
+                                typename cutlass::platform::conditional<
+                                    kIsLast::value, output_t,
+                                    output_accum_t>::type,
+                                output_accum_t, DefaultOp::kCount,
+                                typename DefaultOp::ElementAccumulator,
+                                output_accum_t, kIsFirst::value, kIsLast::value,
+                                cutlass::Array<ElementCompute,
+                                               kQueriesPerBlock>>;
+                        using Epilogue = typename cutlass::epilogue::
+                            threadblock::EpiloguePipelined<
+                                typename DefaultEpilogue::Shape,
+                                typename MM1::Mma::Operator,
+                                DefaultEpilogue::kPartitionsK,
+                                typename cutlass::platform::conditional<
+                                    kIsLast::value,
+                                    typename MM1::OutputTileIterator,
+                                    typename MM1::OutputTileIteratorAccum>::
+                                    type,
+                                typename DefaultEpilogue::
+                                    AccumulatorFragmentIterator,
+                                typename DefaultEpilogue::WarpTileIterator,
+                                typename DefaultEpilogue::SharedLoadIterator,
+                                EpilogueOutputOp,
+                                typename DefaultEpilogue::Padding,
+                                DefaultEpilogue::kFragmentsPerIteration,
+                                true,  // IterationsUnroll
+                                typename MM1::
+                                    OutputTileIteratorAccum  // Read
+                                                             // iterator
+                                >;
+
+                        int col = blockN * MM1::Mma::Shape::kN;
+                        auto source_iter = createOutputAccumIter(col);
+                        auto dest_iter = gemm_kernel_utils::call_conditional<
+                            kIsLast::value, decltype(createOutputIter),
+                            decltype(createOutputAccumIter)>::
+                            apply(createOutputIter, createOutputAccumIter, col);
+                        EpilogueOutputOp rescale(s_prime, out_rescale);
+                        Epilogue epilogue(
+                            shared_storage.epilogue_shared_storage(),
+                            thread_id(), warp_id(), lane_id());
+                        epilogue(rescale, dest_iter, accum_o, source_iter);
+                      }));
+                }));
+            if (!kKeepOutputInRF) {
+              __syncthreads();
+            }
+          }
+        }
+        __syncthreads();  // we modify `m_prime` after
+      }
+
+      if (kKeepOutputInRF) {
+        constexpr bool kIsFirst = true;
+        constexpr bool kIsLast = true;
+        using DefaultEpilogue = typename MM1::DefaultEpilogue;
+        using DefaultOp = typename MM1::DefaultConfig::EpilogueOutputOp;
+        using ElementCompute = typename DefaultOp::ElementCompute;
+        using EpilogueOutputOp = typename cutlass::epilogue::thread::
+            MemoryEfficientAttentionNormalize<
+                output_t,        // output
+                output_accum_t,  // source
+                DefaultOp::kCount,
+                typename DefaultOp::ElementAccumulator,  // accum
+                output_accum_t,                          // compute
+                kIsFirst, kIsLast,
+                cutlass::Array<ElementCompute, kQueriesPerBlock>>;
+        using Epilogue =
+            typename cutlass::epilogue::threadblock::EpiloguePipelined<
+                typename DefaultEpilogue::Shape, typename MM1::Mma::Operator,
+                DefaultEpilogue::kPartitionsK,
+                typename MM1::OutputTileIterator,  // destination
+                typename DefaultEpilogue::AccumulatorFragmentIterator,
+                typename DefaultEpilogue::WarpTileIterator,
+                typename DefaultEpilogue::SharedLoadIterator, EpilogueOutputOp,
+                typename DefaultEpilogue::Padding,
+                DefaultEpilogue::kFragmentsPerIteration,
+                true,                                  // IterationsUnroll
+                typename MM1::OutputTileIteratorAccum  // source tile
+                >;
+        auto dest_iter = createOutputIter(0);
+        EpilogueOutputOp rescale(s_prime, out_rescale);
+        Epilogue epilogue(shared_storage.epilogue_shared_storage(), thread_id(),
+                          warp_id(), lane_id());
+        MM1::Mma::drain_cp_asyncs();
+        epilogue(rescale, dest_iter, accum_o);
+      }
+
+      // Next tile
+      problem_visitor.advance(gridDim.x);
+      __syncthreads();  // Don't start the next iteration until all threads are
+                        // done using shared memory.
+    }
+  }
+
+  template <typename WarpIteratorC>
+  CUTLASS_DEVICE static void iterative_softmax(
+      typename MM1::Mma::FragmentC& frag_o,  // output so far
+      typename WarpIteratorC::Fragment& frag,
+      cutlass::Array<accum_t, kQueriesPerBlock>& mi,
+      cutlass::Array<accum_t, kQueriesPerBlock>& m_prime,
+      cutlass::Array<accum_t, kQueriesPerBlock>& s_prime,
+      cutlass::Array<accum_t, kQueriesPerBlock>& out_rescale,
+      cutlass::Array<accum_t, kQueriesPerBlock * MM0::MmaCore::WarpCount::kN>&
+          addition_storage,
+      int8_t lane_id, int8_t thread_id, int8_t warp_id, int max_col,
+      bool is_first, typename WarpIteratorC::TensorCoord const& tile_offset,
+      float scaling) {
+    /* Iterates on the accumulator and corresponding position on result matrix
+
+    (1) Update `mi[r]` to the max value of the row `r`
+    (2) In a second iteration do the following:
+        (a) accum   <- exp(accum - mi)
+        (b) m_prime <- exp(m_prime - mi)
+        (c) s_prime <- s_prime * m_prime + sum(accum)
+
+    All of this is done on registers, before we store all of this
+    on shared memory for the next matmul with Value.
+    */
+    using Fragment = typename WarpIteratorC::Fragment;
+    using LambdaIterator =
+        typename DefaultMmaAccumLambdaIterator<WarpIteratorC, accum_t,
+                                               kThreadsPerWarp>::Iterator;
+    // Convert to `accum_t` (rather than double)
+    constexpr float kLog2e = 1.4426950408889634074;  // log_2(e) = M_LOG2E
+
+    static_assert(kQueriesPerBlock % kNumWarpsPerBlock == 0, "");
+    static constexpr int kLinesPerWarp = kQueriesPerBlock / kNumWarpsPerBlock;
+
+    frag = cutlass::multiplies<Fragment>()(scaling * kLog2e, frag);
+
+    auto lane_offset =
+        LambdaIterator::get_lane_offset(lane_id, warp_id, tile_offset);
+
+    // First update `mi` to the max per-row
+    {
+      accum_t max;
+      LambdaIterator::iterateRows(
+          lane_offset,
+          [&](int accum_m) {
+            max = -cutlass::platform::numeric_limits<accum_t>::infinity();
+          },
+          [&](int accum_m, int accum_n, int idx) {
+            if (accum_n < max_col) {
+              max = cutlass::fast_max(max, frag[idx]);
+            }
+          },
+          [&](int accum_m) {
+            // Having 4x atomicMax seems faster than reduce within warp
+            // first...
+            atomicMaxFloat(&mi[accum_m], max);
+          });
+    }
+
+    // Make sure we all share the update values for `mi`
+    __syncthreads();
+
+    // Doing this `exp` is quite expensive. Let's
+    // split it across the warps
+    bool restore_mi_to_minus_inf = false;
+    if (lane_id < kLinesPerWarp) {
+      int id = warp_id * kLinesPerWarp + lane_id;
+      auto m_prime_id = m_prime[id];
+      auto mi_id = mi[id];
+      bool changed = m_prime_id < mi_id;  // `false` if both are -inf
+      if (changed) {
+        auto m_prime_exp = exp2f(m_prime_id - mi_id);
+        out_rescale[id] = m_prime_exp;
+        s_prime[id] *= m_prime_exp;
+      } else {
+        // Only when bias is enabled, it's possible that all the first values
+        // of attention are masked to `-inf`. In that case we want to avoid
+        // `nan = exp2f(-inf - (-inf))` so we temporarily set `mi` to 0
+        if (kSupportsBias &&
+            mi_id == -cutlass::platform::numeric_limits<accum_t>::infinity()) {
+          restore_mi_to_minus_inf = true;
+          mi[id] = 0.0f;
+        }
+        out_rescale[id] = 1.0f;
+      }
+    }
+    __syncthreads();  // Update output fragments
+    if (kKeepOutputInRF && !is_first) {
+      using OutputLambda = typename DefaultMmaAccumLambdaIterator<
+          typename MM1::Mma::Operator::IteratorC, accum_t,
+          kThreadsPerWarp>::Iterator;
+      auto output_offset =
+          OutputLambda::get_lane_offset(lane_id, warp_id, tile_offset);
+      accum_t line_rescale;
+      OutputLambda::iterateRows(
+          output_offset,
+          [&](int accum_m) { line_rescale = out_rescale[accum_m]; },
+          [&](int accum_m, int accum_n, int idx) {
+            frag_o[idx] = frag_o[idx] * line_rescale;
+          },
+          [&](int accum_m) {});
+    }
+    // Update accum_m, accum_n, ...
+    {
+      accum_t mi_row, total_row;
+      LambdaIterator::iterateRows(
+          lane_offset, [&](int accum_m) { mi_row = mi[accum_m]; },
+          [&](int accum_m, int accum_n, int idx) {
+            frag[idx] =
+                (accum_n < max_col) ? exp2f(frag[idx] - mi_row) : accum_t(0.0);
+          },
+          [&](int accum_m) {});
+      LambdaIterator::iterateRows(
+          lane_offset, [&](int accum_m) { total_row = 0.0; },
+          [&](int accum_m, int accum_n, int idx) { total_row += frag[idx]; },
+          [&](int accum_m) {
+            if (LambdaIterator::reduceSameRow(
+                    lane_id, total_row,
+                    [](accum_t a, accum_t b) { return a + b; })) {
+              // NOTE: we could atomically add `total_row` to `s_prime`, but
+              // it's faster (and deterministic) to avoid atomics here
+              addition_storage[accum_m + kQueriesPerBlock *
+                                             tile_offset.column()] = total_row;
+            }
+          });
+    }
+
+    __syncthreads();
+    if (lane_id < kLinesPerWarp) {
+      int id = warp_id * kLinesPerWarp + lane_id;
+      accum_t total_row = s_prime[id];
+      if (restore_mi_to_minus_inf) {
+        // Restore `mi`, see above when we set `restore_mi_to_minus_inf=true`
+        mi[id] = -cutlass::platform::numeric_limits<accum_t>::infinity();
+      } else {
+        m_prime[id] = mi[id];
+      }
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < MM0::MmaCore::WarpCount::kN; ++i) {
+        total_row += addition_storage[id + kQueriesPerBlock * i];
+      }
+      s_prime[id] = total_row;
+    }
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace kernel
+}  // namespace gemm
+}  // namespace cutlass
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/flash-attention-v100/kernel/h3/forward.cu
+++ b/flash-attention-v100/kernel/h3/forward.cu
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Copyright contributors to the 1Cat-vLLM project
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+
+#include <cmath>
+#include <limits>
+
+#include <cutlass/gemm/device/default_gemm_configuration.h>
+#include <cutlass/gemm/kernel/default_gemm.h>
+
+#include "default_fmha.h"
+
+namespace {
+using Half = cutlass::half_t;
+constexpr int kHeadDim = 128;
+constexpr int kQueries = 64;
+using Kernel =
+    typename cutlass::gemm::kernel::H3FMHA<Half, cutlass::arch::Sm70, true,
+                                           kQueries, 64, kHeadDim>::FMHAKernel;
+
+// Keep pointer and shape preparation on the caller's CUDA stream, including
+// graph replay. Each independent MHA head is a separate grouped GEMM problem.
+__global__ void prepare_metadata(int64_t* meta, Half* q, Half* k, Half* v,
+                                 Half* out, int queries, int keys, int heads,
+                                 int groups) {
+  int group = blockIdx.x * blockDim.x + threadIdx.x;
+  if (group >= groups) return;
+  int batch = group / heads;
+  int head = group % heads;
+  int64_t q_offset = (int64_t(batch) * queries * heads + head) * kHeadDim;
+  int64_t kv_offset = (int64_t(batch) * keys * heads + head) * kHeadDim;
+  meta[group] = reinterpret_cast<int64_t>(q + q_offset);
+  meta[groups + group] = reinterpret_cast<int64_t>(k + kv_offset);
+  meta[2 * groups + group] = 0;  // No global probability matrix.
+  meta[3 * groups + group] = reinterpret_cast<int64_t>(v + kv_offset);
+  meta[4 * groups + group] = reinterpret_cast<int64_t>(out + q_offset);
+  meta[5 * groups + group] = 0;  // FP32 output state stays in registers.
+  for (int slot = 6; slot < 10; ++slot)
+    meta[slot * groups + group] = int64_t(heads) * kHeadDim;
+  auto sizes = reinterpret_cast<cutlass::gemm::GemmCoord*>(meta + 10 * groups);
+  sizes[group] = cutlass::gemm::GemmCoord(queries, keys, kHeadDim);
+  sizes[groups + group] = cutlass::gemm::GemmCoord(queries, kHeadDim, keys);
+}
+
+__global__ __launch_bounds__(Kernel::kThreadCount,
+                             1) void h3_flash_v100_d128(Kernel::Params params) {
+  extern __shared__ __align__(16) unsigned char storage[];
+  Kernel kernel;
+  kernel(params, *reinterpret_cast<Kernel::SharedStorage*>(storage));
+}
+
+at::Tensor aligned_contiguous(const at::Tensor& tensor) {
+  auto result = tensor.contiguous();
+  // contiguous() may preserve a contiguous view with an unaligned offset.
+  if (reinterpret_cast<uintptr_t>(result.data_ptr()) % 16 != 0)
+    result = result.clone();
+  return result;
+}
+}  // namespace
+
+at::Tensor h3_flash_attention_forward(at::Tensor q, at::Tensor k, at::Tensor v,
+                                      double scale) {
+  TORCH_CHECK(q.is_cuda() && q.dim() == 4 && q.scalar_type() == at::kHalf,
+              "H3 FlashAttention-V100 requires CUDA FP16 BSND tensors");
+  TORCH_CHECK(k.device() == q.device() && v.device() == q.device() &&
+                  k.scalar_type() == q.scalar_type() &&
+                  v.scalar_type() == q.scalar_type(),
+              "H3 Q/K/V must share device and FP16 dtype");
+  TORCH_CHECK(q.size(0) > 0 && q.size(1) > 0 && q.size(2) > 0 &&
+                  q.size(3) == kHeadDim && k.dim() == 4 && k.size(1) > 0 &&
+                  k.size(0) == q.size(0) && k.size(2) == q.size(2) &&
+                  k.size(3) == kHeadDim && k.sizes() == v.sizes(),
+              "H3 FlashAttention-V100 requires non-empty D128 MHA");
+  TORCH_CHECK(std::isfinite(scale) && scale > 0 &&
+                  scale <= std::numeric_limits<float>::max(),
+              "H3 attention scale must be finite and positive");
+  TORCH_CHECK(!q.requires_grad() && !k.requires_grad() && !v.requires_grad(),
+              "H3 FlashAttention-V100 is an inference-only operator");
+  const c10::cuda::CUDAGuard guard(q.device());
+  auto* properties = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(properties->major == 7 && properties->minor == 0,
+              "H3 FlashAttention-V100 requires SM70");
+  int64_t groups64 = q.size(0) * q.size(2);
+  int64_t blocks64 = ((q.size(1) + kQueries - 1) / kQueries) * groups64;
+  TORCH_CHECK(q.size(1) <= INT_MAX && k.size(1) <= INT_MAX &&
+                  groups64 <= INT_MAX / 16 && blocks64 <= INT_MAX,
+              "H3 attention shape exceeds kernel index limits");
+  q = aligned_contiguous(q);
+  k = aligned_contiguous(k);
+  v = aligned_contiguous(v);
+  auto output = at::empty_like(q);
+  int groups = groups64;
+  auto metadata =
+      at::empty({int64_t(groups) * 16}, q.options().dtype(at::kLong));
+  auto* ptr = metadata.data_ptr<int64_t>();
+  auto stream = at::cuda::getCurrentCUDAStream();
+  prepare_metadata<<<(groups + 127) / 128, 128, 0, stream>>>(
+      ptr, reinterpret_cast<Half*>(q.data_ptr()),
+      reinterpret_cast<Half*>(k.data_ptr()),
+      reinterpret_cast<Half*>(v.data_ptr()),
+      reinterpret_cast<Half*>(output.data_ptr()), q.size(1), k.size(1),
+      q.size(2), groups);
+  Kernel::Arguments args;
+  args.problem_sizes0 =
+      reinterpret_cast<cutlass::gemm::GemmCoord*>(ptr + 10 * groups);
+  args.problem_sizes1 = args.problem_sizes0 + groups;
+  args.problem_count = groups;
+  args.threadblock_count = blocks64;
+  args.ptr_Q = reinterpret_cast<Half**>(ptr);
+  args.ptr_K = reinterpret_cast<Half**>(ptr + groups);
+  args.ptr_P = reinterpret_cast<float**>(ptr + 2 * groups);
+  args.ptr_V = reinterpret_cast<Half**>(ptr + 3 * groups);
+  args.ptr_O = reinterpret_cast<Half**>(ptr + 4 * groups);
+  args.ptr_O_accum = reinterpret_cast<float**>(ptr + 5 * groups);
+  args.ldq = ptr + 6 * groups;
+  args.ldk = ptr + 7 * groups;
+  args.ldv = ptr + 8 * groups;
+  args.ldo = ptr + 9 * groups;
+  args.causal = false;
+  args.scale = static_cast<float>(scale);
+  Kernel::Params params(args, nullptr, args.threadblock_count);
+  // The D128 tile fits the default shared-memory limit (26,128 bytes).
+  // Only larger future specializations need the dynamic-memory opt-in.
+  if constexpr (sizeof(Kernel::SharedStorage) > 48 * 1024) {
+    C10_CUDA_CHECK(cudaFuncSetAttribute(
+        h3_flash_v100_d128, cudaFuncAttributeMaxDynamicSharedMemorySize,
+        sizeof(Kernel::SharedStorage)));
+  }
+  h3_flash_v100_d128<<<args.threadblock_count, Kernel::kThreadCount,
+                       sizeof(Kernel::SharedStorage), stream>>>(params);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("forward", &h3_flash_attention_forward);
+}

--- a/flash-attention-v100/kernel/h3/forward.cu
+++ b/flash-attention-v100/kernel/h3/forward.cu
@@ -18,39 +18,48 @@ namespace {
 using Half = cutlass::half_t;
 constexpr int kHeadDim = 128;
 constexpr int kQueries = 64;
-using Kernel =
-    typename cutlass::gemm::kernel::H3FMHA<Half, cutlass::arch::Sm70, true,
-                                           kQueries, 64, kHeadDim>::FMHAKernel;
+template <int Keys>
+using KernelFor = typename cutlass::gemm::kernel::H3FMHA<
+    Half, cutlass::arch::Sm70, true, kQueries, Keys, kHeadDim>::FMHAKernel;
 
-// Keep pointer and shape preparation on the caller's CUDA stream, including
-// graph replay. Each independent MHA head is a separate grouped GEMM problem.
-__global__ void prepare_metadata(int64_t* meta, Half* q, Half* k, Half* v,
-                                 Half* out, int queries, int keys, int heads,
-                                 int groups) {
-  int group = blockIdx.x * blockDim.x + threadIdx.x;
-  if (group >= groups) return;
-  int batch = group / heads;
-  int head = group % heads;
-  int64_t q_offset = (int64_t(batch) * queries * heads + head) * kHeadDim;
-  int64_t kv_offset = (int64_t(batch) * keys * heads + head) * kHeadDim;
-  meta[group] = reinterpret_cast<int64_t>(q + q_offset);
-  meta[groups + group] = reinterpret_cast<int64_t>(k + kv_offset);
-  meta[2 * groups + group] = 0;  // No global probability matrix.
-  meta[3 * groups + group] = reinterpret_cast<int64_t>(v + kv_offset);
-  meta[4 * groups + group] = reinterpret_cast<int64_t>(out + q_offset);
-  meta[5 * groups + group] = 0;  // FP32 output state stays in registers.
-  for (int slot = 6; slot < 10; ++slot)
-    meta[slot * groups + group] = int64_t(heads) * kHeadDim;
-  auto sizes = reinterpret_cast<cutlass::gemm::GemmCoord*>(meta + 10 * groups);
-  sizes[group] = cutlass::gemm::GemmCoord(queries, keys, kHeadDim);
-  sizes[groups + group] = cutlass::gemm::GemmCoord(queries, kHeadDim, keys);
+template <int Keys, bool Fixed>
+__global__ __launch_bounds__(128, 1) void h3_flash_v100_d128(
+    typename KernelFor<Keys>::DirectParams params) {
+  extern __shared__ __align__(16) unsigned char storage[];
+  if constexpr (Fixed) {
+    params.heads = 14;
+    params.queries = 12323;
+    params.keys = 12323;
+  }
+  KernelFor<Keys> kernel;
+  kernel(params,
+         *reinterpret_cast<typename KernelFor<Keys>::SharedStorage*>(storage));
 }
 
-__global__ __launch_bounds__(Kernel::kThreadCount,
-                             1) void h3_flash_v100_d128(Kernel::Params params) {
-  extern __shared__ __align__(16) unsigned char storage[];
-  Kernel kernel;
-  kernel(params, *reinterpret_cast<Kernel::SharedStorage*>(storage));
+template <int Keys, bool Fixed = false>
+void launch_attention(at::Tensor const& q, at::Tensor const& k,
+                      at::Tensor const& v, at::Tensor& output, float scale) {
+  using Kernel = KernelFor<Keys>;
+  typename Kernel::DirectParams params{
+      reinterpret_cast<Half*>(q.data_ptr()),
+      reinterpret_cast<Half*>(k.data_ptr()),
+      reinterpret_cast<Half*>(v.data_ptr()),
+      reinterpret_cast<Half*>(output.data_ptr()),
+      int(q.size(1)),
+      int(k.size(1)),
+      int(q.size(2)),
+      scale};
+  if constexpr (Keys == 128) {
+    // 34,304 bytes/block: allow two resident blocks without extra global
+    // storage.
+    C10_CUDA_CHECK(cudaFuncSetAttribute(
+        h3_flash_v100_d128<Keys, Fixed>,
+        cudaFuncAttributePreferredSharedMemoryCarveout, 100));
+  }
+  h3_flash_v100_d128<Keys, Fixed>
+      <<<dim3((q.size(1) + kQueries - 1) / kQueries, q.size(0) * q.size(2)),
+         Kernel::kThreadCount, sizeof(typename Kernel::SharedStorage),
+         at::cuda::getCurrentCUDAStream()>>>(params);
 }
 
 at::Tensor aligned_contiguous(const at::Tensor& tensor) {
@@ -63,7 +72,7 @@ at::Tensor aligned_contiguous(const at::Tensor& tensor) {
 }  // namespace
 
 at::Tensor h3_flash_attention_forward(at::Tensor q, at::Tensor k, at::Tensor v,
-                                      double scale) {
+                                      double scale, int key_tile) {
   TORCH_CHECK(q.is_cuda() && q.dim() == 4 && q.scalar_type() == at::kHalf,
               "H3 FlashAttention-V100 requires CUDA FP16 BSND tensors");
   TORCH_CHECK(k.device() == q.device() && v.device() == q.device() &&
@@ -80,6 +89,8 @@ at::Tensor h3_flash_attention_forward(at::Tensor q, at::Tensor k, at::Tensor v,
               "H3 attention scale must be finite and positive");
   TORCH_CHECK(!q.requires_grad() && !k.requires_grad() && !v.requires_grad(),
               "H3 FlashAttention-V100 is an inference-only operator");
+  TORCH_CHECK(key_tile == 0 || key_tile == 64 || key_tile == 128,
+              "H3 attention key tile must be 0, 64 or 128");
   const c10::cuda::CUDAGuard guard(q.device());
   auto* properties = at::cuda::getCurrentDeviceProperties();
   TORCH_CHECK(properties->major == 7 && properties->minor == 0,
@@ -87,55 +98,29 @@ at::Tensor h3_flash_attention_forward(at::Tensor q, at::Tensor k, at::Tensor v,
   int64_t groups64 = q.size(0) * q.size(2);
   int64_t blocks64 = ((q.size(1) + kQueries - 1) / kQueries) * groups64;
   TORCH_CHECK(q.size(1) <= INT_MAX && k.size(1) <= INT_MAX &&
-                  groups64 <= INT_MAX / 16 && blocks64 <= INT_MAX,
+                  groups64 <= 65535 && blocks64 <= INT_MAX,
               "H3 attention shape exceeds kernel index limits");
   q = aligned_contiguous(q);
   k = aligned_contiguous(k);
   v = aligned_contiguous(v);
   auto output = at::empty_like(q);
-  int groups = groups64;
-  auto metadata =
-      at::empty({int64_t(groups) * 16}, q.options().dtype(at::kLong));
-  auto* ptr = metadata.data_ptr<int64_t>();
-  auto stream = at::cuda::getCurrentCUDAStream();
-  prepare_metadata<<<(groups + 127) / 128, 128, 0, stream>>>(
-      ptr, reinterpret_cast<Half*>(q.data_ptr()),
-      reinterpret_cast<Half*>(k.data_ptr()),
-      reinterpret_cast<Half*>(v.data_ptr()),
-      reinterpret_cast<Half*>(output.data_ptr()), q.size(1), k.size(1),
-      q.size(2), groups);
-  Kernel::Arguments args;
-  args.problem_sizes0 =
-      reinterpret_cast<cutlass::gemm::GemmCoord*>(ptr + 10 * groups);
-  args.problem_sizes1 = args.problem_sizes0 + groups;
-  args.problem_count = groups;
-  args.threadblock_count = blocks64;
-  args.ptr_Q = reinterpret_cast<Half**>(ptr);
-  args.ptr_K = reinterpret_cast<Half**>(ptr + groups);
-  args.ptr_P = reinterpret_cast<float**>(ptr + 2 * groups);
-  args.ptr_V = reinterpret_cast<Half**>(ptr + 3 * groups);
-  args.ptr_O = reinterpret_cast<Half**>(ptr + 4 * groups);
-  args.ptr_O_accum = reinterpret_cast<float**>(ptr + 5 * groups);
-  args.ldq = ptr + 6 * groups;
-  args.ldk = ptr + 7 * groups;
-  args.ldv = ptr + 8 * groups;
-  args.ldo = ptr + 9 * groups;
-  args.causal = false;
-  args.scale = static_cast<float>(scale);
-  Kernel::Params params(args, nullptr, args.threadblock_count);
-  // The D128 tile fits the default shared-memory limit (26,128 bytes).
-  // Only larger future specializations need the dynamic-memory opt-in.
-  if constexpr (sizeof(Kernel::SharedStorage) > 48 * 1024) {
-    C10_CUDA_CHECK(cudaFuncSetAttribute(
-        h3_flash_v100_d128, cudaFuncAttributeMaxDynamicSharedMemorySize,
-        sizeof(Kernel::SharedStorage)));
-  }
-  h3_flash_v100_d128<<<args.threadblock_count, Kernel::kThreadCount,
-                       sizeof(Kernel::SharedStorage), stream>>>(params);
+  // Keep small/refiner requests on the previous arithmetic path. Large
+  // self-attention reuses each Q fragment across twice as many keys.
+  int selected =
+      key_tile ? key_tile : (q.size(1) >= 1024 && k.size(1) >= 1024 ? 128 : 64);
+  if (selected == 128) {
+    if (q.size(1) == 12323 && k.size(1) == 12323 && q.size(2) == 14)
+      launch_attention<128, true>(q, k, v, output, float(scale));
+    else
+      launch_attention<128>(q, k, v, output, float(scale));
+  } else
+    launch_attention<64>(q, k, v, output, float(scale));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return output;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("forward", &h3_flash_attention_forward);
+  m.def("forward", &h3_flash_attention_forward, pybind11::arg("q"),
+        pybind11::arg("k"), pybind11::arg("v"), pybind11::arg("scale"),
+        pybind11::arg("key_tile") = 0);
 }

--- a/flash-attention-v100/kernel/h3/prefetch_mma.h
+++ b/flash-attention-v100/kernel/h3/prefetch_mma.h
@@ -1,0 +1,207 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+#include "gemm/mma_from_smem.h"
+
+namespace cutlass::gemm::threadblock {
+// Retain the SM70 software pipeline, accepting the first V tile loaded while
+// softmax is computed. This adds no shared-memory or persistent GPU allocation.
+template <typename Mma>
+class H3PrefetchMma : public Mma {
+ public:
+  using Mma::Mma;
+  using Base = typename Mma::Base;
+  using FragmentB = typename Mma::FragmentB;
+  using FragmentC = typename Mma::FragmentC;
+  using IteratorB = typename Mma::IteratorB;
+  using TransformB = typename Mma::TransformB;
+  using Operator = typename Mma::Operator;
+  using Policy = typename Mma::Policy;
+  using WarpFragmentA = typename Operator::FragmentA;
+  using WarpFragmentB = typename Operator::FragmentB;
+  using WarpFragmentAScale = typename Mma::WarpIteratorAScale::Fragment;
+  using FragmentAScaler =
+      FragmentElementwiseScaler<WarpFragmentA, WarpFragmentAScale,
+                                Mma::ScaleOperandA>;
+  static_assert(!Mma::ScaleOperandA);
+  /// Perform a threadblock-scoped matrix multiply-accumulate
+  CUTLASS_DEVICE
+  void operator()(
+      int gemm_k_iterations,  ///< number of iterations of the mainloop
+      FragmentC& accum,       ///< destination accumulator tile
+      // IteratorA iterator_A,                             ///< iterator over A
+      // operand in global memory
+      IteratorB iterator_B,        ///< iterator over B operand in global memory
+      FragmentC const& src_accum,  ///< source accumulator tile
+      FragmentB const* prefetched = nullptr,
+      // TransformA transform_A = TransformA(),            ///< transformation
+      // applied to A fragment
+      TransformB transform_B =
+          TransformB()) {  ///< transformation applied to B fragment
+
+    //
+    // Prologue
+    //
+
+    // Perform accumulation in the 'd' output operand
+    accum = src_accum;
+
+    FragmentB tb_frag_B;
+
+    iterator_B.set_residual_tile(gemm_k_iterations == 1);
+    if (prefetched) {
+      tb_frag_B = *prefetched;
+    } else {
+      tb_frag_B.clear();
+      iterator_B.load(tb_frag_B);
+    }
+
+    ++iterator_B;
+
+    this->smem_iterator_B_.store(transform_B(tb_frag_B));
+
+    ++this->smem_iterator_B_;
+
+    __syncthreads();
+
+    // remember that WarpFragmentAScale and WarpIteratorAScale are empty/no-op
+    // if scaling is disabled.
+
+    // Pair of fragments used to overlap shared memory loads and math
+    // instructions
+    WarpFragmentA warp_frag_A[2];
+    WarpFragmentAScale warp_frag_A_scale[2];
+    WarpFragmentB warp_frag_B[2];
+    warp_frag_A[0].clear();
+    warp_frag_A_scale[0].clear();
+    warp_frag_B[0].clear();
+
+    this->warp_tile_iterator_B_.set_kgroup_index(0);
+
+    this->warp_tile_iterator_A_.load(warp_frag_A[0]);
+    this->warp_tile_iterator_A_scale_.load(warp_frag_A_scale[0]);
+    this->warp_tile_iterator_B_.load(warp_frag_B[0]);
+
+    ++this->warp_tile_iterator_A_;
+    ++this->warp_tile_iterator_A_scale_;
+    ++this->warp_tile_iterator_B_;
+
+    Operator warp_mma;
+
+    int smem_write_stage_idx = 1;
+
+    // Avoid reading out of bounds
+    iterator_B.set_residual_tile(gemm_k_iterations == 2);
+    iterator_B.clear_mask(gemm_k_iterations <= 1);
+
+    // Issue loads during the first warp-level matrix multiply-add *AFTER*
+    // issuing shared memory loads (which have the tightest latency
+    // requirement).
+
+    //
+    // Mainloop
+    //
+
+    // Note: The main loop does not support Base::kWarpGemmIterations == 2.
+    CUTLASS_GEMM_LOOP
+    for (; gemm_k_iterations > 0; --gemm_k_iterations) {
+      //
+      // Loop over GEMM K dimension
+      //
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int warp_mma_k = 0; warp_mma_k < Base::kWarpGemmIterations;
+           ++warp_mma_k) {
+        // Load warp-level tiles from shared memory, wrapping to k offset if
+        // this is the last group as the case may be.
+        bool hasNext = true;
+
+        if (warp_mma_k == Base::kWarpGemmIterations - 1) {
+          if (gemm_k_iterations > 1) {
+            // Write fragments to shared memory
+            this->smem_iterator_B_.store(transform_B(tb_frag_B));
+          }
+
+          __syncthreads();
+
+          ++this->smem_iterator_B_;
+
+          // Add negative offsets to return iterators to the 'start' of the
+          // circular buffer in shared memory SMEM: Don't reset iterator A, as
+          // we are continuing our iteration at this point
+          if (smem_write_stage_idx == 1) {
+            this->smem_iterator_B_.add_tile_offset({-Base::kStages, 0});
+          } else {
+            this->warp_tile_iterator_B_.add_tile_offset(
+                {-Base::kStages * Policy::kPartitionsK *
+                     Base::kWarpGemmIterations,
+                 0});
+          }
+
+          smem_write_stage_idx ^= 1;
+          hasNext = gemm_k_iterations > 1;
+        }
+
+        // Only read the next if we need to
+        if (hasNext) {
+          this->warp_tile_iterator_B_.set_kgroup_index(
+              (warp_mma_k + 1) % Base::kWarpGemmIterations);
+
+          this->warp_tile_iterator_A_.load(warp_frag_A[(warp_mma_k + 1) % 2]);
+          this->warp_tile_iterator_A_scale_.load(
+              warp_frag_A_scale[(warp_mma_k + 1) % 2]);
+          this->warp_tile_iterator_B_.load(warp_frag_B[(warp_mma_k + 1) % 2]);
+
+          ++this->warp_tile_iterator_A_;
+          ++this->warp_tile_iterator_A_scale_;
+          ++this->warp_tile_iterator_B_;
+
+          if (warp_mma_k == 0) {
+            iterator_B.load(tb_frag_B);
+
+            ++iterator_B;
+
+            // Avoid reading out of bounds if this was the last loop iteration
+            iterator_B.set_residual_tile(gemm_k_iterations == 3);
+            iterator_B.clear_mask(gemm_k_iterations <= 2);
+          }
+        }
+
+        warp_mma(accum,
+                 FragmentAScaler::apply(warp_frag_A[warp_mma_k % 2],
+                                        warp_frag_A_scale[warp_mma_k % 2]),
+                 warp_frag_B[warp_mma_k % 2], accum);
+      }
+    }
+  }
+};
+}  // namespace cutlass::gemm::threadblock

--- a/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
+++ b/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
@@ -11,20 +11,26 @@ namespace {
 constexpr int D = 128;
 constexpr int BQ = 128;
 constexpr int BK = 32;
+constexpr int VLD = BK + 8;
+constexpr int THREADS = (BQ / 16) * (BK / 16) * 32;
+static_assert(THREADS * 8 == BK * D);
 constexpr int shared_bytes() {
   constexpr int QLD = D + 8, PLD = BK + 8;
-  return (BQ * QLD + 2 * BK * QLD + BQ * PLD) * 2 +
+  return (BQ * QLD + BK * QLD + D * VLD + BQ * PLD) * 2 +
          (BQ * (BK / 16) * 2 + BQ * 2) * 4;
 }
 
-__global__ void h3_noncausal(const half* q, const half* k, const half* v,
-                             half* output, int length, int heads, float scale) {
+__global__ __launch_bounds__(THREADS,
+                             1) void h3_noncausal(const half* q, const half* k,
+                                                  const half* v, half* output,
+                                                  int length, int heads,
+                                                  float scale) {
   constexpr int QLD = D + 8, PLD = BK + 8;
   extern __shared__ __align__(32) unsigned char raw[];
   half* qs = reinterpret_cast<half*>(raw);
   half* ks = qs + BQ * QLD;
   half* vs = ks + BK * QLD;
-  half* probabilities = vs + BK * QLD;
+  half* probabilities = vs + D * VLD;
   float* scores = reinterpret_cast<float*>(probabilities + BQ * PLD);
   float* maximum = scores + BQ * (BK / 16) * 2;
   float* denominator = maximum + BQ;
@@ -57,14 +63,17 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
   }
   __syncthreads();
   for (int start = 0; start < length; start += BK) {
-    for (int i = tid; i < BK * D; i += blockDim.x) {
-      const int row = start + i / D;
-      const int64_t position = base + int64_t(row) * heads * D + i % D;
-      ks[(i / D) * QLD + i % D] =
-          row < length ? k[position] : __float2half(0.f);
-      vs[(i / D) * QLD + i % D] =
-          row < length ? v[position] : __float2half(0.f);
+    if (start == 0) {
+      for (int i = tid; i < BK * D; i += blockDim.x) {
+        const int row = start + i / D;
+        const int64_t position = base + int64_t(row) * heads * D + i % D;
+        ks[(i / D) * QLD + i % D] =
+            row < length ? k[position] : __float2half(0.f);
+        vs[(i % D) * VLD + i / D] =
+            row < length ? v[position] : __float2half(0.f);
+      }
     }
+    // Join both the initial loads and the previous iteration's prefetch.
     __syncthreads();
     fi::AccumulatorFragment qk;
     fi::init_accumulator_fragment(qk);
@@ -141,6 +150,37 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
         }
       }
     }
+    // Issue the next K/V global loads while the current V tile is consumed.
+    union StagedVector {
+      uint4 packed;
+      half values[8];
+    } next_k, next_v;
+    const int next_row = start + BK + tid / (D / 8);
+    const int next_col = (tid % (D / 8)) * 8;
+    if (next_row < length) {
+      const int64_t position = base + int64_t(next_row) * heads * D + next_col;
+      if ((reinterpret_cast<uintptr_t>(k) % 16 == 0) &&
+          (reinterpret_cast<uintptr_t>(v) % 16 == 0)) {
+        asm volatile("ld.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                     : "=r"(next_k.packed.x), "=r"(next_k.packed.y),
+                       "=r"(next_k.packed.z), "=r"(next_k.packed.w)
+                     : "l"(k + position));
+        asm volatile("ld.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                     : "=r"(next_v.packed.x), "=r"(next_v.packed.y),
+                       "=r"(next_v.packed.z), "=r"(next_v.packed.w)
+                     : "l"(v + position));
+      } else {
+        // Contiguous storage-offset views need scalar global loads.
+#pragma unroll
+        for (int j = 0; j < 8; ++j) {
+          next_k.values[j] = k[position + j];
+          next_v.values[j] = v[position + j];
+        }
+      }
+    } else {
+      next_k.packed = make_uint4(0, 0, 0, 0);
+      next_v.packed = make_uint4(0, 0, 0, 0);
+    }
 #pragma unroll
     for (int part = 0; part < D / BK; ++part) {
       const int col = warp_k * (D * 16 / BK) + part * 16;
@@ -152,13 +192,20 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
 #pragma unroll
       for (int kv = 0; kv < BK; kv += 16) {
         fi::AFragment pa;
-        fi::PVBFragment vb;
+        fi::QKBFragment vb;
         fi::load_a_fragment(pa, probabilities + row * PLD + kv, PLD);
-        fi::load_pv_b_fragment(vb, vs + kv * QLD + col, QLD);
-        fi::mma_sync_m16n16k16_row_row_f16f16f32(pv, pa, vb);
+        fi::load_qk_b_fragment(vb, vs + col * VLD + kv, VLD);
+        fi::mma_sync_m16n16k16_row_col_f16f16f32(pv, pa, vb);
       }
     }
     __syncthreads();
+    if (start + BK < length) {
+      *reinterpret_cast<uint4*>(ks + (tid / (D / 8)) * QLD + next_col) =
+          next_k.packed;
+#pragma unroll
+      for (int j = 0; j < 8; ++j)
+        vs[(next_col + j) * VLD + tid / (D / 8)] = next_v.values[j];
+    }
   }
   {
 #pragma unroll

--- a/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
+++ b/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
@@ -200,11 +200,19 @@ __global__ __launch_bounds__(THREADS,
     }
     __syncthreads();
     if (start + BK < length) {
-      *reinterpret_cast<uint4*>(ks + (tid / (D / 8)) * QLD + next_col) =
-          next_k.packed;
+      const int tile_row = tid / (D / 8);
+      *reinterpret_cast<uint4*>(ks + tile_row * QLD + next_col) = next_k.packed;
+      // Reuse dead P storage to transpose V cooperatively. Direct strided
+      // stores from each thread's eight contiguous values collide heavily.
+      static_assert(BQ * PLD >= BK * QLD);
+      *reinterpret_cast<uint4*>(probabilities + tile_row * QLD + next_col) =
+          next_v.packed;
+      __syncthreads();
 #pragma unroll
-      for (int j = 0; j < 8; ++j)
-        vs[(next_col + j) * VLD + tid / (D / 8)] = next_v.values[j];
+      for (int i = tid; i < D * BK; i += THREADS) {
+        const int d = i / BK, kv = i % BK;
+        vs[d * VLD + kv] = probabilities[kv * QLD + d];
+      }
     }
   }
   {

--- a/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
+++ b/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
@@ -9,31 +9,38 @@
 namespace fi = flashinfer::attention::sm70;
 namespace {
 constexpr int D = 128;
-template <int BQ, int BK, bool Padded = false>
+constexpr int BQ = 128;
+constexpr int BK = 32;
 constexpr int shared_bytes() {
-  constexpr int QLD = D + (Padded ? 8 : 0), PLD = BK + (Padded ? 8 : 0);
-  constexpr int OLD = D + (Padded ? 4 : 0);
+  constexpr int QLD = D + 8, PLD = BK + 8;
   return (BQ * QLD + 2 * BK * QLD + BQ * PLD) * 2 +
-         (BQ * PLD + BQ * OLD + BQ * 3) * 4;
+         (BQ * (BK / 16) * 2 + BQ * 2) * 4;
 }
 
-template <int BQ, int BK, bool Padded = false>
 __global__ void h3_noncausal(const half* q, const half* k, const half* v,
                              half* output, int length, int heads, float scale) {
-  constexpr int QLD = D + (Padded ? 8 : 0), PLD = BK + (Padded ? 8 : 0);
-  constexpr int OLD = D + (Padded ? 4 : 0);
+  constexpr int QLD = D + 8, PLD = BK + 8;
   extern __shared__ __align__(32) unsigned char raw[];
   half* qs = reinterpret_cast<half*>(raw);
   half* ks = qs + BQ * QLD;
   half* vs = ks + BK * QLD;
   half* probabilities = vs + BK * QLD;
   float* scores = reinterpret_cast<float*>(probabilities + BQ * PLD);
-  float* os = scores + BQ * PLD;
-  float* maximum = os + BQ * OLD;
+  float* maximum = scores + BQ * (BK / 16) * 2;
   float* denominator = maximum + BQ;
-  float* alpha = denominator + BQ;
   const int tid = threadIdx.x, warp = tid / 32;
   const int warp_q = warp / (BK / 16), warp_k = warp % (BK / 16);
+  const int lane = tid % 32;
+  // Volta m16n16 accumulator element coordinates, matching the repository's
+  // SM70 WMMA masking convention. SM70 is checked before dispatch.
+  const int fragment_row =
+      (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
+  const int fragment_col = ((lane >> 1) & 1) * 2 + ((lane >> 3) & 1) * 8;
+  fi::AccumulatorFragment accumulators[D / BK];
+  float register_alpha[2];
+#pragma unroll
+  for (int part = 0; part < D / BK; ++part)
+    fi::init_accumulator_fragment(accumulators[part]);
   const int q_start = blockIdx.x * BQ;
   const int head = blockIdx.y % heads;
   const int batch = blockIdx.y / heads;
@@ -43,7 +50,6 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
     qs[(i / D) * QLD + i % D] = row < length
                                     ? q[base + int64_t(row) * heads * D + i % D]
                                     : __float2half(0.f);
-    os[(i / D) * OLD + i % D] = 0.f;
   }
   if (tid < BQ) {
     maximum[tid] = -INFINITY;
@@ -70,53 +76,79 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
       fi::load_qk_b_fragment(kb, ks + warp_k * 16 * QLD + dim, QLD);
       fi::mma_sync_m16n16k16_row_col_f16f16f32(qk, qa, kb);
     }
-    fi::store_accumulator_fragment(scores + warp_q * 16 * PLD + warp_k * 16, qk,
-                                   PLD);
-    __syncthreads();
-    // Each warp reduces one query row. Serial per-thread expf over BK was
-    // the dominant cost in the initial correctness kernel.
-    const int lane = tid % 32;
-    for (int row = warp; row < BQ; row += blockDim.x / 32) {
-      float values[BK / 32];
-      float row_max = -INFINITY;
+    {
+      // Volta distributes each accumulator row across lanes differing in
+      // bits 1 and 3. Reduce its 16 columns in registers, then combine only
+      // the BK/16 warp partials through shared memory.
+      float row_max[2] = {-INFINITY, -INFINITY};
 #pragma unroll
-      for (int part = 0; part < BK / 32; ++part) {
-        const int col = lane + part * 32;
-        values[part] =
-            start + col < length ? scores[row * PLD + col] * scale : -INFINITY;
-        row_max = fmaxf(row_max, values[part]);
+      for (int i = 0; i < qk.num_elements; ++i) {
+        const int col =
+            warp_k * 16 + fragment_col + (i & 1) + ((i >> 2) & 1) * 4;
+        qk.x[i] = start + col < length ? qk.x[i] * scale : -INFINITY;
+        row_max[(i >> 1) & 1] = fmaxf(row_max[(i >> 1) & 1], qk.x[i]);
       }
 #pragma unroll
-      for (int offset = 16; offset > 0; offset /= 2)
-        row_max = fmaxf(row_max, __shfl_xor_sync(0xffffffff, row_max, offset));
-      const float m = fmaxf(maximum[row], row_max);
-      const float a = __expf(maximum[row] - m);
-      float sum = 0.f;
+      for (int r = 0; r < 2; ++r) {
+        row_max[r] =
+            fmaxf(row_max[r], __shfl_xor_sync(0xffffffff, row_max[r], 2));
+        row_max[r] =
+            fmaxf(row_max[r], __shfl_xor_sync(0xffffffff, row_max[r], 8));
+        const int row = warp_q * 16 + fragment_row + r * 2;
+        if ((lane & 10) == 0) scores[row * (BK / 16) + warp_k] = row_max[r];
+      }
+      __syncthreads();
+      float new_max[2], row_sum[2] = {0.f, 0.f};
 #pragma unroll
-      for (int part = 0; part < BK / 32; ++part) {
-        const float p = __expf(values[part] - m);
-        probabilities[row * PLD + lane + part * 32] = __float2half_rn(p);
-        sum += p;
+      for (int r = 0; r < 2; ++r) {
+        const int row = warp_q * 16 + fragment_row + r * 2;
+        new_max[r] = maximum[row];
+#pragma unroll
+        for (int w = 0; w < BK / 16; ++w)
+          new_max[r] = fmaxf(new_max[r], scores[row * (BK / 16) + w]);
+        register_alpha[r] = __expf(maximum[row] - new_max[r]);
       }
 #pragma unroll
-      for (int offset = 16; offset > 0; offset /= 2)
-        sum += __shfl_xor_sync(0xffffffff, sum, offset);
-      if (lane == 0) {
-        denominator[row] = denominator[row] * a + sum;
-        maximum[row] = m;
-        alpha[row] = a;
+      for (int i = 0; i < qk.num_elements; ++i) {
+        const int r = (i >> 1) & 1;
+        const int row = warp_q * 16 + fragment_row + r * 2;
+        const int col =
+            warp_k * 16 + fragment_col + (i & 1) + ((i >> 2) & 1) * 4;
+        const float p = __expf(qk.x[i] - new_max[r]);
+        probabilities[row * PLD + col] = __float2half_rn(p);
+        row_sum[r] += p;
+      }
+      float* partial_sums = scores + BQ * (BK / 16);
+#pragma unroll
+      for (int r = 0; r < 2; ++r) {
+        row_sum[r] += __shfl_xor_sync(0xffffffff, row_sum[r], 2);
+        row_sum[r] += __shfl_xor_sync(0xffffffff, row_sum[r], 8);
+        const int row = warp_q * 16 + fragment_row + r * 2;
+        if ((lane & 10) == 0)
+          partial_sums[row * (BK / 16) + warp_k] = row_sum[r];
+      }
+      __syncthreads();
+      if (warp_k == 0 && (lane & 10) == 0) {
+#pragma unroll
+        for (int r = 0; r < 2; ++r) {
+          const int row = warp_q * 16 + fragment_row + r * 2;
+          float sum = 0.f;
+#pragma unroll
+          for (int w = 0; w < BK / 16; ++w)
+            sum += partial_sums[row * (BK / 16) + w];
+          denominator[row] = denominator[row] * register_alpha[r] + sum;
+          maximum[row] = new_max[r];
+        }
       }
     }
-    __syncthreads();
-    for (int i = tid; i < BQ * D; i += blockDim.x)
-      os[(i / D) * OLD + i % D] *= alpha[i / D];
-    __syncthreads();
 #pragma unroll
     for (int part = 0; part < D / BK; ++part) {
       const int col = warp_k * (D * 16 / BK) + part * 16;
       const int row = warp_q * 16;
-      fi::AccumulatorFragment pv;
-      fi::load_accumulator_fragment(pv, os + row * OLD + col, OLD);
+      auto& pv = accumulators[part];
+#pragma unroll
+      for (int i = 0; i < pv.num_elements; ++i)
+        pv.x[i] *= register_alpha[(i >> 1) & 1];
 #pragma unroll
       for (int kv = 0; kv < BK; kv += 16) {
         fi::AFragment pa;
@@ -125,20 +157,27 @@ __global__ void h3_noncausal(const half* q, const half* k, const half* v,
         fi::load_pv_b_fragment(vb, vs + kv * QLD + col, QLD);
         fi::mma_sync_m16n16k16_row_row_f16f16f32(pv, pa, vb);
       }
-      fi::store_accumulator_fragment(os + row * OLD + col, pv, OLD);
     }
     __syncthreads();
   }
-  for (int i = tid; i < BQ * D; i += blockDim.x) {
-    const int row = q_start + i / D;
-    if (row < length)
-      output[base + int64_t(row) * heads * D + i % D] =
-          __float2half_rn(os[(i / D) * OLD + i % D] / denominator[i / D]);
+  {
+#pragma unroll
+    for (int part = 0; part < D / BK; ++part) {
+      const auto& pv = accumulators[part];
+#pragma unroll
+      for (int i = 0; i < pv.num_elements; ++i) {
+        const int row = warp_q * 16 + fragment_row + ((i >> 1) & 1) * 2;
+        const int col = warp_k * (D * 16 / BK) + part * 16 + fragment_col +
+                        (i & 1) + ((i >> 2) & 1) * 4;
+        if (q_start + row < length)
+          output[base + int64_t(q_start + row) * heads * D + col] =
+              __float2half_rn(pv.x[i] / denominator[row]);
+      }
+    }
   }
 }
 }  // namespace
 
-template <int BQ, int BK, bool Padded = false>
 torch::Tensor forward(torch::Tensor q, torch::Tensor k, torch::Tensor v,
                       double scale) {
   TORCH_CHECK(
@@ -162,22 +201,17 @@ torch::Tensor forward(torch::Tensor q, torch::Tensor k, torch::Tensor v,
               "H3 FlashInfer grid overflow");
   auto output = torch::empty_like(q);
   C10_CUDA_CHECK(cudaFuncSetAttribute(
-      h3_noncausal<BQ, BK, Padded>, cudaFuncAttributeMaxDynamicSharedMemorySize,
-      shared_bytes<BQ, BK, Padded>()));
+      h3_noncausal, cudaFuncAttributeMaxDynamicSharedMemorySize,
+      shared_bytes()));
   dim3 grid((q.size(1) + BQ - 1) / BQ, q.size(0) * q.size(2));
-  h3_noncausal<BQ, BK, Padded>
-      <<<grid, (BQ / 16) * (BK / 16) * 32, shared_bytes<BQ, BK, Padded>(),
-         at::cuda::getCurrentCUDAStream()>>>(
-          reinterpret_cast<const half*>(q.data_ptr<at::Half>()),
-          reinterpret_cast<const half*>(k.data_ptr<at::Half>()),
-          reinterpret_cast<const half*>(v.data_ptr<at::Half>()),
-          reinterpret_cast<half*>(output.data_ptr<at::Half>()), q.size(1),
-          q.size(2), float(scale));
+  h3_noncausal<<<grid, (BQ / 16) * (BK / 16) * 32, shared_bytes(),
+                 at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<const half*>(q.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(k.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(v.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(output.data_ptr<at::Half>()), q.size(1),
+      q.size(2), float(scale));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return output;
 }
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("forward", &forward<64, 32>);
-  m.def("forward_bq16", &forward<16, 64>);
-  m.def("forward_padded", &forward<64, 32, true>);
-}
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("forward", &forward); }

--- a/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
+++ b/flashinfer-sm70/csrc/h3_noncausal_sm70.cu
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <flashinfer/attention/sm70/volta_mma.cuh>
+
+namespace fi = flashinfer::attention::sm70;
+namespace {
+constexpr int D = 128;
+template <int BQ, int BK, bool Padded = false>
+constexpr int shared_bytes() {
+  constexpr int QLD = D + (Padded ? 8 : 0), PLD = BK + (Padded ? 8 : 0);
+  constexpr int OLD = D + (Padded ? 4 : 0);
+  return (BQ * QLD + 2 * BK * QLD + BQ * PLD) * 2 +
+         (BQ * PLD + BQ * OLD + BQ * 3) * 4;
+}
+
+template <int BQ, int BK, bool Padded = false>
+__global__ void h3_noncausal(const half* q, const half* k, const half* v,
+                             half* output, int length, int heads, float scale) {
+  constexpr int QLD = D + (Padded ? 8 : 0), PLD = BK + (Padded ? 8 : 0);
+  constexpr int OLD = D + (Padded ? 4 : 0);
+  extern __shared__ __align__(32) unsigned char raw[];
+  half* qs = reinterpret_cast<half*>(raw);
+  half* ks = qs + BQ * QLD;
+  half* vs = ks + BK * QLD;
+  half* probabilities = vs + BK * QLD;
+  float* scores = reinterpret_cast<float*>(probabilities + BQ * PLD);
+  float* os = scores + BQ * PLD;
+  float* maximum = os + BQ * OLD;
+  float* denominator = maximum + BQ;
+  float* alpha = denominator + BQ;
+  const int tid = threadIdx.x, warp = tid / 32;
+  const int warp_q = warp / (BK / 16), warp_k = warp % (BK / 16);
+  const int q_start = blockIdx.x * BQ;
+  const int head = blockIdx.y % heads;
+  const int batch = blockIdx.y / heads;
+  const int64_t base = int64_t(batch) * length * heads * D + head * D;
+  for (int i = tid; i < BQ * D; i += blockDim.x) {
+    const int row = q_start + i / D;
+    qs[(i / D) * QLD + i % D] = row < length
+                                    ? q[base + int64_t(row) * heads * D + i % D]
+                                    : __float2half(0.f);
+    os[(i / D) * OLD + i % D] = 0.f;
+  }
+  if (tid < BQ) {
+    maximum[tid] = -INFINITY;
+    denominator[tid] = 0.f;
+  }
+  __syncthreads();
+  for (int start = 0; start < length; start += BK) {
+    for (int i = tid; i < BK * D; i += blockDim.x) {
+      const int row = start + i / D;
+      const int64_t position = base + int64_t(row) * heads * D + i % D;
+      ks[(i / D) * QLD + i % D] =
+          row < length ? k[position] : __float2half(0.f);
+      vs[(i / D) * QLD + i % D] =
+          row < length ? v[position] : __float2half(0.f);
+    }
+    __syncthreads();
+    fi::AccumulatorFragment qk;
+    fi::init_accumulator_fragment(qk);
+#pragma unroll
+    for (int dim = 0; dim < D; dim += 16) {
+      fi::AFragment qa;
+      fi::QKBFragment kb;
+      fi::load_a_fragment(qa, qs + warp_q * 16 * QLD + dim, QLD);
+      fi::load_qk_b_fragment(kb, ks + warp_k * 16 * QLD + dim, QLD);
+      fi::mma_sync_m16n16k16_row_col_f16f16f32(qk, qa, kb);
+    }
+    fi::store_accumulator_fragment(scores + warp_q * 16 * PLD + warp_k * 16, qk,
+                                   PLD);
+    __syncthreads();
+    // Each warp reduces one query row. Serial per-thread expf over BK was
+    // the dominant cost in the initial correctness kernel.
+    const int lane = tid % 32;
+    for (int row = warp; row < BQ; row += blockDim.x / 32) {
+      float values[BK / 32];
+      float row_max = -INFINITY;
+#pragma unroll
+      for (int part = 0; part < BK / 32; ++part) {
+        const int col = lane + part * 32;
+        values[part] =
+            start + col < length ? scores[row * PLD + col] * scale : -INFINITY;
+        row_max = fmaxf(row_max, values[part]);
+      }
+#pragma unroll
+      for (int offset = 16; offset > 0; offset /= 2)
+        row_max = fmaxf(row_max, __shfl_xor_sync(0xffffffff, row_max, offset));
+      const float m = fmaxf(maximum[row], row_max);
+      const float a = __expf(maximum[row] - m);
+      float sum = 0.f;
+#pragma unroll
+      for (int part = 0; part < BK / 32; ++part) {
+        const float p = __expf(values[part] - m);
+        probabilities[row * PLD + lane + part * 32] = __float2half_rn(p);
+        sum += p;
+      }
+#pragma unroll
+      for (int offset = 16; offset > 0; offset /= 2)
+        sum += __shfl_xor_sync(0xffffffff, sum, offset);
+      if (lane == 0) {
+        denominator[row] = denominator[row] * a + sum;
+        maximum[row] = m;
+        alpha[row] = a;
+      }
+    }
+    __syncthreads();
+    for (int i = tid; i < BQ * D; i += blockDim.x)
+      os[(i / D) * OLD + i % D] *= alpha[i / D];
+    __syncthreads();
+#pragma unroll
+    for (int part = 0; part < D / BK; ++part) {
+      const int col = warp_k * (D * 16 / BK) + part * 16;
+      const int row = warp_q * 16;
+      fi::AccumulatorFragment pv;
+      fi::load_accumulator_fragment(pv, os + row * OLD + col, OLD);
+#pragma unroll
+      for (int kv = 0; kv < BK; kv += 16) {
+        fi::AFragment pa;
+        fi::PVBFragment vb;
+        fi::load_a_fragment(pa, probabilities + row * PLD + kv, PLD);
+        fi::load_pv_b_fragment(vb, vs + kv * QLD + col, QLD);
+        fi::mma_sync_m16n16k16_row_row_f16f16f32(pv, pa, vb);
+      }
+      fi::store_accumulator_fragment(os + row * OLD + col, pv, OLD);
+    }
+    __syncthreads();
+  }
+  for (int i = tid; i < BQ * D; i += blockDim.x) {
+    const int row = q_start + i / D;
+    if (row < length)
+      output[base + int64_t(row) * heads * D + i % D] =
+          __float2half_rn(os[(i / D) * OLD + i % D] / denominator[i / D]);
+  }
+}
+}  // namespace
+
+template <int BQ, int BK, bool Padded = false>
+torch::Tensor forward(torch::Tensor q, torch::Tensor k, torch::Tensor v,
+                      double scale) {
+  TORCH_CHECK(
+      q.is_cuda() && k.device() == q.device() && v.device() == q.device(),
+      "H3 attention requires same-device CUDA inputs");
+  TORCH_CHECK(q.scalar_type() == torch::kFloat16 &&
+                  k.scalar_type() == q.scalar_type() &&
+                  v.scalar_type() == q.scalar_type(),
+              "H3 FlashInfer-SM70 requires FP16");
+  TORCH_CHECK(
+      q.dim() == 4 && q.size(3) == D && q.size(1) > 0 &&
+          q.sizes() == k.sizes() && q.sizes() == v.sizes(),
+      "H3 FlashInfer-SM70 requires matching nonempty BSHD D128 MHA inputs");
+  TORCH_CHECK(q.is_contiguous() && k.is_contiguous() && v.is_contiguous(),
+              "H3 FlashInfer-SM70 inputs must be contiguous");
+  const c10::cuda::CUDAGuard guard(q.device());
+  const auto* properties = at::cuda::getDeviceProperties(q.get_device());
+  TORCH_CHECK(properties->major == 7 && properties->minor == 0,
+              "H3 FlashInfer kernel requires SM70");
+  TORCH_CHECK(q.size(1) <= INT_MAX && q.size(0) * q.size(2) <= 65535,
+              "H3 FlashInfer grid overflow");
+  auto output = torch::empty_like(q);
+  C10_CUDA_CHECK(cudaFuncSetAttribute(
+      h3_noncausal<BQ, BK, Padded>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+      shared_bytes<BQ, BK, Padded>()));
+  dim3 grid((q.size(1) + BQ - 1) / BQ, q.size(0) * q.size(2));
+  h3_noncausal<BQ, BK, Padded>
+      <<<grid, (BQ / 16) * (BK / 16) * 32, shared_bytes<BQ, BK, Padded>(),
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<const half*>(q.data_ptr<at::Half>()),
+          reinterpret_cast<const half*>(k.data_ptr<at::Half>()),
+          reinterpret_cast<const half*>(v.data_ptr<at::Half>()),
+          reinterpret_cast<half*>(output.data_ptr<at::Half>()), q.size(1),
+          q.size(2), float(scale));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+}
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("forward", &forward<64, 32>);
+  m.def("forward_bq16", &forward<16, 64>);
+  m.def("forward_padded", &forward<64, 32, true>);
+}

--- a/setup.py
+++ b/setup.py
@@ -1243,6 +1243,8 @@ if _is_hip():
 if _is_cuda():
     if _cuda_arch_contains(7, 0):
         ext_modules.append(CMakeExtension(name="vllm._sm70_sampler_C"))
+        ext_modules.append(CMakeExtension(name="vllm._h3_w8a16_C"))
+        ext_modules.append(CMakeExtension(name="vllm._h3_flashinfer_C"))
     build_sm70_fa2 = _cuda_arch_contains(7, 0) and not _cuda_arch_at_least(8, 0)
     if _cuda_arch_at_least(8, 0) or build_sm70_fa2:
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))

--- a/setup.py
+++ b/setup.py
@@ -1245,6 +1245,7 @@ if _is_cuda():
         ext_modules.append(CMakeExtension(name="vllm._sm70_sampler_C"))
         ext_modules.append(CMakeExtension(name="vllm._h3_w8a16_C"))
         ext_modules.append(CMakeExtension(name="vllm._h3_flashinfer_C"))
+        ext_modules.append(CMakeExtension(name="vllm._h3_flashattn_C"))
     build_sm70_fa2 = _cuda_arch_contains(7, 0) and not _cuda_arch_at_least(8, 0)
     if _cuda_arch_at_least(8, 0) or build_sm70_fa2:
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))

--- a/tests/video/test_h3_activation.py
+++ b/tests/video/test_h3_activation.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.models.minimax_h3.activation import silu_prepare_fp16
+from vllm.model_executor.models.minimax_h3.quantization import (
+    DiffusionInt8ConvRotConfig,
+    Int8ConvRotLayerConfig,
+    Int8ConvRotLinearMethod,
+    fp16_gemm_input,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires SM70 GPU"
+)
+
+
+def activation():
+    with set_current_vllm_config(VllmConfig()):
+        return SiluAndMul()
+
+
+@pytest.mark.parametrize(
+    "rows,channels,multiplier", [(17, 257, 1), (129, 3584, 1000), (12352, 3584, 10)]
+)
+def test_fused_silu_preserves_prepared_values_and_scale(rows, channels, multiplier):
+    torch.manual_seed(42)
+    hidden = torch.randn(rows, 2 * channels, device="cuda", dtype=torch.float16)
+    hidden *= multiplier
+    hidden[0].zero_()
+    expected = fp16_gemm_input(activation()(hidden.float()))
+    actual = silu_prepare_fp16(hidden)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert actual[0].dtype == torch.float16 and actual[1].dtype == torch.float32
+    assert torch.isfinite(actual[0]).all()
+
+
+def test_fused_silu_prepared_projection_restores_scale_before_reduction():
+    torch.manual_seed(123)
+    channels = 512
+    hidden = torch.randn(2, 33, 2 * channels, device="cuda", dtype=torch.float16)
+    hidden *= 1000
+    method = Int8ConvRotLinearMethod(
+        DiffusionInt8ConvRotConfig(weight_layout="column"),
+        Int8ConvRotLayerConfig(True),
+        prefix="blocks.0.mlp.fc2",
+    )
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight",
+        torch.nn.Parameter(
+            torch.randint(-128, 128, (256, channels), device="cuda", dtype=torch.int8),
+            False,
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(
+            torch.linspace(1e-4, 1e-2, 256, device="cuda"),
+            False,
+        ),
+    )
+    layer.h3_output_fp32 = True
+    method.process_weights_after_loading(layer)
+    expected = method.apply(layer, activation()(hidden.float()))
+    actual = method.apply_prepared(layer, *silu_prepare_fp16(hidden))
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert actual.shape == (2, 33, 256) and actual.dtype == torch.float32
+
+
+def test_fused_silu_graph_replay_changes_values_and_scale():
+    hidden = torch.randn(129, 7168, device="cuda", dtype=torch.float16)
+    act = activation()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        silu_prepare_fp16(hidden)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        actual = silu_prepare_fp16(hidden)
+    hidden.mul_(1000)
+    graph.replay()
+    expected = fp16_gemm_input(act(hidden.float()))
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/video/test_h3_column_major.py
+++ b/tests/video/test_h3_column_major.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact INT8 layout, scale and GEMM checks for the low-memory Volta route."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3 import cuda_ops
+from vllm.model_executor.models.minimax_h3.quantization import (
+    DiffusionInt8ConvRotConfig,
+    Int8ConvRotLayerConfig,
+    Int8ConvRotLinearMethod,
+)
+
+cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires SM70")
+
+
+@pytest.mark.parametrize("layout", ["row", "column"])
+def test_weight_repack_preserves_values_scales_and_size(layout):
+    config = DiffusionInt8ConvRotConfig(weight_layout=layout)
+    method = Int8ConvRotLinearMethod(
+        config, Int8ConvRotLayerConfig(True), prefix="blocks.0.attn.qkv_proj"
+    )
+    layer = torch.nn.Module()
+    original = torch.arange(257 * 256).to(torch.int8).reshape(257, 256)
+    scales = torch.linspace(0.001, 0.1, 257)
+    layer.register_parameter("weight", torch.nn.Parameter(original.clone(), False))
+    layer.register_parameter(
+        "weight_scale", torch.nn.Parameter(scales[:, None].clone(), False)
+    )
+    for _ in range(2):  # Post-load processing is idempotent.
+        method.process_weights_after_loading(layer)
+        assert torch.equal(layer.weight, original)
+        assert torch.equal(layer.weight_scale, scales)
+        assert layer.weight.untyped_storage().nbytes() == original.numel()
+        assert layer.weight.stride() == ((1, 257) if layout == "column" else (256, 1))
+
+
+@cuda
+@pytest.mark.parametrize("shape", [(0, 7), (1, 256), (257, 259), (129, 1536)])
+def test_column_decode_signed_codes_scales_and_offset(shape):
+    n, k = shape
+    storage = (torch.arange(n * k + 1, device="cuda") % 256 - 128).to(torch.int8)
+    weight = storage[1:].reshape(k, n).t()
+    scales = torch.logspace(-7, 1, n + 1, device="cuda")[1:]
+    actual = cuda_ops.w8a16_extension().dequantize(weight, scales)
+    expected = (weight.float() * scales[:, None]).half()
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert actual.untyped_storage().nbytes() == weight.numel() * 2
+
+
+@cuda
+@pytest.mark.parametrize(
+    "n,k,fp32",
+    [(5376, 5376, False), (7168, 5376, False), (5376, 1792, True), (5376, 3584, True)],
+)
+def test_real_tp4_projection_uses_exact_zero_workspace_plan(n, k, fp32):
+    torch.manual_seed(42)
+    m = 12352  # DiT activation padding; attention has 12323 valid tokens.
+    x = torch.randn(m, k, dtype=torch.float16, device="cuda") * 0.1
+    weight = torch.randn(n, k, dtype=torch.float16, device="cuda") * 0.01
+    packed = weight.t().contiguous().t()
+    plan = cuda_ops._column_major_plan(x.device.index, m, n, k, fp32)
+    assert plan.supported, "pinned cu128 SM70 build must expose the validated plan"
+    expected = cuda_ops.w8a16_extension().gemm(x, weight, fp32)
+    actual = cuda_ops.fp16_gemm(x, packed, fp32)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert actual.dtype == (torch.float32 if fp32 else torch.float16)
+
+
+@cuda
+def test_missing_plan_falls_back_without_changing_math(monkeypatch):
+    monkeypatch.setattr(
+        cuda_ops, "_column_major_plan", lambda *args: SimpleNamespace(supported=False)
+    )
+    x = torch.randn(17, 256, dtype=torch.float16, device="cuda")
+    w = torch.randn(65, 256, dtype=torch.float16, device="cuda")
+    expected = cuda_ops.w8a16_extension().gemm(x, w, True)
+    actual = cuda_ops.fp16_gemm(x, w.t().contiguous().t(), True)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@cuda
+def test_column_plan_rejects_shape_dtype_and_device_mismatch():
+    ops = cuda_ops.w8a16_extension()
+    plan = ops.ColumnMajorGemmPlan(
+        torch.accelerator.current_device_index(), 12352, 5376, 1792, True
+    )
+    assert plan.supported
+    for x, w in [
+        (
+            torch.empty(2, 1792, device="cuda", dtype=torch.float16),
+            torch.empty(1792, 5376, device="cuda", dtype=torch.float16).t(),
+        ),
+        (
+            torch.empty(12352, 1792, device="cuda", dtype=torch.float32),
+            torch.empty(1792, 5376, device="cuda", dtype=torch.float16).t(),
+        ),
+        (
+            torch.empty(12352, 1792, device="cuda", dtype=torch.float16),
+            torch.empty(1792, 5376, dtype=torch.float16).t(),
+        ),
+    ]:
+        with pytest.raises(RuntimeError, match="matching aligned"):
+            plan.run(x, w)
+
+
+@cuda
+def test_column_decode_and_gemm_replay_on_current_stream():
+    torch.manual_seed(123)
+    m, n, k = 12352, 5376, 1792
+    x = torch.randn(m, k, dtype=torch.float16, device="cuda") * 0.1
+    w = torch.randint(-128, 128, (n, k), dtype=torch.int8, device="cuda")
+    scale = torch.rand(n, device="cuda") * 0.001 + 0.0001
+    packed = w.t().contiguous().t()
+    ops = cuda_ops.w8a16_extension()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        cuda_ops.fp16_gemm(x, ops.dequantize(packed, scale), True)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        actual = cuda_ops.fp16_gemm(x, ops.dequantize(packed, scale), True)
+    x.mul_(2)
+    graph.replay()
+    expected = ops.gemm(x, ops.dequantize(w, scale), True)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/video/test_h3_flashattn.py
+++ b/tests/video/test_h3_flashattn.py
@@ -16,10 +16,17 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def test_flashattn_rejects_batch_head_grid_overflow():
+    q = torch.empty(1, 1, 65536, 128, device="cuda", dtype=torch.float16)
+    with pytest.raises(RuntimeError, match="index limits"):
+        flashattn_extension().forward(q, q, q, 128**-0.5)
+
+
 @pytest.mark.parametrize(
     "length", [1, 31, 32, 33, 63, 64, 65, 96, 97, 127, 128, 129, 12323]
 )
-def test_flashattn_d128_mha_tails_and_online_rescaling(length):
+@pytest.mark.parametrize("key_tile", [64, 128])
+def test_flashattn_d128_mha_tails_and_online_rescaling(length, key_tile):
     torch.manual_seed(42)
     q, k, v = [
         torch.randn(2, length, 2, 128, device="cuda", dtype=torch.float16)
@@ -30,13 +37,14 @@ def test_flashattn_d128_mha_tails_and_online_rescaling(length):
     k[:, length // 2 :] *= 4
     rows = torch.linspace(0, length - 1, min(length, 65), device="cuda").long()
     expected = chunked_attention_reference(q[:, rows], k, v, scale=128**-0.5)
-    actual = flashattn_extension().forward(q, k, v, 128**-0.5)
+    actual = flashattn_extension().forward(q, k, v, 128**-0.5, key_tile)
     assert torch.isfinite(actual).all()
     torch.testing.assert_close(actual[:, rows], expected, atol=0.002, rtol=0.03)
 
 
 @pytest.mark.parametrize("layout", ["offset", "strided"])
-def test_flashattn_d128_storage_and_different_q_k_lengths(layout):
+@pytest.mark.parametrize("key_tile", [64, 128])
+def test_flashattn_d128_storage_and_different_q_k_lengths(layout, key_tile):
     torch.manual_seed(42)
     tensors = []
     for length, offset in [(33, 1), (65, 3), (65, 5)]:
@@ -51,7 +59,7 @@ def test_flashattn_d128_storage_and_different_q_k_lengths(layout):
         tensors.append(value)
     q, k, v = tensors
     expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
-    actual = flashattn_extension().forward(q, k, v, 128**-0.5)
+    actual = flashattn_extension().forward(q, k, v, 128**-0.5, key_tile)
     torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
 
 
@@ -89,10 +97,35 @@ def test_flashattn_dispatch_slices_poisoned_padding(monkeypatch):
     assert torch.count_nonzero(actual[:, 243:]) == 0
 
 
-def test_flashattn_graph_replay_uses_new_values():
+@pytest.mark.parametrize("key_tile", [64, 128])
+def test_flashattn_graph_replay_uses_new_values(key_tile):
     ops = flashattn_extension()
     q, k, v = [
         torch.randn(1, 129, 2, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            ops.forward(q, k, v, 128**-0.5, key_tile)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = ops.forward(q, k, v, 128**-0.5, key_tile)
+    for _ in range(2):
+        q.normal_()
+        k.normal_()
+        v.normal_()
+        graph.replay()
+        expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
+        torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
+
+
+def test_flashattn_fixed_shape_graph_replay():
+    ops = flashattn_extension()
+    q, k, v = [
+        torch.randn(1, 12323, 14, 128, device="cuda", dtype=torch.float16)
         for _ in range(3)
     ]
     stream = torch.cuda.Stream()
@@ -104,13 +137,12 @@ def test_flashattn_graph_replay_uses_new_values():
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         actual = ops.forward(q, k, v, 128**-0.5)
+    rows = torch.tensor([0, 31, 32, 63, 64, 127, 128, 12322], device="cuda")
     for _ in range(2):
-        q.normal_()
-        k.normal_()
         v.normal_()
         graph.replay()
-        expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
-        torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
+        expected = chunked_attention_reference(q[:, rows], k, v, scale=128**-0.5)
+        torch.testing.assert_close(actual[:, rows], expected, atol=0.002, rtol=0.03)
 
 
 def test_flashattn_rejects_changed_head_dimension_and_scale():
@@ -121,3 +153,5 @@ def test_flashattn_rejects_changed_head_dimension_and_scale():
     q = q[..., :128].contiguous()
     with pytest.raises(RuntimeError, match="finite and positive"):
         ops.forward(q, q, q, float("nan"))
+    with pytest.raises(RuntimeError, match="key tile"):
+        ops.forward(q, q, q, 128**-0.5, 32)

--- a/tests/video/test_h3_flashattn.py
+++ b/tests/video/test_h3_flashattn.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3.attention import (
+    Attention,
+    AttentionMetadata,
+    attention_backend,
+    chunked_attention_reference,
+)
+from vllm.model_executor.models.minimax_h3.cuda_ops import flashattn_extension
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires SM70 GPU"
+)
+
+
+@pytest.mark.parametrize("length", [1, 31, 63, 64, 65, 127, 128, 129, 12323])
+def test_flashattn_d128_mha_tails_and_online_rescaling(length):
+    torch.manual_seed(42)
+    q, k, v = [
+        torch.randn(2, length, 2, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    # A later key tile increases the maximum. This checks the distinct PV
+    # accumulator mapping, including channels 64..127, across two batches.
+    k[:, length // 2 :] *= 4
+    rows = torch.linspace(0, length - 1, min(length, 65), device="cuda").long()
+    expected = chunked_attention_reference(q[:, rows], k, v, scale=128**-0.5)
+    actual = flashattn_extension().forward(q, k, v, 128**-0.5)
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual[:, rows], expected, atol=0.002, rtol=0.03)
+
+
+@pytest.mark.parametrize("layout", ["offset", "strided"])
+def test_flashattn_d128_storage_and_different_q_k_lengths(layout):
+    torch.manual_seed(42)
+    tensors = []
+    for length, offset in [(33, 1), (65, 3), (65, 5)]:
+        if layout == "offset":
+            value = torch.randn(
+                2 * length * 2 * 128 + offset, device="cuda", dtype=torch.float16
+            )[offset:].reshape(2, length, 2, 128)
+        else:
+            value = torch.randn(
+                2, length * 2, 2, 128, device="cuda", dtype=torch.float16
+            )[:, ::2]
+        tensors.append(value)
+    q, k, v = tensors
+    expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
+    actual = flashattn_extension().forward(q, k, v, 128**-0.5)
+    torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
+
+
+def test_flashattn_dispatch_slices_poisoned_padding(monkeypatch):
+    from vllm.model_executor.models.minimax_h3 import cuda_ops
+
+    native = flashattn_extension()
+    calls = []
+
+    class TracedNative:
+        def forward(self, q, k, v, scale):
+            calls.append(tuple(q.shape))
+            return native.forward(q, k, v, scale)
+
+    monkeypatch.setattr(cuda_ops, "flashattn_extension", lambda: TracedNative())
+    token = attention_backend.set("FLASH_ATTN_V100")
+    try:
+        module = Attention(
+            num_heads=14, num_kv_heads=14, head_size=128, softmax_scale=128**-0.5
+        )
+    finally:
+        attention_backend.reset(token)
+    q, k, v = [
+        torch.randn(1, 257, 14, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    for tensor in (q, k, v):
+        tensor[:, 243:] = float("nan")
+    expected = chunked_attention_reference(
+        q[:, :243], k[:, :243], v[:, :243], scale=128**-0.5
+    )
+    actual = module(q, k, v, AttentionMetadata(extra={"valid_kv_length": 243}))
+    assert calls == [(1, 243, 14, 128)]
+    torch.testing.assert_close(actual[:, :243], expected, atol=0.002, rtol=0.03)
+    assert torch.count_nonzero(actual[:, 243:]) == 0
+
+
+def test_flashattn_graph_replay_uses_new_values():
+    ops = flashattn_extension()
+    q, k, v = [
+        torch.randn(1, 129, 2, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            ops.forward(q, k, v, 128**-0.5)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = ops.forward(q, k, v, 128**-0.5)
+    for _ in range(2):
+        q.normal_()
+        k.normal_()
+        v.normal_()
+        graph.replay()
+        expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
+        torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
+
+
+def test_flashattn_rejects_changed_head_dimension_and_scale():
+    ops = flashattn_extension()
+    q = torch.randn(1, 32, 2, 256, device="cuda", dtype=torch.float16)
+    with pytest.raises(RuntimeError, match="D128 MHA"):
+        ops.forward(q, q, q, 256**-0.5)
+    q = q[..., :128].contiguous()
+    with pytest.raises(RuntimeError, match="finite and positive"):
+        ops.forward(q, q, q, float("nan"))

--- a/tests/video/test_h3_flashattn.py
+++ b/tests/video/test_h3_flashattn.py
@@ -16,7 +16,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize("length", [1, 31, 63, 64, 65, 127, 128, 129, 12323])
+@pytest.mark.parametrize(
+    "length", [1, 31, 32, 33, 63, 64, 65, 96, 97, 127, 128, 129, 12323]
+)
 def test_flashattn_d128_mha_tails_and_online_rescaling(length):
     torch.manual_seed(42)
     q, k, v = [

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -178,6 +178,25 @@ def test_attention_padding_excludes_poisoned_suffix(used, padded):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("length", [127, 128, 129, 12323])
+def test_flashinfer_online_softmax_across_tiles_and_batches(length):
+    from vllm.model_executor.models.minimax_h3.cuda_ops import flashinfer_extension
+
+    torch.manual_seed(42)
+    q, k, v = [
+        torch.randn(2, length, 2, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    ]
+    # Later key tiles raise the softmax maximum and exercise accumulator
+    # rescaling. Check spread-out query rows without a full square matrix.
+    k[:, length // 2 :] *= 4
+    rows = torch.linspace(0, length - 1, min(length, 65), device="cuda").long()
+    expected = chunked_attention_reference(q[:, rows], k, v, scale=128**-0.5)
+    actual = flashinfer_extension().forward(q, k, v, 128**-0.5)
+    torch.testing.assert_close(actual[:, rows], expected, atol=0.002, rtol=0.03)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize("backend", ["FLASH_ATTN_V100", "FLASHINFER_SM70"])
 def test_noncausal_backend_matches_fp32_reference(backend):
     token = attention_backend.set(backend)

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -260,6 +260,66 @@ def test_sm70_w8a16_uses_signed_scales_and_fp32_gemm_reduction():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("groups", [0, 1, 3, 4, 5, 262141])
+def test_sm70_convrot_warp_tails_and_grid_stride(groups):
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+
+    torch.manual_seed(42)
+    # Offset storage also verifies scalar FP16 loads do not require vector
+    # alignment. The largest case crosses the grid's four-warps/block cap.
+    storage = torch.randn(groups * 256 + 1, device="cuda", dtype=torch.float16)
+    x = storage[1:].view(groups, 256)
+    actual = w8a16_extension().rotate(x)
+    torch.testing.assert_close(actual, convrot_reference(x), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("shape", [(0, 256), (1, 1), (17, 31), (19, 7168), (65536, 1)])
+def test_fp16_preparation_preserves_power_of_two_scales(shape):
+    from vllm.model_executor.models.minimax_h3.quantization import fp16_gemm_input
+
+    torch.manual_seed(42)
+    x = torch.randn(*shape, device="cuda")
+    exponents = torch.arange(shape[0], device="cuda") % 140 - 20
+    x = torch.ldexp(x, exponents[:, None])
+    if shape[0] and shape[1] > 1:
+        x[0] = 0
+        # Exact threshold values and their immediate neighbors exercise the
+        # frexp exponent transition used to leave room for ConvRot.
+        if shape[0] > 4:
+            x[1] = 2048
+            x[2] = torch.nextafter(x[1], torch.zeros_like(x[1]))
+            x[3] = torch.nextafter(x[1], torch.full_like(x[1], float("inf")))
+            x[4] = torch.finfo(torch.float32).max
+    maximum = x.abs().amax(-1, keepdim=True)
+    _, exponent = torch.frexp(maximum)
+    expected_scale = torch.ldexp(torch.ones_like(maximum), (exponent - 11).clamp_min(0))
+    expected = (x / expected_scale).half()
+    actual, scale = fp16_gemm_input(x)
+    torch.testing.assert_close(scale, expected_scale, atol=0, rtol=0)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+def test_fp16_preparation_keeps_nonfinite_values_visible():
+    from vllm.model_executor.models.minimax_h3.quantization import fp16_gemm_input
+
+    x = torch.tensor(
+        [[float("nan"), 1e10], [float("inf"), 4096], [-float("inf"), -0.0]],
+        device="cuda",
+    )
+    _, exponent = torch.frexp(x.abs().amax(-1, keepdim=True))
+    expected_scale = torch.ldexp(
+        torch.ones_like(exponent, dtype=torch.float32), (exponent - 11).clamp_min(0)
+    )
+    actual, scale = fp16_gemm_input(x)
+    torch.testing.assert_close(scale, expected_scale, atol=0, rtol=0)
+    torch.testing.assert_close(
+        actual, (x / expected_scale).half(), atol=0, rtol=0, equal_nan=True
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
 def test_encoder_causal_gqa_matches_fp32():
     from vllm.model_executor.models.minimax_h3.encoder import (
         _scaled_dot_product_attention,

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -197,6 +197,27 @@ def test_flashinfer_online_softmax_across_tiles_and_batches(length):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@pytest.mark.parametrize("length", [31, 32, 33, 63, 64, 65])
+def test_flashinfer_prefetch_tail_and_unaligned_storage(length):
+    from vllm.model_executor.models.minimax_h3.cuda_ops import flashinfer_extension
+
+    torch.manual_seed(42)
+    shape = (2, length, 2, 128)
+    count = 2 * length * 2 * 128
+    q, k, v = [
+        torch.randn(count + offset, device="cuda", dtype=torch.float16)[
+            offset:
+        ].reshape(shape)
+        for offset in (1, 3, 5)
+    ]
+    # The next K/V tile can be absent, partial or complete. Storage offsets
+    # also exercise the scalar load path without changing contiguous layout.
+    expected = chunked_attention_reference(q, k, v, scale=128**-0.5)
+    actual = flashinfer_extension().forward(q, k, v, 128**-0.5)
+    torch.testing.assert_close(actual, expected, atol=0.002, rtol=0.03)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize("backend", ["FLASH_ATTN_V100", "FLASHINFER_SM70"])
 def test_noncausal_backend_matches_fp32_reference(backend):
     token = attention_backend.set(backend)

--- a/tests/video/test_h3_qk_norm_rope.py
+++ b/tests/video/test_h3_qk_norm_rope.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3.ops import (
+    fused_qk_norm_rope,
+    qk_norm_rope_reference,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def inputs(tokens, heads, amplitude, weight_dtype):
+    torch.manual_seed(42)
+    # Split projection views have a non-contiguous token stride and offsets.
+    storage = torch.randn(tokens, 3, heads, 128, device="cuda", dtype=torch.float16)
+    storage *= amplitude
+    q, k, _ = storage.unbind(1)
+    q[0].zero_()
+    weights = torch.randn(2, 128, device="cuda", dtype=weight_dtype)
+    angles = torch.randn(tokens, 48, device="cuda")
+    rope = torch.cat((angles.cos(), angles.sin()), -1).half()
+    return q, k, *weights, rope, 1e-5
+
+
+@pytest.mark.parametrize("tokens,heads", [(1, 1), (65, 3), (129, 14), (12323, 14)])
+@pytest.mark.parametrize(
+    "amplitude,weight_dtype", [(1, torch.float16), (2000, torch.float32)]
+)
+@torch.inference_mode()
+def test_rounding_and_partial_rotation(tokens, heads, amplitude, weight_dtype):
+    args = inputs(tokens, heads, amplitude, weight_dtype)
+    expected = qk_norm_rope_reference(*args)
+    actual = fused_qk_norm_rope(*args)
+    for result, reference in zip(actual, expected):
+        assert torch.isfinite(result).all()
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+@torch.inference_mode()
+def test_graph_replay_reads_changed_inputs_and_rope():
+    args = inputs(65, 3, 1000, torch.float16)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            fused_qk_norm_rope(*args)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = fused_qk_norm_rope(*args)
+    for _ in range(2):
+        args[0].normal_()
+        args[1].normal_()
+        args[4].neg_()
+        graph.replay()
+        expected = qk_norm_rope_reference(*args)
+        for result, reference in zip(actual, expected):
+            torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+@torch.inference_mode()
+def test_other_rotary_width_keeps_reference_path():
+    args = list(inputs(65, 3, 1, torch.float16))
+    args[4] = args[4][:, :64]
+    actual = fused_qk_norm_rope(*args)
+    expected = qk_norm_rope_reference(*args)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)

--- a/tools/minimax_h3/build_extensions.py
+++ b/tools/minimax_h3/build_extensions.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Build only the native H3 extensions against the active Torch installation.
+
+Use the regular 1Cat wheel build for a complete release. This helper leaves
+existing vLLM binaries untouched and builds the two independent H3 modules.
+"""
+
+import hashlib
+import json
+import shutil
+import sysconfig
+from pathlib import Path
+
+from torch.utils.cpp_extension import load
+
+root = Path(__file__).resolve().parents[2]
+output = root / "vllm"
+records = []
+for name, source, includes, libraries in (
+    ("_h3_w8a16_C", "csrc/sm70_turbomind/ops/h3_w8a16.cu", [], ["-lcublas"]),
+    (
+        "_h3_flashinfer_C",
+        "flashinfer-sm70/csrc/h3_noncausal_sm70.cu",
+        [str(root / "flashinfer-sm70/include")],
+        [],
+    ),
+):
+    module = load(
+        name=name,
+        sources=[str(root / source)],
+        extra_include_paths=includes,
+        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
+        extra_ldflags=libraries,
+        verbose=True,
+    )
+    target = output / (name + sysconfig.get_config_var("EXT_SUFFIX"))
+    shutil.copy2(module.__file__, target)
+    with target.open("rb") as stream:
+        digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    records.append({"module": name, "source": source, "binary_sha256": digest})
+print(json.dumps(records, indent=2))

--- a/tools/minimax_h3/build_extensions.py
+++ b/tools/minimax_h3/build_extensions.py
@@ -3,11 +3,12 @@
 """Build only the native H3 extensions against the active Torch installation.
 
 Use the regular 1Cat wheel build for a complete release. This helper leaves
-existing vLLM binaries untouched and builds the two independent H3 modules.
+existing vLLM binaries untouched and builds the three independent H3 modules.
 """
 
 import hashlib
 import json
+import os
 import shutil
 import sysconfig
 from pathlib import Path
@@ -17,12 +18,25 @@ from torch.utils.cpp_extension import load
 root = Path(__file__).resolve().parents[2]
 output = root / "vllm"
 records = []
+cutlass_path = os.environ.get("VLLM_CUTLASS_SRC_DIR")
+if not cutlass_path:
+    raise RuntimeError("Set VLLM_CUTLASS_SRC_DIR to CUTLASS v4.4.2 source")
+cutlass = Path(cutlass_path)
 for name, source, includes, libraries in (
     ("_h3_w8a16_C", "csrc/sm70_turbomind/ops/h3_w8a16.cu", [], ["-lcublas"]),
     (
         "_h3_flashinfer_C",
         "flashinfer-sm70/csrc/h3_noncausal_sm70.cu",
         [str(root / "flashinfer-sm70/include")],
+        [],
+    ),
+    (
+        "_h3_flashattn_C",
+        "flash-attention-v100/kernel/h3/forward.cu",
+        [
+            str(cutlass / "include"),
+            str(cutlass / "examples/41_fused_multi_head_attention"),
+        ],
         [],
     ),
 ):

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -37,6 +37,9 @@ class VideoSubcommand(CLISubcommand):
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
             mode.add_argument("--fp16-cache-layer", action="append", default=[])
+            mode.add_argument(
+                "--int8-weight-layout", choices=["row", "column"], default="column"
+            )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
             if name == "generate":
                 mode.add_argument("--prompt", default=DEFAULT_PROMPT)
@@ -73,6 +76,7 @@ class VideoSubcommand(CLISubcommand):
             attention_backend=args.attention_backend,
             fp16_weight_cache_gib=args.fp16_weight_cache_gib,
             fp16_cache_layers=tuple(args.fp16_cache_layer),
+            int8_weight_layout=args.int8_weight_layout,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/model_executor/models/minimax_h3/activation.py
+++ b/vllm/model_executor/models/minimax_h3/activation.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Prepare H3's wide-range gated activation without an FP32 temporary."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _silu_prepare_kernel(H, Y, S, K: tl.constexpr, BLOCK: tl.constexpr):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK)
+    gate = tl.load(H + row * (2 * K) + cols, cols < K, other=0).to(tl.float32)
+    up = tl.load(H + row * (2 * K) + K + cols, cols < K, other=0).to(tl.float32)
+    value = (gate * (1.0 / (1.0 + tl.exp(-gate)))) * up
+    magnitude = tl.abs(value)
+    magnitude = tl.where(magnitude != magnitude, float("inf"), magnitude)
+    maximum = tl.max(magnitude, 0)
+    exponent = (maximum.to(tl.int32, bitcast=True) >> 23) & 255
+    scale_exp = tl.where(exponent == 255, 0, tl.maximum(exponent - 137, 0))
+    scale = ((scale_exp + 127) << 23).to(tl.float32, bitcast=True)
+    tl.store(Y + row * K + cols, value / scale, cols < K)
+    tl.store(S + row, scale)
+
+
+def silu_prepare_fp16(hidden: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Preserve FP32 SiLU/product and power-of-two scaling before rounding.
+
+    The scale leaves the same ConvRot256 headroom as ``prepare_fp16``. Disable
+    FMA contraction to retain the established SiLU arithmetic order.
+    """
+    if not hidden.is_cuda or hidden.dtype != torch.float16:
+        raise ValueError("H3 fused SiLU preparation requires CUDA FP16 input")
+    if hidden.ndim < 2 or hidden.shape[-1] % 2 or hidden.numel() == 0:
+        raise ValueError("H3 fused SiLU requires non-empty [gate, up] rows")
+    flat = hidden.reshape(-1, hidden.shape[-1]).contiguous()
+    rows, width = flat.shape
+    channels = width // 2
+    if channels > 16384:
+        raise ValueError("H3 fused SiLU supports at most 16384 channels")
+    values = torch.empty((rows, channels), dtype=torch.float16, device=hidden.device)
+    scale = torch.empty((rows, 1), dtype=torch.float32, device=hidden.device)
+    _silu_prepare_kernel[(rows,)](
+        flat,
+        values,
+        scale,
+        channels,
+        triton.next_power_of_2(channels),
+        num_warps=8,
+        enable_fp_fusion=False,
+    )
+    return values.reshape(*hidden.shape[:-1], channels), scale

--- a/vllm/model_executor/models/minimax_h3/attention.py
+++ b/vllm/model_executor/models/minimax_h3/attention.py
@@ -105,10 +105,10 @@ class Attention(nn.Module):
             raise ValueError("invalid packed H3 attention lengths")
         q_valid, k_valid, v_valid = (x[:, :used].contiguous() for x in (q, k, v))
         if self.backend == "FLASH_ATTN_V100":
-            from flash_attn_v100 import flash_attn_func
+            from .cuda_ops import flashattn_extension
 
-            attended = flash_attn_func(
-                q_valid, k_valid, v_valid, causal=False, softmax_scale=self.scale
+            attended = flashattn_extension().forward(
+                q_valid, k_valid, v_valid, self.scale
             )
         elif self.backend == "FLASHINFER_SM70":
             from .cuda_ops import flashinfer_extension

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -40,10 +40,13 @@ class H3Config:
     attention_backend: str = "FLASH_ATTN_V100"
     fp16_weight_cache_gib: float = 0.0
     fp16_cache_layers: tuple[str, ...] = ()
+    int8_weight_layout: str = "column"
 
     def __post_init__(self) -> None:
         if self.partition not in ("fl2va", "ref2va"):
             raise H3InputError("partition must be fl2va or ref2va")
+        if self.int8_weight_layout not in ("row", "column"):
+            raise H3InputError("H3 INT8 weight layout must be row or column")
         if self.tensor_parallel_size not in (1, 2, 4):
             raise H3InputError("native H3 supports TP1, TP2, or TP4")
         if self.attention_backend not in (

--- a/vllm/model_executor/models/minimax_h3/cuda_ops.py
+++ b/vllm/model_executor/models/minimax_h3/cuda_ops.py
@@ -6,6 +6,8 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
+import torch
+
 
 @lru_cache(maxsize=1)
 def w8a16_extension():
@@ -25,9 +27,47 @@ def w8a16_extension():
         name="onecat_h3_w8a16",
         sources=[str(source)],
         extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
-        extra_ldflags=["-lcublas"],
+        extra_ldflags=["-lcublas", "-lcublasLt"],
         verbose=False,
     )
+
+
+@lru_cache(maxsize=32)
+def _column_major_plan(device, m, n, k, output_fp32):
+    return w8a16_extension().ColumnMajorGemmPlan(device, m, n, k, output_fp32)
+
+
+def fp16_gemm(input, weight, output_fp32=False):
+    """Use a zero-workspace Volta plan for dense column-major H3 weights.
+
+    Plan entries contain host descriptors only. Unaligned inputs, empty shapes
+    and library versions without the validated algorithm use the original
+    row-major GEMM. Warm up each shape before capturing a CUDA graph.
+    """
+    ops = w8a16_extension()
+    if weight.is_contiguous():
+        return ops.gemm(input, weight, output_fp32)
+    if (
+        input.is_cuda
+        and weight.device == input.device
+        and input.dim() == weight.dim() == 2
+        and input.is_contiguous()
+        and input.dtype == weight.dtype == torch.float16
+        and weight.stride() == (1, weight.shape[0])
+        and input.shape[1] == weight.shape[1]
+        and min(*input.shape, weight.shape[0]) > 0
+        and input.data_ptr() % 16 == weight.data_ptr() % 16 == 0
+    ):
+        plan = _column_major_plan(
+            input.device.index,
+            input.shape[0],
+            weight.shape[0],
+            input.shape[1],
+            bool(output_fp32),
+        )
+        if plan.supported:
+            return plan.run(input, weight)
+    return ops.gemm(input, weight.contiguous(), output_fp32)
 
 
 @lru_cache(maxsize=1)

--- a/vllm/model_executor/models/minimax_h3/cuda_ops.py
+++ b/vllm/model_executor/models/minimax_h3/cuda_ops.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Lazy build of native H3 SM70 extensions for source development."""
 
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -44,6 +45,36 @@ def flashinfer_extension():
         name="onecat_h3_flashinfer_sm70",
         sources=[str(root / "flashinfer-sm70/csrc/h3_noncausal_sm70.cu")],
         extra_include_paths=[str(root / "flashinfer-sm70/include")],
+        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
+        verbose=False,
+    )
+
+
+@lru_cache(maxsize=1)
+def flashattn_extension():
+    try:
+        from vllm import _h3_flashattn_C
+
+        return _h3_flashattn_C
+    except ImportError:
+        pass
+    from torch.utils.cpp_extension import load
+
+    root = Path(__file__).resolve().parents[4]
+    cutlass_path = os.environ.get("VLLM_CUTLASS_SRC_DIR")
+    if not cutlass_path:
+        raise RuntimeError(
+            "Build the H3 FlashAttention-V100 extension (_h3_flashattn_C), or "
+            "set VLLM_CUTLASS_SRC_DIR to CUTLASS v4.4.2 for source development"
+        )
+    cutlass = Path(cutlass_path)
+    return load(
+        name="onecat_h3_flashattn_sm70",
+        sources=[str(root / "flash-attention-v100/kernel/h3/forward.cu")],
+        extra_include_paths=[
+            str(cutlass / "include"),
+            str(cutlass / "examples/41_fused_multi_head_attention"),
+        ],
         extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
         verbose=False,
     )

--- a/vllm/model_executor/models/minimax_h3/ops.py
+++ b/vllm/model_executor/models/minimax_h3/ops.py
@@ -37,6 +37,25 @@ class RotaryEmbedding(nn.Module):
 
 
 def fused_qk_norm_rope(q, k, q_weight, k_weight, rope_table, eps):
+    if (
+        q.is_cuda
+        and not torch.is_grad_enabled()
+        and q.dtype == k.dtype == rope_table.dtype == torch.float16
+        and q.ndim == k.ndim == 3
+        and q.shape[-1] == k.shape[-1] == 128
+        and q.shape[0] == k.shape[0]
+        and rope_table.shape == (q.shape[0], 96)
+        and q_weight.shape == k_weight.shape == (128,)
+        and all(t.device == q.device for t in (k, q_weight, k_weight, rope_table))
+        and all(t.stride(-1) == 1 for t in (q, k, q_weight, k_weight, rope_table))
+    ):
+        from .qk_norm_rope import qk_norm_rope
+
+        return qk_norm_rope(q, k, q_weight, k_weight, rope_table, eps)
+    return qk_norm_rope_reference(q, k, q_weight, k_weight, rope_table, eps)
+
+
+def qk_norm_rope_reference(q, k, q_weight, k_weight, rope_table, eps):
     # This reference retains the normalized FP16 rounding boundary. The CUDA
     # implementation must preserve it, including partial (96/128) rotation.
     def apply(x, weight):

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -456,7 +456,10 @@ class MiniMaxH3Pipeline(nn.Module):
                 transformer_path, expected_partition=self.partition
             )
             overrides = checkpoint.arch_overrides
-            quant = DiffusionInt8ConvRotConfig(layer_configs=checkpoint.layer_configs)
+            quant = DiffusionInt8ConvRotConfig(
+                layer_configs=checkpoint.layer_configs,
+                weight_layout=config.int8_weight_layout,
+            )
         architecture = json.loads((path / "transformer/config.json").read_text())
         token = attention_backend.set(config.attention_backend)
         try:

--- a/vllm/model_executor/models/minimax_h3/qk_norm_rope.py
+++ b/vllm/model_executor/models/minimax_h3/qk_norm_rope.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""H3 D128 RMSNorm and partial RoPE with explicit FP16 rounding boundaries."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _qk_norm_rope_kernel(
+    x_ptr,
+    weight_ptr,
+    rope_ptr,
+    output_ptr,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    token_stride: tl.constexpr,
+    head_stride: tl.constexpr,
+    rope_stride: tl.constexpr,
+    eps: tl.constexpr,
+    block_rows: tl.constexpr,
+):
+    rows = tl.program_id(0) * block_rows + tl.arange(0, block_rows)
+    columns = tl.arange(0, 128)
+    token, head = rows // heads, rows % heads
+    offsets = token[:, None] * token_stride + head[:, None] * head_stride
+    valid = rows[:, None] < tokens * heads
+    x = tl.load(x_ptr + offsets + columns[None, :], valid, 0).to(tl.float32)
+    inverse_rms = tl.rsqrt(tl.sum(x * x, 1) / 128 + eps)
+    weight = tl.load(weight_ptr + columns).to(tl.float32)
+    normalized = ((x * inverse_rms[:, None]) * weight[None, :]).to(tl.float16)
+
+    # H3 rotates two 48-channel halves and leaves the final 32 channels intact.
+    partner = tl.where(
+        columns < 48, columns + 48, tl.where(columns < 96, columns - 48, columns)
+    )
+    paired = tl.load(x_ptr + offsets + partner[None, :], valid, 0).to(tl.float32)
+    paired_weight = tl.load(weight_ptr + partner).to(tl.float32)
+    paired = ((paired * inverse_rms[:, None]) * paired_weight[None, :]).to(tl.float16)
+    rope_column = tl.where(columns < 48, columns, columns - 48)
+    rope_offsets = token[:, None] * rope_stride + rope_column[None, :]
+    rotated_mask = valid & (columns[None, :] < 96)
+    cosine = tl.load(rope_ptr + rope_offsets, rotated_mask, 0).to(tl.float32)
+    sine = tl.load(rope_ptr + rope_offsets + 48, rotated_mask, 0).to(tl.float32)
+
+    # The reference rounds normalization and each product to FP16 before
+    # addition/subtraction. Fusing these into an FMA changes model output.
+    first = (normalized.to(tl.float32) * cosine).to(tl.float16).to(tl.float32)
+    second = (paired.to(tl.float32) * sine).to(tl.float16).to(tl.float32)
+    rotated = tl.where(columns[None, :] < 48, first - second, first + second).to(
+        tl.float16
+    )
+    output = tl.where(columns[None, :] < 96, rotated, normalized)
+    tl.store(output_ptr + rows[:, None] * 128 + columns[None, :], output, valid)
+
+
+def qk_norm_rope(q, k, q_weight, k_weight, rope_table, eps):
+    outputs = []
+    for x, weight in ((q, q_weight), (k, k_weight)):
+        output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
+        if x.numel():
+            _qk_norm_rope_kernel[(triton.cdiv(x.shape[0] * x.shape[1], 4),)](
+                x,
+                weight,
+                rope_table,
+                output,
+                *x.shape[:2],
+                *x.stride()[:2],
+                rope_table.stride(0),
+                eps,
+                4,
+                num_warps=4,
+                enable_fp_fusion=False,
+            )
+        outputs.append(output)
+    return tuple(outputs)

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -18,10 +18,12 @@ from typing import Any
 import torch
 from torch.nn import Module
 
+from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
+    RowParallelLinear,
     UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -371,23 +373,9 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
         if x.dtype not in (torch.float16, torch.float32):
             raise ValueError("H3 W8A16 requires FP16 or FP32 activations")
         if x.is_cuda:
-            from .cuda_ops import fp16_gemm, w8a16_extension
-
-            ops = w8a16_extension()
             shape = x.shape
             x, scale = fp16_gemm_input(x)
-            if self.layer_config.convrot:
-                if self.layer_config.convrot_groupsize != 256:
-                    raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
-                x = ops.rotate(x)
-            weight = getattr(layer, "h3_fp16_weight", None)
-            if weight is None:
-                weight = ops.dequantize(layer.weight, layer.weight_scale)
-            output = fp16_gemm(
-                x, weight, getattr(layer, "h3_output_fp32", False) or scale is not None
-            )
-            if scale is not None:
-                output = output * scale
+            output = self.apply_prepared(layer, x, scale)
             output = output.reshape(*shape[:-1], layer.weight.shape[0])
             return output if bias is None else output + bias
         original_shape = x.shape
@@ -404,3 +392,43 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
         else:
             output = torch.nn.functional.linear(x, weight, bias)
         return output.reshape(*original_shape[:-1], layer.weight.shape[0])
+
+    def apply_prepared(self, layer, values, scale):
+        """Project FP16 rows with an explicit scale restored before TP reduction."""
+        from .cuda_ops import fp16_gemm, w8a16_extension
+
+        ops = w8a16_extension()
+        x = values.reshape(-1, values.shape[-1])
+        if self.layer_config.convrot:
+            if self.layer_config.convrot_groupsize != 256:
+                raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
+            x = ops.rotate(x)
+        weight = getattr(layer, "h3_fp16_weight", None)
+        if weight is None:
+            weight = ops.dequantize(layer.weight, layer.weight_scale)
+        output = fp16_gemm(
+            x, weight, getattr(layer, "h3_output_fp32", False) or scale is not None
+        )
+        if scale is not None:
+            output = output * scale
+        return output.reshape(*values.shape[:-1], layer.weight.shape[0])
+
+
+class H3RowParallelLinear(RowParallelLinear):
+    """H3-only optional prepared input; retain normal module hooks and TP sum."""
+
+    def forward(self, input_, input_scale=None):
+        if input_scale is None:
+            return super().forward(input_)
+        if (
+            not self.input_is_parallel
+            or self.bias is not None
+            or not isinstance(self.quant_method, Int8ConvRotLinearMethod)
+        ):
+            raise ValueError(
+                "Prepared H3 rows require a bias-free INT8 local projection"
+            )
+        output = self.quant_method.apply_prepared(self, input_, input_scale)
+        if self.reduce_results and self.tp_size > 1:
+            output = tensor_model_parallel_all_reduce(output)
+        return (output, None) if self.return_bias else output

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -153,8 +153,12 @@ class DiffusionInt8ConvRotConfig(QuantizationConfig):
         quantized_layers: list[str] | None = None,
         convrot_groupsize: int = 256,
         ignored_layers: list[str] | None = None,
+        weight_layout: str = "column",
     ) -> None:
         super().__init__()
+        if weight_layout not in ("row", "column"):
+            raise ValueError("H3 INT8 weight layout must be row or column")
+        self.weight_layout = weight_layout
         self.ignored_layers = ignored_layers or []
         self.layer_configs: dict[str, Int8ConvRotLayerConfig] = {}
         self.is_checkpoint_quantized = True
@@ -197,6 +201,7 @@ class DiffusionInt8ConvRotConfig(QuantizationConfig):
             quantized_layers=config.get("quantized_layers"),
             convrot_groupsize=config.get("convrot_groupsize", 256),
             ignored_layers=config.get("ignored_layers"),
+            weight_layout=config.get("weight_layout", "column"),
         )
 
     def configure_layers(
@@ -349,7 +354,15 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             raise ValueError(
                 f"{self.prefix} contains non-finite or non-positive INT8 weight scales."
             )
-        layer.weight.data = layer.weight.data.contiguous()
+        # Preserve logical [N,K] coordinates and every signed INT8 byte. The
+        # CPU stager keeps strides, so this costs no additional GPU residency.
+        # Limit the new layout to DiT projections validated with TP4.
+        if self.quant_config.weight_layout == "column" and self.prefix.startswith(
+            "blocks."
+        ):
+            layer.weight.data = layer.weight.data.t().contiguous().t()
+        else:
+            layer.weight.data = layer.weight.data.contiguous()
         layer.weight_scale.data = scale.data.reshape(-1).contiguous()
 
     def apply(
@@ -358,7 +371,7 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
         if x.dtype not in (torch.float16, torch.float32):
             raise ValueError("H3 W8A16 requires FP16 or FP32 activations")
         if x.is_cuda:
-            from .cuda_ops import w8a16_extension
+            from .cuda_ops import fp16_gemm, w8a16_extension
 
             ops = w8a16_extension()
             shape = x.shape
@@ -370,7 +383,7 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             weight = getattr(layer, "h3_fp16_weight", None)
             if weight is None:
                 weight = ops.dequantize(layer.weight, layer.weight_scale)
-            output = ops.gemm(
+            output = fp16_gemm(
                 x, weight, getattr(layer, "h3_output_fp32", False) or scale is not None
             )
             if scale is not None:

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -69,6 +69,10 @@ def fp16_gemm_input(x):
         return flat, None
     if flat.dtype != torch.float32:
         raise ValueError("H3 GEMM activations must be FP16 or FP32")
+    if flat.is_cuda:
+        from .cuda_ops import w8a16_extension
+
+        return w8a16_extension().prepare_fp16(flat)
     maximum = flat.abs().amax(-1, keepdim=True)
     _, exponent = torch.frexp(maximum)
     scale = torch.ldexp(torch.ones_like(maximum), (exponent - 11).clamp_min(0))

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -41,7 +41,11 @@ from .modulation import (
     rms_norm_indexed_scale_shift,
 )
 from .ops import RMSNorm, RotaryEmbedding, fused_qk_norm_rope
-from .quantization import preserve_fp32_output
+from .quantization import (
+    H3RowParallelLinear,
+    Int8ConvRotLinearMethod,
+    preserve_fp32_output,
+)
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (
@@ -618,7 +622,7 @@ class MiniMaxH3MLP(nn.Module):
         self.act_fn = SiluAndMul()
         # Chunk the fused fc1 output as [gate, up], then compute
         # silu(gate) * up.
-        self.fc2 = RowParallelLinear(
+        self.fc2 = H3RowParallelLinear(
             arch.ffn_hidden_size,
             arch.hidden_size,
             bias=False,
@@ -631,6 +635,18 @@ class MiniMaxH3MLP(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden, _ = self.fc1(x)
+        if (
+            hidden.is_cuda
+            and hidden.dtype == torch.float16
+            and 0 < hidden.shape[-1] <= 32768
+            and isinstance(self.fc2.quant_method, Int8ConvRotLinearMethod)
+        ):
+            from .activation import silu_prepare_fp16
+
+            values, scale = silu_prepare_fp16(hidden)
+            del hidden
+            out, _ = self.fc2(values, scale)
+            return out
         # Real H3 gated products exceed FP16 even when both factors are finite.
         # The following row projection rescales these FP32 activations into
         # FP16 Tensor Core range and restores their scale in its FP32 output.


### PR DESCRIPTION
## Purpose

Accelerate native H3 SM70 attention and INT8 ConvRot GEMM operands without a persistent FP16 weight cache. The D128 operator uses a wider K tile, direct batch/head addressing, actual warp-count softmax distribution and V-load/softmax overlap. An H3-only MLP path combines FP32 SiLU/product evaluation with power-of-two FP16 input preparation, restoring scale before the normal TP sum. Column-major INT8 storage and zero-workspace cuBLASLt remain enabled.

This fixes the former length-63 wide-QK NaNs: four warps were launched while softmax inferred eight from tile area, leaving half the rows unnormalized. CUTLASS provenance and BSD notices are retained. This remains stacked on #557; AI assistance was used, with human review required before promoting this Draft.

## Test Plan

Fix 1344x768, 39 frames/24 FPS, seed42, 20 actual updates /21 sigma positions, INT8 ConvRot FL2VA, TP4 GPU0-3, zero persistent FP16 cache/Lt workspace and prompt-verified cached text. Keep full-denoise, paired-operator and profiler evidence separate. Freshly decode changes in attention reduction order; reuse decoded media only after exact video/audio latent comparison.

## Test Result

- Standard CMake component build and repository pre-commit checks pass. 103 targeted attention/activation/INT8/numerics tests pass. After formatting/rebuild, SASS is byte-for-byte identical and the 41 affected attention/activation tests pass again (a repeated subset). Isolated CUDA12.8 memcheck/racecheck/synccheck each pass 25 attention cases. Ordinary tests cover changed-value CUDA Graph replay; isolated sanitizers do not capture graphs.
- **62.804019 s complete denoise**, **3.140201 s/update**, **55.151783 useful model TFLOPS/card**, versus 69.062335 s (9.06% less time). Each card's peak Torch allocation falls from 6.647851467 to **6.566735744 GiB**; NVML peak device-used memory is 8.419433594 GiB. No persistent FP16 cache or Lt workspace.
- Native attention paired control: **25.572351 ->20.110336 ms**, **42.565744 ->54.126701 useful TFLOPS**. Separate prototype measurements near 55 TFLOPS are not pooled into formal acceptance. The retained hot specialization uses 246 registers, 34,304 shared bytes/block and no spills. Q128/K128 improves only 1.48% against the retained native path and remains a prototype.
- Wide attention changes online reduction/FP16 probability rounding. Its fresh native video decode passes automatic checks; video/audio latent relative RMS changes versus old K64 are 10.5741% /1.8484%. Eight sampled frames show no obvious count/color/geometry regression, but **human audiovisual scoring remains pending**. Subsequent SiLU fusion and buffer release are bitwise equal to the wide-attention latents; their decode reuse is explicit. MP4 SHA256: `97b9196c49a8e1bf61cb8368f4db7d7013e99bc107650945dbe92b4b59b0184a`.

These are single unprofiled development measurements after a one-call warmup, not end-to-end or three-run 243-frame acceptance. **Under-50-second denoise, attention 60 TFLOPS, formal >80 TFLOPS/card and human quality gates remain incomplete.** Full BF16/Ref2VA coverage is still pending. NVML utilization does not establish Tensor Core saturation.

## Reproduction and rollback

Use `--int8-weight-layout column --fp16-weight-cache-gib 0 --num-frames 39 --num-inference-steps 21 --attention-backend FLASH_ATTN_V100`. Revert to parent `f825756607db` and rebuild the attention extension to restore the combined prior implementation; the extension also exposes `key_tile=64` for primitive comparison. `--int8-weight-layout row` independently restores the original GEMM layout path.

CONTROL.md and `flashattention-qk50/` retain exact commands, hashes, monitor curves, source prototypes and failures. Two native control probes with identical extension module names were invalidated due to import caching; only the qualified-name/schema-checked `native-verified-results.json` is valid paired evidence. The former sanitizer module-loading issue remains recorded separately. Final media/raw rank reports are under `outputs/quality39-int8-flashattn-native-wide-silu-release-20steps/FLASH_ATTN_V100/`.
