### PR TITLE
[Kernel] Reduce DFlash2 weight and scale memory on SM70

### DIFF
--- a/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
+++ b/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
@@ -26,23 +26,44 @@ from benchmark_sm70_quasar_nvfp4_oracle import (
 )
 
 
-def _latency(call, repeats):
-    for _ in range(5):
-        call()
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        call()
-    samples = []
-    for _ in range(3):
+def _paired_latency(control, shared, m):
+    # Multiple nodes amortize Python replay overhead for these short kernels.
+    nodes = 16 if m <= 32 else 1
+    graphs = []
+    for call in (control, shared):
+        for _ in range(5):
+            call()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for _ in range(nodes):
+                call()
+        graphs.append(graph)
+
+    def measure(graph):
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
         start.record()
-        for _ in range(repeats):
+        for _ in range(10):
             graph.replay()
         end.record()
         end.synchronize()
-        samples.append(start.elapsed_time(end) * 1000 / repeats)
-    return statistics.median(samples)
+        return start.elapsed_time(end) * 1000 / (10 * nodes)
+
+    # ABBA pairs expose drift and balance which layout runs first.
+    samples = []
+    for _ in range(8):
+        samples.append([measure(graphs[i]) for i in (0, 1, 1, 0)])
+    before = statistics.median(s[0] for s in samples)
+    after = statistics.median(s[3] for s in samples)
+    candidate = statistics.median((s[1] + s[2]) / 2 for s in samples)
+    return dict(
+        control_before_us=before,
+        shared_us=candidate,
+        control_after_us=after,
+        ratio=candidate / ((before + after) / 2),
+        abba_samples_us=samples,
+        graph_nodes=nodes,
+    )
 
 
 def _equal_bits(actual, expected):
@@ -152,17 +173,7 @@ def _check_projection(projection, rank, rows):
                 "graph_bits_equal": True,
             }
             if rank == 0:
-                repeats = 100 if m <= 32 else 10
-                # Bracket the candidate with controls to expose clock drift.
-                before = _latency(control, repeats)
-                candidate = _latency(shared, repeats)
-                after = _latency(control, repeats)
-                case.update(
-                    control_before_us=before,
-                    shared_us=candidate,
-                    control_after_us=after,
-                    ratio=candidate / ((before + after) / 2),
-                )
+                case.update(_paired_latency(control, shared, m))
             result["cases"].append(case)
     return result
 

--- a/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
+++ b/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare shared TurboMind codes against QPN2 on real TP4 projection shards.
+
+Load the task-built sm70_nvfp4_shared_sidecar first. Its control and shared
+kernels are compiled together; TurboMind itself comes from --core-library.
+This is an operator benchmark, not an end-to-end DFlash2 speed measurement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+from benchmark_sm70_quasar_nvfp4_oracle import (
+    QPN2_CONFIGS,
+    _load_projections,
+    _unpack_codes,
+)
+
+
+def _latency(call, repeats):
+    for _ in range(5):
+        call()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        call()
+    samples = []
+    for _ in range(3):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(repeats):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000 / repeats)
+    return statistics.median(samples)
+
+
+def _equal_bits(actual, expected):
+    return torch.equal(actual.view(torch.int16), expected.view(torch.int16))
+
+
+def _check_projection(projection, rank, rows):
+    packed = projection.packed.cuda()
+    raw_scales = projection.scales.cuda()
+    logical_n = packed.shape[0]
+    n = (logical_n + 31) // 32 * 32
+    k = packed.shape[1] * 2
+    padded = torch.zeros((n, k // 2), dtype=torch.uint8, device="cuda")
+    padded_scales = torch.zeros((n, k // 16), dtype=raw_scales.dtype, device="cuda")
+    padded[:logical_n].copy_(packed)
+    padded_scales[:logical_n].copy_(raw_scales)
+    global_scale = 1.0 / projection.weight_global_divisor
+    effective_scales = (padded_scales.t().float() * global_scale).half().contiguous()
+    tm_weight, tm_scales, meta = torch.ops._C.nvfp4_sm70_prepare(
+        _unpack_codes(padded), effective_scales, 16, False
+    )
+    codes, scales = torch.ops._qpn2_shared_control.prepare(padded, padded_scales)
+    shared_scales = torch.ops._C.nvfp4_qpn2_prepare_scales_sm70(raw_scales)
+    assert torch.equal(shared_scales, scales), "Scale-only preparation differs"
+
+    # Inspect real CUDA converter output independently of either GEMM reader.
+    lane = torch.arange(32, device="cuda")
+    col = ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) != 0) * 4
+    mapped = (
+        tm_weight.reshape(n // 32, k // 16, 2, 32)[..., col]
+        .permute(0, 1, 3, 2)
+        .contiguous()
+        .view(torch.uint8)
+    )
+    assert torch.equal(mapped.flatten(), codes.flatten()), "4-bit code mapping differs"
+    del mapped, effective_scales, padded, padded_scales, packed, raw_scales
+    split_k, nacc = QPN2_CONFIGS[(k, n)]
+    result = {
+        "rank": rank,
+        "projection": projection.name,
+        "logical_n": logical_n,
+        "n": n,
+        "k": k,
+        "code_bits_equal": True,
+        "scale_bits_equal": True,
+        "removed_code_bytes": codes.numel(),
+        "cases": [],
+    }
+    for m in rows:
+        for gated in [False, True] if projection.name == "mlp_gate_up" else [False]:
+            x = torch.randn((m, k), dtype=torch.float16, device="cuda") * 0.1
+            old = torch.empty((m, n // 2 if gated else n), device="cuda", dtype=x.dtype)
+            new = torch.empty_like(old)
+
+            def control(old=old, x=x, gated=gated):
+                torch.ops._qpn2_shared_control.dispatch(
+                    old,
+                    x,
+                    codes,
+                    scales,
+                    global_scale,
+                    split_k,
+                    nacc,
+                    tm_weight,
+                    tm_scales,
+                    16,
+                    int(meta[0]),
+                    int(meta[1]),
+                    gated,
+                    1024,
+                )
+
+            def shared(new=new, x=x, gated=gated):
+                torch.ops._C.nvfp4_qpn2_tm_dispatch_sm70_out(
+                    new,
+                    x,
+                    tm_weight,
+                    shared_scales,
+                    global_scale,
+                    split_k,
+                    nacc,
+                    tm_scales,
+                    16,
+                    int(meta[0]),
+                    int(meta[1]),
+                    gated,
+                    1024,
+                )
+
+            control()
+            shared()
+            assert _equal_bits(new, old), (rank, projection.name, m, gated, "eager")
+            # Capture both paths and change inputs between replays.
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                control()
+                shared()
+            for _ in range(2):
+                x.normal_(std=0.1)
+                graph.replay()
+                assert _equal_bits(new, old), (rank, projection.name, m, gated, "graph")
+            del graph
+            case = {
+                "m": m,
+                "gated": gated,
+                "eager_bits_equal": True,
+                "graph_bits_equal": True,
+            }
+            if rank == 0:
+                repeats = 100 if m <= 32 else 10
+                # Bracket the candidate with controls to expose clock drift.
+                before = _latency(control, repeats)
+                candidate = _latency(shared, repeats)
+                after = _latency(control, repeats)
+                case.update(
+                    control_before_us=before,
+                    shared_us=candidate,
+                    control_after_us=after,
+                    ratio=candidate / ((before + after) / 2),
+                )
+            result["cases"].append(case)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--core-library", type=Path, required=True)
+    parser.add_argument("--shared-library", type=Path, required=True)
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--ranks", type=int, nargs="+", default=[0, 1, 2, 3])
+    parser.add_argument(
+        "--rows",
+        type=int,
+        nargs="+",
+        default=[1, 8, 16, 32, 33, 64, 135, 1019, 1024, 4096],
+    )
+    args = parser.parse_args()
+    spec = importlib.util.spec_from_file_location("vllm._C", args.core_library)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vllm._C"] = module
+    spec.loader.exec_module(module)
+    stable_library = args.core_library.with_name("_C_stable_libtorch.abi3.so")
+    torch.ops.load_library(str(stable_library))
+    torch.ops.load_library(str(args.shared_library))
+    assert torch.cuda.get_device_capability() == (7, 0)
+    torch.manual_seed(20260908)
+    report = {
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "model": str(args.model),
+        "source_sha": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "source_diff_sha256": hashlib.sha256(
+            subprocess.check_output(["git", "diff", "HEAD"])
+        ).hexdigest(),
+        "libraries": {
+            str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in [args.core_library, stable_library, args.shared_library]
+        },
+        "results": [],
+    }
+    try:
+        for rank in args.ranks:
+            for projection in _load_projections(args.model, rank, 4):
+                result = _check_projection(projection, rank, args.rows)
+                report["results"].append(result)
+                print(json.dumps(result), flush=True)
+                torch.cuda.empty_cache()
+        report["passed"] = True
+    finally:
+        args.json_out.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
+++ b/benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py
@@ -70,7 +70,7 @@ def _equal_bits(actual, expected):
     return torch.equal(actual.view(torch.int16), expected.view(torch.int16))
 
 
-def _check_projection(projection, rank, rows):
+def _check_projection(projection, rank, rows, compact_scales=False):
     packed = projection.packed.cuda()
     raw_scales = projection.scales.cuda()
     logical_n = packed.shape[0]
@@ -88,6 +88,13 @@ def _check_projection(projection, rank, rows):
     codes, scales = torch.ops._qpn2_shared_control.prepare(padded, padded_scales)
     shared_scales = torch.ops._C.nvfp4_qpn2_prepare_scales_sm70(raw_scales)
     assert torch.equal(shared_scales, scales), "Scale-only preparation differs"
+    if compact_scales:
+        restored = torch.empty_like(tm_scales)
+        torch.ops._C.nvfp4_qpn2_restore_tm_scales_sm70_out(
+            restored, shared_scales, global_scale
+        )
+        assert _equal_bits(restored, tm_scales), "Restored TurboMind scales differ"
+        del restored
 
     # Inspect real CUDA converter output independently of either GEMM reader.
     lane = torch.arange(32, device="cuda")
@@ -110,6 +117,8 @@ def _check_projection(projection, rank, rows):
         "code_bits_equal": True,
         "scale_bits_equal": True,
         "removed_code_bytes": codes.numel(),
+        "compact_scales": compact_scales,
+        "removed_scale_bytes": tm_scales.numel() * 2 if compact_scales else 0,
         "cases": [],
     }
     for m in rows:
@@ -119,6 +128,23 @@ def _check_projection(projection, rank, rows):
             new = torch.empty_like(old)
 
             def control(old=old, x=x, gated=gated):
+                if compact_scales:
+                    torch.ops._C.nvfp4_qpn2_tm_dispatch_sm70_out(
+                        old,
+                        x,
+                        tm_weight,
+                        shared_scales,
+                        global_scale,
+                        split_k,
+                        nacc,
+                        tm_scales,
+                        16,
+                        int(meta[0]),
+                        int(meta[1]),
+                        gated,
+                        1024,
+                    )
+                    return
                 torch.ops._qpn2_shared_control.dispatch(
                     old,
                     x,
@@ -145,7 +171,7 @@ def _check_projection(projection, rank, rows):
                     global_scale,
                     split_k,
                     nacc,
-                    tm_scales,
+                    shared_scales if compact_scales else tm_scales,
                     16,
                     int(meta[0]),
                     int(meta[1]),
@@ -186,6 +212,11 @@ def main():
     parser.add_argument("--json-out", type=Path, required=True)
     parser.add_argument("--ranks", type=int, nargs="+", default=[0, 1, 2, 3])
     parser.add_argument(
+        "--compact-scales",
+        action="store_true",
+        help="Compare temporary TurboMind scales with persistent shared-code scales.",
+    )
+    parser.add_argument(
         "--rows",
         type=int,
         nargs="+",
@@ -221,7 +252,9 @@ def main():
     try:
         for rank in args.ranks:
             for projection in _load_projections(args.model, rank, 4):
-                result = _check_projection(projection, rank, args.rows)
+                result = _check_projection(
+                    projection, rank, args.rows, args.compact_scales
+                )
                 report["results"].append(result)
                 print(json.dumps(result), flush=True)
                 torch.cuda.empty_cache()

--- a/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
+++ b/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
@@ -50,3 +50,18 @@ TORCH_LIBRARY_FRAGMENT(_qpn2_shared_control, ops) {
       "int tm_q_ld, bool gated_silu, int min_prefill_m) -> ()");
   ops.impl("dispatch", torch::kCUDA, &nvfp4_qpn2_prefill_dispatch_sm70_out);
 }
+
+// Full-model overlays must update both layouts from the declared source.
+// Older core DSOs can dispatch M9..32 to TurboMind even when current Python
+// reports QPN2 M<=32. Load the core DSO before this optional implementation
+// overlay, and use the same overlay in both model arms.
+#ifdef VLLM_QPN2_SHARED_ALIGN_NATIVE_CONTROL
+TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
+  ops.impl("nvfp4_qpn2_prepare_sm70", &nvfp4_qpn2_prepare_sm70);
+  ops.impl("nvfp4_qpn2_gemm_sm70_out", &nvfp4_qpn2_gemm_sm70_out);
+  ops.impl("nvfp4_qpn2_gated_sm70_out", &nvfp4_qpn2_gated_sm70_out);
+  ops.impl("nvfp4_qpn2_dispatch_sm70_out", &nvfp4_qpn2_dispatch_sm70_out);
+  ops.impl("nvfp4_qpn2_prefill_dispatch_sm70_out",
+           &nvfp4_qpn2_prefill_dispatch_sm70_out);
+}
+#endif

--- a/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
+++ b/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+// Compile the production QPN2/QPN4 sources without rebuilding all of vLLM.
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/stack.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include "../../csrc/ops.h"
+
+void nvfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                         torch::Tensor weight, torch::Tensor scales,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
+                         bool gated_silu) {
+  static const auto op = c10::Dispatcher::singleton().findSchemaOrThrow(
+      "_C::nvfp4_gemm_sm70_out", "");
+  torch::jit::Stack stack{out,        input, weight, scales,
+                          group_size, k_ld,  q_ld,   gated_silu};
+  op.callBoxed(&stack);
+}
+
+void silu_and_mul(torch::Tensor& out, torch::Tensor& input) {
+  static const auto op =
+      c10::Dispatcher::singleton().findSchemaOrThrow("_C::silu_and_mul", "");
+  torch::jit::Stack stack{out, input};
+  op.callBoxed(&stack);
+}
+
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def("nvfp4_qpn2_prepare_scales_sm70(Tensor weight_scale) -> Tensor");
+  ops.impl("nvfp4_qpn2_prepare_scales_sm70", torch::kCUDA,
+           &nvfp4_qpn2_prepare_scales_sm70);
+  ops.def(
+      "nvfp4_qpn2_tm_dispatch_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor tm_weight, Tensor scales, float global_scale, int split_k, "
+      "int accumulator_chains, Tensor tm_scales, int tm_group_size, "
+      "int tm_k_ld, int tm_q_ld, bool gated_silu, int min_prefill_m) -> ()");
+  ops.impl("nvfp4_qpn2_tm_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_tm_dispatch_sm70_out);
+}
+
+// Control operators from the same compiler invocation as the shared reader.
+TORCH_LIBRARY_FRAGMENT(_qpn2_shared_control, ops) {
+  ops.def("prepare(Tensor weight_packed, Tensor weight_scale) -> Tensor[]");
+  ops.impl("prepare", torch::kCUDA, &nvfp4_qpn2_prepare_sm70);
+  ops.def(
+      "dispatch(Tensor(a!) out, Tensor input, Tensor codes, Tensor scales, "
+      "float global_scale, int split_k, int accumulator_chains, "
+      "Tensor tm_weight, Tensor tm_scales, int tm_group_size, int tm_k_ld, "
+      "int tm_q_ld, bool gated_silu, int min_prefill_m) -> ()");
+  ops.impl("dispatch", torch::kCUDA, &nvfp4_qpn2_prefill_dispatch_sm70_out);
+}

--- a/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
+++ b/benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp
@@ -28,6 +28,17 @@ void silu_and_mul(torch::Tensor& out, torch::Tensor& input) {
 
 TORCH_LIBRARY_FRAGMENT(_C, ops) {
   ops.def("nvfp4_qpn2_prepare_scales_sm70(Tensor weight_scale) -> Tensor");
+  ops.def(
+      "nvfp4_qpn2_restore_tm_scales_sm70_out(Tensor(a!) out, "
+      "Tensor scales, float global_scale) -> ()");
+  ops.impl("nvfp4_qpn2_restore_tm_scales_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_restore_tm_scales_sm70_out);
+  ops.def(
+      "nvfp4_qpn2_compact_tm_gemm_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor weight, Tensor scales, float global_scale, int k_ld, "
+      "int q_ld, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn2_compact_tm_gemm_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_compact_tm_gemm_sm70_out);
   ops.impl("nvfp4_qpn2_prepare_scales_sm70", torch::kCUDA,
            &nvfp4_qpn2_prepare_scales_sm70);
   ops.def(

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -244,6 +244,14 @@ std::vector<torch::Tensor> nvfp4_qpn2_prepare_sm70(torch::Tensor weight_packed,
                                                    torch::Tensor weight_scale);
 
 torch::Tensor nvfp4_qpn2_prepare_scales_sm70(torch::Tensor weight_scale);
+void nvfp4_qpn2_restore_tm_scales_sm70_out(torch::Tensor out,
+                                           torch::Tensor scales,
+                                           double global_scale);
+void nvfp4_qpn2_compact_tm_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                                         torch::Tensor weight,
+                                         torch::Tensor scales,
+                                         double global_scale, int64_t k_ld,
+                                         int64_t q_ld, bool gated_silu);
 
 void nvfp4_qpn2_tm_dispatch_sm70_out(
     torch::Tensor out, torch::Tensor input, torch::Tensor tm_weight,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -243,6 +243,14 @@ void fp8_gemm_sm70_prescaled_m1_out(torch::Tensor out, torch::Tensor _in_feats,
 std::vector<torch::Tensor> nvfp4_qpn2_prepare_sm70(torch::Tensor weight_packed,
                                                    torch::Tensor weight_scale);
 
+torch::Tensor nvfp4_qpn2_prepare_scales_sm70(torch::Tensor weight_scale);
+
+void nvfp4_qpn2_tm_dispatch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor tm_weight,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_scales, int64_t tm_group_size,
+    int64_t tm_k_ld, int64_t tm_q_ld, bool gated_silu, int64_t min_prefill_m);
+
 void nvfp4_qpn2_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
                               torch::Tensor codes, torch::Tensor scales,
                               double global_scale, int64_t split_k,

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_layout.cuh
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_layout.cuh
@@ -7,7 +7,7 @@
 // Both layouts use E2M1 nibbles ordered [0,2,4,6,1,3,5,7] per K=8.
 // TurboMind SM70 HMMA884 B/Pack1 stores [N/32, K/8, column, word].
 // QPN2 stores [N/32, K/16, lane, uint2]. Only the word addresses differ.
-template <bool TurboMindLayout>
+template <bool TurboMindLayout, bool CacheCodes = false>
 struct Nvfp4Qpn2CodeReader {
   const uint8_t* base;
 
@@ -26,6 +26,9 @@ struct Nvfp4Qpn2CodeReader {
     if constexpr (TurboMindLayout) {
       const auto* ptr = reinterpret_cast<const uint32_t*>(base) +
                         static_cast<size_t>(group) * 64;
+      if constexpr (CacheCodes) {
+        return make_uint2(__ldg(ptr), __ldg(ptr + 32));
+      }
       return make_uint2(__ldcs(ptr), __ldcs(ptr + 32));
     } else {
       return __ldcs(reinterpret_cast<const uint2*>(base) +

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_layout.cuh
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_layout.cuh
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#pragma once
+
+#include <cuda_runtime.h>
+
+// Both layouts use E2M1 nibbles ordered [0,2,4,6,1,3,5,7] per K=8.
+// TurboMind SM70 HMMA884 B/Pack1 stores [N/32, K/8, column, word].
+// QPN2 stores [N/32, K/16, lane, uint2]. Only the word addresses differ.
+template <bool TurboMindLayout>
+struct Nvfp4Qpn2CodeReader {
+  const uint8_t* base;
+
+  __device__ __forceinline__ Nvfp4Qpn2CodeReader(const uint8_t* codes, int tile,
+                                                 int groups_k16, int lane) {
+    if constexpr (TurboMindLayout) {
+      const int col =
+          ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+      base = codes + (static_cast<size_t>(tile) * groups_k16 * 64 + col) * 4;
+    } else {
+      base = codes + (static_cast<size_t>(tile) * groups_k16 * 32 + lane) * 8;
+    }
+  }
+
+  __device__ __forceinline__ uint2 load(int group) const {
+    if constexpr (TurboMindLayout) {
+      const auto* ptr = reinterpret_cast<const uint32_t*>(base) +
+                        static_cast<size_t>(group) * 64;
+      return make_uint2(__ldcs(ptr), __ldcs(ptr + 32));
+    } else {
+      return __ldcs(reinterpret_cast<const uint2*>(base) +
+                    static_cast<size_t>(group) * 32);
+    }
+  }
+};

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
@@ -130,7 +130,8 @@ __device__ __forceinline__ void dequant_e2m1x8(unsigned packed, half2 scale,
         "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
       : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
 
-template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false>
+template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false,
+          bool CacheCodes = false>
 __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
                                        const uint8_t* __restrict__ group_scales,
                                        const half* __restrict__ input,
@@ -150,8 +151,8 @@ __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
   const int groups_k16 = k >> 4;
   const int groups_per_warp = groups_k16 / SplitK;
   const int group_begin = warp * groups_per_warp;
-  const Nvfp4Qpn2CodeReader<TurboMindLayout> reader(codes, tile, groups_k16,
-                                                    lane);
+  const Nvfp4Qpn2CodeReader<TurboMindLayout, CacheCodes> reader(
+      codes, tile, groups_k16, lane);
   const uint8_t* scale_ptr =
       group_scales + static_cast<size_t>(tile) * groups_k16 * 32 + lane;
   const half2 global_scale2 = __float2half2_rn(global_scale * 16384.0f);
@@ -373,6 +374,16 @@ void launch_qpn2(const uint8_t* codes, const uint8_t* scales, const half* input,
   // Reusing it before traversing N improves cache locality without repacking.
   const dim3 grid =
       TurboMindLayout ? dim3(row_blocks, n / 32) : dim3(n / 32, row_blocks);
+  if constexpr (TurboMindLayout) {
+    // Cache the TP4 GDN/attention output weights (3.75 MiB). The larger
+    // QKV and MLP projections retain streaming loads; caching regresses them.
+    if (k == 1536 && n == 5120) {
+      nvfp4_qpn2_sm70_kernel<SplitK, NAcc, RowTiles, true, true>
+          <<<grid, (32 * SplitK), 0, stream>>>(codes, scales, input, output, n,
+                                               k, m, global_scale);
+      return;
+    }
+  }
   nvfp4_qpn2_sm70_kernel<SplitK, NAcc, RowTiles, TurboMindLayout>
       <<<grid, (32 * SplitK), 0, stream>>>(codes, scales, input, output, n, k,
                                            m, global_scale);

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
@@ -142,10 +142,11 @@ __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
 
   const int lane = threadIdx.x & 31;
   const int warp = threadIdx.x >> 5;
-  const int tile = blockIdx.x;
+  const int tile = TurboMindLayout ? blockIdx.y : blockIdx.x;
   const int quadpair = (lane >> 2) & 3;
   const int local_row = (lane & 3) + ((lane & 16) ? 4 : 0);
-  const int row_base = blockIdx.y * kQpn2RowsPerCta * RowTiles;
+  const int row_base =
+      (TurboMindLayout ? blockIdx.x : blockIdx.y) * kQpn2RowsPerCta * RowTiles;
   const int groups_k16 = k >> 4;
   const int groups_per_warp = groups_k16 / SplitK;
   const int group_begin = warp * groups_per_warp;
@@ -253,10 +254,12 @@ __global__ void nvfp4_qpn2_gated_sm70_kernel(
   const int projection = warp_in_block / SplitK;
   const int warp = warp_in_block - projection * SplitK;
   const int hidden_tiles = hidden >> 5;
-  const int tile = blockIdx.x + projection * hidden_tiles;
+  const int output_tile = TurboMindLayout ? blockIdx.y : blockIdx.x;
+  const int tile = output_tile + projection * hidden_tiles;
   const int quadpair = (lane >> 2) & 3;
   const int local_row = (lane & 3) + ((lane & 16) ? 4 : 0);
-  const int row_base = blockIdx.y * kQpn2RowsPerCta * RowTiles;
+  const int row_base =
+      (TurboMindLayout ? blockIdx.x : blockIdx.y) * kQpn2RowsPerCta * RowTiles;
   const int groups_k16 = k >> 4;
   const int groups_per_warp = groups_k16 / SplitK;
   const int group_begin = warp * groups_per_warp;
@@ -354,7 +357,7 @@ __global__ void nvfp4_qpn2_gated_sm70_kernel(
       const half up_half = __float2half(up);
       const float gate_float = __half2float(gate_half);
       const half silu = __float2half(gate_float / (1.0f + expf(-gate_float)));
-      output[static_cast<size_t>(output_row) * hidden + blockIdx.x * 32 +
+      output[static_cast<size_t>(output_row) * hidden + output_tile * 32 +
              output_col] = __hmul(silu, up_half);
     }
   }
@@ -365,7 +368,11 @@ void launch_qpn2(const uint8_t* codes, const uint8_t* scales, const half* input,
                  half* output, int n, int k, int m, float global_scale,
                  cudaStream_t stream) {
   constexpr int kRowsPerCta = kQpn2RowsPerCta * RowTiles;
-  const dim3 grid(n / 32, (m + kRowsPerCta - 1) / kRowsPerCta);
+  const int row_blocks = (m + kRowsPerCta - 1) / kRowsPerCta;
+  // Schedule adjacent row blocks against the same TurboMind weight tile.
+  // Reusing it before traversing N improves cache locality without repacking.
+  const dim3 grid =
+      TurboMindLayout ? dim3(row_blocks, n / 32) : dim3(n / 32, row_blocks);
   nvfp4_qpn2_sm70_kernel<SplitK, NAcc, RowTiles, TurboMindLayout>
       <<<grid, (32 * SplitK), 0, stream>>>(codes, scales, input, output, n, k,
                                            m, global_scale);
@@ -376,7 +383,9 @@ void launch_qpn2_gated(const uint8_t* codes, const uint8_t* scales,
                        const half* input, half* output, int hidden, int k,
                        int m, float global_scale, cudaStream_t stream) {
   constexpr int kRowsPerCta = kQpn2RowsPerCta * RowTiles;
-  const dim3 grid(hidden / 32, (m + kRowsPerCta - 1) / kRowsPerCta);
+  const int row_blocks = (m + kRowsPerCta - 1) / kRowsPerCta;
+  const dim3 grid = TurboMindLayout ? dim3(row_blocks, hidden / 32)
+                                    : dim3(hidden / 32, row_blocks);
   nvfp4_qpn2_gated_sm70_kernel<SplitK, NAcc, RowTiles, TurboMindLayout>
       <<<grid, (64 * SplitK), 0, stream>>>(codes, scales, input, output, hidden,
                                            k, m, global_scale);
@@ -525,7 +534,8 @@ void nvfp4_qpn2_gemm_sm70_impl(torch::Tensor out, torch::Tensor input,
   launch_qpn2<SPLIT, NACC, ROWS, TurboMindLayout>(         \
       code_ptr, scale_ptr, input_ptr, output_ptr, n, k, m, \
       static_cast<float>(global_scale), stream)
-  const bool native_two_tile = qpn2_m16_native_enabled(m);
+  // Separate 8-row CTAs pair better with the shared layout's tile ordering.
+  const bool native_two_tile = !TurboMindLayout && qpn2_m16_native_enabled(m);
   if (native_two_tile && split_k == 8 && accumulator_chains == 1) {
     VLLM_LAUNCH_QPN2(2, 8, 1);
   } else if (native_two_tile && split_k == 8) {
@@ -579,7 +589,7 @@ void nvfp4_qpn2_gated_sm70_impl(torch::Tensor out, torch::Tensor input,
   launch_qpn2_gated<SPLIT, NACC, ROWS, TurboMindLayout>(        \
       code_ptr, scale_ptr, input_ptr, output_ptr, hidden, k, m, \
       static_cast<float>(global_scale), stream)
-  const bool native_two_tile = qpn2_m16_native_enabled(m);
+  const bool native_two_tile = !TurboMindLayout && qpn2_m16_native_enabled(m);
   if (native_two_tile && split_k == 8 && accumulator_chains == 1) {
     VLLM_LAUNCH_QPN2_GATED(2, 8, 1);
   } else if (native_two_tile && split_k == 8) {

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
@@ -106,6 +106,25 @@ __device__ __forceinline__ half2 fp8e4m3_to_half2(uint8_t value) {
   return __halves2half2(converted, converted);
 }
 
+// QPN2 stores [N/32, K/16, lane], while TurboMind V/Pack1 stores
+// [K/16, N] in logical column order. Preserve FP32 multiply then FP16 RNE.
+__global__ void nvfp4_qpn2_restore_tm_scales_kernel(half* output,
+                                                    const uint8_t* scales,
+                                                    float global_scale, int n,
+                                                    int groups) {
+  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= n * groups) {
+    return;
+  }
+  const int group = index / n;
+  const int column = index % n;
+  const int col = column % 32;
+  const int lane = ((col & 24) >> 1) | (col & 3) | ((col & 4) << 2);
+  const int source = ((column / 32) * groups + group) * 32 + lane;
+  const half raw = __low2half(fp8e4m3_to_half2(scales[source]));
+  output[index] = __float2half_rn(__fmul_rn(__half2float(raw), global_scale));
+}
+
 __device__ __forceinline__ void dequant_e2m1x8(unsigned packed, half2 scale,
                                                half2 output[4]) {
   constexpr unsigned kSign = 0x80008000u;
@@ -635,6 +654,40 @@ void nvfp4_qpn2_gated_sm70_out(torch::Tensor out, torch::Tensor input,
 }
 
 #ifndef VLLM_NVFP4_QPN2_STANDALONE
+void nvfp4_qpn2_restore_tm_scales_sm70_out(torch::Tensor out,
+                                           torch::Tensor scales,
+                                           double global_scale) {
+  TORCH_CHECK(out.is_cuda() && scales.is_cuda() &&
+                  out.device() == scales.device() && out.is_contiguous() &&
+                  scales.is_contiguous(),
+              "QPN2 scale restore requires contiguous tensors on one GPU");
+  TORCH_CHECK(
+      out.dim() == 2 && out.scalar_type() == torch::kFloat16 &&
+          scales.scalar_type() == torch::kUInt8 &&
+          out.numel() == scales.numel() && out.size(1) % 32 == 0,
+      "QPN2 scale restore expects FP16 [K/16,N] and packed uint8 scales");
+  const at::cuda::OptionalCUDAGuard guard(device_of(out));
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  nvfp4_qpn2_restore_tm_scales_kernel<<<(out.numel() + 255) / 256, 256, 0,
+                                        stream>>>(
+      reinterpret_cast<half*>(out.data_ptr()), scales.data_ptr<uint8_t>(),
+      static_cast<float>(global_scale), out.size(1), out.size(0));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn2_compact_tm_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                                         torch::Tensor weight,
+                                         torch::Tensor scales,
+                                         double global_scale, int64_t k_ld,
+                                         int64_t q_ld, bool gated_silu) {
+  // Only the fallback needs these scales. Serial calls reuse the allocator's
+  // temporary block; model admission excludes fallback-sized CUDA graphs.
+  auto expanded = torch::empty({input.size(1) / 16, weight.size(1) * 8},
+                               input.options().dtype(torch::kFloat16));
+  nvfp4_qpn2_restore_tm_scales_sm70_out(expanded, scales, global_scale);
+  nvfp4_gemm_sm70_out(out, input, weight, expanded, 16, k_ld, q_ld, gated_silu);
+}
+
 template <bool TurboMindLayout>
 void nvfp4_qpn2_dispatch_sm70_impl(torch::Tensor out, torch::Tensor input,
                                    torch::Tensor codes, torch::Tensor scales,
@@ -655,6 +708,23 @@ void nvfp4_qpn2_dispatch_sm70_impl(torch::Tensor out, torch::Tensor input,
     return;
   }
 
+  if constexpr (TurboMindLayout) {
+    if (tm_scales.scalar_type() == torch::kUInt8) {
+      if (!gated_silu) {
+        nvfp4_qpn2_compact_tm_gemm_sm70_out(out, input, tm_weight, tm_scales,
+                                            global_scale, tm_k_ld, tm_q_ld,
+                                            false);
+      } else {
+        auto gate_up =
+            torch::empty({input.size(0), out.size(1) * 2}, input.options());
+        nvfp4_qpn2_compact_tm_gemm_sm70_out(gate_up, input, tm_weight,
+                                            tm_scales, global_scale, tm_k_ld,
+                                            tm_q_ld, false);
+        silu_and_mul(out, gate_up);
+      }
+      return;
+    }
+  }
   if (!gated_silu) {
     nvfp4_gemm_sm70_out(out, input, tm_weight, tm_scales, tm_group_size,
                         tm_k_ld, tm_q_ld, false);

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu
@@ -17,6 +17,8 @@
 #include <cstdlib>
 #include <mutex>
 
+#include "nvfp4_qpn2_layout.cuh"
+
 #ifndef VLLM_NVFP4_QPN2_STANDALONE
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
@@ -76,7 +78,7 @@ __global__ void nvfp4_qpn2_prepack_codes_kernel(
 
 __global__ void nvfp4_qpn2_prepack_scales_kernel(
     uint8_t* __restrict__ output, const uint8_t* __restrict__ scales, int n,
-    int k) {
+    int k, int logical_n) {
   const size_t index =
       static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const size_t numel = static_cast<size_t>(n) * k / 16;
@@ -90,7 +92,9 @@ __global__ void nvfp4_qpn2_prepack_scales_kernel(
   const int group = static_cast<int>(outer % groups_k16);
   const int tile = static_cast<int>(outer / groups_k16);
   const int column = tile * 32 + qpn2_col_from_lane(lane);
-  output[index] = scales[static_cast<size_t>(column) * groups_k16 + group];
+  output[index] = column < logical_n
+                      ? scales[static_cast<size_t>(column) * groups_k16 + group]
+                      : 0;
 }
 
 __device__ __forceinline__ half2 fp8e4m3_to_half2(uint8_t value) {
@@ -126,7 +130,7 @@ __device__ __forceinline__ void dequant_e2m1x8(unsigned packed, half2 scale,
         "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
       : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
 
-template <int SplitK, int NAcc, int RowTiles = 1>
+template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false>
 __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
                                        const uint8_t* __restrict__ group_scales,
                                        const half* __restrict__ input,
@@ -145,8 +149,8 @@ __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
   const int groups_k16 = k >> 4;
   const int groups_per_warp = groups_k16 / SplitK;
   const int group_begin = warp * groups_per_warp;
-  const uint2* code_ptr = reinterpret_cast<const uint2*>(codes) +
-                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const Nvfp4Qpn2CodeReader<TurboMindLayout> reader(codes, tile, groups_k16,
+                                                    lane);
   const uint8_t* scale_ptr =
       group_scales + static_cast<size_t>(tile) * groups_k16 * 32 + lane;
   const half2 global_scale2 = __float2half2_rn(global_scale * 16384.0f);
@@ -166,7 +170,7 @@ __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
 #pragma unroll 4
   for (int group = group_begin; group < group_begin + groups_per_warp;
        ++group) {
-    const uint2 packed = __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    const uint2 packed = reader.load(group);
     const half2 scale = __hmul2(
         fp8e4m3_to_half2(__ldg(scale_ptr + static_cast<size_t>(group) * 32)),
         global_scale2);
@@ -235,7 +239,7 @@ __global__ void nvfp4_qpn2_sm70_kernel(const uint8_t* __restrict__ codes,
   }
 }
 
-template <int SplitK, int NAcc, int RowTiles = 1>
+template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false>
 __global__ void nvfp4_qpn2_gated_sm70_kernel(
     const uint8_t* __restrict__ codes, const uint8_t* __restrict__ group_scales,
     const half* __restrict__ input, half* __restrict__ output, int hidden,
@@ -256,8 +260,8 @@ __global__ void nvfp4_qpn2_gated_sm70_kernel(
   const int groups_k16 = k >> 4;
   const int groups_per_warp = groups_k16 / SplitK;
   const int group_begin = warp * groups_per_warp;
-  const uint2* code_ptr = reinterpret_cast<const uint2*>(codes) +
-                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const Nvfp4Qpn2CodeReader<TurboMindLayout> reader(codes, tile, groups_k16,
+                                                    lane);
   const uint8_t* scale_ptr =
       group_scales + static_cast<size_t>(tile) * groups_k16 * 32 + lane;
   const half2 global_scale2 = __float2half2_rn(global_scale * 16384.0f);
@@ -277,7 +281,7 @@ __global__ void nvfp4_qpn2_gated_sm70_kernel(
 #pragma unroll 4
   for (int group = group_begin; group < group_begin + groups_per_warp;
        ++group) {
-    const uint2 packed = __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    const uint2 packed = reader.load(group);
     const half2 scale = __hmul2(
         fp8e4m3_to_half2(__ldg(scale_ptr + static_cast<size_t>(group) * 32)),
         global_scale2);
@@ -356,24 +360,24 @@ __global__ void nvfp4_qpn2_gated_sm70_kernel(
   }
 }
 
-template <int SplitK, int NAcc, int RowTiles = 1>
+template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false>
 void launch_qpn2(const uint8_t* codes, const uint8_t* scales, const half* input,
                  half* output, int n, int k, int m, float global_scale,
                  cudaStream_t stream) {
   constexpr int kRowsPerCta = kQpn2RowsPerCta * RowTiles;
   const dim3 grid(n / 32, (m + kRowsPerCta - 1) / kRowsPerCta);
-  nvfp4_qpn2_sm70_kernel<SplitK, NAcc, RowTiles>
+  nvfp4_qpn2_sm70_kernel<SplitK, NAcc, RowTiles, TurboMindLayout>
       <<<grid, (32 * SplitK), 0, stream>>>(codes, scales, input, output, n, k,
                                            m, global_scale);
 }
 
-template <int SplitK, int NAcc, int RowTiles = 1>
+template <int SplitK, int NAcc, int RowTiles = 1, bool TurboMindLayout = false>
 void launch_qpn2_gated(const uint8_t* codes, const uint8_t* scales,
                        const half* input, half* output, int hidden, int k,
                        int m, float global_scale, cudaStream_t stream) {
   constexpr int kRowsPerCta = kQpn2RowsPerCta * RowTiles;
   const dim3 grid(hidden / 32, (m + kRowsPerCta - 1) / kRowsPerCta);
-  nvfp4_qpn2_gated_sm70_kernel<SplitK, NAcc, RowTiles>
+  nvfp4_qpn2_gated_sm70_kernel<SplitK, NAcc, RowTiles, TurboMindLayout>
       <<<grid, (64 * SplitK), 0, stream>>>(codes, scales, input, output, hidden,
                                            k, m, global_scale);
 }
@@ -465,15 +469,39 @@ std::vector<torch::Tensor> nvfp4_qpn2_prepare_sm70(torch::Tensor weight_packed,
                                      stream>>>(
       scales.data_ptr<uint8_t>(),
       reinterpret_cast<const uint8_t*>(weight_scale.data_ptr()),
-      static_cast<int>(n), static_cast<int>(k));
+      static_cast<int>(n), static_cast<int>(k), static_cast<int>(n));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return {codes, scales};
 }
 
-void nvfp4_qpn2_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
-                              torch::Tensor codes, torch::Tensor scales,
-                              double global_scale, int64_t split_k,
-                              int64_t accumulator_chains) {
+torch::Tensor nvfp4_qpn2_prepare_scales_sm70(torch::Tensor weight_scale) {
+  TORCH_CHECK(weight_scale.is_cuda() && weight_scale.dim() == 2 &&
+                  weight_scale.is_contiguous() &&
+                  weight_scale.scalar_type() == at::ScalarType::Float8_e4m3fn,
+              "QPN2 scale preparation expects a contiguous CUDA E4M3 matrix");
+  const int64_t logical_n = weight_scale.size(0);
+  const int64_t n = (logical_n + 31) / 32 * 32;
+  const int64_t k = weight_scale.size(1) * 16;
+  TORCH_CHECK(logical_n > 0 && k > 0 && k % 64 == 0,
+              "QPN2 scale preparation shape alignment mismatch");
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(weight_scale));
+  auto scales =
+      torch::empty({n, k / 16}, weight_scale.options().dtype(torch::kUInt8));
+  const int blocks = (scales.numel() + kPrepareThreads - 1) / kPrepareThreads;
+  nvfp4_qpn2_prepack_scales_kernel<<<blocks, kPrepareThreads, 0,
+                                     at::cuda::getCurrentCUDAStream()>>>(
+      scales.data_ptr<uint8_t>(),
+      reinterpret_cast<const uint8_t*>(weight_scale.data_ptr()),
+      static_cast<int>(n), static_cast<int>(k), static_cast<int>(logical_n));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return scales;
+}
+
+template <bool TurboMindLayout>
+void nvfp4_qpn2_gemm_sm70_impl(torch::Tensor out, torch::Tensor input,
+                               torch::Tensor codes, torch::Tensor scales,
+                               double global_scale, int64_t split_k,
+                               int64_t accumulator_chains) {
   check_qpn2_tensors(out, input, codes, scales, false);
   TORCH_CHECK(split_k == 8 || split_k == 16 || split_k == 32,
               "NVFP4 QPN2 split_k must be 8, 16, or 32");
@@ -493,10 +521,10 @@ void nvfp4_qpn2_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   const int k = static_cast<int>(input.size(1));
   const int m = static_cast<int>(input.size(0));
 
-#define VLLM_LAUNCH_QPN2(ROWS, SPLIT, NACC)                                  \
-  launch_qpn2<SPLIT, NACC, ROWS>(code_ptr, scale_ptr, input_ptr, output_ptr, \
-                                 n, k, m, static_cast<float>(global_scale),  \
-                                 stream)
+#define VLLM_LAUNCH_QPN2(ROWS, SPLIT, NACC)                \
+  launch_qpn2<SPLIT, NACC, ROWS, TurboMindLayout>(         \
+      code_ptr, scale_ptr, input_ptr, output_ptr, n, k, m, \
+      static_cast<float>(global_scale), stream)
   const bool native_two_tile = qpn2_m16_native_enabled(m);
   if (native_two_tile && split_k == 8 && accumulator_chains == 1) {
     VLLM_LAUNCH_QPN2(2, 8, 1);
@@ -523,10 +551,11 @@ void nvfp4_qpn2_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void nvfp4_qpn2_gated_sm70_out(torch::Tensor out, torch::Tensor input,
-                               torch::Tensor codes, torch::Tensor scales,
-                               double global_scale, int64_t split_k,
-                               int64_t accumulator_chains) {
+template <bool TurboMindLayout>
+void nvfp4_qpn2_gated_sm70_impl(torch::Tensor out, torch::Tensor input,
+                                torch::Tensor codes, torch::Tensor scales,
+                                double global_scale, int64_t split_k,
+                                int64_t accumulator_chains) {
   check_qpn2_tensors(out, input, codes, scales, true);
   TORCH_CHECK(split_k == 8 || split_k == 16,
               "NVFP4 QPN2 gated split_k must be 8 or 16");
@@ -547,7 +576,7 @@ void nvfp4_qpn2_gated_sm70_out(torch::Tensor out, torch::Tensor input,
   const int m = static_cast<int>(input.size(0));
 
 #define VLLM_LAUNCH_QPN2_GATED(ROWS, SPLIT, NACC)               \
-  launch_qpn2_gated<SPLIT, NACC, ROWS>(                         \
+  launch_qpn2_gated<SPLIT, NACC, ROWS, TurboMindLayout>(        \
       code_ptr, scale_ptr, input_ptr, output_ptr, hidden, k, m, \
       static_cast<float>(global_scale), stream)
   const bool native_two_tile = qpn2_m16_native_enabled(m);
@@ -568,22 +597,39 @@ void nvfp4_qpn2_gated_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+void nvfp4_qpn2_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                              torch::Tensor codes, torch::Tensor scales,
+                              double global_scale, int64_t split_k,
+                              int64_t accumulator_chains) {
+  nvfp4_qpn2_gemm_sm70_impl<false>(out, input, codes, scales, global_scale,
+                                   split_k, accumulator_chains);
+}
+
+void nvfp4_qpn2_gated_sm70_out(torch::Tensor out, torch::Tensor input,
+                               torch::Tensor codes, torch::Tensor scales,
+                               double global_scale, int64_t split_k,
+                               int64_t accumulator_chains) {
+  nvfp4_qpn2_gated_sm70_impl<false>(out, input, codes, scales, global_scale,
+                                    split_k, accumulator_chains);
+}
+
 #ifndef VLLM_NVFP4_QPN2_STANDALONE
-void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
-                                  torch::Tensor codes, torch::Tensor scales,
-                                  double global_scale, int64_t split_k,
-                                  int64_t accumulator_chains,
-                                  torch::Tensor tm_weight,
-                                  torch::Tensor tm_scales,
-                                  int64_t tm_group_size, int64_t tm_k_ld,
-                                  int64_t tm_q_ld, bool gated_silu) {
+template <bool TurboMindLayout>
+void nvfp4_qpn2_dispatch_sm70_impl(torch::Tensor out, torch::Tensor input,
+                                   torch::Tensor codes, torch::Tensor scales,
+                                   double global_scale, int64_t split_k,
+                                   int64_t accumulator_chains,
+                                   torch::Tensor tm_weight,
+                                   torch::Tensor tm_scales,
+                                   int64_t tm_group_size, int64_t tm_k_ld,
+                                   int64_t tm_q_ld, bool gated_silu) {
   if (input.size(0) <= kQpn2DispatchMaxRows) {
     if (gated_silu) {
-      nvfp4_qpn2_gated_sm70_out(out, input, codes, scales, global_scale,
-                                split_k, accumulator_chains);
+      nvfp4_qpn2_gated_sm70_impl<TurboMindLayout>(
+          out, input, codes, scales, global_scale, split_k, accumulator_chains);
     } else {
-      nvfp4_qpn2_gemm_sm70_out(out, input, codes, scales, global_scale, split_k,
-                               accumulator_chains);
+      nvfp4_qpn2_gemm_sm70_impl<TurboMindLayout>(
+          out, input, codes, scales, global_scale, split_k, accumulator_chains);
     }
     return;
   }
@@ -598,6 +644,31 @@ void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
   nvfp4_gemm_sm70_out(gate_up, input, tm_weight, tm_scales, tm_group_size,
                       tm_k_ld, tm_q_ld, false);
   silu_and_mul(out, gate_up);
+}
+
+void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
+                                  torch::Tensor codes, torch::Tensor scales,
+                                  double global_scale, int64_t split_k,
+                                  int64_t accumulator_chains,
+                                  torch::Tensor tm_weight,
+                                  torch::Tensor tm_scales,
+                                  int64_t tm_group_size, int64_t tm_k_ld,
+                                  int64_t tm_q_ld, bool gated_silu) {
+  nvfp4_qpn2_dispatch_sm70_impl<false>(
+      out, input, codes, scales, global_scale, split_k, accumulator_chains,
+      tm_weight, tm_scales, tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
+}
+
+// Internal entry for the shared-layout dispatcher, also used with prefill off.
+void nvfp4_qpn2_shared_decode_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_weight,
+    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
+    int64_t tm_q_ld, bool gated_silu) {
+  nvfp4_qpn2_dispatch_sm70_impl<true>(
+      out, input, codes, scales, global_scale, split_k, accumulator_chains,
+      tm_weight, tm_scales, tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
 }
 #endif
 

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -16,6 +16,8 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include "nvfp4_qpn2_layout.cuh"
+
 namespace {
 
 constexpr int kPrepareThreads = 256;
@@ -137,7 +139,7 @@ __device__ __forceinline__ half nvfp4_scale_code_to_half(uint8_t scale_code,
   return __hfma(raw_scale, scale_hi, correction);
 }
 
-template <bool UseScaleCode>
+template <bool UseScaleCode, bool TurboMindLayout = false>
 __global__ void nvfp4_qpn4_dequantize_sm70_kernel(
     half* __restrict__ output, const uint8_t* __restrict__ codes,
     const void* __restrict__ packed_scales, half scale_hi, half scale_lo, int n,
@@ -164,7 +166,13 @@ __global__ void nvfp4_qpn4_dequantize_sm70_kernel(
     scale = reinterpret_cast<const half*>(packed_scales)[word_index];
   }
   half2 weights[8];
-  fp4x16_to_half2x8(reinterpret_cast<const uint2*>(codes)[word_index], weights);
+  if constexpr (TurboMindLayout) {
+    const Nvfp4Qpn2CodeReader<true> reader(codes, tile, groups_k16, lane);
+    fp4x16_to_half2x8(reader.load(group), weights);
+  } else {
+    fp4x16_to_half2x8(reinterpret_cast<const uint2*>(codes)[word_index],
+                      weights);
+  }
   const half2 scale2 = __halves2half2(scale, scale);
 #pragma unroll
   for (int pair = 0; pair < 8; ++pair) {
@@ -554,9 +562,10 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
   return {packed_codes, packed_scale_codes};
 }
 
-void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
-                                    torch::Tensor scales, double global_scale,
-                                    bool use_scale_code) {
+template <bool TurboMindLayout>
+void nvfp4_qpn4_dequantize_sm70_impl(torch::Tensor out, torch::Tensor codes,
+                                     torch::Tensor scales, double global_scale,
+                                     bool use_scale_code) {
   TORCH_CHECK(out.is_cuda() && codes.is_cuda() && scales.is_cuda(),
               "nvfp4_qpn4_dequantize_sm70_out: tensors must be CUDA");
   TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
@@ -589,14 +598,14 @@ void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
       split_half_scale(static_cast<float>(global_scale) * kFp4Bias);
   const half zero_scale = __float2half_rn(0.0f);
   if (use_scale_code) {
-    nvfp4_qpn4_dequantize_sm70_kernel<true>
+    nvfp4_qpn4_dequantize_sm70_kernel<true, TurboMindLayout>
         <<<blocks, kPrepareThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
             reinterpret_cast<half*>(out.data_ptr<at::Half>()),
             codes.data_ptr<uint8_t>(), scales.data_ptr<uint8_t>(),
             split_scale.hi, split_scale.lo, static_cast<int>(n),
             static_cast<int>(k));
   } else {
-    nvfp4_qpn4_dequantize_sm70_kernel<false>
+    nvfp4_qpn4_dequantize_sm70_kernel<false, TurboMindLayout>
         <<<blocks, kPrepareThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
             reinterpret_cast<half*>(out.data_ptr<at::Half>()),
             codes.data_ptr<uint8_t>(), scales.data_ptr<at::Half>(), zero_scale,
@@ -605,10 +614,18 @@ void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
-                                 torch::Tensor input, torch::Tensor codes,
-                                 torch::Tensor scales, double global_scale,
-                                 bool use_scale_code, bool gated_silu) {
+void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
+                                    torch::Tensor scales, double global_scale,
+                                    bool use_scale_code) {
+  nvfp4_qpn4_dequantize_sm70_impl<false>(out, codes, scales, global_scale,
+                                         use_scale_code);
+}
+
+template <bool TurboMindLayout>
+void nvfp4_qpn4_prefill_sm70_impl(torch::Tensor out, int64_t dense_weight_ptr,
+                                  torch::Tensor input, torch::Tensor codes,
+                                  torch::Tensor scales, double global_scale,
+                                  bool use_scale_code, bool gated_silu) {
   TORCH_CHECK(input.is_cuda() && out.is_cuda(),
               "nvfp4_qpn4_prefill_sm70_out: input and output must be CUDA");
   TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
@@ -635,8 +652,8 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
           ? torch::empty({k, n}, input.options())
           : torch::from_blob(reinterpret_cast<void*>(dense_weight_ptr), {k, n},
                              input.options());
-  nvfp4_qpn4_dequantize_sm70_out(dense_weight, codes, scales, global_scale,
-                                 use_scale_code);
+  nvfp4_qpn4_dequantize_sm70_impl<TurboMindLayout>(
+      dense_weight, codes, scales, global_scale, use_scale_code);
   if (!gated_silu) {
     at::mm_out(out, input, dense_weight);
     return;
@@ -652,7 +669,54 @@ void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                 torch::Tensor input, torch::Tensor codes,
+                                 torch::Tensor scales, double global_scale,
+                                 bool use_scale_code, bool gated_silu) {
+  nvfp4_qpn4_prefill_sm70_impl<false>(out, dense_weight_ptr, input, codes,
+                                      scales, global_scale, use_scale_code,
+                                      gated_silu);
+}
+
 #ifndef VLLM_QPN4_STANDALONE
+void nvfp4_qpn2_shared_decode_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_weight,
+    torch::Tensor tm_scales, int64_t tm_group_size, int64_t tm_k_ld,
+    int64_t tm_q_ld, bool gated_silu);
+
+// This distinct operator is the layout capability gate. Old binaries never
+// consume TurboMind codes as QPN2. A zero threshold disables dense prefill.
+void nvfp4_qpn2_tm_dispatch_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor tm_weight,
+    torch::Tensor scales, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, torch::Tensor tm_scales, int64_t tm_group_size,
+    int64_t tm_k_ld, int64_t tm_q_ld, bool gated_silu, int64_t min_prefill_m) {
+  TORCH_CHECK(min_prefill_m == 0 || min_prefill_m > 8,
+              "Shared QPN2 prefill threshold must be zero or exceed M=8");
+  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && tm_weight.dim() == 2 &&
+                  tm_weight.is_cuda() && tm_weight.is_contiguous() &&
+                  tm_weight.scalar_type() == torch::kInt32,
+              "Shared QPN2 expects a packed TurboMind int32 matrix");
+  const int64_t k = input.size(1);
+  const int64_t n = gated_silu ? out.size(1) * 2 : out.size(1);
+  TORCH_CHECK(
+      tm_group_size == 16 && tm_weight.size(0) == k &&
+          tm_weight.size(1) * 8 == n,
+      "Shared QPN2 requires non-interleaved SM70 NVFP4 B/Pack1 weights");
+  auto codes = tm_weight.view(torch::kUInt8);
+  if (min_prefill_m != 0 && input.size(0) >= min_prefill_m) {
+    auto prefill_scales = scales.view({k / 16, n});
+    nvfp4_qpn4_prefill_sm70_impl<true>(out, 0, input, codes, prefill_scales,
+                                       global_scale, true, gated_silu);
+    return;
+  }
+  nvfp4_qpn2_shared_decode_sm70_out(
+      out, input, codes, scales, global_scale, split_k, accumulator_chains,
+      tm_weight, tm_scales, tm_group_size, tm_k_ld, tm_q_ld, gated_silu);
+}
+
 void nvfp4_qpn2_dispatch_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor codes, torch::Tensor scales,
                                   double global_scale, int64_t split_k,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -358,6 +358,17 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor[]");
   ops.impl("nvfp4_qpn2_prepare_sm70", torch::kCUDA, &nvfp4_qpn2_prepare_sm70);
 
+  ops.def("nvfp4_qpn2_prepare_scales_sm70(Tensor weight_scale) -> Tensor");
+  ops.impl("nvfp4_qpn2_prepare_scales_sm70", torch::kCUDA,
+           &nvfp4_qpn2_prepare_scales_sm70);
+  ops.def(
+      "nvfp4_qpn2_tm_dispatch_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor tm_weight, Tensor scales, float global_scale, int split_k, "
+      "int accumulator_chains, Tensor tm_scales, int tm_group_size, "
+      "int tm_k_ld, int tm_q_ld, bool gated_silu, int min_prefill_m) -> ()");
+  ops.impl("nvfp4_qpn2_tm_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_tm_dispatch_sm70_out);
+
   ops.def(
       "nvfp4_qpn2_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor scales, float global_scale, int split_k, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -359,6 +359,17 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("nvfp4_qpn2_prepare_sm70", torch::kCUDA, &nvfp4_qpn2_prepare_sm70);
 
   ops.def("nvfp4_qpn2_prepare_scales_sm70(Tensor weight_scale) -> Tensor");
+  ops.def(
+      "nvfp4_qpn2_restore_tm_scales_sm70_out(Tensor(a!) out, "
+      "Tensor scales, float global_scale) -> ()");
+  ops.impl("nvfp4_qpn2_restore_tm_scales_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_restore_tm_scales_sm70_out);
+  ops.def(
+      "nvfp4_qpn2_compact_tm_gemm_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor weight, Tensor scales, float global_scale, int k_ld, "
+      "int q_ld, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn2_compact_tm_gemm_sm70_out", torch::kCUDA,
+           &nvfp4_qpn2_compact_tm_gemm_sm70_out);
   ops.impl("nvfp4_qpn2_prepare_scales_sm70", torch::kCUDA,
            &nvfp4_qpn2_prepare_scales_sm70);
   ops.def(

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -411,3 +411,42 @@ The PR remains Draft. Raw artifacts include `memory-stacks/`,
 `memory-recovery-summary.json`, `memory-recovery-candidate-server-1/`, its
 per-rank inventory, and the retained interruption logs. The service has
 exited and released its GPU locks.
+
+### Speed and scored-quality follow-up, 2026-09-08 evening
+
+At source `2d683cc1355fddfb7742c32c21ab0a2210a3f045`, the two completed
+candidate answers above pass both the original MBPP assertions and EvalPlus
+base/plus tests: 2/2 in each. Only final content is scored; reasoning snippets
+cannot rescue an empty final. EvalPlus dataset hash is
+`ee43ecabebf20deef4bb776a405ac5b1`. This is a two-task check, not broad admission.
+
+A new same-source paired run keeps both shared-code paths enabled and uses
+the same compact-scale sidecar in both arms. Control restores the three
+LM-head preparation functions from `0afb9a47ee` and disables compact scales;
+candidate uses the current head preparation and compact scales. Production
+arguments remain unchanged. Each arm schedules one warmup plus five speed
+requests, 32 natural-EOS MBPP tasks with a 16384-token cap, and four concurrent
+requests. Concurrent per-request global engine counters are excluded.
+
+Both attempts are interrupted before reaching the candidate. The 19:57
+attempt completes six speed requests and two quality requests; the 20:18
+attempt completes six speed requests and three quality requests. The latter
+records parent SIGINT, followed by child SIGTERM during cleanup. Neither log
+reports an OOM or CUDA computation failure; the signal sender is unknown.
+These are incomplete runs, not successful 32-task or concurrency checks.
+
+The controls themselves expose unresolved restart variation: MBPP28 returns
+270 tokens in the first process and 634 in the second, first differing at
+zero-based token 8. Each process repeats its own sequence identically six
+times. Their measured decode medians, 233.57 and 253.62 tokens/s, cannot be
+used as a memory-optimization speed comparison because the outputs differ
+and no new candidate arm completes. The core and attention binary hashes
+still match the recorded versions. This observation does not establish
+semantic degradation or attribute the difference to compact scales.
+
+Keep the interrupted artifacts and `quality-validation-followup-summary.json`.
+Owned GPU services and the waiting scorer have exited. Resume the paired
+check only with an uninterrupted GPU reservation; investigate control
+restart reproducibility before claiming exact model parity. PR561 remains
+Draft, and broad quality, concurrency and actual 256K-input admission remain
+outstanding.

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -50,9 +50,10 @@ unchanged.
 For all 256 supported QUASAR TP4 target projections, the removed codes
 total 2.835693 GiB per rank (11.342773 GiB across four ranks). The remaining
 QPN2 scale allocation is approximately 0.354 GiB per rank. This is a tensor
-storage calculation; allocator reservations and automatically sized KV
-cache can conceal the reduction in NVML usage. Hold KV bytes fixed when
-comparing total memory.
+storage calculation. Validate with the production KV allocation policy:
+automatic sizing at the existing memory utilization, context and concurrency
+settings. Record weight storage, KV budget/capacity and total NVML usage
+separately, because freed weight memory can become additional KV capacity.
 
 ## Validation recorded on 2026-09-08
 
@@ -75,8 +76,8 @@ in the same invocation. M8 shared/control ratios range from 0.982 to 1.044;
 M16 ordinary projections are 1.091–1.123; gated M32 is 1.150. Large-prefill
 ratios are 0.989–1.020. These are operator measurements under unlocked
 clocks, not evidence of a model speedup. Two separated 32-bit loads cost
-more than the previous 64-bit load for some shapes; retaining an explicit
-opt-in exposes this memory/performance tradeoff.
+more than the previous 64-bit load for some shapes. These measurements
+describe the initial shared reader, before the scheduling recovery below.
 
 A bounded experiment replaced the shared reader's two streaming loads with
 read-only cached loads. All 28 rank-0 cases remained bitwise equal. Although
@@ -84,6 +85,57 @@ the K=1536 output projections improved, QKV and MLP regressed (gated M8
 ratio 1.131, MLP down M16 ratio 1.167). The global replacement was rejected;
 the implementation retains streaming loads. Selective cache policies are
 outside this change.
+
+### Scheduling recovery
+
+The shared decode grid now places row blocks for the same weight tile next
+to one another, improving reuse before traversing N. Shared M=9–16 uses
+separate 8-row CTAs instead of retaining two row tiles in one CTA. The legacy
+layout still honors `VLLM_SM70_NVFP4_QPN2_M16_NATIVE`. Split-K, accumulator
+chains and each row's arithmetic order are unchanged. No additional weight
+or temporary tensor is allocated.
+
+The focused rank-0 check passes all 21 ordinary/gated M=8/16/32 cases in
+eager execution and changed-input CUDA Graph replay. Timing now captures
+16 nodes per graph and takes eight ABBA rounds, retaining all raw samples.
+Weighted by the model's projection counts, counting fused gate/up once:
+
+| M | Initial shared/dual ratio | Reordered shared/dual ratio |
+| --- | --- | --- |
+| 8 | 1.0137 | 1.0434 |
+| 16 | 1.0624 | 1.0138 |
+| 32 | 1.0738 | 0.9968 |
+
+Each ratio uses that run's control. Absolute times across the two timing
+methods or unlocked-clock runs are not comparable. These projection sums
+show M16/M32 recovery, with a remaining M8 regression; they do not establish
+production throughput. Expanded partial-row/four-shard validation and the
+production service comparison remain pending.
+
+Rejected experiments retain their evidence: adjacent-column vector loads
+plus a lane shuffle pass bitwise but regress speed, including the variant
+using two row tiles at M17–32. Shared unroll factors one and two also regress
+the weighted costs. Unroll eight brings gated M32 close to the control but
+worsens gated M8, so it is not applied globally. A bounded combination of
+selective output-projection caching and gated-M32 unrolling is still an
+experimental candidate, outside the implementation above. Hardware counter
+profiling failed with `ERR_NVGPUCTRPERM`; no counter-based claim is made.
+
+### Production service contract
+
+Use the existing serving configuration: TP4, max length 262144,
+`gpu_memory_utilization=0.8`, automatic E4M3 KV allocation, chunk4096,
+maxseq4, FP16 activations, DFlash2 q7 with FP16 draft KV, FP32 logits,
+context pipeline/KV graph and CUDA Graph enabled. Preserve production
+sampling and xhigh thinking. Compare weight loading, KV capacity and NVML
+usage separately, and report pure decode separately from TTFT.
+
+An earlier diagnostic used a fixed 2 GiB KV pool and 8K/E5M2 settings.
+It does not represent the production contract and is excluded from
+production memory/performance conclusions. The corrected server confirms
+E4M3/256K/automatic KV arguments and 11.08 GiB model loading on all four
+control ranks, but was externally terminated during compilation. There is
+no completed production A/B result yet.
 
 The first sidecar build omitted `ENABLE_SM70_TURBOMIND`, hiding declarations
 in `ops.h`; defining it fixes the build. The initial benchmark omitted the

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -181,11 +181,65 @@ six recorded native binary hashes are unchanged between arms. The existing
 the actual installed `_C` preparation/dispatch completes 36 projection/M
 combinations: all six projections differ at M16/M32, while M1/M8/135/1024
 match, including the gated cases reached. This exposes a native-version
-validation gap that the same-build comparison could not detect. A direct
-TurboMind comparison at M9/16/32 is queued to distinguish route selection
-from arithmetic. Do not attribute the token mismatch to shared code storage
-without localizing it. Retain the default-off switch and Draft PR until the
-native comparison and model parity are resolved.
+validation gap that the same-build comparison could not detect. All 18 direct
+comparisons at M9/16/32 match the installed dispatch to TurboMind bitwise,
+while differing from current-source shared QPN2. Current Python's M<=32 log
+does not prove that an older native binary selects QPN2 for those rows.
+
+### Latest production allocation and source-aligned comparison
+
+The 17:55/17:57 CST pair keeps the production contract above and loads both
+legacy and shared QPN2 implementations from the same source-built sidecar.
+Its optional `VLLM_QPN2_SHARED_ALIGN_NATIVE_CONTROL` build definition
+overrides the legacy CUDA registrations only in this benchmark overlay.
+Load the existing core DSO first, then the sidecar in every worker; loading
+the sidecar alone leaves the old control dispatch active. Dispatch-table
+inspection before and after importing `vllm._C` confirms that the owned
+registration remains selected. A complete native rebuild naturally contains
+both implementations and does not need this overlay.
+
+| Latest recorded allocation | Dual layout | Shared layout |
+| --- | --- | --- |
+| Model loading, GiB/rank | 11.08 | 8.20 |
+| Automatic KV budget, GiB/rank | 12.68 | 15.76 |
+| Logical KV tokens | 1,190,275 | 1,479,578 |
+| Graph capture increment, GiB/rank | 0.26 | 0.26 |
+| Idle worker NVML, MiB/rank | 26,040 | 26,030 |
+
+All four workers agree on the recorded per-rank values. Both snapshots show
+zero running/waiting requests and zero KV usage. Idle worker usage is
+25.430 versus 25.420 GiB/rank; under automatic sizing, saved weight memory
+increases KV capacity rather than substantially decreasing total residency.
+The 8.20 GiB loading measurement includes the target, draft and runtime
+weight layouts; it is not the target checkpoint size divided by four.
+The phase measurements are not a complete live tensor/allocator ledger.
+
+Aligning native dispatch does **not** resolve model parity. MBPP28 returns
+998 versus 297 tokens, with its first difference at token 155 (one-based).
+Both arms repeat their own sequence across warmup and three measured
+requests. MBPP0 returns 887 versus 760 tokens and first differs at token 287.
+All outputs finish naturally with nonempty final answers. Thus the verified
+old-binary route mismatch is not a complete explanation of the model result.
+Keep the earlier mixed-native cohort separate; neither cohort passes the
+deterministic gate.
+
+For reproducibility, median pure decode in this latest pair is 222.82 versus
+236.75 tokens/s; round time is 19.286 versus 19.234 ms and TTFT is 120.01
+versus 121.19 ms. Different emitted sequences and acceptance behavior prevent
+a matched-output speed claim. The next localization must compare actual
+activations at the first-divergence prefix, preserving production KV,
+context and sampling. Do not repeat unchanged full-model timing or adjust
+those settings to conceal the discrepancy. Retain the default-off switch
+and Draft PR pending model parity and broader acceptance.
+
+The retained task artifacts, whose directory is recorded in the local handoff,
+include
+`source-aligned-summary.json`, `source-aligned-server-{0,1}/`,
+`core-binary-oracle.json` and `core-tm-oracle.json`. The source-aligned DSO
+SHA256 is `45a0dd65ec0c8d99adbe26bd1267479cbb64ba17013b2b026a5a6e34100306d9`.
+It was built from source `608718f7a9` plus the optional sidecar registration
+patch, recorded by diff hash in both manifests. Both services exit after
+recording results and release their GPU locks.
 
 An earlier fixed 2 GiB KV/8K/E5M2 diagnostic is excluded from production
 conclusions. The first corrected control attempt exposes an old Flash-V100

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -105,19 +105,20 @@ changed-input CUDA Graph replay. Timing captures 16 nodes per graph for
 small M and takes eight ABBA rounds, retaining all raw samples.
 Weighted by the model's projection counts, counting fused gate/up once:
 
-| M | Initial shared/dual ratio | Final shared/dual ratio |
+| M | Repeated-projection shared/dual | Working-set shared/dual |
 | --- | --- | --- |
-| 8 | 1.0137 | 1.0013 |
-| 16 | 1.0624 | 0.9869 |
-| 32 | 1.0738 | 0.9591 |
+| 8 | 1.0013 | 1.0259 |
+| 16 | 0.9869 | 0.9915 |
+| 32 | 0.9591 | 0.9019 |
 
 Each ratio uses that run's control. Absolute times across the two timing
-methods or unlocked-clock runs are not comparable. These projection sums
-show recovery in this repeated-operator workload; they do not establish
-production throughput. Repeated access favors cache-resident weights. An
-additional working-set check cycles six distinct real projection tensors
-in the model's 3-GDN/1-attention layer pattern, exceeding L2 capacity; that
-measurement and the complete production A/B remain pending.
+methods or unlocked-clock runs are not comparable. The working-set check
+cycles six distinct real projection tensors in the model's 3-GDN/1-attention
+pattern, exceeding L2 capacity, with 256 calls per graph. It preserves the
+M16/M32 gain, while M8 retains a 2.59% cost. Without selective caching,
+the working-set M8 ratio was 1.0639, so caching remains beneficial here.
+These are isolated projections with independent inputs, without attention
+or communication, and do not establish production throughput.
 
 Rejected experiments retain their evidence: adjacent-column vector loads
 plus a lane shuffle pass bitwise but regress speed, including the variant
@@ -146,11 +147,45 @@ verification-round time 19.046 ms and TTFT 114.93 ms. Actual concurrency is
 one; maxseq4 is capacity. A separate MBPP0 request completes with 2105
 tokens and natural EOS. This is a focused check, not full quality admission.
 
-The shared production server logs 8.20 GiB model loading on all four ranks,
-then is externally terminated after compilation. Candidate KV capacity,
-NVML, output parity and endpoint speed remain unmeasured. The loading log
-is a runtime measurement distinct from the exact 2.835693 GiB code-storage
-calculation; do not report a full-service memory or throughput improvement.
+The shared production retry completes after the user authorizes using idle
+GPUs 0–3. The former reservation scheduler has no running or queued jobs
+when it is gracefully released; active work is not preempted.
+
+| Recorded allocation | Dual layout | Shared layout |
+| --- | --- | --- |
+| Model loading, GiB/rank | 11.08 | 8.20 |
+| Automatic KV budget, GiB/rank | 12.68 | 15.76 |
+| Logical KV tokens | 1,190,275 | 1,479,578 |
+| Graph capture increment, GiB/rank | 0.33 | 0.26 |
+| Idle worker NVML, MiB/rank | 26,114 | 26,030 |
+
+Both idle snapshots have zero running/waiting requests and zero KV usage.
+Automatic sizing turns the released memory into 289,303 additional logical
+KV tokens, a 24.31% increase. NVML usage stays near 25.5 GiB/rank. Loading,
+available KV budget and capture increments come from different profiling
+stages; do not sum them as an exact allocation ledger or attribute every
+budget difference to the exact 2.835693 GiB removed code storage.
+
+**Output parity fails; production speed is not accepted.** The same MBPP28
+prompt (135 input tokens), seed and sampling produce 260 control tokens and
+754 shared tokens, each stable within its own warmup/three-repeat cohort.
+The first difference is token 16 (one-based). MBPP0 produces 2105 versus 1093
+tokens; both finish naturally with nonempty final answers. These differences
+do not establish semantic degradation, but fail the deterministic gate.
+
+Shared median pure decode is 221.40 tokens/s, round time 19.435 ms and
+TTFT 112.37 ms. The different output sequences and acceptance lengths prevent
+a matched-output throughput claim. Input text, launch script, seeds and the
+six recorded native binary hashes are unchanged between arms. The existing
+336 operator checks use same-build source controls. A further oracle against
+the actual installed `_C` preparation/dispatch completes 36 projection/M
+combinations: all six projections differ at M16/M32, while M1/M8/135/1024
+match, including the gated cases reached. This exposes a native-version
+validation gap that the same-build comparison could not detect. A direct
+TurboMind comparison at M9/16/32 is queued to distinguish route selection
+from arithmetic. Do not attribute the token mismatch to shared code storage
+without localizing it. Retain the default-off switch and Draft PR until the
+native comparison and model parity are resolved.
 
 An earlier fixed 2 GiB KV/8K/E5M2 diagnostic is excluded from production
 conclusions. The first corrected control attempt exposes an old Flash-V100

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -30,9 +30,24 @@ The common reader implements this address change for ordinary/gated QPN2
 and the prefill dequantizer. Arithmetic, accumulation and activation order
 are preserved.
 
-Scales remain separate because TurboMind merges the global scale into FP16
+By default, scales remain separate because TurboMind merges the global scale into FP16
 while QPN2 retains E4M3 plus a separate global scale. Recovering the original
 E4M3 data from rounded FP16 would change the numerical contract.
+
+With `VLLM_SM70_NVFP4_QPN2_SHARED_SCALES=1`, compatible shared-code layers
+instead retain only the original packed E4M3 scales. TurboMind fallback
+restores the loader's FP32 multiplication followed by FP16 round-to-nearest
+into a temporary scale tensor. Serial fallback calls reuse allocator blocks;
+the largest supported layer requires 5.3125 MiB. QPN2 small-M decode and
+bounded dense prefill keep their existing scale reader and arithmetic.
+
+This second opt-in requires the rebuilt compact-scale operator and the
+DFlash2 TP4 q7 contract without DBO. All configured CUDA graph capture sizes
+must be at most 32; otherwise persistent TurboMind scales are retained.
+Larger graphs would retain temporary scales for every captured projection,
+negating the intended saving. Direct prepared-layer calls and TurboMind
+warmup also restore scales before consuming them. The switch defaults to
+zero while model admission remains outstanding.
 
 The new opaque C++ dispatcher keeps dynamic M selection outside Dynamo:
 
@@ -293,3 +308,106 @@ CUDA_VISIBLE_DEVICES=0 VLLM_SM70_NVFP4_QPN2_M16_NATIVE=1 \
 The matching `_C_stable_libtorch.abi3.so` must accompany the core library.
 The JSON records library hashes, the source base and diff hash, shard
 shapes, bitwise comparisons, and both control timings.
+
+## Residual allocation follow-up: LM head and compact scales
+
+A metadata-only TP4 census confirms that model loading still consumes
+8.203933716 GiB/rank after code sharing. It includes two additional
+606.25 MiB/rank FP16 LM-head matrices. One belongs to the target's packed
+layout. Allocation-history frames identify the other as the draft's
+placeholder LM-head packing: the draft later shares the target head, but
+the native FP16 weight cache retains that old packed tensor. Python model
+parameter enumeration alone misses this native cache ownership.
+
+FP32 dense logits and FP32 candidate rerank both consume the original FP16
+parameter. Preparation now omits the packed FP16 matrix and FP16-only
+rerank scratch when those are the selected consumers. QPN8 candidate
+screening retains its codes and scales, and an explicitly requested Tensor
+Core top1 route still prepares its required FP16 layout. Avoiding unused
+packing also prevents the draft placeholder's native-cache retention.
+There is no change to LM-head arithmetic or candidate selection.
+
+The expected tensor-storage reductions across TP4 are 4.736328 GiB for
+the two FP16 head matrices, plus the unused rerank scratch, and 2.835693 GiB
+for persistent TurboMind scales. The remaining head QPN8 copy is about
+1.184545 GiB across TP4; retained QPN2 scales are 1.417847 GiB. Keep these
+tensor counts separate from measured loading and automatic KV capacity.
+
+Focused validation on the same CUDA 12.8/Torch 2.10 runtime:
+
+- 43 CPU checks pass across LM-head preparation, QPN2 loading/dispatch and
+  TurboMind warmup. Coverage includes explicit packed top1, scale-buffer
+  aliasing, native capability and capture-size gates.
+- Six real LM-head shard cases preserve QPN8 codes/scales, candidate IDs,
+  FP32 logits and changed-input graph replay bits. Candidate/control timing
+  ratios range from 0.9969 to 1.0010; this is operator evidence.
+- Compact scales pass all 224 ordinary/gated cases across 24 real TP4
+  shards, including restored FP16 scale bits and changed-input graph replay.
+  Tested M is 8/16/32/33/135/512/1023/1024. With the model's projection
+  counts and fused gate/up counted once, compact/persistent time ratios are:
+
+| M | Compact / persistent scales |
+| --- | --- |
+| 8 | 1.0008 |
+| 16 | 1.0004 |
+| 32 | 1.0002 |
+| 33 | 1.1394 |
+| 135 | 1.0587 |
+| 512 | 1.0307 |
+| 1023 | 1.0163 |
+| 1024 | 0.9996 |
+
+The fallback cost is explicit: reconstructing scales adds 2.87–3.43 ms
+across the isolated projection calls for M33–1023. This is neither TTFT
+nor model latency. Main decode arithmetic and measured operator time are
+preserved. `--compact-scales` on the benchmark above compares this path
+against shared codes with persistent TurboMind scales.
+
+The first restoration experiment confused QPN lane order with TurboMind's
+logical column order. The actual converter confirms TurboMind scales are
+stored as `[K/16,N]`; using the inverse QPN lane map fixes the failed scale
+comparison. Retain the failed mapping evidence. Two LM-head harness setup
+failures (an unpinned import path and missing outer inference mode) are
+separate from numerical validation. The corrected build and targeted
+pre-commit checks pass.
+
+The full production follow-up control reaches the same 8.20 GiB/rank load,
+then receives termination during compilation. It has no endpoint result;
+keep this interrupted cohort separate from completed measurements.
+
+The candidate retry completes at 18:59 CST under the unchanged production
+contract, with shared codes and compact scales enabled. The census agrees
+on all four ranks: both 606.25 MiB FP16 head allocations and the persistent
+TurboMind scales are absent; QPN8 head codes/scales remain. Census operations
+do not change allocated GPU bytes.
+
+| Latest production allocation | Prior shared codes | Compact scales and head cleanup |
+| --- | --- | --- |
+| Model loading, GiB/rank | 8.203934 | 6.286138 |
+| Model loading across TP4, GiB | 32.815735 | 25.144552 |
+| Automatic KV budget, GiB/rank | 15.76 | 17.70 |
+| Logical KV tokens | 1,479,578 | 1,661,426 |
+| Graph capture increment, GiB/rank | 0.26 | 0.26 |
+| Idle worker NVML, MiB/rank | 26,030 | 26,036 |
+
+Measured loading decreases by 7.671183 GiB across TP4. Automatic KV capacity
+increases by 12.29%; total residency stays near the production budget.
+Do not equate the phase allocation delta exactly to the sum of removed
+tensor bytes: allocator granularity and discarded scratch also contribute.
+
+The MBPP28 warmup and three measured requests return the same 754-token
+sequence as the archived `production-server-1` shared-code cohort. MBPP0
+also matches all 1093 tokens. Both finish naturally with nonempty answers.
+Median pure decode is 225.66 tokens/s, round time 19.068 ms, and TTFT
+107.95 ms; the archived same-output cohort recorded 221.40 tokens/s,
+19.435 ms and 112.37 ms. No slowdown appears in this focused comparison,
+but the controls are not contemporaneous and clocks are unlocked; do not
+claim the approximately 2% difference as a speedup.
+
+This focused parity result does not resolve the distinct token differences
+in the earlier 17:55/17:57 cohorts, nor admit concurrency or long context.
+The PR remains Draft. Raw artifacts include `memory-stacks/`,
+`head-memory-oracle.json`, `compact-scale-oracle.json`,
+`memory-recovery-summary.json`, `memory-recovery-candidate-server-1/`, its
+per-rank inventory, and the retained interruption logs. The service has
+exited and released its GPU locks.

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -1,0 +1,131 @@
+# DFlash2 QPN2 and TurboMind shared NVFP4 weights
+
+## Scope and activation
+
+`VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT=1` removes the separate QPN2 code
+buffer from compatible SM70 TP4 NVFP4 projections. It requires a rebuild
+providing `nvfp4_qpn2_prepare_scales_sm70` and
+`nvfp4_qpn2_tm_dispatch_sm70_out`. Older binaries retain the existing
+separate layouts and log the missing capability. The switch defaults to
+zero pending broader model quality and concurrency performance acceptance.
+
+The existing QPN2 model and shape gates still apply. The target is
+Qwen3.8-27B-QUASAR-NVFP4 with DFlash2 q7. This does not enable QPN2 on
+additional models or quantization schemes. Set the switch before loading;
+changing it on a loaded model does not reclaim or restore weight buffers.
+
+## Storage and dispatch
+
+TurboMind keeps its non-interleaved SM70 HMMA884 B/Pack1 codes and FP16
+scales. QPN2 stores only its packed E4M3 scales, including zero padding to
+N=32 alignment. It reads the TurboMind code tensor directly. No QPN2 code
+buffer, code alias buffer, or transient full QPN2 repack is registered.
+
+Both formats preserve each E2M1 nibble. Within K=8 their physical order is
+`[0, 2, 4, 6, 1, 3, 5, 7]`. For QPN lane `l`, let
+`c = ((l >> 2) & 3) * 8 + (l & 3) + ((l & 16) ? 4 : 0)`.
+The two words for K/16 group `g` in N/32 tile `t` are TurboMind words
+`(t * (K / 8) + 2 * g) * 32 + c` and that index plus 32.
+The common reader implements this address change for ordinary/gated QPN2
+and the prefill dequantizer. Arithmetic, accumulation and activation order
+are preserved.
+
+Scales remain separate because TurboMind merges the global scale into FP16
+while QPN2 retains E4M3 plus a separate global scale. Recovering the original
+E4M3 data from rounded FP16 would change the numerical contract.
+
+The new opaque C++ dispatcher keeps dynamic M selection outside Dynamo:
+
+| Live M, with default prefill threshold | Route |
+| --- | --- |
+| 1–32 | QPN2 reading TurboMind codes |
+| 33–1023 | Existing TurboMind GEMM |
+| 1024 and above | Existing bounded FP16 prefill, reading TurboMind codes |
+
+With QPN2 prefill disabled, the shared operator receives a zero threshold
+and all M above 32 use TurboMind. Python still handles empty inputs and
+crops padded outputs before bias. TurboMind warmup and state ownership are
+unchanged.
+
+For all 256 supported QUASAR TP4 target projections, the removed codes
+total 2.835693 GiB per rank (11.342773 GiB across four ranks). The remaining
+QPN2 scale allocation is approximately 0.354 GiB per rank. This is a tensor
+storage calculation; allocator reservations and automatically sized KV
+cache can conceal the reduction in NVML usage. Hold KV bytes fixed when
+comparing total memory.
+
+## Validation recorded on 2026-09-08
+
+Integration base: `e5d63c51f0fcc1ddf75d229e3df06bf52df206f5`.
+Torch 2.10.0+cu128, CUDA 12.8, V100-SXM2-32GB, FP16 activations;
+`VLLM_SM70_NVFP4_QPN2_M16_NATIVE=1`. Actual checkpoint shards for TP ranks
+0–3 were tested sequentially on one V100. These tests do not measure TP
+communication or whole-model throughput.
+
+- Nine CPU tests pass, covering shared loading without code preparation,
+  old-binary fallback, original routes, output cropping, and prefill off.
+- All 24 real projection shards match the old CUDA converter's code bits
+  and packed scale bits, including GDN N=4120 padded to 4128.
+- All 280 cases at M=1/8/16/32/33/64/135/1019/1024/4096 match FP16 output
+  bits in eager execution and CUDA Graph replay after changing inputs.
+  Gate/up is tested both as a linear projection and with fused SiLU.
+
+Rank-0 graph timing brackets the shared candidate with controls compiled
+in the same invocation. M8 shared/control ratios range from 0.982 to 1.044;
+M16 ordinary projections are 1.091–1.123; gated M32 is 1.150. Large-prefill
+ratios are 0.989–1.020. These are operator measurements under unlocked
+clocks, not evidence of a model speedup. Two separated 32-bit loads cost
+more than the previous 64-bit load for some shapes; retaining an explicit
+opt-in exposes this memory/performance tradeoff.
+
+A bounded experiment replaced the shared reader's two streaming loads with
+read-only cached loads. All 28 rank-0 cases remained bitwise equal. Although
+the K=1536 output projections improved, QKV and MLP regressed (gated M8
+ratio 1.131, MLP down M16 ratio 1.167). The global replacement was rejected;
+the implementation retains streaming loads. Selective cache policies are
+outside this change.
+
+The first sidecar build omitted `ENABLE_SM70_TURBOMIND`, hiding declarations
+in `ops.h`; defining it fixes the build. The initial benchmark omitted the
+stable activation library, so gated TurboMind dispatch failed to resolve
+`silu_and_mul`; loading the matching stable library fixes the harness.
+Neither failure was a shared-reader numerical discrepancy.
+
+## Reproduce the focused operator check
+
+Use an isolated worktree and owned GPU locks. The sidecar adds the two new
+operators to an existing build and registers controls privately. Do not
+load it into a build that already registers these operators.
+
+```bash
+export CUDA_HOME=/path/to/cuda-12.8
+export TORCH_CUDA_ARCH_LIST=7.0
+export TORCH_EXTENSIONS_DIR="$PWD/.cache/torch_extensions"
+CUDA_VISIBLE_DEVICES='' .venv/bin/python - <<'PY'
+from torch.utils.cpp_extension import load
+load(
+    name="nvfp4_qpn2_shared",
+    sources=[
+        "csrc/sm70_turbomind/ops/nvfp4_qpn2_sm70.cu",
+        "csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu",
+        "benchmarks/kernels/sm70_nvfp4_shared_sidecar.cpp",
+    ],
+    extra_cflags=["-O3", "-fvisibility=hidden", "-DENABLE_SM70_TURBOMIND"],
+    extra_cuda_cflags=[
+        "-O3", "--use_fast_math", "-lineinfo", "-Xcompiler=-fvisibility=hidden"
+    ],
+    extra_ldflags=["-Wl,-Bsymbolic"],
+    is_python_module=False,
+)
+PY
+CUDA_VISIBLE_DEVICES=0 VLLM_SM70_NVFP4_QPN2_M16_NATIVE=1 \
+  .venv/bin/python benchmarks/kernels/benchmark_sm70_nvfp4_shared_weight.py \
+  --model /path/to/Qwen3.8-27B-QUASAR-NVFP4 \
+  --core-library /path/to/lib/_C.abi3.so \
+  --shared-library "$TORCH_EXTENSIONS_DIR/nvfp4_qpn2_shared/nvfp4_qpn2_shared.so" \
+  --json-out /path/to/task-artifacts/operator-results.json
+```
+
+The matching `_C_stable_libtorch.abi3.so` must accompany the core library.
+The JSON records library hashes, the source base and diff hash, shard
+shapes, bitwise comparisons, and both control timings.

--- a/docs/design/sm70_dflash2_shared_nvfp4.md
+++ b/docs/design/sm70_dflash2_shared_nvfp4.md
@@ -83,8 +83,7 @@ A bounded experiment replaced the shared reader's two streaming loads with
 read-only cached loads. All 28 rank-0 cases remained bitwise equal. Although
 the K=1536 output projections improved, QKV and MLP regressed (gated M8
 ratio 1.131, MLP down M16 ratio 1.167). The global replacement was rejected;
-the implementation retains streaming loads. Selective cache policies are
-outside this change.
+the final recovery caches only the K=1536/N=5120 output projections.
 
 ### Scheduling recovery
 
@@ -95,30 +94,38 @@ layout still honors `VLLM_SM70_NVFP4_QPN2_M16_NATIVE`. Split-K, accumulator
 chains and each row's arithmetic order are unchanged. No additional weight
 or temporary tensor is allocated.
 
-The focused rank-0 check passes all 21 ordinary/gated M=8/16/32 cases in
-eager execution and changed-input CUDA Graph replay. Timing now captures
-16 nodes per graph and takes eight ABBA rounds, retaining all raw samples.
+Read-only cached loads are selected only for the 3.75 MiB GDN/attention
+output weights at K=1536/N=5120. Larger QKV and MLP weights retain streaming
+loads. This changes cache policy without allocating a tensor or changing
+the accumulation order.
+
+The final candidate passes all 336 ordinary/gated cases on 24 real TP4
+shards at M=1/8/9/15/16/17/18/24/31/32/33/1024, in eager execution and
+changed-input CUDA Graph replay. Timing captures 16 nodes per graph for
+small M and takes eight ABBA rounds, retaining all raw samples.
 Weighted by the model's projection counts, counting fused gate/up once:
 
-| M | Initial shared/dual ratio | Reordered shared/dual ratio |
+| M | Initial shared/dual ratio | Final shared/dual ratio |
 | --- | --- | --- |
-| 8 | 1.0137 | 1.0434 |
-| 16 | 1.0624 | 1.0138 |
-| 32 | 1.0738 | 0.9968 |
+| 8 | 1.0137 | 1.0013 |
+| 16 | 1.0624 | 0.9869 |
+| 32 | 1.0738 | 0.9591 |
 
 Each ratio uses that run's control. Absolute times across the two timing
 methods or unlocked-clock runs are not comparable. These projection sums
-show M16/M32 recovery, with a remaining M8 regression; they do not establish
-production throughput. Expanded partial-row/four-shard validation and the
-production service comparison remain pending.
+show recovery in this repeated-operator workload; they do not establish
+production throughput. Repeated access favors cache-resident weights. An
+additional working-set check cycles six distinct real projection tensors
+in the model's 3-GDN/1-attention layer pattern, exceeding L2 capacity; that
+measurement and the complete production A/B remain pending.
 
 Rejected experiments retain their evidence: adjacent-column vector loads
 plus a lane shuffle pass bitwise but regress speed, including the variant
 using two row tiles at M17–32. Shared unroll factors one and two also regress
 the weighted costs. Unroll eight brings gated M32 close to the control but
-worsens gated M8, so it is not applied globally. A bounded combination of
-selective output-projection caching and gated-M32 unrolling is still an
-experimental candidate, outside the implementation above. Hardware counter
+worsens gated M8, so it is not applied. Combining it with selective output
+caching does not establish an advantage over caching alone; retain unroll
+four. Hardware counter
 profiling failed with `ERR_NVGPUCTRPERM`; no counter-based claim is made.
 
 ### Production service contract
@@ -130,12 +137,28 @@ context pipeline/KV graph and CUDA Graph enabled. Preserve production
 sampling and xhigh thinking. Compare weight loading, KV capacity and NVML
 usage separately, and report pure decode separately from TTFT.
 
-An earlier diagnostic used a fixed 2 GiB KV pool and 8K/E5M2 settings.
-It does not represent the production contract and is excluded from
-production memory/performance conclusions. The corrected server confirms
-E4M3/256K/automatic KV arguments and 11.08 GiB model loading on all four
-control ranks, but was externally terminated during compilation. There is
-no completed production A/B result yet.
+The corrected production control completes with 11.08 GiB model loading
+per rank, a 12.68 GiB KV budget, 1,190,275 logical KV tokens, 0.33 GiB graph
+capture increment and 26,114 MiB NVML worker usage per rank. The existing
+MBPP28 speed item returns the same 260 tokens with natural EOS in warmup
+and three measured requests. Median pure decode is 277.52 tokens/s,
+verification-round time 19.046 ms and TTFT 114.93 ms. Actual concurrency is
+one; maxseq4 is capacity. A separate MBPP0 request completes with 2105
+tokens and natural EOS. This is a focused check, not full quality admission.
+
+The shared production server logs 8.20 GiB model loading on all four ranks,
+then is externally terminated after compilation. Candidate KV capacity,
+NVML, output parity and endpoint speed remain unmeasured. The loading log
+is a runtime measurement distinct from the exact 2.835693 GiB code-storage
+calculation; do not report a full-service memory or throughput improvement.
+
+An earlier fixed 2 GiB KV/8K/E5M2 diagnostic is excluded from production
+conclusions. The first corrected control attempt exposes an old Flash-V100
+extension without E4M3 precision revision four. Both production arms now
+use a frozen copy of the production revision-four DSO, SHA256
+`a751fed902279b0de23537c4aad2dc4fee360146d7fce7ef0c4f255a77f48b02`.
+The failed and externally interrupted logs remain separate from the
+completed control. Preserve the production runtime arguments when retrying.
 
 The first sidecar build omitted `ENABLE_SM70_TURBOMIND`, hiding declarations
 in `ops.h`; defining it fixes the build. The initial benchmark omitted the

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -82,8 +82,21 @@ fails. Shared 221.40 tok/s cannot establish a matched-output speed comparison.
 Inputs, launch arguments and recorded binaries match. Comparing the actual
 installed `_C` operators exposes M16/M32 differences on all six projections;
 M1/M8/135/1024 match. The 336 earlier checks used same-build source controls.
-Next compare installed dispatch directly with TurboMind at M9/16/32 to
-localize route selection before another model run.
+All 18 installed-dispatch comparisons at M9/16/32 equal TurboMind bitwise.
+The optional sidecar overlay now permits both model arms to use legacy/shared
+QPN2 from the same declared source, instead of trusting a Python route log.
+The 17:55/17:57 CST source-aligned pair reproduces the loading and KV capacity
+values above, with 26,040 versus 26,030 MiB idle worker usage and 0.26 GiB
+graph capture increments in both arms. Both have zero active requests/KV use.
+However, parity still fails: MBPP28 first differs at token 155, returning
+998 versus 297 tokens; MBPP0 differs at token 287, returning 887 versus 760.
+Within-arm speed repeats are stable and all outputs finish naturally. The
+native version gap does not fully explain model parity. Raw medians of
+222.82 versus 236.75 tok/s and 19.286 versus 19.234 ms/round are different
+output workloads, not an accepted model speedup. Preserve this cohort in
+`source-aligned-summary.json` separately from the older mixed-native pair.
+Next compare actual activations at the first-divergence prefix; do not repeat
+unchanged endpoint timing or change production KV/context/sampling settings.
 Keep the feature default-off and PR Draft; do not repeat the old-extension,
 fixed-KV harness failures or passed 336 checks as a substitute for localization.
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -59,19 +59,24 @@ dispatch. All 280 real TP4-shard operator cases match output bits, including
 gated output, padding and CUDA Graph replay with changed inputs. The removed
 target codes total approximately 2.836 GiB per rank for QUASAR 27B.
 
-Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in. Shared row-first scheduling
-and 8-row CTAs reduce the rank-0 weighted M16 ratio from 1.0624 to 1.0138 and
-M32 from 1.0738 to 0.9968; M8 remains 1.0434 in the revised ABBA benchmark.
-The focused 21 cases pass bitwise; expanded validation is pending. These
-isolated projection ratios do not establish model throughput. Reject the
-slower vector-load/shuffle and global unroll 1/2 experiments.
+Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in. Shared row-first scheduling,
+8-row CTAs and selective caching for K=1536/N=5120 output weights yield
+weighted M8/M16/M32 ratios of 1.0013/0.9869/0.9591 in the repeated-operator
+ABBA benchmark. All 336 final cases on 24 real shards pass bitwise,
+including partial rows. A working-set check is pending; these isolated
+projection ratios do not establish model throughput. Reject the slower
+vector-load/shuffle and global unroll 1/2/8 experiments.
 
 Production validation must retain automatic KV at utilization 0.8, TP4,
 256K context, E4M3 KV, chunk 4096, maxseq 4 and the existing DFlash2 q7 graph,
 FP32-logit and sampling settings. The fixed 2 GiB/8K/E5M2 diagnostic is excluded
-from production conclusions. The corrected control loaded 11.08 GiB/rank but
-was externally terminated during compilation; full production A/B remains
-pending. The design note records the failed paths and remaining acceptance.
+from production conclusions. With matching revision-four Flash-V100, the
+production control completes: 11.08 GiB loading/rank, 12.68 GiB KV budget,
+1,190,275 KV tokens and 277.52 tokens/s median single-request pure decode.
+Shared loading is 8.20 GiB/rank, but that service is externally terminated
+after compilation. Candidate KV/endpoint/output results and full production
+A/B remain pending. The design note records the failed paths and remaining
+acceptance; do not repeat the old-extension or fixed-KV harness failures.
 
 ## DFlash2 E4M3 FP32 default policy, 2026-09-08
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -51,6 +51,18 @@ It contributes no accepted whole-round improvement. Changed draft GEMM
 arithmetic is also excluded: better local FP64 error still changes proposal
 distributions. Historical failed numerical, memory-budget, route-coverage,
 sanitizer-timeout and slower-kernel results remain recorded in the worklog.
+## DFlash2 shared NVFP4 codes, 2026-09-08
+
+The [shared QPN2/TurboMind weight path](sm70_dflash2_shared_nvfp4.md) removes
+the extra QPN2 codes while retaining both scale formats and opaque dynamic-M
+dispatch. All 280 real TP4-shard operator cases match output bits, including
+gated output, padding and CUDA Graph replay with changed inputs. The removed
+target codes total approximately 2.836 GiB per rank for QUASAR 27B.
+
+Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in: M8 is close to the original
+layout, but some M16 operators and gated M32 regress by about 9–15%. Do not
+claim model throughput from these operator measurements. The design note
+records build and harness failures so they are not repeated.
 
 ## DFlash2 E4M3 FP32 default policy, 2026-09-08
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -51,6 +51,42 @@ It contributes no accepted whole-round improvement. Changed draft GEMM
 arithmetic is also excluded: better local FP64 error still changes proposal
 distributions. Historical failed numerical, memory-budget, route-coverage,
 sanitizer-timeout and slower-kernel results remain recorded in the worklog.
+## DFlash2 residual weight memory recovery, 2026-09-08
+
+Follow-up in the [shared NVFP4 report](sm70_dflash2_shared_nvfp4.md) removes
+unused FP16 LM-head packing when FP32 logits consume the original parameter.
+Allocation stacks identify the extra 606.25 MiB/rank matrix as draft-head
+packing retained in the native cache after target-head sharing; avoiding
+the unused preparation removes that allocation too. QPN8 screening remains
+enabled, and explicit packed Tensor Core top1 retains its layout.
+
+`VLLM_SM70_NVFP4_QPN2_SHARED_SCALES=1` optionally retains only QPN2 E4M3
+scales and restores temporary FP16 scales for TurboMind fallback. It requires
+the shared-code path, rebuilt native operators, DFlash2 TP4 q7 without DBO,
+and capture sizes <=32 so graphs do not retain each fallback's temporary
+scales. The largest temporary is 5.3125 MiB. The switch defaults off.
+
+43 CPU checks, 224 real-shard scale/output checks and six LM-head cases pass,
+including changed-input graph replay. Decode scale-cost ratios are within
+0.1% of one; head ratios are 0.9969–1.0010. M135 fallback projections cost
+5.87% more, adding 3.13 ms across the isolated projection sequence; this is
+not TTFT. Preserve the rejected initial lane-map and harness setup evidence.
+
+Production candidate completes at 18:59 CST: loading 6.286138 GiB/rank,
+25.144552 GiB/TP4, down 7.671183 GiB from shared codes alone. Both unused
+head matrices and persistent TM scales are absent on all four ranks. KV is
+still automatic E4M3 at utilization0.8, maxlen256K/chunk4096/maxseq4/q7;
+budget17.70 GiB/rank, 1,661,426 logical tokens, idleNVML26,036 MiB/rank.
+MBPP28 repeats match all754 tokens of the archived shared-code cohort;
+MBPP0 matches all1093. Median decode225.66 tok/s, round19.068 ms,
+TTFT107.95 ms. Historical same-output values were221.40/19.435/112.37;
+no observed focused slowdown, but no contemporaneous speedup claim.
+
+The current paired control was terminated during compilation and has no
+endpoint result. Keep it separate. Earlier other-cohort parity differences
+are not resolved by the latest archived-cohort match. Concurrency and
+long-context admission remain outstanding; PR561 stays Draft.
+
 ## DFlash2 shared NVFP4 codes, 2026-09-08
 
 The [shared QPN2/TurboMind weight path](sm70_dflash2_shared_nvfp4.md) removes

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -87,6 +87,18 @@ endpoint result. Keep it separate. Earlier other-cohort parity differences
 are not resolved by the latest archived-cohort match. Concurrency and
 long-context admission remain outstanding; PR561 stays Draft.
 
+Evening quality follow-up at source2d683cc135: the two completed candidate
+final answers pass original assertions and EvalPlus base/plus tests (2/2
+each). Two attempts to run a current 32-task plus four-concurrent A/B are
+interrupted before candidate execution. Latest parent receives SIGINT;
+child receives SIGTERM during cleanup, without a logged OOM/CUDA failure.
+The controls themselves return270 versus634 tokens on MBPP28 (first
+difference at zero-based token8), with six identical repeats within each
+process. Different-output medians233.57/253.62 tok/s do not prove an
+optimization speed delta. Preserve this restart-variation evidence and
+the interrupted1957/2018 cohorts. No new32-task/concurrency pass is claimed;
+resume with an uninterrupted GPU reservation and verify control stability.
+
 ## DFlash2 shared NVFP4 codes, 2026-09-08
 
 The [shared QPN2/TurboMind weight path](sm70_dflash2_shared_nvfp4.md) removes

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -59,10 +59,19 @@ dispatch. All 280 real TP4-shard operator cases match output bits, including
 gated output, padding and CUDA Graph replay with changed inputs. The removed
 target codes total approximately 2.836 GiB per rank for QUASAR 27B.
 
-Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in: M8 is close to the original
-layout, but some M16 operators and gated M32 regress by about 9–15%. Do not
-claim model throughput from these operator measurements. The design note
-records build and harness failures so they are not repeated.
+Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in. Shared row-first scheduling
+and 8-row CTAs reduce the rank-0 weighted M16 ratio from 1.0624 to 1.0138 and
+M32 from 1.0738 to 0.9968; M8 remains 1.0434 in the revised ABBA benchmark.
+The focused 21 cases pass bitwise; expanded validation is pending. These
+isolated projection ratios do not establish model throughput. Reject the
+slower vector-load/shuffle and global unroll 1/2 experiments.
+
+Production validation must retain automatic KV at utilization 0.8, TP4,
+256K context, E4M3 KV, chunk 4096, maxseq 4 and the existing DFlash2 q7 graph,
+FP32-logit and sampling settings. The fixed 2 GiB/8K/E5M2 diagnostic is excluded
+from production conclusions. The corrected control loaded 11.08 GiB/rank but
+was externally terminated during compilation; full production A/B remains
+pending. The design note records the failed paths and remaining acceptance.
 
 ## DFlash2 E4M3 FP32 default policy, 2026-09-08
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -63,8 +63,9 @@ Keep `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT` opt-in. Shared row-first scheduling,
 8-row CTAs and selective caching for K=1536/N=5120 output weights yield
 weighted M8/M16/M32 ratios of 1.0013/0.9869/0.9591 in the repeated-operator
 ABBA benchmark. All 336 final cases on 24 real shards pass bitwise,
-including partial rows. A working-set check is pending; these isolated
-projection ratios do not establish model throughput. Reject the slower
+including partial rows. A six-tensor working set yields ratios
+1.0259/0.9915/0.9019; M8 retains a cost and these isolated projection ratios
+do not establish model throughput. Reject the slower
 vector-load/shuffle and global unroll 1/2/8 experiments.
 
 Production validation must retain automatic KV at utilization 0.8, TP4,
@@ -73,10 +74,18 @@ FP32-logit and sampling settings. The fixed 2 GiB/8K/E5M2 diagnostic is excluded
 from production conclusions. With matching revision-four Flash-V100, the
 production control completes: 11.08 GiB loading/rank, 12.68 GiB KV budget,
 1,190,275 KV tokens and 277.52 tokens/s median single-request pure decode.
-Shared loading is 8.20 GiB/rank, but that service is externally terminated
-after compilation. Candidate KV/endpoint/output results and full production
-A/B remain pending. The design note records the failed paths and remaining
-acceptance; do not repeat the old-extension or fixed-KV harness failures.
+The shared production retry completes: loading 8.20 GiB/rank, KV 15.76 GiB,
+1,479,578 logical tokens (+24.31%) and idle NVML 26,030 MiB/rank versus 26,114.
+However, MBPP28 differs at token 16 and completes 754 versus 260 tokens; MBPP0
+completes 1093 versus 2105. Both arms finish naturally, but deterministic parity
+fails. Shared 221.40 tok/s cannot establish a matched-output speed comparison.
+Inputs, launch arguments and recorded binaries match. Comparing the actual
+installed `_C` operators exposes M16/M32 differences on all six projections;
+M1/M8/135/1024 match. The 336 earlier checks used same-build source controls.
+Next compare installed dispatch directly with TurboMind at M9/16/32 to
+localize route selection before another model run.
+Keep the feature default-off and PR Draft; do not repeat the old-extension,
+fixed-KV harness failures or passed 336 checks as a substitute for localization.
 
 ## DFlash2 E4M3 FP32 default policy, 2026-09-08
 

--- a/tests/model_executor/layers/test_sm70_lm_head.py
+++ b/tests/model_executor/layers/test_sm70_lm_head.py
@@ -155,6 +155,33 @@ def test_packed_lm_head_routes_still_prepare_layout(
     prepare_qpn8.assert_called_once_with(layer)
 
 
+@pytest.mark.parametrize("dense", [False, True])
+@pytest.mark.parametrize("tc_top1", [False, True])
+def test_fp32_qpn8_only_packs_for_explicit_tc_top1(monkeypatch, dense, tc_top1) -> None:
+    _set_lm_head_routes(monkeypatch, qpn8=True, dense=dense, tc_top1=tc_top1)
+    monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_FP32_LOGITS", True)
+    monkeypatch.setattr(
+        vocab_embedding, "_is_sm70_lm_head_fastpath_eligible", lambda _layer: True
+    )
+    layer = SimpleNamespace(weight=_FakeCudaTensor((62080, 5120)), tp_size=4)
+    prepare = Mock(return_value=(object(), torch.tensor([5120])))
+    monkeypatch.setattr(torch.ops._C, "sm70_f16_prepare", Mock(), raising=False)
+    monkeypatch.setattr(vocab_embedding.sm70_ops, "sm70_f16_prepare", prepare)
+    prepare_qpn8 = Mock(return_value=True)
+    monkeypatch.setattr(
+        vocab_embedding, "_prepare_sm70_dflash2_qpn8_rerank", prepare_qpn8
+    )
+
+    assert vocab_embedding.maybe_prepare_sm70_lm_head_top1(layer)
+    assert layer._sm70_dflash2_fp32_logits
+    prepare_qpn8.assert_called_once_with(layer)
+    assert hasattr(layer, "_sm70_f16_tm_weight") == tc_top1
+    if tc_top1:
+        prepare.assert_called_once_with(layer.weight)
+    else:
+        prepare.assert_not_called()
+
+
 def test_raw_top1_readiness_does_not_enable_dense_fastpath(monkeypatch) -> None:
     _set_lm_head_routes(monkeypatch, raw_top1=True, dense=True)
     layer = SimpleNamespace(_sm70_f16_raw_top1_ready=True)

--- a/tests/quantization/test_sm70_nvfp4_qpn2.py
+++ b/tests/quantization/test_sm70_nvfp4_qpn2.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch.nn.parameter import Parameter
 
@@ -243,8 +244,14 @@ def _make_small_layer() -> torch.nn.Module:
     return layer
 
 
-def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
+@pytest.mark.parametrize(
+    "shared_requested,shared_available", [(False, True), (True, False), (True, True)]
+)
+def test_nvfp4_qpn2_prepare_and_dispatch_contract(
+    monkeypatch, shared_requested, shared_available
+):
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2", "1")
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT", str(int(shared_requested)))
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2_PREFILL", "1")
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M", "9")
     envs.disable_envs_cache()
@@ -261,15 +268,28 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
     monkeypatch.setattr(nvfp4_scheme, "_is_qpn2_layer", lambda layer: True)
     monkeypatch.setattr(nvfp4_scheme, "_missing_qpn2_ops", lambda: [])
     monkeypatch.setattr(nvfp4_scheme, "_missing_qpn2_prefill_ops", lambda: [])
+    monkeypatch.setattr(
+        nvfp4_scheme,
+        "_missing_qpn2_shared_ops",
+        lambda: [] if shared_available else ["nvfp4_qpn2_tm_dispatch_sm70_out"],
+    )
     monkeypatch.setitem(nvfp4_scheme._SM70_NVFP4_QPN2_CONFIGS, (64, 64, False), (8, 2))
     monkeypatch.setitem(nvfp4_scheme._SM70_NVFP4_QPN2_CONFIGS, (64, 64, True), (8, 2))
+    shared = shared_requested and shared_available
+
+    def fake_prepare_codes(weight, scales):
+        assert not shared, "Shared preparation must not allocate QPN2 codes"
+        return torch.empty_like(weight), torch.empty(scales.shape, dtype=torch.uint8)
+
+    def fake_prepare_scales(scales):
+        assert shared
+        return torch.empty(scales.shape, dtype=torch.uint8)
+
     monkeypatch.setattr(
-        nvfp4_scheme.sm70_ops,
-        "nvfp4_qpn2_prepare_sm70",
-        lambda weight, scales: (
-            torch.empty_like(weight),
-            torch.empty(scales.shape, dtype=torch.uint8),
-        ),
+        nvfp4_scheme.sm70_ops, "nvfp4_qpn2_prepare_sm70", fake_prepare_codes
+    )
+    monkeypatch.setattr(
+        nvfp4_scheme.sm70_ops, "nvfp4_qpn2_prepare_scales_sm70", fake_prepare_scales
     )
 
     def fake_prepare(prepared_layer, *, interleave_gated_silu=False):
@@ -306,12 +326,25 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
         fake_combined_dispatch,
     )
 
+    def fake_shared_dispatch(*args):
+        assert shared
+        assert args[2] is getattr(layer, sm70_tm.STATE_ATTR).weight
+        fake_combined_dispatch(*args)
+
+    monkeypatch.setattr(
+        nvfp4_scheme.sm70_ops,
+        "nvfp4_qpn2_tm_dispatch_sm70_out",
+        fake_shared_dispatch,
+    )
+
     try:
         scheme.process_weights_after_loading(layer)
         assert layer.sm70_nvfp4_qpn2
         assert layer.sm70_nvfp4_qpn2_gated_silu
         assert layer.sm70_nvfp4_qpn2_global_scale == 0.5
         assert layer.sm70_nvfp4_qpn2_prefill_enabled
+        assert layer.sm70_nvfp4_qpn2_shared_weight == shared
+        assert hasattr(layer, "sm70_nvfp4_qpn2_codes") != shared
         assert layer.weight.numel() == 0
         assert layer.weight_scale.numel() == 0
 
@@ -334,5 +367,9 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(monkeypatch):
         assert torch.equal(large_fused, torch.full_like(large_fused, 5))
         assert combined_calls[2][-2:] == (False, 9)
         assert combined_calls[3][-2:] == (True, 9)
+        if shared:
+            layer.sm70_nvfp4_qpn2_prefill_enabled = False
+            scheme.apply_weights(layer, x)
+            assert combined_calls[-1][-1] == 0
     finally:
         envs.disable_envs_cache()

--- a/tests/quantization/test_sm70_nvfp4_qpn2.py
+++ b/tests/quantization/test_sm70_nvfp4_qpn2.py
@@ -245,10 +245,16 @@ def _make_small_layer() -> torch.nn.Module:
 
 
 @pytest.mark.parametrize(
-    "shared_requested,shared_available", [(False, True), (True, False), (True, True)]
+    "shared_requested,shared_available,compact",
+    [
+        (False, True, False),
+        (True, False, False),
+        (True, True, False),
+        (True, True, True),
+    ],
 )
 def test_nvfp4_qpn2_prepare_and_dispatch_contract(
-    monkeypatch, shared_requested, shared_available
+    monkeypatch, shared_requested, shared_available, compact
 ):
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2", "1")
     monkeypatch.setenv("VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT", str(int(shared_requested)))
@@ -257,6 +263,7 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(
     envs.disable_envs_cache()
     layer = _make_small_layer()
     calls = []
+    monkeypatch.setattr(nvfp4_scheme, "_compact_qpn2_scales_enabled", lambda: compact)
 
     monkeypatch.setattr(nvfp4_scheme.sm70_tm, "use_turbomind", lambda enabled: True)
     scheme = CompressedTensorsW4A4Fp4()
@@ -344,6 +351,11 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(
         assert layer.sm70_nvfp4_qpn2_global_scale == 0.5
         assert layer.sm70_nvfp4_qpn2_prefill_enabled
         assert layer.sm70_nvfp4_qpn2_shared_weight == shared
+        state = getattr(layer, sm70_tm.STATE_ATTR)
+        assert state.use_scale_code == compact
+        if compact:
+            assert state.scales is layer.sm70_nvfp4_qpn2_scales
+            assert state.global_scale == layer.sm70_nvfp4_qpn2_global_scale
         assert hasattr(layer, "sm70_nvfp4_qpn2_codes") != shared
         assert layer.weight.numel() == 0
         assert layer.weight_scale.numel() == 0
@@ -373,3 +385,19 @@ def test_nvfp4_qpn2_prepare_and_dispatch_contract(
             assert combined_calls[-1][-1] == 0
     finally:
         envs.disable_envs_cache()
+
+
+@pytest.mark.parametrize(
+    "capture_sizes,expected", [([], True), ([1, 8, 32], True), ([8, 64], False)]
+)
+def test_compact_scales_exclude_fallback_sized_graphs(
+    monkeypatch, capture_sizes, expected
+):
+    monkeypatch.setattr(envs, "VLLM_SM70_NVFP4_QPN2_SHARED_SCALES", True)
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_qpn2_compact_tm_gemm_sm70_out", lambda: None, raising=False
+    )
+    config = _runtime_config()
+    config.compilation_config = SimpleNamespace(cudagraph_capture_sizes=capture_sizes)
+    monkeypatch.setattr(nvfp4_scheme, "get_current_vllm_config", lambda: config)
+    assert nvfp4_scheme._compact_qpn2_scales_enabled() == expected

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
@@ -237,7 +238,8 @@ def test_fp8_warmup_supports_modelopt_turbomind_layout(monkeypatch):
     assert all(call[3:] == (128, 128, 64) for call in calls)
 
 
-def test_nvfp4_warmup_uses_converter_padded_output_size(monkeypatch):
+@pytest.mark.parametrize("compact", [False, True])
+def test_nvfp4_warmup_uses_converter_padded_output_size(monkeypatch, compact):
     state = SimpleNamespace(
         weight=torch.empty((32, 4), dtype=torch.int32),
         scales=torch.empty((2, 32), dtype=torch.float16),
@@ -248,6 +250,8 @@ def test_nvfp4_warmup_uses_converter_padded_output_size(monkeypatch):
         padded_output_size=32,
         op_kind="nvfp4",
         gated_silu=False,
+        use_scale_code=compact,
+        global_scale=0.125,
     )
     calls = []
     monkeypatch.setattr(
@@ -258,10 +262,22 @@ def test_nvfp4_warmup_uses_converter_padded_output_size(monkeypatch):
         "nvfp4_gemm_sm70_out",
         lambda *args: calls.append(args),
     )
+    compact_calls = []
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "nvfp4_qpn2_compact_tm_gemm_sm70_out",
+        lambda *args: compact_calls.append(args),
+    )
 
     count = warmup._warmup_fp4_dense_layers([state], [1, 4])
 
     assert count == 2
+    if compact:
+        assert not calls
+        assert all(call[4] == state.global_scale for call in compact_calls)
+        calls = compact_calls
+    else:
+        assert not compact_calls
     assert [tuple(call[0].shape) for call in calls] == [(1, 32), (4, 32)]
     assert [tuple(call[1].shape) for call in calls] == [(1, 32), (4, 32)]
 

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -1338,6 +1338,31 @@ if hasattr(torch.ops._C, "nvfp4_qpn2_prepare_scales_sm70"):
         )
 
 
+def nvfp4_qpn2_compact_tm_gemm_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    k_ld: int,
+    q_ld: int,
+    gated_silu: bool = False,
+) -> None:
+    """Restore temporary TurboMind scales from the retained QPN2 scale codes."""
+    _op("nvfp4_qpn2_compact_tm_gemm_sm70_out")(
+        out, input, weight, scales, global_scale, k_ld, q_ld, gated_silu
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn2_compact_tm_gemm_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn2_compact_tm_gemm_sm70_out")
+    def _nvfp4_qpn2_compact_tm_gemm_sm70_out_fake(
+        out, input, weight, scales, global_scale, k_ld, q_ld, gated_silu
+    ) -> None:
+        return None
+
+
 def nvfp4_qpn2_tm_dispatch_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -1319,6 +1319,79 @@ if hasattr(torch.ops._C, "nvfp4_qpn2_prepare_sm70"):
         return [codes, scales]
 
 
+def nvfp4_qpn2_prepare_scales_sm70(weight_scale: torch.Tensor) -> torch.Tensor:
+    """Pack E4M3 scales, padding N to 32, without allocating weight codes."""
+    return _op("nvfp4_qpn2_prepare_scales_sm70")(weight_scale)
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn2_prepare_scales_sm70"):
+
+    @register_fake("_C::nvfp4_qpn2_prepare_scales_sm70")
+    def _nvfp4_qpn2_prepare_scales_sm70_fake(
+        weight_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        n, groups = weight_scale.shape
+        return torch.empty(
+            ((n + 31) // 32 * 32, groups),
+            device=weight_scale.device,
+            dtype=torch.uint8,
+        )
+
+
+def nvfp4_qpn2_tm_dispatch_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    tm_weight: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    split_k: int,
+    accumulator_chains: int,
+    tm_scales: torch.Tensor,
+    tm_group_size: int,
+    tm_k_ld: int,
+    tm_q_ld: int,
+    gated_silu: bool,
+    min_prefill_m: int,
+) -> None:
+    """Use shared TurboMind codes for QPN2, TurboMind and dense prefill."""
+    _op("nvfp4_qpn2_tm_dispatch_sm70_out")(
+        out,
+        input,
+        tm_weight,
+        scales,
+        global_scale,
+        split_k,
+        accumulator_chains,
+        tm_scales,
+        tm_group_size,
+        tm_k_ld,
+        tm_q_ld,
+        gated_silu,
+        min_prefill_m,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn2_tm_dispatch_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn2_tm_dispatch_sm70_out")
+    def _nvfp4_qpn2_tm_dispatch_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        tm_weight: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+        split_k: int,
+        accumulator_chains: int,
+        tm_scales: torch.Tensor,
+        tm_group_size: int,
+        tm_k_ld: int,
+        tm_q_ld: int,
+        gated_silu: bool,
+        min_prefill_m: int,
+    ) -> None:
+        return None
+
+
 def nvfp4_qpn2_gemm_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -192,6 +192,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST: str | None = None
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
+    VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT: bool = False
     VLLM_SM70_NVFP4_QPN2_M16_NATIVE: bool = True
     VLLM_SM70_NVFP4_QPN2_PREFILL: bool = False
     VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY: str | None = None
@@ -1904,6 +1905,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # QPN2 is an explicit opt-in for compatible NVFP4 small-M shapes; larger M
     # stays on the existing TurboMind path.
     "VLLM_SM70_NVFP4_QPN2": lambda: bool(int(os.getenv("VLLM_SM70_NVFP4_QPN2", "0"))),
+    # Share TurboMind B/Pack1 codes with QPN2, preserving both scale formats.
+    # Opt in until same-contract GPU correctness and performance gates pass.
+    "VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT", "0"))
+    ),
     # Reuse each packed NVFP4 tile across two eight-row verifier groups in one
     # CTA. This is a default-off Qwen3.8 DFlash2 B2 operator candidate.
     "VLLM_SM70_NVFP4_QPN2_M16_NATIVE": lambda: bool(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,6 +193,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
     VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT: bool = False
+    VLLM_SM70_NVFP4_QPN2_SHARED_SCALES: bool = False
     VLLM_SM70_NVFP4_QPN2_M16_NATIVE: bool = True
     VLLM_SM70_NVFP4_QPN2_PREFILL: bool = False
     VLLM_SM70_NVFP4_QPN2_PREFILL_LIBRARY: str | None = None
@@ -1909,6 +1910,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Opt in until same-contract GPU correctness and performance gates pass.
     "VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT", "0"))
+    ),
+    "VLLM_SM70_NVFP4_QPN2_SHARED_SCALES": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QPN2_SHARED_SCALES", "0"))
     ),
     # Reuse each packed NVFP4 tile across two eight-row verifier groups in one
     # CTA. This is a default-off Qwen3.8 DFlash2 B2 operator candidate.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -201,6 +201,25 @@ def _missing_qpn2_prefill_ops() -> list[str]:
     ]
 
 
+def _compact_qpn2_scales_enabled() -> bool:
+    if not envs.VLLM_SM70_NVFP4_QPN2_SHARED_SCALES:
+        return False
+    if not hasattr(torch.ops._C, "nvfp4_qpn2_compact_tm_gemm_sm70_out"):
+        logger.warning_once("Compact QPN2 scales require rebuilt native operators.")
+        return False
+    config = get_current_vllm_config()
+    sizes = config.compilation_config.cudagraph_capture_sizes or []
+    # Graphs retain temporary allocations per captured operator. Keep persistent
+    # FP16 scales when a fallback-sized graph could negate the memory saving.
+    if any(size > 32 for size in sizes):
+        logger.warning_once(
+            "Compact QPN2 scales require CUDA graph capture sizes <=32; "
+            "retaining persistent TurboMind scales."
+        )
+        return False
+    return _is_sm70_dflash2_nvfp4_qpn2_runtime_contract()
+
+
 def _explicit_nvfp4_emulation_requested() -> bool:
     if envs.VLLM_USE_NVFP4_CT_EMULATIONS or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation":
         return True
@@ -455,6 +474,15 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 layer.sm70_nvfp4_qpn2_nacc = nacc
                 layer.sm70_nvfp4_qpn2_gated_silu = suffix == "gate_up_proj"
                 layer.sm70_nvfp4_qpn2_prefill_enabled = qpn2_prefill_enabled
+                if qpn2_shared and _compact_qpn2_scales_enabled():
+                    state = getattr(layer, sm70_tm.STATE_ATTR)
+                    state.scales = qpn2_scales
+                    state.global_scale = qpn2_global_scale
+                    state.use_scale_code = True
+                    logger.info_once(
+                        "SM70 QPN2 retains E4M3 scales only; TurboMind restores "
+                        "temporary FP16 scales for fallback shapes."
+                    )
                 logger.info_once(
                     "SM70 NVFP4 QPN2 M<=32 route enabled for a compatible "
                     "TP4 projection contract."

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -182,6 +182,17 @@ def _missing_qpn2_ops() -> list[str]:
     ]
 
 
+def _missing_qpn2_shared_ops() -> list[str]:
+    return [
+        name
+        for name in (
+            "nvfp4_qpn2_prepare_scales_sm70",
+            "nvfp4_qpn2_tm_dispatch_sm70_out",
+        )
+        if not hasattr(torch.ops._C, name)
+    ]
+
+
 def _missing_qpn2_prefill_ops() -> list[str]:
     return [
         name
@@ -380,16 +391,34 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                     )
                     use_qpn2 = False
             if use_qpn2:
-                qpn2_weight, qpn2_weight_scale, qpn2_output_size = (
-                    _pad_qpn2_output_rows(layer.weight.data, layer.weight_scale.data)
-                )
-                qpn2_codes, qpn2_scales = sm70_ops.nvfp4_qpn2_prepare_sm70(
-                    qpn2_weight, qpn2_weight_scale
-                )
+                qpn2_shared = envs.VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT
+                if qpn2_shared and (missing_shared_ops := _missing_qpn2_shared_ops()):
+                    logger.warning_once(
+                        "SM70 NVFP4 shared QPN2 weights are unavailable; "
+                        "retaining separate layouts. Missing ops: %s.",
+                        str(missing_shared_ops),
+                    )
+                    qpn2_shared = False
+                if qpn2_shared:
+                    qpn2_output_size = (layer.weight.shape[0] + 31) // 32 * 32
+                    qpn2_scales = sm70_ops.nvfp4_qpn2_prepare_scales_sm70(
+                        layer.weight_scale.data
+                    )
+                else:
+                    qpn2_weight, qpn2_weight_scale, qpn2_output_size = (
+                        _pad_qpn2_output_rows(
+                            layer.weight.data, layer.weight_scale.data
+                        )
+                    )
+                    qpn2_codes, qpn2_scales = sm70_ops.nvfp4_qpn2_prepare_sm70(
+                        qpn2_weight, qpn2_weight_scale
+                    )
                 qpn2_global_scale = float(layer.weight_global_scale.item())
                 qpn2_prefill_enabled = False
                 if _sm70_nvfp4_qpn2_prefill_enabled():
-                    missing_prefill_ops = _missing_qpn2_prefill_ops()
+                    missing_prefill_ops = (
+                        [] if qpn2_shared else _missing_qpn2_prefill_ops()
+                    )
                     if missing_prefill_ops:
                         logger.warning_once(
                             "The requested SM70 NVFP4 QPN2-packed prefill "
@@ -411,13 +440,15 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 k = layer.input_size_per_partition
                 n = qpn2_output_size
                 split_k, nacc = _SM70_NVFP4_QPN2_CONFIGS[(k, n, False)]
-                layer.register_buffer(
-                    "sm70_nvfp4_qpn2_codes", qpn2_codes, persistent=False
-                )
+                if not qpn2_shared:
+                    layer.register_buffer(
+                        "sm70_nvfp4_qpn2_codes", qpn2_codes, persistent=False
+                    )
                 layer.register_buffer(
                     "sm70_nvfp4_qpn2_scales", qpn2_scales, persistent=False
                 )
                 layer.sm70_nvfp4_qpn2 = True
+                layer.sm70_nvfp4_qpn2_shared_weight = qpn2_shared
                 layer.sm70_nvfp4_qpn2_global_scale = qpn2_global_scale
                 layer.sm70_nvfp4_qpn2_output_size = qpn2_output_size
                 layer.sm70_nvfp4_qpn2_split_k = split_k
@@ -428,6 +459,11 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                     "SM70 NVFP4 QPN2 M<=32 route enabled for a compatible "
                     "TP4 projection contract."
                 )
+                if qpn2_shared:
+                    logger.info_once(
+                        "SM70 NVFP4 QPN2 shares TurboMind 4-bit weights; "
+                        "only QPN2 E4M3 scales are stored separately."
+                    )
                 if qpn2_prefill_enabled:
                     logger.info_once(
                         "SM70 NVFP4 opaque QPN2 decode plus QPN2-packed "
@@ -517,7 +553,28 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             split_k, nacc = _SM70_NVFP4_QPN2_CONFIGS[
                 (x_2d.shape[1], kernel_output_size * 2, True)
             ]
-        if getattr(layer, "sm70_nvfp4_qpn2_prefill_enabled", False):
+        if getattr(layer, "sm70_nvfp4_qpn2_shared_weight", False):
+            min_prefill_m = (
+                envs.VLLM_SM70_NVFP4_QPN2_PREFILL_MIN_M
+                if layer.sm70_nvfp4_qpn2_prefill_enabled
+                else 0
+            )
+            sm70_ops.nvfp4_qpn2_tm_dispatch_sm70_out(
+                out_2d,
+                x_2d,
+                state.weight,
+                layer.sm70_nvfp4_qpn2_scales,
+                float(layer.sm70_nvfp4_qpn2_global_scale),
+                split_k,
+                nacc,
+                state.scales,
+                state.group_size,
+                state.k_ld,
+                state.q_ld,
+                gated_silu,
+                min_prefill_m,
+            )
+        elif getattr(layer, "sm70_nvfp4_qpn2_prefill_enabled", False):
             sm70_ops.nvfp4_qpn2_prefill_dispatch_sm70_out(
                 out_2d,
                 x_2d,

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -447,6 +447,16 @@ def apply_prepared_linear(
             state.k_ld,
             state.q_ld,
         )
+    elif state.op_kind == "nvfp4" and state.use_scale_code:
+        sm70_ops.nvfp4_qpn2_compact_tm_gemm_sm70_out(
+            out,
+            reshaped_x,
+            state.weight,
+            state.scales,
+            state.global_scale,
+            state.k_ld,
+            state.q_ld,
+        )
     elif state.op_kind == "nvfp4":
         sm70_ops.nvfp4_gemm_sm70_out(
             out,

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -65,11 +65,15 @@ def _sm70_dflash2_qpn8_rerank_requested() -> bool:
     )
 
 
-def _sm70_lm_head_packed_layout_requested() -> bool:
-    return (
-        _sm70_env_bool("VLLM_SM70_ENABLE_LM_HEAD_FASTPATH", False)
-        or _sm70_env_bool("VLLM_SM70_LM_HEAD_TOP1_TC", False)
-        or _sm70_dflash2_qpn8_rerank_requested()
+def _sm70_lm_head_packed_layout_requested(fp32_logits: bool = False) -> bool:
+    # FP32 dense logits and candidate rerank read the original FP16 parameter.
+    # Only an explicitly enabled packed top1 still consumes this layout.
+    return _sm70_env_bool("VLLM_SM70_LM_HEAD_TOP1_TC", False) or (
+        not fp32_logits
+        and (
+            _sm70_env_bool("VLLM_SM70_ENABLE_LM_HEAD_FASTPATH", False)
+            or _sm70_dflash2_qpn8_rerank_requested()
+        )
     )
 
 
@@ -177,6 +181,8 @@ def _is_sm70_dflash2_qpn8_rerank_eligible(layer: torch.nn.Module) -> bool:
 
 @torch.inference_mode()
 def _prepare_sm70_dflash2_qpn8_rerank(layer: torch.nn.Module) -> bool:
+    if getattr(layer, "_sm70_dflash2_qpn8_rerank_prepared", False):
+        return True
     if not _is_sm70_dflash2_qpn8_rerank_eligible(layer):
         return False
 
@@ -230,32 +236,33 @@ def _prepare_sm70_dflash2_qpn8_rerank(layer: torch.nn.Module) -> bool:
         torch.empty((max_rows, candidates), dtype=rerank_dtype, device=device),
         persistent=False,
     )
-    selected_rows = max_rows * candidates
-    layer.register_buffer(
-        "_sm70_dflash2_rerank_selected_raw",
-        torch.empty((selected_rows, hidden), dtype=torch.float16, device=device),
-        persistent=False,
-    )
-    layer.register_buffer(
-        "_sm70_dflash2_rerank_selected_packed",
-        torch.empty((selected_rows, hidden), dtype=torch.float16, device=device),
-        persistent=False,
-    )
-    layer.register_buffer(
-        "_sm70_dflash2_rerank_expanded",
-        torch.empty((max_rows, selected_rows), dtype=torch.float16, device=device),
-        persistent=False,
-    )
-    layer.register_buffer(
-        "_sm70_dflash2_rerank_partials",
-        torch.empty((max_rows, selected_rows), dtype=torch.float32, device=device),
-        persistent=False,
-    )
-    layer.register_buffer(
-        "_sm70_dflash2_rerank_barriers",
-        torch.zeros(64, dtype=torch.int32, device=device),
-        persistent=False,
-    )
+    if not fp32_logits:
+        selected_rows = max_rows * candidates
+        layer.register_buffer(
+            "_sm70_dflash2_rerank_selected_raw",
+            torch.empty((selected_rows, hidden), dtype=torch.float16, device=device),
+            persistent=False,
+        )
+        layer.register_buffer(
+            "_sm70_dflash2_rerank_selected_packed",
+            torch.empty((selected_rows, hidden), dtype=torch.float16, device=device),
+            persistent=False,
+        )
+        layer.register_buffer(
+            "_sm70_dflash2_rerank_expanded",
+            torch.empty((max_rows, selected_rows), dtype=torch.float16, device=device),
+            persistent=False,
+        )
+        layer.register_buffer(
+            "_sm70_dflash2_rerank_partials",
+            torch.empty((max_rows, selected_rows), dtype=torch.float32, device=device),
+            persistent=False,
+        )
+        layer.register_buffer(
+            "_sm70_dflash2_rerank_barriers",
+            torch.zeros(64, dtype=torch.int32, device=device),
+            persistent=False,
+        )
     layer.register_buffer(
         "_sm70_dflash2_rerank_dense_logits",
         torch.empty((max_rows, rows), dtype=rerank_dtype, device=device),
@@ -383,12 +390,15 @@ def maybe_prepare_sm70_lm_head_top1(layer: torch.nn.Module) -> bool:
     raw_top1_requested = _sm70_env_bool(
         "VLLM_SM70_LM_HEAD_TOP1", _sm70_lm_head_top1_default()
     )
-    packed_layout_requested = _sm70_lm_head_packed_layout_requested()
+    packed_layout_requested = _sm70_lm_head_packed_layout_requested(
+        getattr(layer, "_sm70_dflash2_fp32_logits", False)
+    )
     if raw_top1_requested:
         layer._sm70_f16_raw_top1_ready = True
 
     if not packed_layout_requested:
-        logger.info_once("SM70 raw-weight LM head top1 path prepared.")
+        _prepare_sm70_dflash2_qpn8_rerank(layer)
+        logger.info_once("SM70 original-weight LM head path prepared.")
         return True
 
     if not hasattr(torch.ops._C, "sm70_f16_prepare"):

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -581,6 +581,19 @@ def _warmup_fp4_dense_layers(
             elif state.op_kind == "nvfp4":
                 if not hasattr(torch.ops._C, "nvfp4_gemm_sm70_out"):
                     continue
+                if getattr(state, "use_scale_code", False):
+                    sm70_ops.nvfp4_qpn2_compact_tm_gemm_sm70_out(
+                        out,
+                        x,
+                        state.weight,
+                        state.scales,
+                        state.global_scale,
+                        int(state.k_ld),
+                        int(state.q_ld),
+                        gated_silu,
+                    )
+                    calls += 1
+                    continue
                 sm70_ops.nvfp4_gemm_sm70_out(
                     out,
                     x,


### PR DESCRIPTION
## Purpose

DFlash2 QPN2 stores target NVFP4 codes separately from TurboMind, and FP32 LM-head serving still prepares unused FP16 packed copies. Add shared-code and compact-scale paths, and omit unused LM-head packing while retaining accelerated QPN2/QPN8 execution.

Under the production TP4 configuration, the latest follow-up reduces model loading from **8.203934 to 6.286138 GiB/rank** after code sharing, saving **7.671183 GiB across TP4**. Automatic KV budget increases from **15.76 to 17.70 GiB/rank**. The original dual-code loading measurement was 11.08 GiB/rank.

- `VLLM_SM70_NVFP4_QPN2_SHARED_WEIGHT=1` reads TurboMind codes directly, removing 2.835693 GiB/rank of duplicate target codes. Shared scheduling/cache recovery retains the existing arithmetic and dynamic-M fallback.
- `VLLM_SM70_NVFP4_QPN2_SHARED_SCALES=1` keeps QPN2 E4M3 scales and restores exact FP16 scales temporarily for TurboMind fallback. Small-M QPN2 decode and bounded dense prefill are unchanged. Admission requires rebuilt operators, shared codes, the DFlash2 TP4 q7/no-DBO contract, and graph capture sizes <=32. Larger graphs retain persistent scales to avoid capturing a separate temporary for every projection. Both switches default off.
- FP32 dense/candidate LM-head paths retain the original FP16 parameter and QPN8 screening layout. Skip unused FP16 packing and rerank scratch; explicit packed Tensor Core top1 still receives its layout. Allocation stacks identify the second 606.25 MiB/rank copy as draft placeholder-head packing retained by the native cache after target-head sharing. Avoiding unused packing prevents both copies without changing candidate selection or logits arithmetic.

Base: `e5d63c51f0fcc1ddf75d229e3df06bf52df206f5` on `onecat/main`. Head: `d26804a9ccce2f2ac3fa4f3a69874575c1aa98e1`. This extends the existing memory recovery PR rather than creating a duplicate. AI assistance was used; human review remains pending. Keep this PR Draft.

## Test Plan

Verify loader aliases, capability and graph-size gates, explicit packed top1, warmup dispatch, real checkpoint scale/output bits, and changed-input CUDA Graph replay. Measure operator costs independently from whole-model throughput. Preserve production serving: 4×V100-SXM2-32GB, Torch2.10.0+cu128/CUDA12.8, TP4, FP16 model/draft KV, maxlen262144, utilization0.8, automatic E4M3 KV, chunk4096, maxseq4, DFlash2 q7/probabilistic, FP32 logits, context pipeline/KV graph and CUDA Graph. Sampling remains temperature1/top_p0.95/top_k20/seed0, xhigh thinking and natural EOS.

## Test Result

- `.venv/bin/python -m pytest tests/quantization/test_sm70_warmup.py tests/quantization/test_sm70_nvfp4_qpn2.py tests/model_executor/layers/test_sm70_lm_head.py -q`: **43 passed**.
- CUDA sidecar builds and targeted pre-commit checks pass, including Ruff, changed-line clang-format, mypy and Markdown.
- Previous shared-code recovery passes **336 real-shard cases**, with weighted repeated-operator M8/M16/M32 ratios1.0013/0.9869/0.9591. A six-tensor working set gives1.0259/0.9915/0.9019; these are projection measurements, not model speed.
- Compact scales pass **224 ordinary/gated cases on24 real TP4 shards** at M8/16/32/33/135/512/1023/1024. Restored FP16 scales and outputs are bitwise identical, including changed-input graph replay. `benchmark_sm70_nvfp4_shared_weight.py --compact-scales` reproduces the comparison against shared codes with persistent scales.
- Compact/persistent projection ratios are M8 **1.0008**, M16 **1.0004**, M32 **1.0002**. Fallback costs are explicit: M33 **1.1394**, M135 **1.0587**, M512 **1.0307**, M1023 **1.0163**. M1024 bounded prefill is **0.9996**. Scale restoration adds about2.87–3.43ms across the isolated fallback projection sequence; this is not TTFT or model latency.
- Six real LM-head cases preserve QPN8 code/scale bits, candidate IDs and FP32 logits in eager and changed-input graph replay. Candidate/control timing ratios range **0.9969–1.0010**.

Latest completed production allocation:

| Metric | Prior shared-code cohort | Compact scales + head cleanup |
| --- | --- | --- |
| Model loading, GiB/rank | 8.203934 | 6.286138 |
| Model loading, GiB/TP4 | 32.815735 | 25.144552 |
| Automatic KV budget, GiB/rank | 15.76 | 17.70 |
| Logical KV tokens | 1,479,578 | 1,661,426 |
| Graph capture increment, GiB/rank | 0.26 | 0.26 |
| Idle worker NVML, MiB/rank | 26,030 | 26,036 |

All four ranks agree. Census operations do not change allocated bytes. Both unused head matrices and persistent TurboMind scales are absent; the QPN8 acceleration copy remains. Idle snapshots show no active/waiting requests and zero KV usage. Automatic KV capacity grows12.29%, so total residency stays near the existing memory budget.

The latest MBPP28 warmup/three measured requests match all **754 tokens** of the archived shared-code cohort; MBPP0 matches all **1093 tokens**. Both finish naturally with nonempty answers. Median pure decode is **225.66tok/s**, verification round **19.068ms**, TTFT **107.95ms**. Archived same-output values were221.40tok/s,19.435ms and112.37ms. No focused slowdown appears, but these are not contemporaneous controls; do not claim the approximately2% difference as a speedup.

## Remaining acceptance and evidence boundaries

The current paired control was terminated during compilation and has no endpoint result. Earlier source-aligned cohorts produced different tokens; the latest archived-cohort match does not explain those differences or admit broader concurrency/long context. The switches remain opt-in and this PR remains Draft.

A benchmark-only sidecar option aligns legacy/shared QPN2 native implementations. The older installed core dispatched M9–32 to TurboMind despite newer Python route logs; that validation gap is separately documented. Failed lane mapping, old Flash-V100 extension, harness import/inference-mode errors, interrupted services and excluded fixed2GiB/8K/E5M2 diagnostics remain recorded.

`docs/design/sm70_dflash2_shared_nvfp4.md` and the migration ledger retain contracts, reproduction, storage accounting, measured deltas and rejected variants. Task artifacts contain commands, manifests, source/diff and binary hashes, allocation stacks, operator samples and endpoint responses. Test services have exited and released their locks.


### Latest speed and quality follow-up

Inference source remains 2d683cc1355fddfb7742c32c21ab0a2210a3f045; the latest commit adds evidence only. The two completed candidate final answers pass MBPP base and EvalPlus hidden tests (2/2 each, dataset hash ee43ecabebf20deef4bb776a405ac5b1).

Two current same-source A/B attempts were interrupted before candidate execution, after six speed requests and only two/three quality requests. The latest parent received SIGINT and its cleanup sent SIGTERM to the child; there was no logged OOM or CUDA computation failure, and the sender remains unidentified. The planned 32-task and four-concurrent checks have no passing result.

Controls retaining old scales and head layouts show restart variation: MBPP28 returns 270 versus 634 tokens, first differing at zero-based token 8, while each process repeats its own output identically six times. Different-output decode medians 233.57/253.62 tokens/s are not a memory-optimization speed comparison. No new overall speed or broad quality parity is claimed. Preserve the interrupted cohorts, resolve uninterrupted GPU ownership and control reproducibility, and keep this PR Draft. No owned GPU/API or scorer processes remain.
