### PR TITLE
[Core] Shard H3 residual rows and rotate before TP gather

### DIFF
--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -14,6 +14,76 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Local ConvRot before gather: 58.19 seconds
+
+The optional residual-sharded route now rotates normalized FP16 rows on their
+owning rank before all-gather. QKV and gate/up projections consume those exact
+gathered bits without repeating ConvRot. Each rank rotates one quarter of the
+rows; the original ConvRot256 arithmetic, INT8 scales, projection shapes and
+FLOP hooks are preserved. CPU/unquantized paths retain ordinary forwards.
+This reuses a read-only working-tree snapshot from the independent FI task,
+based on `53780abef0e9ef190aa55a1f61d8fd5fbd390aa1`, with the regression adapted
+to native FlashAttention. Snapshot patch SHA256:
+`ce41592338adeef0388c7b5b826351d378c468bfa58e7df3def662cf7056dc4b`.
+The source was uncommitted in that tree at capture; no FI attention delegation
+or H3 CUDA binary change is involved.
+
+The unchanged 1344x768, 39-frame/24-FPS, seed42, INT8 ConvRot FL2VA, TP4 GPU0-3
+workload completes **20 actual updates in 58.190385 s**, or **2.909519 s/update
+and 59.524500 useful model TFLOPS/card**. This reduces the previous optional
+58.794562 s result by 0.604177 s (1.03%). Per-card useful FLOPs remain
+3,463,753,579,661,312. Peak denoise Torch allocation is unchanged at
+**6.195001125 GiB/card**; NVML peak device-used memory is 8.046386719 GiB/card.
+Persistent FP16 cache and Lt workspace remain zero. This is one unprofiled,
+cached-text development run after a one-call warmup, not formal acceptance.
+Three paired two-update checks give medians 5.878070 ->5.813375 s (1.10%).
+
+Both complete video/audio latent tensors are **bitwise equal** to the previous
+58.79-second run, finite and identical across ranks. Its decoded media is
+reused only after these checks and verification of the MP4 hash below. There
+is no new VAE or end-to-end timing. Automatic validity is preserved; the prior
+human audiovisual review remains pending. The option still defaults to false;
+the flag-off baseline remains 62.804019 s. Omit the flag to restore that path,
+or use parent `2a560b0a7fa0` to revert only the local-rotation change.
+
+Validation: 62 targeted tests pass, one GPU case is deselected. A separate
+torchrun invocation runs one actual four-rank test, passing on every rank:
+cached/uncached INT8 projections, two valid/padded lengths, consecutive blocks,
+rank-specific weights, residuals above 65504, exact output and unchanged FLOP
+hooks. Pre-commit passes. Do not combine distributed GPU test modules in one
+pytest lifetime: the repository fixture tears down distributed state between
+tests. Earlier sanitizer runs cover unchanged operators, not a new run here.
+
+Eight further attention variants remain artifact-only. All match the native
+output exactly across 12 tested lengths and pass sampled FP32 references;
+none establishes a stable paired speedup including wrapper/copy costs:
+
+| Candidate | Native control ms | Candidate ms | Decision |
+| --- | ---: | ---: | --- |
+| Register row max/sum | 20.210688 | 20.071424 | No stable paired gain |
+| Separate max/sum exchange | 20.093952 | 20.232191 | No gain |
+| Head-contiguous Q/K/V packing | 19.866625 | 20.254721 | Packing loses |
+| Direct Q/K vector iterators | 20.256767 | 21.655552 | Hot register spills |
+| Direct Q iterator | 20.048897 | 20.049919 | No gain |
+| Direct K iterator | 19.971071 | 20.135937 | No gain |
+| Direct V iterator | 20.254721 | 19.984385 | Clock drift; unstable gain |
+| PV-only 64x32 warp | 20.199425 | 23.879681 | Slower after mapping fix |
+
+Query-window attention/projection overlap also loses, including a version
+retaining the full-shape attention specialization and validated cloned GEMM
+plans. A three-window TP4 block pipeline takes about 6.04 s versus 5.87 s for
+two updates and introduces nonzero latent deltas; it is not integrated. Its
+raw hook counter includes 29 padding rows and is explicitly invalid for
+acceptance accounting. See `flashattention-register50/failed-paths.json` for
+exact jobs, sources and outcomes; do not repeat unchanged candidates.
+
+Latest evidence: `flashattention-register50/REPORT.md`, `report.json`, source
+snapshot hashes, paired probes, test logs and NVML curves. Media:
+`outputs/quality39-int8-flashattn-localrot-20steps/FLASH_ATTN_V100/`.
+**Under 50 seconds, attention 60 TFLOPS, formal per-card 80 TFLOPS and human
+quality acceptance remain incomplete.** GEMM/attention operand reuse remains
+the main optimization target; this small ConvRot gain does not resolve it.
+
 ### Optional FP32 residual row sharding: 58.79 seconds
 
 `--residual-sequence-parallel` enables an experimental TP4 FL2VA INT8 path

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,115 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Optional FP32 residual row sharding: 58.79 seconds
+
+`--residual-sequence-parallel` enables an experimental TP4 FL2VA INT8 path
+for either native SM70 attention backend. It defaults to false in both
+`video generate` and `video serve`. This reuses the committed residual dataflow
+from the independent FlashInfer branch at `5b4f0bba31`, adapting its backend
+gate and tests for FlashAttention-V100. No FlashInfer attention code is ported
+or delegated to when FlashAttention is selected.
+
+Each rank retains only its FP32 residual rows through the DiT blocks. The
+existing normalization boundary produces FP16 rows, which are gathered before
+QKV and MLP projection. Output projections retain FP32 partial sums and use
+FP32 reduce-scatter. Final heads receive the gathered FP32 rows. This reduces
+repeated normalization/gating work and intermediate data movement, preserving
+INT8/scale information, all GEMMs, valid attention tokens and denoise updates.
+The feature rejects unsupported TP sizes, BF16 checkpoints, Ref2VA, multiple
+requests and simultaneous Ulysses hooks. The original path remains available
+by omitting the flag; source rollback is kernel parent `9764b6c20259`.
+
+On the unchanged 1344x768, 39-frame/24-FPS, seed42, INT8 ConvRot FL2VA,
+TP4 GPU0-3 request, **20 actual updates take 58.794562 s**:
+**2.939728 s/update and 58.912822 useful model TFLOPS/card**. This is a 6.38%
+time reduction from the 62.804019 s default. Per-card useful FLOPs remain
+3,463,753,579,661,312. Peak denoise Torch allocation falls from 6.566735744 to
+**6.195001125 GiB/card**; NVML peak device-used memory is 8.171386719 GiB/card.
+Persistent FP16 weight cache and cuBLASLt workspace stay zero. This is one
+unprofiled development run with a one-call warmup and prompt-verified cached
+text, not an end-to-end or formal repeated measurement.
+
+Fresh VAE decoding takes 8.478661 s, with 34.904292 s VAE loading reported
+separately. All automatic media checks pass. FP32 reduction order changes:
+video/audio latent relative RMS differences from the 62.80-second baseline
+are 3.87465% /1.20270%. Decoded-video SSIM is 0.983989 and PSNR 38.238221 dB;
+these are auxiliary comparisons, not quality thresholds. Eight sampled frames
+show a consistent red boat, yellow duck and background. Human audiovisual
+scoring remains pending, so the option is not promoted to the default.
+MP4 SHA256 is
+`f00ba75587f58e2a63a105647cb634eebd60b154ab7b3551f385ca2df96e5243`.
+
+Separate two-update Nsight Systems traces explain the gain. Rank0 exclusive
+wall seconds close to each trace's own denoise NVTX span:
+
+| Category | Replicated residual | Sharded residual |
+| --- | ---: | ---: |
+| GEMM | 2.539663 | 2.550870 |
+| Attention | 2.005245 | 2.023926 |
+| TP collectives | 1.076831 | 0.845654 |
+| Other GPU kernels | 0.440786 | 0.237076 |
+| ConvRot | 0.125264 | 0.126346 |
+| Weight dequantization | 0.059483 | 0.059765 |
+| Copies | 0.012490 | 0.012507 |
+| FP16 preparation outside fused kernels | 0.000026 | 0.000025 |
+| No recorded GPU activity | 0.031895 | 0.035798 |
+| Complete trace span | 6.291683 | 5.891967 |
+
+The fused activation's preparation is included in other GPU kernels. GEMM
+and attention still consume about 78% of the new trace. This is not an idle
+optimization. Explicit copies are small; the profile does not establish an
+HBM-copy bottleneck. At 60 useful attention TFLOPS alone, the old trace still
+projects roughly 61 seconds for 20 updates with all other costs held fixed;
+this is an Amdahl illustration, not a measurement or hardware lower bound.
+
+NCU on the unchanged native wide attention reports 246 registers/thread,
+34,304 shared bytes/block, 12.47% achieved occupancy, 49.23% tensor-pipe
+activity, 66.46% L1/shared data-path throughput and 4.57% HBM throughput.
+SASS samples point to QK shared stores waiting for operands, shared-load/HMMA
+dependencies and PV address instructions. Higher occupancy alone is not a
+sufficient fix. Eight isolated paired candidates pass sampled FP32 references
+but fail to establish a speedup; all remain outside the installed extension:
+
+| Candidate | Native control ms | Candidate ms | Decision |
+| --- | ---: | ---: | --- |
+| Pretranspose V to column layout | 20.215809 | 21.629951 | Packing/zeroing loses |
+| Warp/shared row maximum | 20.073471 | 20.227072 | No gain |
+| Q32/K256 | 20.044800 | 24.824833 | Reuse/traffic regression |
+| Unroll fixed QK loop | 20.204544 | 20.252672 | No gain |
+| Unroll fixed PV loop | 19.892223 | 20.021248 | No gain |
+| Eight warps | 20.045824 | 26.279936 | Register spills |
+| Global-load cache policy cg | 20.264959 | 20.225023 | 0.2% noise |
+| Q32/K128, four warps, three CTAs | 20.711424 | 26.468351 | Reuse regression |
+
+A further artifact-only GEMM/reduce-scatter overlap probe uses zero persistent
+cache and workspace, unlike the earlier independent 10-GiB-cache probe. Three
+paired two-update runs give medians 5.872043 ->5.742729 s (2.20%). It preserves
+useful FLOPs and reduces temporary memory, but has nonzero latent differences
+and no complete-video quality validation. Extra packing, streams and GEMM-plan
+APIs are not integrated for this modest prefix gain. Do not report 57.43 s as
+measured full-20 denoise, or repeat these variants without a new hypothesis.
+
+Validation: 70 targeted numerics/service/configuration tests pass. One actual
+four-rank collective test passes on every rank, covering both native attention
+backends, three valid/padded lengths, consecutive blocks, rank-dependent
+weights, FP32 residual values above 65504 and poisoned padding. Pre-commit
+checks pass. No CUDA source or installed binary changes in this follow-up;
+prior attention sanitizer coverage is retained, not presented as a new run.
+The actual full-20 run records all ranks' finite, mutually identical final
+latents and unchanged FLOP counts.
+
+Evidence root: `flashattention-pipeline50/` (exact jobs, NCU/SASS, both Nsight
+traces, candidate source/binaries, negative results, tests, reports and NVML
+curves). Fresh output:
+`outputs/quality39-int8-flashattn-residual-20steps/FLASH_ATTN_V100/`.
+Installed attention SHA256 remains
+`bdb3dcf0eea8c23f992536182a06d26f7b61c7bb6ddefa4b3c88590b81ad0005`.
+
+**Under 50 seconds, attention 60 TFLOPS, formal per-card 80 TFLOPS and human
+quality acceptance remain incomplete.** Keep the arithmetic operand-reuse
+focus; do not mistake 100% NVML utilization for Tensor Core saturation.
+
 ### Wide QK reuse and fused MLP preparation: 62.80 seconds
 
 The retained native implementation completes the unchanged 1344x768,

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -107,11 +107,15 @@ For the measured TP4 FL2VA INT8 development workload, optionally add
 FP32 residual rows sharded across ranks and gathers normalized FP16 inputs at
 the existing precision boundary. Both native SM70 attention backends support
 this option; it rejects BF16, Ref2VA, adapters and non-TP4 configurations. It defaults to
-false. The native FlashAttention 39-frame/20-update run measures 58.794562 s
+false. Normalized FP16 rows are now rotated locally before all-gather, avoiding
+four copies of the same ConvRot work while preserving gathered bits and GEMMs.
+The native FlashAttention 39-frame/20-update run measures 58.190385 s
 and 6.195001125 GiB peak denoise allocation/card, versus 62.804019 s and
 6.566735744 GiB without the flag, with zero persistent cache in both cases.
-Automatic media checks pass; changed FP32 reduction order requires human
-quality review, which remains pending. Omit the flag to restore the default.
+Its complete audio/video latents equal the earlier 58.794562-second sharded
+run bitwise, so that run's checked decode is reused. Automatic checks pass;
+the sharded route changes FP32 reduction order from the default and its human
+quality review remains pending. Omit the flag to restore the default.
 These are short development measurements, not the 243-frame acceptance run.
 
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -97,6 +97,18 @@ large FP32 activation intermediate without lowering arithmetic precision or
 adding a persistent cache. CPU, unquantized and FP32-input paths keep their
 existing implementation.
 
+For the measured TP4 FL2VA INT8 development workload, optionally add
+`--residual-sequence-parallel` to `video generate` or `video serve`. This keeps
+FP32 residual rows sharded across ranks and gathers normalized FP16 inputs at
+the existing precision boundary. Both native SM70 attention backends support
+this option; it rejects BF16, Ref2VA and non-TP4 configurations. It defaults to
+false. The native FlashAttention 39-frame/20-update run measures 58.794562 s
+and 6.195001125 GiB peak denoise allocation/card, versus 62.804019 s and
+6.566735744 GiB without the flag, with zero persistent cache in both cases.
+Automatic media checks pass; changed FP32 reduction order requires human
+quality review, which remains pending. Omit the flag to restore the default.
+These are short development measurements, not the 243-frame acceptance run.
+
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
 `nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
 replace the five-axis human quality review. Useful TFLOPS use actual local

--- a/tests/video/test_h3_local_rotation.py
+++ b/tests/video/test_h3_local_rotation.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact ConvRot-before-gather regression on TP4, with real INT8 projections."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.video import test_h3_residual_parallel as residual_tests
+from vllm.model_executor.models.minimax_h3 import transformer
+from vllm.model_executor.models.minimax_h3.quantization import (
+    DiffusionInt8ConvRotConfig,
+    H3QKVParallelLinear,
+    Int8ConvRotLayerConfig,
+    Int8ConvRotLinearMethod,
+    rotate_local_fp16,
+)
+
+tp4_group = residual_tests.tp4_group
+
+
+def test_cpu_rotation_preserves_original_path_and_rejects_pre_rotated_input():
+    method = Int8ConvRotLinearMethod(
+        DiffusionInt8ConvRotConfig(), Int8ConvRotLayerConfig(True), prefix="blocks.0"
+    )
+    layer = SimpleNamespace(quant_method=method, bias=None, gather_output=False)
+    x = torch.randn(17, 256, dtype=torch.float16)
+    actual, rotated = rotate_local_fp16(layer, x)
+    assert actual is x and not rotated
+    with pytest.raises(ValueError, match="Pre-rotated H3"):
+        H3QKVParallelLinear.forward(layer, x, input_is_rotated=True)
+
+
+@torch.inference_mode()
+def test_gpu_local_rotation_preserves_tp4_blocks_and_hooks(tp4_group, monkeypatch):
+    from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+    from vllm.video.metrics import DenoiseWorkCounter
+
+    group = tp4_group
+    names = ("attn.qkv_proj", "attn.out_proj", "mlp.fc1", "mlp.fc2")
+    quant = DiffusionInt8ConvRotConfig(
+        layer_configs={
+            f"blocks.0.{name}": {"format": "int8_tensorwise", "convrot": True}
+            for name in names
+        }
+    )
+    arch = transformer.MiniMaxH3DiTArchConfig(
+        hidden_size=512,
+        num_attention_heads=8,
+        ffn_hidden_size=1024,
+        adaln_curve_grid=2,
+        adaln_out_features=18 * 512,
+    )
+    token = attention_backend.set("FLASH_ATTN_V100")
+    try:
+        block = (
+            transformer.MiniMaxH3DiTBlock(
+                arch, quant, prefix="blocks.0", residual_sequence_parallel=True
+            )
+            .cuda()
+            .eval()
+        )
+    finally:
+        attention_backend.reset(token)
+    torch.manual_seed(1234 + group.rank_in_group)
+    for name, parameter in block.named_parameters():
+        if parameter.dtype == torch.int8:
+            parameter.random_(-7, 8)
+        elif name.endswith("weight_scale"):
+            parameter.fill_(0.005)
+        elif "norm" in name:
+            parameter.fill_(1)
+        else:
+            parameter.normal_(0, 0.03)
+    for layer in block.modules():
+        method = getattr(layer, "quant_method", None)
+        if isinstance(method, Int8ConvRotLinearMethod):
+            method.process_weights_after_loading(layer)
+    original = rotate_local_fp16
+    observed = []
+
+    def checked_rotation(layer, values):
+        result, selected = original(layer, values)
+        assert selected
+        observed.append(tuple(values.shape))
+        return result, selected
+
+    for cached in (False, True):
+        if cached:
+            for layer in block.modules():
+                if isinstance(
+                    getattr(layer, "quant_method", None), Int8ConvRotLinearMethod
+                ):
+                    layer.h3_fp16_weight = w8a16_extension().dequantize(
+                        layer.weight, layer.weight_scale
+                    )
+        for valid in (33, 131):
+            torch.manual_seed(42)
+            total = (valid + 3) // 4 * 4
+            full = torch.randn(total, 512, device="cuda", dtype=torch.float32)
+            full[::5, 0] = 70000
+            local = full.chunk(4, dim=0)[group.rank_in_group].clone()
+            kwargs = dict(
+                t_emb=torch.randn(1, 8, device="cuda"),
+                combined_indices=torch.arange(total, device="cuda") % 3,
+                rope_table=torch.randn(total, 96, device="cuda"),
+                cu_seqlens=torch.tensor([0, valid], device="cuda", dtype=torch.int32),
+                max_seqlen=valid,
+                packed_total=total,
+            )
+            outputs, counts = [], []
+            for enabled in (False, True):
+                observed.clear()
+                monkeypatch.setattr(
+                    transformer,
+                    "rotate_local_fp16",
+                    checked_rotation if enabled else lambda layer, x: (x, False),
+                )
+                counter = DenoiseWorkCounter(
+                    block, used_length=valid, video_outputs=valid, audio_outputs=0
+                )
+                value = local.clone()
+                try:
+                    for _ in range(2):
+                        value = block(value, **kwargs)
+                    counts.append((counter.flops, dict(counter.by_layer)))
+                finally:
+                    counter.close()
+                outputs.append(value)
+                if enabled:
+                    assert observed == [(total // 4, 512)] * 4
+            assert counts[0] == counts[1]
+            assert torch.isfinite(outputs[1]).all()
+            assert outputs[1].abs().max() > torch.finfo(torch.float16).max
+            torch.testing.assert_close(outputs[0], outputs[1], atol=0, rtol=0)

--- a/tests/video/test_h3_residual_parallel.py
+++ b/tests/video/test_h3_residual_parallel.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TP4 residual tests: launch the GPU cases with torchrun --nproc-per-node=4."""
+
+import argparse
+import os
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.model_executor.models.minimax_h3.transformer import MiniMaxH3DiTBlock
+
+
+@pytest.mark.parametrize("backend", ["FLASH_ATTN_V100", "FLASHINFER_SM70"])
+def test_residual_parallel_accepts_native_sm70_backends(backend):
+    config = H3Config(
+        transformer_path="int8.safetensors",
+        attention_backend=backend,
+        residual_sequence_parallel=True,
+    )
+    assert config.residual_sequence_parallel
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"tensor_parallel_size": 1},
+        {"tensor_parallel_size": 2},
+        {"attention_backend": "TORCH_SDPA"},
+        {"partition": "ref2va"},
+        {"transformer_path": None},
+    ],
+)
+def test_residual_parallel_rejects_unvalidated_deployments(change):
+    config = H3Config(
+        transformer_path="int8.safetensors",
+        attention_backend="FLASHINFER_SM70",
+        residual_sequence_parallel=True,
+    )
+    with pytest.raises(H3InputError, match="residual sequence parallelism"):
+        replace(config, **change)
+
+
+@pytest.mark.parametrize("mode", ["generate", "serve"])
+def test_residual_parallel_is_explicit_in_both_entrypoints(mode):
+    from vllm.entrypoints.cli.video import VideoSubcommand
+
+    parser = argparse.ArgumentParser()
+    VideoSubcommand().subparser_init(parser.add_subparsers())
+    assert not parser.parse_args(["video", mode]).residual_sequence_parallel
+    assert parser.parse_args(
+        ["video", mode, "--residual-sequence-parallel"]
+    ).residual_sequence_parallel
+
+
+@pytest.mark.parametrize(
+    "rows,total,dtype,extra",
+    [
+        (4, 17, torch.float32, {}),
+        (16, 16, torch.float32, {}),
+        (4, 16, torch.float16, {}),
+        (4, 16, torch.float32, {"num_requests": 2}),
+        (4, 16, torch.float32, {"sp_seq_lens": [4] * 4}),
+    ],
+)
+def test_residual_parallel_rejects_invalid_rows_before_collectives(
+    rows, total, dtype, extra
+):
+    block = SimpleNamespace(
+        residual_group=SimpleNamespace(world_size=4, rank_in_group=0)
+    )
+    with pytest.raises(ValueError, match="local FP32 rows"):
+        MiniMaxH3DiTBlock.forward(
+            block,
+            torch.zeros(rows, 8, dtype=dtype),
+            t_emb=torch.zeros(1, 8),
+            combined_indices=torch.zeros(total, dtype=torch.long),
+            rope_table=torch.zeros(total, 8),
+            cu_seqlens=torch.tensor([0, total]),
+            max_seqlen=total,
+            packed_total=total,
+            **extra,
+        )
+
+
+@pytest.fixture
+def tp4_group():
+    if os.environ.get("WORLD_SIZE") != "4":
+        pytest.skip("requires torchrun --nproc-per-node=4 on a leased GPU group")
+    from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed import (
+        cleanup_dist_env_and_memory,
+        get_tp_group,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.accelerator.set_device_index(local_rank)
+    torch.set_num_threads(2)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(tensor_parallel_size=4))
+    ):
+        init_distributed_environment(4, rank, "env://", local_rank, "nccl")
+        initialize_model_parallel(4)
+        try:
+            yield get_tp_group()
+        finally:
+            cleanup_dist_env_and_memory()
+
+
+@torch.inference_mode()
+def test_gpu_residual_parallel_matches_replicated_blocks(tp4_group):
+    # The repository's autouse fixture tears down distributed state after each
+    # test. Keep all collective shapes inside the same torchrun lifetime.
+    for valid in (32, 33, 131):
+        for backend in ("FLASH_ATTN_V100", "FLASHINFER_SM70"):
+            _check_replicated_blocks(tp4_group, valid, backend)
+
+
+def _check_replicated_blocks(group, valid, backend):
+    from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.transformer import (
+        MiniMaxH3DiTArchConfig,
+    )
+
+    arch = MiniMaxH3DiTArchConfig(
+        hidden_size=512,
+        num_attention_heads=8,
+        ffn_hidden_size=1024,
+        adaln_curve_grid=2,
+        adaln_out_features=18 * 512,
+    )
+    token = attention_backend.set(backend)
+    try:
+        baseline = MiniMaxH3DiTBlock(arch, None, prefix="blocks.0").cuda().eval()
+        candidate = (
+            MiniMaxH3DiTBlock(
+                arch, None, prefix="blocks.0", residual_sequence_parallel=True
+            )
+            .cuda()
+            .eval()
+        )
+    finally:
+        attention_backend.reset(token)
+    # Rank-dependent projection weights exercise real TP partial sums.
+    torch.manual_seed(1234 + group.rank_in_group)
+    for name, parameter in baseline.named_parameters():
+        if "norm" in name:
+            parameter.fill_(1)
+        else:
+            parameter.normal_(0, 0.03)
+    candidate.load_state_dict(baseline.state_dict())
+    torch.manual_seed(42)
+    total = (valid + 3) // 4 * 4
+    x = torch.randn(total, 512, device="cuda", dtype=torch.float32)
+    x[::5, 0] = 70000  # Residuals must not pass through an FP16 collective.
+    kwargs = dict(
+        t_emb=torch.randn(1, 8, device="cuda"),
+        combined_indices=torch.arange(total, device="cuda") % 3,
+        rope_table=torch.randn(total, 96, device="cuda"),
+        cu_seqlens=torch.tensor([0, valid], device="cuda", dtype=torch.int32),
+        max_seqlen=valid,
+        packed_total=total,
+    )
+    rows = total // 4
+    actual = x.narrow(0, group.rank_in_group * rows, rows).clone()
+    expected = x.clone()
+    for _ in range(2):
+        expected = baseline(expected, **kwargs)
+        actual = candidate(actual, **kwargs)
+    actual = group.all_gather(actual, dim=0)
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all()
+    assert actual.abs().max() > torch.finfo(torch.float16).max
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=3e-4)
+    # Modifying padding must not change any valid attention output.
+    if valid < total:
+        changed = x.clone()
+        changed[valid:] *= 10
+        altered = candidate(
+            changed.narrow(0, group.rank_in_group * rows, rows), **kwargs
+        )
+        original = candidate(x.narrow(0, group.rank_in_group * rows, rows), **kwargs)
+        torch.testing.assert_close(
+            group.all_gather(altered, dim=0)[:valid],
+            group.all_gather(original, dim=0)[:valid],
+            rtol=0,
+            atol=0,
+        )

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -40,6 +40,11 @@ class VideoSubcommand(CLISubcommand):
             mode.add_argument(
                 "--int8-weight-layout", choices=["row", "column"], default="column"
             )
+            mode.add_argument(
+                "--residual-sequence-parallel",
+                action="store_true",
+                help=("Experimental FP32 residual sharding for TP4 FL2VA INT8"),
+            )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
             if name == "generate":
                 mode.add_argument("--prompt", default=DEFAULT_PROMPT)
@@ -77,6 +82,7 @@ class VideoSubcommand(CLISubcommand):
             fp16_weight_cache_gib=args.fp16_weight_cache_gib,
             fp16_cache_layers=tuple(args.fp16_cache_layer),
             int8_weight_layout=args.int8_weight_layout,
+            residual_sequence_parallel=args.residual_sequence_parallel,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -41,6 +41,7 @@ class H3Config:
     fp16_weight_cache_gib: float = 0.0
     fp16_cache_layers: tuple[str, ...] = ()
     int8_weight_layout: str = "column"
+    residual_sequence_parallel: bool = False
 
     def __post_init__(self) -> None:
         if self.partition not in ("fl2va", "ref2va"):
@@ -55,6 +56,17 @@ class H3Config:
             "TORCH_SDPA",
         ):
             raise H3InputError(f"unsupported H3 attention: {self.attention_backend}")
+        if self.residual_sequence_parallel and (
+            self.tensor_parallel_size != 4
+            or self.attention_backend not in ("FLASH_ATTN_V100", "FLASHINFER_SM70")
+            or self.partition != "fl2va"
+            or not self.transformer_path
+        ):
+            raise H3InputError(
+                "experimental residual sequence parallelism requires TP4, "
+                "FLASH_ATTN_V100 or FLASHINFER_SM70 and an FL2VA INT8 "
+                "ConvRot checkpoint"
+            )
         if (
             not math.isfinite(self.fp16_weight_cache_gib)
             or self.fp16_weight_cache_gib < 0

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -464,7 +464,10 @@ class MiniMaxH3Pipeline(nn.Module):
         token = attention_backend.set(config.attention_backend)
         try:
             self.transformer = MiniMaxH3DiTModel(
-                architecture, quant_config=quant, arch_overrides=overrides
+                architecture,
+                quant_config=quant,
+                arch_overrides=overrides,
+                residual_sequence_parallel=config.residual_sequence_parallel,
             )
         finally:
             attention_backend.reset(token)

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -21,8 +21,11 @@ from torch.nn import Module
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
     LinearBase,
     LinearMethodBase,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
     RowParallelLinear,
     UnquantizedLinearMethod,
 )
@@ -393,13 +396,13 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             output = torch.nn.functional.linear(x, weight, bias)
         return output.reshape(*original_shape[:-1], layer.weight.shape[0])
 
-    def apply_prepared(self, layer, values, scale):
+    def apply_prepared(self, layer, values, scale, *, input_is_rotated=False):
         """Project FP16 rows with an explicit scale restored before TP reduction."""
         from .cuda_ops import fp16_gemm, w8a16_extension
 
         ops = w8a16_extension()
         x = values.reshape(-1, values.shape[-1])
-        if self.layer_config.convrot:
+        if self.layer_config.convrot and not input_is_rotated:
             if self.layer_config.convrot_groupsize != 256:
                 raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
             x = ops.rotate(x)
@@ -412,6 +415,55 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
         if scale is not None:
             output = output * scale
         return output.reshape(*values.shape[:-1], layer.weight.shape[0])
+
+
+def rotate_local_fp16(layer, values):
+    """Rotate local residual rows before their bit-preserving TP all-gather."""
+    method = layer.quant_method
+    if (
+        values.is_cuda
+        and values.dtype == torch.float16
+        and isinstance(method, Int8ConvRotLinearMethod)
+        and method.layer_config.convrot
+        and method.layer_config.convrot_groupsize == 256
+        and layer.bias is None
+        and not layer.gather_output
+    ):
+        from .cuda_ops import w8a16_extension
+
+        return w8a16_extension().rotate(values), True
+    return values, False
+
+
+class _H3RotatedColumnInput(ColumnParallelLinear):
+    def forward(self, input_, *, input_is_rotated=False):
+        if not input_is_rotated:
+            return super().forward(input_)
+        method = self.quant_method
+        if (
+            not input_.is_cuda
+            or input_.dtype != torch.float16
+            or self.bias is not None
+            or self.gather_output
+            or not isinstance(method, Int8ConvRotLinearMethod)
+            or not method.layer_config.convrot
+            or method.layer_config.convrot_groupsize != 256
+        ):
+            raise ValueError(
+                "Pre-rotated H3 columns require bias-free INT8 FP16 inputs"
+            )
+        # The module still receives every gathered row: ordinary forward hooks
+        # and useful-FLOP accounting retain the original full projection shape.
+        output = method.apply_prepared(self, input_, None, input_is_rotated=True)
+        return (output, None) if self.return_bias else output
+
+
+class H3QKVParallelLinear(_H3RotatedColumnInput, QKVParallelLinear):
+    """QKV projection accepting explicitly rotated, gathered FP16 rows."""
+
+
+class H3MergedColumnParallelLinear(_H3RotatedColumnInput, MergedColumnParallelLinear):
+    """Gate/up projection accepting explicitly rotated, gathered FP16 rows."""
 
 
 class H3RowParallelLinear(RowParallelLinear):

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 import torch.nn as nn
 
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import (
@@ -799,6 +799,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        residual_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
@@ -815,6 +816,14 @@ class MiniMaxH3DiTBlock(nn.Module):
             quant_config,
             prefix=f"{prefix}.mlp",
         )
+        self.residual_group = get_tp_group() if residual_sequence_parallel else None
+        if self.residual_group is not None:
+            if self.residual_group.world_size != 4:
+                raise ValueError("H3 residual sequence parallelism requires TP4")
+            # These projections return unreduced FP32 partial sums. Reduce-scatter
+            # keeps that precision and assigns each rank its residual rows.
+            self.attn.out_proj.reduce_results = False
+            self.mlp.fc2.reduce_results = False
         self.adaln_proj = MiniMaxH3AdalnProj(
             arch,
             arch.adaln_out_features,
@@ -845,6 +854,23 @@ class MiniMaxH3DiTBlock(nn.Module):
         norm1 -> scale/shift -> attention -> gated residual, followed by
         norm2 -> scale/shift -> MLP -> gated residual.
         """
+        group = self.residual_group
+        if group is not None:
+            total = combined_indices.shape[0]
+            if (
+                num_requests != 1
+                or sp_seq_lens is not None
+                or total % group.world_size
+                or x.shape[0] != total // group.world_size
+                or x.dtype != _FP32_DTYPE
+            ):
+                raise ValueError(
+                    "H3 residual sequence parallelism needs local FP32 rows, "
+                    "TP-aligned global metadata and a single request without Ulysses"
+                )
+            combined_indices = combined_indices.narrow(
+                0, group.rank_in_group * x.shape[0], x.shape[0]
+            )
         (
             shift_msa,
             scale_msa,
@@ -864,6 +890,9 @@ class MiniMaxH3DiTBlock(nn.Module):
             self.norm1.variance_epsilon,
             output_dtype=_COMPUTE_DTYPE,
         )
+        if group is not None:
+            # Gather only after the existing normalization's FP16 boundary.
+            h = group.all_gather(h, dim=0)
         h = self.attn(
             h,
             rope_table=rope_table,
@@ -874,6 +903,8 @@ class MiniMaxH3DiTBlock(nn.Module):
             sp_seq_lens=sp_seq_lens,
             video_layout=video_layout,
         )
+        if group is not None:
+            h = group.reduce_scatter(h, dim=0)
         x, h = indexed_gate_rms_norm_scale_shift(
             residual,
             gate_msa,
@@ -886,7 +917,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             output_dtype=_COMPUTE_DTYPE,
         )
         residual = x
+        if group is not None:
+            h = group.all_gather(h, dim=0)
         h = self.mlp(h)
+        if group is not None:
+            h = group.reduce_scatter(h, dim=0)
         return indexed_gate(residual, gate_mlp, h, combined_indices)
 
 
@@ -1013,6 +1048,8 @@ class MiniMaxH3DiTModel(nn.Module):
         config: Mapping[str, Any],
         quant_config: QuantizationConfig | None = None,
         arch_overrides: Mapping[str, Any] | None = None,
+        *,
+        residual_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         config_mapping = dict(config)
@@ -1036,6 +1073,15 @@ class MiniMaxH3DiTModel(nn.Module):
         self._qkv_checkpoint_is_runtime_layout = bool(
             getattr(quant_config, "is_checkpoint_int8_convrot_serialized", False)
         )
+        self.residual_sequence_parallel = residual_sequence_parallel
+        if residual_sequence_parallel and (
+            get_tensor_model_parallel_world_size() != 4
+            or not self._qkv_checkpoint_is_runtime_layout
+        ):
+            raise ValueError(
+                "H3 residual sequence parallelism requires TP4 "
+                "and serialized INT8 ConvRot"
+            )
         self.hidden_size = arch.hidden_size
         self.num_attention_heads = arch.num_attention_heads
         self.num_channels_latents = arch.latents_dim
@@ -1100,6 +1146,7 @@ class MiniMaxH3DiTModel(nn.Module):
                     arch,
                     quant_config,
                     prefix=f"blocks.{i}",
+                    residual_sequence_parallel=residual_sequence_parallel,
                 )
                 for i in range(arch.num_layers)
             ]
@@ -1520,6 +1567,23 @@ class MiniMaxH3DiTModel(nn.Module):
                 block_rope,
                 block_combined,
             )
+        residual_group = None
+        if self.residual_sequence_parallel:
+            residual_group = get_tp_group()
+            if (
+                local_len != seq_len
+                or hidden.shape[0] != seq_len
+                or block_combined.shape[0] != seq_len
+                or block_rope.shape[0] != seq_len
+                or seq_len % residual_group.world_size
+                or num_requests != 1
+            ):
+                raise ValueError(
+                    "H3 residual sequence parallelism requires a single request "
+                    "with TP-aligned global rows and no sequence-parallel hooks"
+                )
+            rows = seq_len // residual_group.world_size
+            hidden = hidden.narrow(0, residual_group.rank_in_group * rows, rows)
         for block in self.blocks:
             hidden = block(
                 hidden,
@@ -1532,6 +1596,9 @@ class MiniMaxH3DiTModel(nn.Module):
                 num_requests=num_requests,
                 video_layout=video_layout,
             )
+        if residual_group is not None:
+            # Final heads and the existing padding boundary consume full FP32 rows.
+            hidden = residual_group.all_gather(hidden, dim=0)
         if local_len == seq_len:
             hidden = self.sp_gather(hidden)
             video_logits, audio_logits = self.final_layer(

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -21,8 +21,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -42,9 +40,12 @@ from .modulation import (
 )
 from .ops import RMSNorm, RotaryEmbedding, fused_qk_norm_rope
 from .quantization import (
+    H3MergedColumnParallelLinear,
+    H3QKVParallelLinear,
     H3RowParallelLinear,
     Int8ConvRotLinearMethod,
     preserve_fp32_output,
+    rotate_local_fp16,
 )
 
 if TYPE_CHECKING:
@@ -375,7 +376,7 @@ class MiniMaxH3Attention(nn.Module):
         self.head_dim = arch.attention_head_dim
         inner_dim = self.total_num_heads * self.head_dim
         self.softmax_scale = self.head_dim**-0.5
-        self.qkv_proj = QKVParallelLinear(
+        self.qkv_proj = H3QKVParallelLinear(
             hidden_size=arch.hidden_size,
             head_size=self.head_dim,
             total_num_heads=self.total_num_heads,
@@ -547,6 +548,7 @@ class MiniMaxH3Attention(nn.Module):
         num_requests: int = 1,
         sp_seq_lens: list[int] | None = None,
         video_layout: VideoTokenLayout | None = None,
+        input_is_rotated: bool = False,
     ) -> torch.Tensor:
         """x: [T, hidden] packed thd rows -> [T, hidden].
 
@@ -560,7 +562,10 @@ class MiniMaxH3Attention(nn.Module):
         all-to-all restores the row shard before the output projection.
         """
         total = x.shape[0]
-        qkv, _ = self.qkv_proj(x)
+        if input_is_rotated:
+            qkv, _ = self.qkv_proj(x, input_is_rotated=True)
+        else:
+            qkv, _ = self.qkv_proj(x)
         q_size = self.num_heads * self.head_dim
         kv_size = self.num_kv_heads * self.head_dim
         q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
@@ -610,7 +615,7 @@ class MiniMaxH3MLP(nn.Module):
         prefix: str,
     ) -> None:
         super().__init__()
-        self.fc1 = MergedColumnParallelLinear(
+        self.fc1 = H3MergedColumnParallelLinear(
             arch.hidden_size,
             [arch.ffn_hidden_size, arch.ffn_hidden_size],
             bias=False,
@@ -633,8 +638,11 @@ class MiniMaxH3MLP(nn.Module):
         )
         preserve_fp32_output(self.fc2)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        hidden, _ = self.fc1(x)
+    def forward(self, x: torch.Tensor, *, input_is_rotated=False) -> torch.Tensor:
+        if input_is_rotated:
+            hidden, _ = self.fc1(x, input_is_rotated=True)
+        else:
+            hidden, _ = self.fc1(x)
         if (
             hidden.is_cuda
             and hidden.dtype == torch.float16
@@ -890,8 +898,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             self.norm1.variance_epsilon,
             output_dtype=_COMPUTE_DTYPE,
         )
+        input_is_rotated = False
         if group is not None:
-            # Gather only after the existing normalization's FP16 boundary.
+            # Rotation is row-independent. Compute it once on each row's owner,
+            # after the existing FP16 boundary, then gather its exact FP16 bits.
+            h, input_is_rotated = rotate_local_fp16(self.attn.qkv_proj, h)
             h = group.all_gather(h, dim=0)
         h = self.attn(
             h,
@@ -902,6 +913,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             num_requests=num_requests,
             sp_seq_lens=sp_seq_lens,
             video_layout=video_layout,
+            input_is_rotated=input_is_rotated,
         )
         if group is not None:
             h = group.reduce_scatter(h, dim=0)
@@ -917,9 +929,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             output_dtype=_COMPUTE_DTYPE,
         )
         residual = x
+        input_is_rotated = False
         if group is not None:
+            h, input_is_rotated = rotate_local_fp16(self.mlp.fc1, h)
             h = group.all_gather(h, dim=0)
-        h = self.mlp(h)
+        h = self.mlp(h, input_is_rotated=input_is_rotated)
         if group is not None:
             h = group.reduce_scatter(h, dim=0)
         return indexed_gate(residual, gate_mlp, h, combined_indices)


### PR DESCRIPTION
## Purpose

Add opt-in `--residual-sequence-parallel` for TP4 FL2VA INT8 on both native SM70 attention backends. Each rank keeps FP32 residual rows, normalizes at the existing FP16 boundary, rotates those local rows once, gathers their exact bits for QKV/gate-up GEMMs, and reduce-scatters FP32 projection results. This avoids replicated normalization/gating and ConvRot work with no persistent weight cache. The option defaults to false and rejects unvalidated BF16/Ref2VA/adapter combinations.

Native FlashAttention, 1344x768,39 frames/24 FPS,seed42,20 actual updates/21 sigma positions now takes **58.190385 s** (2.909519 s/update, **59.524500 useful model TFLOPS/card**). The prior sharded run takes58.794562 s; the flag-off baseline takes62.804019 s. Peak denoise Torch allocation remains **6.195001125 GiB/card** versus6.566735744 GiB for the default. Persistent FP16 cache and Lt workspace are zero. These are separate single unprofiled development runs with prompt-verified cached text and one-call warmup, not end-to-end or formal medians.

Residual sharding reuses the independent FI implementation at `5b4f0bba31f532057cf288787a6c8dafa5ec471f`. Local rotation reuses its read-only working-tree snapshot based on `53780abef0e9ef190aa55a1f61d8fd5fbd390aa1`, uncommitted at capture; patch SHA256 `ce41592338adeef0388c7b5b826351d378c468bfa58e7df3def662cf7056dc4b`. The regression is adapted to native FlashAttention. This existing PR consolidates FA integration and validation of that common dataflow; it does not duplicate #564's independent FI attention-kernel work. No FI attention delegation or installed H3 CUDA binary change occurs. Latest retained source: `ca5b6a855b`; integration main: `e7fa44deb2`; original campaign base: `56f534e672`.

## Test Plan

Retain the original ConvRot256 arithmetic, FP16 boundary, scales, GEMMs and useful-FLOP hooks. Check actual TP4 cached/uncached INT8 blocks and a complete20-update request, with profiler timing separate. Keep the option disabled pending human quality review; omit it for rollback, or use parent `2a560b0a7fa0` to revert local rotation only.

## Test Result

- `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/video/test_h3_numerics.py tests/video/test_h3_activation.py tests/video/test_h3_local_rotation.py tests/video/test_h3_service.py -q -x -k 'not gpu_local_rotation'`:62 passed,1 deselected. The exact environment/interpreter is recorded in the evidence job JSON.
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=$PWD .venv/bin/python -m torch.distributed.run --standalone --nproc-per-node=4 -m pytest tests/video/test_h3_local_rotation.py -q -x -k gpu`:one four-rank test passes on every rank. It covers two valid/padded lengths, consecutive blocks, rank-specific weights, cached/uncached INT8, FP32 residuals above65504, exact outputs and unchanged FLOP hooks. Run distributed modules in separate pytest lifetimes because fixtures tear down distributed state.
- Three paired two-update medians:5.878070 ->5.813375 s. Full20 video/audio latents are finite, equal across ranks and **bitwise equal** to the58.79-second run. Its checked media is reused after latent and MP4-hash checks; no fresh VAE decode or new end-to-end result is claimed.
- The initial sharded run had a fresh decode passing automatic checks, with video/audio latent relative RMS deltas3.87465%/1.20270% from the default, SSIM0.983989 and PSNR38.238221 dB. Human audiovisual scoring remains pending. Earlier70-targeted/78-integration test results are recorded separately, not added to this round's counts.
- Pre-commit passes. Eight new attention variants pass12-length output/reference checks but lack stable paired gains; query-window overlap and a TP4 block pipeline also lose. None is installed. The pipeline prototype's padding-inflated raw FLOP counter is excluded from acceptance.
- Evidence: `/data/minimax-h3/native-h3-20260908/flashattention-register50/REPORT.md`, `report.json`, exact job JSON, source hashes, failed paths and NVML curves. Media: `outputs/quality39-int8-flashattn-localrot-20steps/FLASH_ATTN_V100/` under the artifact root's parent. Local reproduction: the report's `reproduce.py --output <new-directory>` command. See CONTROL.md for prior NCU/SASS and Nsight root-cause evidence.

**Under50 seconds, standalone attention60 TFLOPS, formal243-frame/three-run/per-card80 TFLOPS and human quality gates remain incomplete.**

AI assistance: OpenAI Codex implemented, tested and documented this draft at the user's request. Human review of every changed line and the pending audiovisual quality gate are still required before merge.
