### PR TITLE
[Test] Record H3 local rotation and 58.19-second development evidence

### DIFF
--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,89 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Attention-focused diagnosis and V prefetch: 69.06 seconds
+
+The user redirects the next optimization to GEMM/attention arithmetic and data
+movement, with **60 useful TFLOPS for D128 attention** as the next operator
+milestone. Preserve the under-50-second complete-denoise and >80 TFLOPS/card
+model targets; none of these targets has passed.
+
+A fresh two-update trace of the 69.92-second native baseline records 2.515795 s
+of GEMM service (94.413296 useful TFLOPS) and 2.580667 s of attention service
+(42.179368 useful TFLOPS) on the critical rank. These are service rates, not
+complete-model throughput. The actual B1/N12323/H14/D128 noncausal attention
+call has 1,088,506,166,272 useful FLOPs; 60 TFLOPS requires 18.141769 ms.
+
+NCU on the same baseline binary finds 234 registers/thread, 26,128 shared
+bytes/block, two resident blocks and 12.5% occupancy. Tensor pipe activity is
+36.99%; HBM throughput is only 1.51%, while the L1/shared data path reaches
+61.64%. SASS-correlated samples identify long-scoreboard consumers at the
+QK/V shared stores after global loads, and short-scoreboard consumers at QK
+HMMA instructions. This supports addressing operand movement and latency
+hiding *inside* attention. It does not establish an HBM bandwidth limit.
+
+The retained change loads the first V fragment before softmax and passes it
+to a small adaptation of the existing SM70 PV software pipeline. Residual
+masks, FP16 rounding, FP32 accumulation and math order are unchanged. It keeps
+234 registers without spills, the same shared footprint and zero persistent
+FP16 cache / zero Lt workspace. The native helper's paired operator median
+is 24.522753 versus 25.702400 ms (44.387601 versus 42.350370 TFLOPS); clocks
+vary, so this is a development microbenchmark, not formal model acceptance.
+
+The new binary's independent NCU run reduces long-scoreboard stalls per
+issued instruction from 0.646730 to 0.342021. Tensor pipe activity rises from
+36.99% to 37.91%; short-scoreboard stalls remain. Do not interpret that stall
+ratio change as an equivalent wall-time reduction. Remaining work should
+address QK's shared-load/HMMA dependencies and input reuse.
+
+The installed CMake build completes the unchanged 39-frame/20-update TP4
+workload in **69.062335 s**, or 3.453117 s/update and 50.154018 useful
+TFLOPS/card: a 1.23% reduction from 69.923404 s. All ranks retain exactly
+6.647851467 GiB peak Torch allocation. Video/audio latents are bitwise equal;
+reuse of the baseline decode is explicit, with MP4 SHA256
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+Automatic media checks inherit the identical baseline output; human scoring
+is pending. The artifact prototype's 68.980006 s is a separate build/run.
+Neither timing is end-to-end or the formal three-run 243-frame acceptance.
+
+Eighteen native GPU tests pass, including newly added 32/33/96/97-key residual
+boundaries, strided storage, poisoned padding, online rescaling and graph
+replay. The standard CMake FlashAttention component builds. Binary SHA256 is
+`540474cfad758d4328ad0e0f00c745be62d3d8caaebea1d4bc19b86354442b9f`.
+
+CUDA12.8 isolated memcheck, racecheck and synccheck each pass thirteen cases
+with zero errors/hazards. Full pytest under memcheck completed its seventeen
+selected tests but reported a CUDA `cuKernelGetFunction` invalid-handle API
+error during module loading, as in the earlier full-environment diagnostic.
+Retain that failed log; the isolated run loads the exact installed extension
+without importing the full vLLM runtime. Ordinary GPU graph replay is covered
+by pytest; the isolated sanitizer harness does not test graph capture.
+
+Rejected or paused probes, all outside production source:
+
+| Probe | Paired candidate / control | Decision |
+| --- | --- | --- |
+| Manual QK shared fill | 44.529663 / 24.239103 ms | Exact but slower; retain original pipeline |
+| QK internal K64 stage | 25.759745 / 25.328640 ms | Exact, no improvement |
+| PV internal K64 stage | 26.507263 / 24.967169 ms | Exact, slower |
+| QK first-tile persistence / next-K prefetch | 25.236481 / 25.414656 ms | Only 0.7%, registers 234 to 254; not retained |
+| Q64/K128 with a 32x64 QK warp | NaN at length 63 | Rejected; grouped version spills, direct indexing removes spills but does not fix numerics |
+
+The wider QK path needs its accumulator/shared-memory mapping and boundary
+behavior fixed before any timing can be admitted. Its split-32 conversion
+attempt also fails length 63; do not repeat these variants unchanged. Earlier
+Q128/K32 wide-PV variants corrupt the length-one output; their direct-store
+workaround spills and slows down. Manual PV fill and larger Q/K tiles remain
+rejected in the retained artifact records.
+
+Evidence is under `flashattention-warp50/`: `report.json`,
+`attention60-root-cause.json`, `native-steps.nsys-rep`, both NCU reports and
+SASS-correlated samples, candidate source/build logs, native tests and quality
+commands. Media, rank/phase CSVs and NVML curves are under
+`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
+Rollback is the kernel parent `8cacbb70219c` plus a rebuild of
+`_h3_flashattn_C`; keep the existing column-major INT8 path.
+
 ### Low-memory follow-up: 69.92 seconds, under-50 target incomplete
 
 The user requires no substantial memory increase. Keep the persistent FP16

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,0 +1,75 @@
+# H3 reproducible validation
+
+This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
+Component numerics and a short end-to-end route are working. Keep profiler
+diagnostics separate from the three formal timing runs.
+
+## Fixed workload
+
+The acceptance helper uses the Chinese paper-boat/duck prompt in
+`H3Request`, 1344x768, 243 frames, 24 FPS, seed 42 and 50 sigma positions.
+The checkpoint schedule performs 49 DiT calls. All four ranks must report
+their actual completed call counts.
+
+After installing 1Cat with `.[video]` and building the H3 extensions:
+
+```bash
+python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
+  --output-dir /path/to/reference-fixtures
+python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
+```
+
+The runner performs one warmup and three unprofiled requests in one engine.
+The warmup's automatic media checks must pass before formal timing starts.
+Use `FLASHINFER_SM70` for the independent Volta attention path. A nonzero FP16
+weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
+arguments. The default budget is zero.
+
+## Reports and interpretation
+
+```bash
+python -m pip install matplotlib
+python tools/minimax_h3/report.py /path/to/acceptance/run-1
+```
+
+Each request retains `video.mp4`, the original waveform, sampled screenshots,
+`run.json`, and `nvml.jsonl`. The report helper exports rank throughput and phase
+times as CSV, and six NVML curves as PNG/SVG. Phase times include overlapping
+aggregate and component fields; do not sum all fields indiscriminately.
+
+Useful FLOPs count the actual local model matrices and effective attention
+lengths. Padding, Hadamard rotations, weight dequantization and extra output
+rows do not inflate the numerator. Each rank uses the slowest rank's full
+denoise wall time. Formal evaluation rejects mismatched requests/configurations,
+profiled timing, duplicate ranks and incomplete schedules.
+
+The performance gate requires all four per-rank medians to be strictly above
+80 TFLOPS and the three denoise times' population coefficient of variation to
+be at most 5%. Memory is a separate 30 GiB gate. NVML utilization is never
+interpreted as Tensor Core activity. Retain Nsight Compute counter evidence and
+Nsight Systems communication/stall traces separately.
+
+The evaluator leaves overall `accepted` false. Final review must score prompt
+following, subject consistency, temporal continuity, detail and audio at least
+4/5 each and reject flicker, deformation or audio/video faults.
+
+## Evidence completed so far
+
+- Both fixed INT8 partition files are downloaded and SHA256 manifests saved.
+  The original BF16 DiT partitions and shared components are downloaded; their
+  full file manifest is being generated.
+- Real TP4 text-encoder outputs are finite and bitwise identical between ranks.
+- Real 50-block INT8 DiT single-forward checks pass after preserving large
+  condition projections, residuals, gated products and row-projection outputs
+  in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
+- The native numerical/service suite passed 23 tests before the additional
+  request preflight changes. Six acceptance-contract tests pass.
+- A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
+  passed the automatic media checks. It is not a quality/performance baseline.
+- A full primary FL2VA INT8 / Flash-V100 eager video is running. Full quality,
+  both-backend comparisons, original BF16 comparisons, mixed references,
+  extra seeds and formal timing remain pending.
+- Standard CMake configuration, build and component installation of both H3
+  extensions pass. Complete release-wheel validation remains pending.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -126,7 +126,24 @@ as the full pipeline's memory gate. This single short run does not satisfy the
 primary three-run timing contract or the >80 TFLOPS threshold.
 
 The profiler-only run uses the first two updates of the unchanged 20-update
-schedule. Its critical-rank trace attributes about 52% of the synchronized
+schedule. Its rank-0 trace attributes about 52% of the synchronized
 span to attention, 25% to GEMM and 10% to communication before this optimization.
 Explicit wall coverage and kernel service are retained separately. Profiling
 results never replace unprofiled timing.
+
+The selected cooperative-transpose kernel completes the same 20-update denoise
+in 87.824099 s (4.391205 s/update), with 39.439671 useful TFLOPS on each rank.
+Compared with the original 105.642574 s FlashInfer baseline, throughput improves
+by 20.29%. Both final video and audio latent tensors are bitwise identical to
+the previously decoded prefetch result. Only after checking both tensors and
+the MP4 hash, this run reuses that validated decoder output. Its metadata marks
+`short_clip_denoise_quality_with_reused_decode`; it does not provide a new VAE
+or end-to-end timing measurement. Text embeddings are also cached and verified.
+
+The final binary passes all 47 video tests and the ordinary CMake component
+build. CUDA 12.8 memcheck, racecheck and synccheck each pass all six new
+tail/unaligned cases without errors or hazards. Matched-shape Nsight Compute
+reports 25.091% tensor-pipe activity, up from 16.976% before prefetch. This
+counter is diagnostic, not effective model throughput. The 39-frame result
+remains below 80 TFLOPS/card; primary-load quality, three formal timing runs
+and the full-pipeline memory gate remain incomplete.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -6,45 +6,53 @@ is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
-updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality, without a substantial memory increase. The latest native
-FlashAttention V-prefetch route measures **69.062335 s**, or 3.453117 s/update
-and 50.154018 useful TFLOPS/card. The prior full-tile/column-major INT8 route
-measured 69.923404 s; this is a 1.23% reduction. Both use zero persistent
-FP16 cache and zero Lt workspace. Peak allocated denoise memory remains
-6.647851467 GiB on all four cards; NVML peak device-used memory is 8.583496 GiB.
+updates**, retaining 1344x768, 39 frames/24 FPS, seed42, INT8 ConvRot FL2VA,
+TP4 GPU0-3 and output quality, without a substantial memory increase. The
+latest native wide-QK plus fused MLP route measures **62.804019 s**, or
+**3.140201 s/update and 55.151783 useful model TFLOPS/card**, compared with
+69.062335 s previously (9.06% reduction). Cache and Lt workspace are zero.
+Peak Torch denoise allocation is **6.566735744 GiB/card**, down from
+6.647851467; NVML peak device-used memory is 8.419433594 GiB/card.
 
-Video and audio latents are bitwise equal to the prior route. The baseline
-decode is explicitly reused: MP4 SHA256 remains
-`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
-The identical media retains the automatic checks; human audiovisual scoring
-remains pending. Earlier timing/decoder experiments remain in CONTROL.md.
+The main gain reuses Q operands across a wider K tile and fixes softmax's
+incorrect inferred warp count. A second change fuses FP32 SiLU/product with
+power-of-two FP16 input preparation and releases the gate buffer before GEMM.
+The native B1/N12323/H14/D128 attention paired control is 25.572351 ->20.110336
+ms (42.565744 ->54.126701 useful TFLOPS). The **60 TFLOPS attention** milestone
+requires <=18.141769 ms. A larger-Q prototype improves only 1.48% against the
+new native path and is not enabled. Preserve the arithmetic/data-movement
+focus identified in the earlier NCU/SASS evidence in CONTROL.md.
 
-This is one unprofiled complete native run after a one-call warmup, with
-prompt-verified cached text. The separate V-prefetch prototype measured
-68.980006 s. Do not combine different builds into a formal median or present
-these as end-to-end generation / three-run 243-frame acceptance.
+Wide attention changes online reduction and FP16 probability rounding; its
+64.284648-second native run was freshly decoded. Video/audio latent relative
+RMS deltas against the previous K64 implementation are 10.5741% /1.8484%.
+Automatic media checks pass, and eight sampled frames show no obvious count,
+color or geometry regression. Human audiovisual scoring is still pending.
+The subsequent MLP fusion (62.852804 s) and buffer release (62.804019 s) are
+bitwise equal to the wide-attention latents; their decoder reuse is explicit.
+The output MP4 SHA256 is
+`97b9196c49a8e1bf61cb8368f4db7d7013e99bc107650945dbe92b4b59b0184a`.
 
-The user's next operator milestone is **60 useful TFLOPS for D128 attention**.
-The current workload's B1/N12323/H14/D128 attention requires 18.141769 ms to
-meet that milestone. The native helper's paired microbenchmark measures
-24.522753 ms (44.387601 TFLOPS), so this milestone is also incomplete.
-The old baseline's two-update trace separates GEMM service at 94.413296
-TFLOPS from attention service at 42.179368 TFLOPS. NCU and SASS samples locate
-operand-load/shared-store/HMMA dependencies inside attention; retain the
-arithmetic/data-movement focus. See CONTROL.md for the full evidence and
-failed wider-QK paths.
+There are **103 passing targeted tests** for attention, fused activation,
+INT8 layout/Lt and model numerics. After repository formatting and rebuilding,
+the resulting SASS is byte-for-byte identical and the 41 affected attention
+and activation tests pass again; this is a repeated subset, not 144 distinct
+tests. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass 25
+attention cases with zero errors/hazards. Ordinary pytest covers graph
+replay; isolated sanitizers do not capture graphs. N73483 uses sampled FP32
+reference rows, avoiding a full quadratic allocation. Sixteen lengths retain
+bitwise K64 primitive rollback. Two earlier same-module-name control probes
+are explicitly invalidated because Python reused the candidate extension;
+only `native-verified-results.json` is valid native paired-control evidence.
 
-The standard CMake FlashAttention component builds; 18 native GPU tests pass,
-including the new 32/33/96/97-key residual boundaries, poisoned padding,
-noncontiguous storage, online rescaling and CUDA Graph replay. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass
-thirteen cases without errors/hazards. The full-environment memcheck loader
-error and isolated harness limits are retained in CONTROL.md. Previous INT8
-layout/Lt validation remains recorded. Evidence is in `flashattention-warp50/`;
-media and NVML reports are in
-`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
-**Neither 60 TFLOPS attention, 50-second denoise nor >80 TFLOPS/card model
-acceptance is achieved.**
+These are separate single unprofiled development runs after a one-call warmup,
+with prompt-verified cached text. Do not pool different builds into a formal
+median or present this as end-to-end / three-run 243-frame acceptance.
+Evidence and NVML plots are in `flashattention-qk50/`; media and raw rank/NVML
+reports are in
+`outputs/quality39-int8-flashattn-native-wide-silu-release-20steps/FLASH_ATTN_V100/`.
+**Attention 60 TFLOPS, under-50-second denoise, formal >80 TFLOPS/card and human
+quality gates remain incomplete.**
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -147,3 +147,17 @@ reports 25.091% tensor-pipe activity, up from 16.976% before prefetch. This
 counter is diagnostic, not effective model throughput. The 39-frame result
 remains below 80 TFLOPS/card; primary-load quality, three formal timing runs
 and the full-pipeline memory gate remain incomplete.
+
+Fused FP32 input preparation and warp-shuffle ConvRot subsequently reduce the
+same 20-update denoise to 86.200372 s (4.310019 s/update), or 40.182583 useful
+TFLOPS on every rank. Final video/audio latents remain bitwise identical;
+the run retains explicit cached-text/decoder-reuse labels. The video suite
+passes 58 tests, with a subsequently added nonfinite-input test passing
+separately. All eleven new rotation/scaling cases pass memcheck, racecheck
+and synccheck, and the W8A16 CMake component builds.
+
+A recovered ComfyUI V100 attention source was also audited. On aligned D128
+controls it is about 1.9 times slower than current FlashInfer, and its raw
+unaligned path has query-tail synchronization and numerical failures. Those
+controls do not replace H3 quality or performance acceptance. The mainline
+and >80 TFLOPS/card target remain unchanged; see CONTROL.md for evidence.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,9 +1,28 @@
 # H3 reproducible validation
 
 This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
-Component numerics and short cached-text generation are working. FlashInfer-SM70
+Component numerics and short cached-text generation are working. FlashAttention-V100
 is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
+
+The dedicated D128 FlashAttention-V100 route completes the INT8 FL2VA
+1344x768/39-frame/seed42/20-update development workload in 77.342982 s,
+or 3.867149 s/update and 44.784329 useful TFLOPS on each of GPU0-3.
+The comparison FlashInfer checkpoint takes 86.200372 s with the same W8A16
+preparation and cache-off settings. This is one unprofiled complete denoise
+measurement after a one-call warmup, using verified cached text embeddings.
+Fresh VAE decode takes 5.650908 s, excluding its 35.935474 s load.
+Automatic media checks pass; full human audiovisual quality remains pending.
+Video/audio latents differ from FlashInfer (relative L2 0.107541/0.018019),
+so this route does not claim bitwise equivalence or reuse its decoded output.
+
+The native route, independent memory/synchronization checks, matched operator
+benchmarks and NCU counters are documented in `CONTROL.md`. Source/build logs,
+the per-rank report, NVML curves and generated media are retained under
+`/data/minimax-h3/native-h3-20260908/flashattention-mainline/` and
+`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-fused-20steps/`.
+The primary 243-frame warmup/three-run contract has not been executed for this
+candidate. **80 TFLOPS/card is not achieved.**
 
 ## Short development checks
 
@@ -13,7 +32,7 @@ extent while developing kernels or debugging components:
 ```bash
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
+  --tensor-parallel-size 4 --attention-backend FLASH_ATTN_V100 \
   --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 
@@ -38,12 +57,12 @@ python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
   --output-dir /path/to/reference-fixtures
 python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --attention-backend FLASHINFER_SM70 --output-dir /path/to/acceptance
+  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
 ```
 
 The runner performs one warmup and three unprofiled requests in one engine.
 The warmup's automatic media checks must pass before formal timing starts.
-Use `FLASH_ATTN_V100` for an explicit comparison or rollback. A nonzero FP16
+Use `FLASHINFER_SM70` for an explicit comparison or rollback. A nonzero FP16
 weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
 arguments. The default budget is zero.
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,7 +1,8 @@
 # H3 reproducible validation
 
 This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
-Component numerics and a short end-to-end route are working. Keep profiler
+Component numerics and short cached-text generation are working. FlashInfer-SM70
+is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
 ## Short development checks
@@ -37,12 +38,12 @@ python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
   --output-dir /path/to/reference-fixtures
 python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
+  --attention-backend FLASHINFER_SM70 --output-dir /path/to/acceptance
 ```
 
 The runner performs one warmup and three unprofiled requests in one engine.
 The warmup's automatic media checks must pass before formal timing starts.
-Use `FLASHINFER_SM70` for the independent Volta attention path. A nonzero FP16
+Use `FLASH_ATTN_V100` for an explicit comparison or rollback. A nonzero FP16
 weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
 arguments. The default budget is zero.
 
@@ -83,8 +84,9 @@ following, subject consistency, temporal continuity, detail and audio at least
 - Real 50-block INT8 DiT single-forward checks pass after preserving large
   condition projections, residuals, gated products and row-projection outputs
   in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
-- The current numerical/service suite passes 38 tests, including short clips
-  and the optimized FlashInfer kernel. Seven acceptance-contract tests pass, including excluded timing.
+- The current numerical/service suite passes 47 tests, including short clips,
+  the optimized FlashInfer kernel, prefetch tails and unaligned storage views.
+  Seven acceptance-contract tests pass, including excluded timing.
 - A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
   passed the automatic media checks. It is not a quality/performance baseline.
 - The earlier full primary video was interrupted before completion and is
@@ -93,8 +95,10 @@ following, subject consistency, temporal continuity, detail and audio at least
   with Flash-V100 and 10.55566 s with the FlashInfer candidate: 30.6664 versus
   32.8142 useful TFLOPS on each rank. Both produced finite, rank-identical
   latents. These are development results, not full-schedule acceptance.
-- Full quality, original BF16 comparisons, mixed references, extra seeds and
-  formal three-run timing remain pending.
+- Original BF16 FL2VA text-to-video completed 20 updates at 39 frames through
+  Flash-V100 with FP16/FP32 computation. All automatic checks pass; denoise took
+  110.569167 s. Other original-checkpoint backend/partition combinations, mixed
+  references, extra seeds, full quality and formal three-run timing remain pending.
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
 
@@ -110,3 +114,19 @@ longer show the severe two-forward artifacts. Flash-V100 took 113.459387 s
 (5.672969 s/call); FlashInfer took 105.642574 s (5.282129 s/call). Both used the
 same INT8 checkpoint, prompt, seed, 39 frames, cached text and shift rules.
 Full primary acceptance and human audiovisual review remain pending.
+
+The subsequent FlashInfer V-layout/KV-prefetch optimization completes the same
+20-update short request in 90.880784 s (4.544039 s/update), with 38.113157 useful
+TFLOPS on each rank. Video/audio latents and the exported MP4 are bitwise
+identical to the previous FlashInfer result; automatic media checks pass.
+CUDA 12.8 memcheck/synccheck each pass the six new tail/unaligned cases with
+zero errors. The standard CMake FlashInfer component builds successfully.
+The 6.647851 GiB Torch peak is measured during DiT only and must not be treated
+as the full pipeline's memory gate. This single short run does not satisfy the
+primary three-run timing contract or the >80 TFLOPS threshold.
+
+The profiler-only run uses the first two updates of the unchanged 20-update
+schedule. Its critical-rank trace attributes about 52% of the synchronized
+span to attention, 25% to GEMM and 10% to communication before this optimization.
+Explicit wall coverage and kernel service are retained separately. Profiling
+results never replace unprofiled timing.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -5,24 +5,26 @@ Component numerics and short cached-text generation are working. FlashAttention-
 is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
-The dedicated D128 FlashAttention-V100 route completes the INT8 FL2VA
-1344x768/39-frame/seed42/20-update development workload in 77.342982 s,
-or 3.867149 s/update and 44.784329 useful TFLOPS on each of GPU0-3.
-The comparison FlashInfer checkpoint takes 86.200372 s with the same W8A16
-preparation and cache-off settings. This is one unprofiled complete denoise
-measurement after a one-call warmup, using verified cached text embeddings.
-Fresh VAE decode takes 5.650908 s, excluding its 35.935474 s load.
-Automatic media checks pass; full human audiovisual quality remains pending.
-Video/audio latents differ from FlashInfer (relative L2 0.107541/0.018019),
-so this route does not claim bitwise equivalence or reuse its decoded output.
+The current short-development target is **under 50 seconds for 20 actual DiT
+updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
+output quality. QK/RoPE fusion now completes this workload in **74.411059 s**,
+or 3.720553 s/update and 46.548909 useful TFLOPS/card. The prior FlashAttention
+checkpoint took 77.342982 s; FlashInfer took 86.200372 s with the same W8A16
+preparation and cache-off settings. These are individual unprofiled development
+measurements after a one-call warmup, using verified cached text embeddings.
 
-The native route, independent memory/synchronization checks, matched operator
-benchmarks and NCU counters are documented in `CONTROL.md`. Source/build logs,
-the per-rank report, NVML curves and generated media are retained under
-`/data/minimax-h3/native-h3-20260908/flashattention-mainline/` and
-`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-fused-20steps/`.
-The primary 243-frame warmup/three-run contract has not been executed for this
-candidate. **80 TFLOPS/card is not achieved.**
+The fused QK/RoPE result is bitwise equal to the prior FlashAttention checkpoint
+for both video and audio latents. Fresh VAE decoding also produces the identical
+MP4 SHA256, and all automatic media checks pass. Human audiovisual quality
+review remains pending. This equivalence is to the FlashAttention control;
+its earlier difference from FlashInfer is still recorded in CONTROL.md.
+
+The four-rank trace, matched failed probes and retained fusion are documented
+in CONTROL.md and `/data/minimax-h3/native-h3-20260908/flashattention-feeding-round2/`.
+Media, NVML and phase reports are under
+`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-rope-20steps/`.
+24 targeted tests and three isolated CUDA sanitizer checks pass. Neither the
+50-second development goal nor the primary >80 TFLOPS/card gate is achieved.
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -4,6 +4,24 @@ This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
 Component numerics and a short end-to-end route are working. Keep profiler
 diagnostics separate from the three formal timing runs.
 
+## Short development checks
+
+Use the native entrypoint with the same spatial canvas and a short temporal
+extent while developing kernels or debugging components:
+
+```bash
+vllm video generate --model /path/to/MiniMax-H3 \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
+  --num-frames 39 --num-inference-steps 3 --output-dir /path/to/development
+```
+
+This produces 1.625 seconds and performs two DiT forwards. It is an execution,
+numerical-range and profiling workload; two forwards cannot establish the
+checkpoint's final video quality. The streaming VAE requires at least 22 frames.
+Keep the requested 50 sigma positions when evaluating final quality. Do not run
+the full acceptance runner for routine development.
+
 ## Fixed workload
 
 The acceptance helper uses the Chinese paper-boat/duck prompt in
@@ -30,7 +48,7 @@ arguments. The default budget is zero.
 ## Reports and interpretation
 
 ```bash
-python -m pip install matplotlib
+uv pip install --python .venv/bin/python matplotlib
 python tools/minimax_h3/report.py /path/to/acceptance/run-1
 ```
 
@@ -58,18 +76,29 @@ following, subject consistency, temporal continuity, detail and audio at least
 ## Evidence completed so far
 
 - Both fixed INT8 partition files are downloaded and SHA256 manifests saved.
-  The original BF16 DiT partitions and shared components are downloaded; their
-  full file manifest is being generated.
+  The original BF16 DiT partitions and shared components are downloaded, and
+  their 98-file checksum manifest is complete.
 - Real TP4 text-encoder outputs are finite and bitwise identical between ranks.
 - Real 50-block INT8 DiT single-forward checks pass after preserving large
   condition projections, residuals, gated products and row-projection outputs
   in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
-- The native numerical/service suite passed 23 tests before the additional
-  request preflight changes. Six acceptance-contract tests pass.
+- The current numerical/service suite passes 38 tests, including short clips
+  and the optimized FlashInfer kernel. Seven acceptance-contract tests pass, including excluded timing.
 - A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
   passed the automatic media checks. It is not a quality/performance baseline.
-- A full primary FL2VA INT8 / Flash-V100 eager video is running. Full quality,
-  both-backend comparisons, original BF16 comparisons, mixed references,
-  extra seeds and formal timing remain pending.
+- The earlier full primary video was interrupted before completion and is
+  retained as partial diagnostics only. Development now uses 39-frame clips.
+  Cached-text INT8 TP4 denoise (two forwards after warmup) measured 11.29494 s
+  with Flash-V100 and 10.55566 s with the FlashInfer candidate: 30.6664 versus
+  32.8142 useful TFLOPS on each rank. Both produced finite, rank-identical
+  latents. These are development results, not full-schedule acceptance.
+- Full quality, original BF16 comparisons, mixed references, extra seeds and
+  formal three-run timing remain pending.
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
+
+The final short export contains 39 decoded frames and valid audio, but its
+two-forward image has clear ghosting and grid artifacts. It is not quality
+accepted. Other GPU workers were present during that export run, so its JSON
+marks timing invalid. Both the evaluator and report helper reject explicitly
+excluded timing. The earlier isolated candidate comparison is retained separately.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -13,12 +13,13 @@ extent while developing kernels or debugging components:
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
-  --num-frames 39 --num-inference-steps 3 --output-dir /path/to/development
+  --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 
-This produces 1.625 seconds and performs two DiT forwards. It is an execution,
-numerical-range and profiling workload; two forwards cannot establish the
-checkpoint's final video quality. The streaming VAE requires at least 22 frames.
+This produces 1.625 seconds and performs 20 DiT forwards. It is the short
+quality/development workload; the sigma-point convention needs 21 positions
+for 20 actual updates. One- or two-forward runs remain numerical/execution
+diagnostics and must not be used to judge normal model image quality. The streaming VAE requires at least 22 frames.
 Keep the requested 50 sigma positions when evaluating final quality. Do not run
 the full acceptance runner for routine development.
 
@@ -97,8 +98,15 @@ following, subject consistency, temporal continuity, detail and audio at least
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
 
-The final short export contains 39 decoded frames and valid audio, but its
-two-forward image has clear ghosting and grid artifacts. It is not quality
+The earlier two-forward short export contains 39 decoded frames and valid
+audio, but its image has clear ghosting and grid artifacts. It is not quality
 accepted. Other GPU workers were present during that export run, so its JSON
 marks timing invalid. Both the evaluator and report helper reject explicitly
 excluded timing. The earlier isolated candidate comparison is retained separately.
+
+A subsequent matched 20-forward comparison completed on exclusively leased
+GPUs 0–3. Both backends pass automatic media checks, and inspected frames no
+longer show the severe two-forward artifacts. Flash-V100 took 113.459387 s
+(5.672969 s/call); FlashInfer took 105.642574 s (5.282129 s/call). Both used the
+same INT8 checkpoint, prompt, seed, 39 frames, cached text and shift rules.
+Full primary acceptance and human audiovisual review remain pending.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -7,33 +7,44 @@ diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
 updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality, without a substantial memory increase. Exact full-tile
-FlashAttention specialization and column-major INT8/Lt now complete this workload
-in **69.923404 s**, or 3.496170 s/update and 49.536398 useful TFLOPS/card.
-The preceding QK/RoPE baseline took 74.411059 s; the new route reduces that time
-by 6.03%. Both use zero persistent FP16 cache. New Lt workspace is also zero.
-Peak allocated denoise memory remains exactly 6.647851467 GiB on all four cards;
-NVML peak device-used memory, including runtime allocations, is 8.583496 GiB.
+output quality, without a substantial memory increase. The latest native
+FlashAttention V-prefetch route measures **69.062335 s**, or 3.453117 s/update
+and 50.154018 useful TFLOPS/card. The prior full-tile/column-major INT8 route
+measured 69.923404 s; this is a 1.23% reduction. Both use zero persistent
+FP16 cache and zero Lt workspace. Peak allocated denoise memory remains
+6.647851467 GiB on all four cards; NVML peak device-used memory is 8.583496 GiB.
 
-Both video and audio latents are bitwise equal to the prior FlashAttention
-baseline. Fresh VAE decoding produces identical PCM samples and MP4 bytes;
-MP4 SHA256 is `17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
-All automatic media checks pass. Human audiovisual quality scoring remains
-pending. Earlier FlashInfer comparisons remain recorded in CONTROL.md.
+Video and audio latents are bitwise equal to the prior route. The baseline
+decode is explicitly reused: MP4 SHA256 remains
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+The identical media retains the automatic checks; human audiovisual scoring
+remains pending. Earlier timing/decoder experiments remain in CONTROL.md.
 
-These are individual unprofiled development measurements after a one-invocation
-warmup with prompt-verified cached text embeddings. Do not interpret them as
-end-to-end generation or the formal three-measurement 243-frame acceptance.
-The separate low-memory prototype took 69.868952 s; combining different builds
-into a formal median is not permitted.
+This is one unprofiled complete native run after a one-call warmup, with
+prompt-verified cached text. The separate V-prefetch prototype measured
+68.980006 s. Do not combine different builds into a formal median or present
+these as end-to-end generation / three-run 243-frame acceptance.
 
-The standard CMake components build. 86 targeted GPU/CPU tests pass, including
-INT8 offsets/scales, padded-M12352 projection equality, fallback and CUDA Graph
-replay. Isolated CUDA12.8 memcheck/racecheck/synccheck pass without errors or
-hazards. Evidence is under `flashattention-lowmem50/`; serialized GPU test logs
-are under `flashattention-under50/`. Media and NVML reports are under
-`outputs/quality39-int8-flashattn-lowmem-native-20steps/FLASH_ATTN_V100/` in the
-recorded artifact root. **Neither 50 seconds nor >80 TFLOPS/card is achieved.**
+The user's next operator milestone is **60 useful TFLOPS for D128 attention**.
+The current workload's B1/N12323/H14/D128 attention requires 18.141769 ms to
+meet that milestone. The native helper's paired microbenchmark measures
+24.522753 ms (44.387601 TFLOPS), so this milestone is also incomplete.
+The old baseline's two-update trace separates GEMM service at 94.413296
+TFLOPS from attention service at 42.179368 TFLOPS. NCU and SASS samples locate
+operand-load/shared-store/HMMA dependencies inside attention; retain the
+arithmetic/data-movement focus. See CONTROL.md for the full evidence and
+failed wider-QK paths.
+
+The standard CMake FlashAttention component builds; 18 native GPU tests pass,
+including the new 32/33/96/97-key residual boundaries, poisoned padding,
+noncontiguous storage, online rescaling and CUDA Graph replay. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass
+thirteen cases without errors/hazards. The full-environment memcheck loader
+error and isolated harness limits are retained in CONTROL.md. Previous INT8
+layout/Lt validation remains recorded. Evidence is in `flashattention-warp50/`;
+media and NVML reports are in
+`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
+**Neither 60 TFLOPS attention, 50-second denoise nor >80 TFLOPS/card model
+acceptance is achieved.**
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -7,24 +7,33 @@ diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
 updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality. QK/RoPE fusion now completes this workload in **74.411059 s**,
-or 3.720553 s/update and 46.548909 useful TFLOPS/card. The prior FlashAttention
-checkpoint took 77.342982 s; FlashInfer took 86.200372 s with the same W8A16
-preparation and cache-off settings. These are individual unprofiled development
-measurements after a one-call warmup, using verified cached text embeddings.
+output quality, without a substantial memory increase. Exact full-tile
+FlashAttention specialization and column-major INT8/Lt now complete this workload
+in **69.923404 s**, or 3.496170 s/update and 49.536398 useful TFLOPS/card.
+The preceding QK/RoPE baseline took 74.411059 s; the new route reduces that time
+by 6.03%. Both use zero persistent FP16 cache. New Lt workspace is also zero.
+Peak allocated denoise memory remains exactly 6.647851467 GiB on all four cards;
+NVML peak device-used memory, including runtime allocations, is 8.583496 GiB.
 
-The fused QK/RoPE result is bitwise equal to the prior FlashAttention checkpoint
-for both video and audio latents. Fresh VAE decoding also produces the identical
-MP4 SHA256, and all automatic media checks pass. Human audiovisual quality
-review remains pending. This equivalence is to the FlashAttention control;
-its earlier difference from FlashInfer is still recorded in CONTROL.md.
+Both video and audio latents are bitwise equal to the prior FlashAttention
+baseline. Fresh VAE decoding produces identical PCM samples and MP4 bytes;
+MP4 SHA256 is `17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+All automatic media checks pass. Human audiovisual quality scoring remains
+pending. Earlier FlashInfer comparisons remain recorded in CONTROL.md.
 
-The four-rank trace, matched failed probes and retained fusion are documented
-in CONTROL.md and `/data/minimax-h3/native-h3-20260908/flashattention-feeding-round2/`.
-Media, NVML and phase reports are under
-`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-rope-20steps/`.
-24 targeted tests and three isolated CUDA sanitizer checks pass. Neither the
-50-second development goal nor the primary >80 TFLOPS/card gate is achieved.
+These are individual unprofiled development measurements after a one-invocation
+warmup with prompt-verified cached text embeddings. Do not interpret them as
+end-to-end generation or the formal three-measurement 243-frame acceptance.
+The separate low-memory prototype took 69.868952 s; combining different builds
+into a formal median is not permitted.
+
+The standard CMake components build. 86 targeted GPU/CPU tests pass, including
+INT8 offsets/scales, padded-M12352 projection equality, fallback and CUDA Graph
+replay. Isolated CUDA12.8 memcheck/racecheck/synccheck pass without errors or
+hazards. Evidence is under `flashattention-lowmem50/`; serialized GPU test logs
+are under `flashattention-under50/`. Media and NVML reports are under
+`outputs/quality39-int8-flashattn-lowmem-native-20steps/FLASH_ATTN_V100/` in the
+recorded artifact root. **Neither 50 seconds nor >80 TFLOPS/card is achieved.**
 
 ## Short development checks
 
@@ -35,6 +44,7 @@ extent while developing kernels or debugging components:
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 --attention-backend FLASH_ATTN_V100 \
+  --int8-weight-layout column --fp16-weight-cache-gib 0 \
   --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from copy import deepcopy
+from dataclasses import asdict
+
+import pytest
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+from vllm.video.metrics import evaluate_performance
+
+
+def measurements():
+    run = {
+        "config": asdict(H3Config()),
+        "request": asdict(H3Request()),
+        "gpus": [0, 1, 2, 3],
+        "measurement": {"profiled": False, "warmup_runs": 1},
+        "ranks": [
+            {
+                "rank": rank,
+                "dit_calls": 49,
+                "useful_denoise_flops": 6_000_000_000_000_000,
+                "peak_allocated_bytes": 29 * 1024**3,
+                "stage_seconds": {"denoise": 60.0 if rank == 3 else 50.0},
+            }
+            for rank in range(4)
+        ],
+    }
+    return [deepcopy(run) for _ in range(3)]
+
+
+def test_all_ranks_use_slowest_rank_wall_time_and_strict_threshold():
+    runs = measurements()
+    report = evaluate_performance(runs)
+    assert report["rank_median_tflops"] == [100.0] * 4
+    assert report["performance_passed"]
+    for run in runs:
+        run["ranks"][2]["useful_denoise_flops"] = 4_800_000_000_000_000
+    assert not evaluate_performance(runs)["performance_passed"]
+
+
+@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls"])
+def test_rejects_incomparable_measurements(invalid):
+    runs = measurements()
+    if invalid == "profiled":
+        runs[1]["measurement"]["profiled"] = True
+    elif invalid == "seed":
+        runs[1]["request"]["sampling"]["seed"] = 2026
+    elif invalid == "rank":
+        runs[1]["ranks"][3]["rank"] = 2
+    else:
+        runs[1]["ranks"][0]["dit_calls"] = 48
+    with pytest.raises(ValueError):
+        evaluate_performance(runs)
+
+
+def test_memory_gate_and_variability_are_reported_separately():
+    runs = measurements()
+    runs[0]["ranks"][1]["peak_allocated_bytes"] = 31 * 1024**3
+    runs[0]["ranks"][3]["stage_seconds"]["denoise"] = 80.0
+    report = evaluate_performance(runs)
+    assert not report["memory_passed"]
+    assert report["denoise_cv"] > 0.05
+    assert not report["performance_passed"]

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -39,7 +39,7 @@ def test_all_ranks_use_slowest_rank_wall_time_and_strict_threshold():
     assert not evaluate_performance(runs)["performance_passed"]
 
 
-@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls"])
+@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls", "excluded"])
 def test_rejects_incomparable_measurements(invalid):
     runs = measurements()
     if invalid == "profiled":
@@ -48,6 +48,8 @@ def test_rejects_incomparable_measurements(invalid):
         runs[1]["request"]["sampling"]["seed"] = 2026
     elif invalid == "rank":
         runs[1]["ranks"][3]["rank"] = 2
+    elif invalid == "excluded":
+        runs[1]["timing_valid"] = False
     else:
         runs[1]["ranks"][0]["dit_calls"] = 48
     with pytest.raises(ValueError):

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Warm up once, then measure the approved H3 workload three times."""
+
+import argparse
+import json
+from pathlib import Path
+
+from vllm.model_executor.models.minimax_h3.comfy_checkpoint import (
+    inspect_comfy_checkpoint,
+)
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+from vllm.video.engine import H3Engine
+from vllm.video.metrics import evaluate_performance
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--transformer-path", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--fp16-weight-cache-gib", type=float, default=0)
+    parser.add_argument("--fp16-cache-layer", action="append", default=[])
+    parser.add_argument(
+        "--attention-backend",
+        choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
+        default="FLASH_ATTN_V100",
+    )
+    args = parser.parse_args()
+    inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")
+    config = H3Config(
+        model=args.model,
+        transformer_path=args.transformer_path,
+        attention_backend=args.attention_backend,
+        fp16_weight_cache_gib=args.fp16_weight_cache_gib,
+        fp16_cache_layers=tuple(args.fp16_cache_layer),
+    )
+    results = []
+    with H3Engine(config) as engine:
+        warmup = engine.generate(H3Request(), args.output_dir / "warmup")
+        if not warmup["ranks"][0]["quality"]["automatic_passed"]:
+            raise RuntimeError("warmup media checks failed; fix quality before timing")
+        for index in range(3):
+            result = engine.generate(H3Request(), args.output_dir / f"run-{index + 1}")
+            result["measurement"] = {"profiled": False, "warmup_runs": 1}
+            (args.output_dir / f"run-{index + 1}" / "run.json").write_text(
+                json.dumps(result, indent=2, ensure_ascii=False)
+            )
+            results.append(result)
+    report = evaluate_performance(results)
+    report["quality"] = [run["ranks"][0]["quality"] for run in results]
+    report["accepted"] = False  # Human quality review is always required.
+    (args.output_dir / "acceptance.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument(
         "--attention-backend",
         choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
-        default="FLASHINFER_SM70",
+        default="FLASH_ATTN_V100",
     )
     args = parser.parse_args()
     inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument(
         "--attention-backend",
         choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
-        default="FLASH_ATTN_V100",
+        default="FLASHINFER_SM70",
     )
     args = parser.parse_args()
     inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")

--- a/tools/minimax_h3/fixtures.py
+++ b/tools/minimax_h3/fixtures.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Extract immutable image/video/audio references from the pinned H3 example."""
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from vllm.model_executor.models.minimax_h3.config import BASE_REVISION
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    source = args.model_root / "assets/ref2va.mp4"
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to prepare reference fixtures")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    for name, options in (
+        ("first.png", ["-frames:v", "1"]),
+        ("reference.mp4", ["-t", "4", "-c:v", "libx264", "-crf", "18", "-c:a", "aac"]),
+        ("reference.wav", ["-t", "4", "-vn", "-ar", "32000", "-c:a", "pcm_f32le"]),
+    ):
+        subprocess.run(
+            [ffmpeg, "-v", "error", "-y", "-i", str(source), *options, str(out / name)],
+            check=True,
+        )
+    subprocess.run(
+        [
+            ffmpeg,
+            "-v",
+            "error",
+            "-y",
+            "-sseof",
+            "-0.1",
+            "-i",
+            str(source),
+            "-frames:v",
+            "1",
+            str(out / "last.png"),
+        ],
+        check=True,
+    )
+    files = []
+    for path in (source, *sorted(out.iterdir())):
+        if not path.is_file() or path.suffix == ".json":
+            continue
+        with path.open("rb") as stream:
+            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+        files.append(
+            {"filename": path.name, "sha256": digest, "bytes": path.stat().st_size}
+        )
+    (out / "manifest.json").write_text(
+        json.dumps({"revision": BASE_REVISION, "files": files}, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3/report.py
+++ b/tools/minimax_h3/report.py
@@ -11,6 +11,11 @@ from pathlib import Path
 def export_report(run_dir):
     run_dir = Path(run_dir)
     run = json.loads((run_dir / "run.json").read_text())
+    if run.get("timing_valid") is False:
+        raise ValueError(
+            "Cannot report excluded timing: "
+            + run.get("timing_exclusion_reason", "run marked invalid")
+        )
     ranks = sorted(run["ranks"], key=lambda rank: rank["rank"])
     denoise_seconds = max(rank["stage_seconds"]["denoise"] for rank in ranks)
     rows = []
@@ -80,7 +85,8 @@ def export_report(run_dir):
     for axis in axes[-1]:
         axis.set_xlabel("Seconds from first NVML sample")
     figure.suptitle(
-        f"H3 {run['config']['attention_backend']} — "
+        f"H3 {run['config']['attention_backend']} "
+        f"({run.get('mode', 'native request')}) — "
         "NVML diagnostics (Tensor Core activity requires Nsight Compute)"
     )
     figure.tight_layout()

--- a/tools/minimax_h3/report.py
+++ b/tools/minimax_h3/report.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Export measured H3 rank throughput, phase times and NVML curves."""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+def export_report(run_dir):
+    run_dir = Path(run_dir)
+    run = json.loads((run_dir / "run.json").read_text())
+    ranks = sorted(run["ranks"], key=lambda rank: rank["rank"])
+    denoise_seconds = max(rank["stage_seconds"]["denoise"] for rank in ranks)
+    rows = []
+    for rank in ranks:
+        rows.append(
+            {
+                "rank": rank["rank"],
+                "gpu": run["gpus"][rank["rank"]],
+                "useful_flops": rank["useful_denoise_flops"],
+                "denoise_seconds": denoise_seconds,
+                "effective_tflops": rank["useful_denoise_flops"]
+                / denoise_seconds
+                / 1e12,
+                "peak_allocated_gib": rank["peak_allocated_bytes"] / 1024**3,
+                "dit_calls": rank["dit_calls"],
+            }
+        )
+    with (run_dir / "rank-performance.csv").open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    with (run_dir / "phase-times.csv").open("w", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["rank", "phase", "seconds"])
+        for rank in ranks:
+            for phase, seconds in rank["stage_seconds"].items():
+                writer.writerow([rank["rank"], phase, seconds])
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    samples = [
+        json.loads(line)
+        for line in (run_dir / "nvml.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    if not samples:
+        raise ValueError("no NVML samples were recorded")
+    start = min(sample["timestamp"] for sample in samples)
+    fields = [
+        ("gpu_util_percent", "GPU utilization (%)", 1),
+        ("memory_used_bytes", "Device memory (GiB)", 1024**3),
+        ("power_watts", "Power (W)", 1),
+        ("sm_clock_mhz", "SM clock (MHz)", 1),
+        ("temperature_c", "Temperature (C)", 1),
+        ("memory_util_percent", "Memory controller utilization (%)", 1),
+    ]
+    figure, axes = plt.subplots(3, 2, figsize=(14, 10), sharex=True)
+    for axis, (key, label, divisor) in zip(axes.flat, fields):
+        for gpu in run["gpus"]:
+            points = [
+                sample
+                for sample in samples
+                if sample["gpu"] == gpu and sample.get(key) is not None
+            ]
+            axis.plot(
+                [point["timestamp"] - start for point in points],
+                [point[key] / divisor for point in points],
+                label=f"GPU {gpu}",
+                linewidth=1,
+            )
+        axis.set_ylabel(label)
+        axis.grid(alpha=0.25)
+    axes[0, 0].legend(ncol=4, fontsize=8)
+    for axis in axes[-1]:
+        axis.set_xlabel("Seconds from first NVML sample")
+    figure.suptitle(
+        f"H3 {run['config']['attention_backend']} — "
+        "NVML diagnostics (Tensor Core activity requires Nsight Compute)"
+    )
+    figure.tight_layout()
+    for extension in ("png", "svg"):
+        figure.savefig(run_dir / f"nvml-curves.{extension}", dpi=160)
+    plt.close(figure)
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(export_report(args.run_dir), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -138,6 +138,34 @@ def evaluate_performance(runs):
     """Evaluate three unprofiled post-warmup runs; never use utilization as FLOPs."""
     if len(runs) != 3 or any(len(run["ranks"]) != 4 for run in runs):
         raise ValueError("acceptance requires three four-rank measurements")
+    baseline = runs[0]
+    for run in runs:
+        if sorted(rank["rank"] for rank in run["ranks"]) != list(range(4)):
+            raise ValueError("each measurement must contain four unique TP ranks")
+        if any(run[key] != baseline[key] for key in ("config", "request", "gpus")):
+            raise ValueError("acceptance measurements must use the same configuration")
+        sampling = run["request"]["sampling"]
+        expected = {
+            "width": 1344,
+            "height": 768,
+            "num_frames": 243,
+            "fps": 24,
+            "seed": 42,
+            "num_inference_steps": 50,
+        }
+        if any(sampling.get(key) != value for key, value in expected.items()):
+            raise ValueError("acceptance requires the fixed primary workload")
+        if run.get("measurement", {}).get("profiled") is not False:
+            raise ValueError("formal timing must be explicitly recorded as unprofiled")
+        if any(rank["dit_calls"] != 49 for rank in run["ranks"]):
+            raise ValueError("the primary schedule requires 49 completed DiT calls")
+        if any(
+            type(rank["useful_denoise_flops"]) is not int
+            or rank["useful_denoise_flops"] <= 0
+            for rank in run["ranks"]
+        ):
+            raise ValueError("useful FLOPs must be positive integer counts")
+    ordered = [sorted(run["ranks"], key=lambda rank: rank["rank"]) for run in runs]
     seconds = [
         max(rank["stage_seconds"]["denoise"] for rank in run["ranks"]) for run in runs
     ]
@@ -146,14 +174,20 @@ def evaluate_performance(runs):
     medians = []
     for rank in range(4):
         values = [
-            run["ranks"][rank]["useful_denoise_flops"] / duration / 1e12
-            for run, duration in zip(runs, seconds)
+            ranks[rank]["useful_denoise_flops"] / duration / 1e12
+            for ranks, duration in zip(ordered, seconds)
         ]
         medians.append(statistics.median(values))
     cv = statistics.pstdev(seconds) / statistics.mean(seconds)
+    memory_passed = all(
+        rank["peak_allocated_bytes"] <= 30 * 1024**3
+        for run in runs
+        for rank in run["ranks"]
+    )
     return {
         "rank_median_tflops": medians,
         "denoise_seconds": seconds,
         "denoise_cv": cv,
+        "memory_passed": memory_passed,
         "performance_passed": all(value > 80 for value in medians) and cv <= 0.05,
     }

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -163,6 +163,8 @@ def evaluate_performance(runs):
             raise ValueError("acceptance requires the fixed primary workload")
         if run.get("measurement", {}).get("profiled") is not False:
             raise ValueError("formal timing must be explicitly recorded as unprofiled")
+        if run.get("timing_valid") is False:
+            raise ValueError("run timing was excluded from performance evidence")
         if any(rank["dit_calls"] != 49 for rank in run["ranks"]):
             raise ValueError("the primary schedule requires 49 completed DiT calls")
         if any(


### PR DESCRIPTION
## Purpose

Keep reproducible native H3 acceptance tooling and record the opt-in residual-sharding/local-ConvRot result from #568. The benchmark exposes `--residual-sequence-parallel`, serializes it with deployment configuration, and rejects timing sets mixing that option. Formal qualification still requires its original workload, one warmup and three measurements; no formal run is claimed here.

The unchanged short request (INT8 ConvRot FL2VA, TP4 GPU0-3, native FlashAttention,1344x768,39 frames/24 FPS,seed42,20 actual updates/21 sigma positions,zero persistent cache/Lt workspace) measures **58.190385 s**, **59.524500 useful model TFLOPS/card**, and **6.195001125 GiB peak denoise allocation/card**. Earlier residual sharding measures58.794562 s; default flag-off remains62.804019 s. These single cached-text development results are not end-to-end or formal medians.

## Test Plan

Count each rank's actual useful GEMM/attention work, excluding padding, rotation and dequantization, divided by the slowest rank's complete denoise wall time. Require comparable configurations, unprofiled timing, correct update counts, memory and variability gates. Separate automatic validity from human quality. Omit the residual option for rollback.

## Test Result

- The previously recorded eight acceptance tests pass, including rejection of mixed residual configurations. This follow-up merges identical tested #568 source and updates validation documents; no repeat acceptance/GPU run is claimed for the merge. Required pre-commit checks pass.
- #568 adds62 targeted passes and one actual TP4 test passing on every rank for native FlashAttention, covering cached/uncached INT8, valid/padded lengths, FP32 range, exact outputs and FLOP hooks. Earlier70-targeted/78-integration results remain historical, not additive counts.
- Three paired two-update medians:5.878070 ->5.813375 s. Full20 video/audio latents are bitwise equal to the58.79-second run and finite/equal across ranks. Its checked media is reused after latent/hash checks; **no new VAE decode**. The original sharded-route human audiovisual review remains pending.
- Eight additional attention candidates, query-window overlap and a TP4 block pipeline do not establish a gain and remain artifact-only. The pipeline prototype's raw counter includes padding and is invalid for acceptance. Prior NCU/SASS/Nsight evidence still places GEMM/attention at about78% of residual-route denoise.
- Latest evidence: `/data/minimax-h3/native-h3-20260908/flashattention-register50/REPORT.md`, `report.json`, source provenance, exact jobs, reproduction wrapper and NVML curves. See `docs/design/minimax_h3/VALIDATION.md` and `CONTROL.md`. Media: `outputs/quality39-int8-flashattn-localrot-20steps/FLASH_ATTN_V100/` under the artifact root's parent.

**Under50 seconds, standalone attention60 TFLOPS, formal243-frame/each-card80 TFLOPS/three-run/CV<=5% qualification, human quality and the remaining BF16/Ref2VA matrix remain incomplete.**

Dependency/base: #568 (`codex/v100-h3-fa-residual-20260908`), retained source `ca5b6a855b`. Original campaign base `56f534e672`; integrated main `e7fa44deb2`. Local rotation reuses the independent FI working-tree snapshot based on `53780abef0e9ef190aa55a1f61d8fd5fbd390aa1`, uncommitted at capture; patch hash/provenance is recorded in CONTROL.md. There is no FI attention delegation. This existing PR owns acceptance tooling/evidence, while #568 owns runtime changes and #564 owns independent FI kernel work; it does not create duplicate runtime changes.

AI assistance: OpenAI Codex implemented and documented this draft at the user's request. Human source review and audiovisual scoring remain pending before merge.
