### PR TITLE
[Bugfix][Core] Preserve singleton prefill semantics in speculative GDN

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -311,9 +311,14 @@ def _build(
     batch_spec: BatchSpec,
     num_decode_draft_tokens: list[int] | None = None,
     use_common_metadata: bool = False,
+    is_prefilling: list[bool] | None = None,
 ) -> GDNAttentionMetadata:
     """Build GDN attention metadata, optionally with spec-decode kwargs."""
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
+    if is_prefilling is not None:
+        common = common.replace(
+            is_prefilling=torch.tensor(is_prefilling, dtype=torch.bool, device=DEVICE)
+        )
     kwargs: dict = {}
     if num_decode_draft_tokens is not None:
         num_decode_draft_tokens_cpu = torch.tensor(
@@ -409,6 +414,97 @@ def test_gdn_build_classification(
     assert meta.num_prefills == test_case.expected_num_prefills
     assert meta.num_prefill_tokens == test_case.expected_num_prefill_tokens
     assert meta.num_spec_decodes == test_case.expected_num_spec_decodes
+
+
+@pytest.mark.parametrize("use_full_cuda_graph", [False, True])
+@pytest.mark.parametrize(
+    (
+        "num_speculative_tokens",
+        "query_len",
+        "seq_len",
+        "is_prefilling",
+        "expected_prefills",
+        "expected_initial_state",
+    ),
+    [
+        pytest.param(7, 1, 1, True, 1, [False], id="fresh-singleton"),
+        pytest.param(7, 1, 17, True, 1, [True], id="cached-singleton-extension"),
+        pytest.param(7, 1, 17, False, 0, None, id="regular-decode"),
+        pytest.param(7, 2, 2, True, 1, [False], id="two-token-prefill"),
+        pytest.param(7, 17, 17, True, 1, [False], id="longer-prefill"),
+        pytest.param(7, 1, 1, None, 0, None, id="legacy-metadata"),
+        pytest.param(0, 1, 1, True, 0, None, id="non-speculative-unchanged"),
+    ],
+)
+def test_singleton_prefill_state_initialization(
+    local_gdn_model: str,
+    use_full_cuda_graph: bool,
+    num_speculative_tokens: int,
+    query_len: int,
+    seq_len: int,
+    is_prefilling: bool | None,
+    expected_prefills: int,
+    expected_initial_state: list[bool] | None,
+):
+    builder = _create_gdn_builder(
+        local_gdn_model,
+        num_speculative_tokens=num_speculative_tokens,
+        use_full_cuda_graph=use_full_cuda_graph,
+        max_cudagraph_capture_size=8,
+    )
+    meta = _build(
+        builder,
+        BatchSpec(seq_lens=[seq_len], query_lens=[query_len]),
+        num_decode_draft_tokens=[-1] if num_speculative_tokens else None,
+        is_prefilling=None if is_prefilling is None else [is_prefilling],
+    )
+
+    assert meta.num_spec_decodes == 0
+    assert meta.num_prefills == expected_prefills
+    assert meta.num_decodes == 1 - expected_prefills
+    assert meta.num_prefill_tokens == query_len * expected_prefills
+    if expected_initial_state is None:
+        assert meta.has_initial_state is None
+    else:
+        assert meta.has_initial_state is not None
+        assert meta.has_initial_state.tolist() == expected_initial_state
+
+
+@pytest.mark.parametrize("poison", [10.0, float("nan")], ids=["recycled", "nan"])
+def test_singleton_prefill_masks_recycled_conv_state(local_gdn_model: str, poison):
+    from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
+        causal_conv1d_torch,
+    )
+
+    builder = _create_gdn_builder(local_gdn_model, num_speculative_tokens=7)
+    meta = _build(
+        builder,
+        BatchSpec(seq_lens=[1], query_lens=[1]),
+        num_decode_draft_tokens=[-1],
+        is_prefilling=[True],
+    )
+    assert meta.num_prefills == 1
+    assert meta.has_initial_state is not None
+    assert meta.non_spec_query_start_loc is not None
+    assert meta.non_spec_state_indices_tensor is not None
+    states = torch.full((1, 1, 3), poison, dtype=torch.float32, device=DEVICE)
+    output = causal_conv1d_torch(
+        x=torch.ones((1, 1), dtype=torch.float32, device=DEVICE),
+        weight=torch.ones((1, 4), dtype=torch.float32, device=DEVICE),
+        bias=None,
+        conv_states=states,
+        query_start_loc=meta.non_spec_query_start_loc,
+        cache_indices=torch.zeros_like(meta.non_spec_state_indices_tensor),
+        has_initial_state=meta.has_initial_state,
+        activation=None,
+    )
+    torch.testing.assert_close(output, torch.ones_like(output), rtol=0, atol=0)
+    torch.testing.assert_close(
+        states,
+        torch.tensor([[[0.0, 0.0, 1.0]]], device=DEVICE),
+        rtol=0,
+        atol=0,
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -1452,7 +1452,15 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-                split_decodes_and_prefills(m, decode_threshold=1)
+                split_decodes_and_prefills(
+                    m,
+                    decode_threshold=1,
+                    # A singleton prefill must initialize speculative GDN state,
+                    # rather than consume a recycled recurrent-state slot.
+                    treat_short_extends_as_decodes=not (
+                        self.use_spec_decode and m.is_prefilling is not None
+                    ),
+                )
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None


### PR DESCRIPTION
## Purpose

Fixes #562

Fix one-token initial prefills in a 1Cat DFlash2 engine being classified as
recurrent decodes and consuming recycled convolution/SSM state. The observed
symptoms were wrong greedy output and a history-dependent CUDA gather assertion
with Xid43 on both V100s.

**Base:** 1CatAI/1Cat-vLLM `main` at
`e5d63c51f0fcc1ddf75d229e3df06bf52df206f5`. At this revision, `gdn_attn.py` and
attention `utils.py` are byte-for-byte identical to the affected v1.5.0 files.
The patch is generated against main, not against a local deployment overlay.
Main was fetched again for submission and remained at that SHA. The narrow patch
applied without a source-context conflict. In the complete checkout, Ruff restored
the test file's original import grouping (the earlier sparse checkout classified
some imports differently); there is no unrelated import diff in this PR.

**Commit:** `81f4e9ad2e05760d5fa5596371c4691c1205627e` on
`zhaochengggg:fix/dflash-singleton-gdn-prefill`.

**Mechanism.** In the no-active-spec branch,
`GDNAttentionMetadataBuilder.build()` uses the default
`treat_short_extends_as_decodes=True`. A `query_len=1` initial prefill is therefore
treated as a decode even when MRv2 supplied `is_prefilling=True`.
`has_initial_state` becomes `None`, bypassing the prefill initialization contract.
The first target step is already corrupted; this is not an established
off-by-one in DFlash2's selector. The downstream assertion was located at draft
graph replay, but its exact captured gather index was not recovered.

**Changes.** Honor explicit prefill flags only when speculative decoding is
configured and the flag exists:

```diff
- split_decodes_and_prefills(m, decode_threshold=1)
+ split_decodes_and_prefills(
+     m,
+     decode_threshold=1,
+     treat_short_extends_as_decodes=not (
+         self.use_spec_decode and m.is_prefilling is not None
+     ),
+ )
```

This preserves the active speculative branch, real decode rows, no-flag legacy
callers, and non-speculative behavior. A cached one-token prefill extension
follows prefill semantics but keeps its valid initial state; no global state
zeroing, kernel workaround, new dependency, or configuration option is added.
The existing GDN metadata tests gain 16 CPU cases covering classification,
initial-state flags, graph-buffer settings, and finite/NaN recycled conv state.
The complete patch changes only the builder and its existing test file.

**Related work / non-duplication.** The same root cause is already described in
[vllm-project issue #51562](https://github.com/vllm-project/vllm/issues/51562) and
[open PR #51565](https://github.com/vllm-project/vllm/pull/51565).
This is a narrow, GPU-validated **1Cat fork adaptation**, not an independent
discovery claim or another PR to vllm-project. PR #51565 is broader: it also
handles non-speculative first chunks, resumed short chunks, padding, and FULL
graph buffer staging. This patch does not claim to replace that work.
No corresponding open 1Cat fix was found at the inspected snapshot.
[1Cat PR #556](https://github.com/1CatAI/1Cat-vLLM/pull/556) addresses DFlash2
numerics/strided q8 verification, not this metadata classification site.
The complete upstream diff cannot be treated as a drop-in replacement in this
fork; the integration evidence and scope of this adaptation are detailed below.

**AI assistance / human review.** GitHub Copilot assisted with investigation,
patch/test preparation, and this description. The account owner explicitly
authorized publication of this prepared patch as a **Draft PR** and authorized
their DCO identity. The reported local commands were agent-executed; no claim is
made that a human independently reran them. The submitting human remains
responsible for every changed line and end-to-end acceptance before this PR is
marked ready. The commit attributes Copilot and includes the authorized DCO
sign-off.

### Upstream alignment (v1.5.0-era fork integration)

We separately tested a context-resolved integration of the **complete**
vllm-project PR #51565 diff at head
`53995de1e5781416206cabfc3ddf539611f82cc0` on the v1.5.0-era 1Cat base
`e5d63c51f0fcc1ddf75d229e3df06bf52df206f5`. The raw diff did not apply unchanged;
the faulty call is shared, but the surrounding implementations differ.

That integration produced **49 passed, 3 failed, 2 GPU-only skipped**, including
**6 passed / 2 failed** among the eight new upstream regression cases:

| Failure | Why a full drop-in backport is insufficient |
|---|---|
| Missing `prefill_has_initial_state` | 1Cat lacks this upstream prefill-only metadata prerequisite. |
| Missing `prefill_query_start_loc` | The associated prefill-only query/state metadata, including `prefill_state_indices`, also differs. |
| Padding states `[0,1,0,0]` instead of `[0,1,-1,-1]` | 1Cat slot 0 is live; padding requires `PAD_SLOT_ID=-1`. The full patch's graph staging replaces prepared sentinels with raw block-table zeroes. |

The last test passes on the untouched fork. Lint/format/whitespace checks passed,
but the failed CPU gate prevented any GPU validation of the complete upstream
transplant. This does **not** establish a bug in #51565's upstream environment.

Local evidence, relative to the investigation package:
`upstream-51565/cpu-after.log`, `upstream-51565/validation-summary.json`,
`upstream-51565/cpu-baseline-padding.log`, and
`upstream-51565/fork-context-transplant.patch`. These provenance files are not
part of this two-file source PR; the key failure details are included above.

**This PR deliberately submits only the previously validated narrow adaptation.**
The fork needs this scoped fix rather than waiting for an unadapted upstream
backport: it preserves existing state-slot/padding/graph contracts and adds the
16 focused CPU cases. If the broader upstream work is adopted later, reconcile
its prerequisites and this downstream change. The rejected full-transplant
candidate is not included, and no duplicate PR is being opened in vllm-project.

## Test Plan

In an isolated environment correctly built for the proposed checkout, run the
focused existing test file and the repository-pinned Ruff 0.14.0 checks:

```bash
CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest \
  tests/v1/attention/test_gdn_metadata_builder.py \
  --confcutdir=tests/v1/attention -q \
  -k 'singleton_prefill or gdn_build_classification or common_gdn_metadata_matches or mixed_decode_stays_decode_fastpath or full_cuda_graph_decode_padding_uses_pad_slot'
.venv/bin/python -m ruff check \
  vllm/v1/attention/backends/gdn_attn.py \
  tests/v1/attention/test_gdn_metadata_builder.py
.venv/bin/python -m ruff format --check \
  vllm/v1/attention/backends/gdn_attn.py \
  tests/v1/attention/test_gdn_metadata_builder.py
git diff --check
```

GPU acceptance: use the linked Issue's TP2 / FP16 KV / batch2048 / seven-token
DFlash2 / no-compile FULL-graph configuration. Compare uninstrumented target-only
and patched DFlash2 on fresh `[32]`, then 4096/200 + sanity + `[32]`; compare
greedy and logprobs token IDs at lengths 1, 2, 17, 1024, 2048, and repeated 1024.
Retain short runs, 67 C cutoff, cooldown below 50 C, and clean shutdown.
Do not deliberately repeat device-side assertions merely to obtain more samples.

## Test Result

**Earlier CPU evidence on the pinned main modules:** with the new tests but the
unmodified builder, **6 failed / 26 passed**; with this patch,
**32 passed / 30 deselected**. The failing assertions pin singleton routing and
recycled-state initialization. Ruff lint/format and clean-base patch application
passed.

Scope of that local CPU run: `validate-main-cpu.py` loaded the two audited main
modules and main's tests with installed v1.5.0 runtime dependencies, disabled
CUDA initialization, and excluded unrelated parent fixtures. This is not a full
main build, full repository test suite, CUDA Graph execution test, or main GPU
benchmark. The canonical command above remains a human/full-checkout acceptance
step.

**Submission-checkout rerun:** the same 32 focused CPU cases passed again on the
actual fork worktree (30 deselected), with the same installed-v1.5.0 dependency
bridge and CUDA initialization prohibited. The bridge is recorded locally as
`submission/validate-narrow-cpu.py`, with results in `submission/narrow-cpu.log`.
The normal commit hooks were enabled: Ruff 0.14.0 lint/format, local mypy, typos,
SPDX/import/configuration checks, and the DCO hook all passed. No hook was skipped
or bypassed. No GPU workload was run merely to publish this Draft PR.

**Previously measured GPU evidence, v1.5.0 plus only the same source fix:**

| Case | Before | After |
|---|---|---|
| Fresh `[32]`, 8 output tokens | Wrong text, e.g. `+BCDEFGHIJLMNOP` | `" 1000 kg car is"` |
| Exact singleton IDs | Mismatch | `[220,16,15,15,15,20332,1740,369]` |
| 4K + sanity + singleton | CUDA assertion / Xid43 / HTTP timeout | Completes; reference IDs match |
| Lengths 2/17/1024/2048/repeated-1024 | Pass | Pass, including greedy/logprobs parity |
| Multi-block state freshness | Not the failing trigger | 4/4 cases pass |

Same 4096-input / 200-output streaming workload, TP2, one request:

| Configuration | TTFT (s) | Decode (tok/s) | Total (s) | Startup (s) | Peak GPU0/1 (C) |
|---|---:|---:|---:|---:|---:|
| Earlier compiled target-only best | 3.859 | 43.189 | 8.466 | 130.117 | 51 / 60 |
| Stock DFlash2, passing long request | 3.815 | 153.254 | 5.114 | 72.122 | 49 / 58 |
| DFlash2 + singleton fix | 3.822 | 153.309 | 5.120 | 71.106 | 50 / 59 |

The stock DFlash2 performance run deliberately excluded its known failing
singleton; it is **not** an all-input correctness pass. Decode rate is
`199 / (last_nonempty_event_time - first_nonempty_event_time)`.
The fixed and stock long outputs have the same SHA256. The 0.04% decode-rate
difference is measurement noise: this is a correctness fix with **no meaningful
observed throughput regression**, not an additional performance optimization.

The original failures really generated Xid43. Corrected runs did not repeat the
assertion; AER increments stayed zero, and both GPUs returned to 0 MiB after
shutdown. No main GPU result, broad quality evaluation, high-concurrency
coverage, or guarantee for other architectures is claimed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

