### PR TITLE
[Video] Add explicit NVENC export for native H3

### DIFF
--- a/docs/design/minimax_h3/API.md
+++ b/docs/design/minimax_h3/API.md
@@ -23,6 +23,40 @@ This remains one partition per engine. For reference generation, select
 `--partition ref2va` and the corresponding transformer. Keep a stable public API
 URL in the frontend's own reverse proxy when deploying it separately.
 
+### GPU video encoding
+
+Both `vllm video generate` and `vllm video serve` accept
+`--video-encoder h264_nvenc`. Select an FFmpeg executable built with NVENC:
+
+```bash
+IMAGEIO_FFMPEG_EXE=/usr/bin/ffmpeg vllm video serve \
+  --model /path/to/MiniMax-H3 \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --tensor-parallel-size 4 --video-encoder h264_nvenc \
+  --host 127.0.0.1 --port 8000 --output-dir ./h3-jobs
+```
+
+The encoder runs on the rank-0 GPU inside the engine's leased group. RGBA
+packing runs on the input tensor's device; NVENC handles RGB-to-YUV420 conversion
+and H.264 compression. The current subprocess pipe still transfers raw frames
+through host memory. Audio encoding, MP4 muxing, and file I/O remain on the CPU.
+This does not distribute one video's encoding across the DiT tensor-parallel
+group. See [NVIDIA's FFmpeg guide](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/ffmpeg-with-nvidia-gpu/index.html).
+
+The default remains `libx264` with CRF 18 / medium. NVENC uses VBR CQ 18 / p4 /
+HQ; equal numeric quality settings do not guarantee equal bitrate or quality.
+The selected FFmpeg must support `h264_nvenc`, packed RGBA, and `-rgb_mode`.
+Some imageio-ffmpeg bundled executables omit NVENC. A requested NVENC export
+fails with an `encode.log` diagnostic if unavailable; it never silently switches
+to CPU encoding.
+
+Rank-0 run metadata records `video_encoder`, `encoding_device`,
+`preparation_device`, `ffmpeg_executable`, and `export_stage_seconds`.
+The latter separates frame preparation/copy, WAV writing, FFmpeg startup/feed,
+and encoder/muxer completion. Feed time includes pipe backpressure and overlaps
+encoding, so these are sequential wall intervals rather than GPU kernel timings.
+The frontend video API and output audio/video contract are unchanged.
+
 ## Endpoints
 
 | Method | Path | Result |

--- a/docs/design/minimax_h3/API.md
+++ b/docs/design/minimax_h3/API.md
@@ -56,6 +56,8 @@ The latter separates frame preparation/copy, WAV writing, FFmpeg startup/feed,
 and encoder/muxer completion. Feed time includes pipe backpressure and overlaps
 encoding, so these are sequential wall intervals rather than GPU kernel timings.
 The frontend video API and output audio/video contract are unchanged.
+See [the V100 export measurement](GPU_EXPORT.md) for measured latency, output
+quality, file-size tradeoffs, and the remaining host-memory transfer cost.
 
 ## Endpoints
 

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -14,6 +14,76 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Local ConvRot before gather: 58.19 seconds
+
+The optional residual-sharded route now rotates normalized FP16 rows on their
+owning rank before all-gather. QKV and gate/up projections consume those exact
+gathered bits without repeating ConvRot. Each rank rotates one quarter of the
+rows; the original ConvRot256 arithmetic, INT8 scales, projection shapes and
+FLOP hooks are preserved. CPU/unquantized paths retain ordinary forwards.
+This reuses a read-only working-tree snapshot from the independent FI task,
+based on `53780abef0e9ef190aa55a1f61d8fd5fbd390aa1`, with the regression adapted
+to native FlashAttention. Snapshot patch SHA256:
+`ce41592338adeef0388c7b5b826351d378c468bfa58e7df3def662cf7056dc4b`.
+The source was uncommitted in that tree at capture; no FI attention delegation
+or H3 CUDA binary change is involved.
+
+The unchanged 1344x768, 39-frame/24-FPS, seed42, INT8 ConvRot FL2VA, TP4 GPU0-3
+workload completes **20 actual updates in 58.190385 s**, or **2.909519 s/update
+and 59.524500 useful model TFLOPS/card**. This reduces the previous optional
+58.794562 s result by 0.604177 s (1.03%). Per-card useful FLOPs remain
+3,463,753,579,661,312. Peak denoise Torch allocation is unchanged at
+**6.195001125 GiB/card**; NVML peak device-used memory is 8.046386719 GiB/card.
+Persistent FP16 cache and Lt workspace remain zero. This is one unprofiled,
+cached-text development run after a one-call warmup, not formal acceptance.
+Three paired two-update checks give medians 5.878070 ->5.813375 s (1.10%).
+
+Both complete video/audio latent tensors are **bitwise equal** to the previous
+58.79-second run, finite and identical across ranks. Its decoded media is
+reused only after these checks and verification of the MP4 hash below. There
+is no new VAE or end-to-end timing. Automatic validity is preserved; the prior
+human audiovisual review remains pending. The option still defaults to false;
+the flag-off baseline remains 62.804019 s. Omit the flag to restore that path,
+or use parent `2a560b0a7fa0` to revert only the local-rotation change.
+
+Validation: 62 targeted tests pass, one GPU case is deselected. A separate
+torchrun invocation runs one actual four-rank test, passing on every rank:
+cached/uncached INT8 projections, two valid/padded lengths, consecutive blocks,
+rank-specific weights, residuals above 65504, exact output and unchanged FLOP
+hooks. Pre-commit passes. Do not combine distributed GPU test modules in one
+pytest lifetime: the repository fixture tears down distributed state between
+tests. Earlier sanitizer runs cover unchanged operators, not a new run here.
+
+Eight further attention variants remain artifact-only. All match the native
+output exactly across 12 tested lengths and pass sampled FP32 references;
+none establishes a stable paired speedup including wrapper/copy costs:
+
+| Candidate | Native control ms | Candidate ms | Decision |
+| --- | ---: | ---: | --- |
+| Register row max/sum | 20.210688 | 20.071424 | No stable paired gain |
+| Separate max/sum exchange | 20.093952 | 20.232191 | No gain |
+| Head-contiguous Q/K/V packing | 19.866625 | 20.254721 | Packing loses |
+| Direct Q/K vector iterators | 20.256767 | 21.655552 | Hot register spills |
+| Direct Q iterator | 20.048897 | 20.049919 | No gain |
+| Direct K iterator | 19.971071 | 20.135937 | No gain |
+| Direct V iterator | 20.254721 | 19.984385 | Clock drift; unstable gain |
+| PV-only 64x32 warp | 20.199425 | 23.879681 | Slower after mapping fix |
+
+Query-window attention/projection overlap also loses, including a version
+retaining the full-shape attention specialization and validated cloned GEMM
+plans. A three-window TP4 block pipeline takes about 6.04 s versus 5.87 s for
+two updates and introduces nonzero latent deltas; it is not integrated. Its
+raw hook counter includes 29 padding rows and is explicitly invalid for
+acceptance accounting. See `flashattention-register50/failed-paths.json` for
+exact jobs, sources and outcomes; do not repeat unchanged candidates.
+
+Latest evidence: `flashattention-register50/REPORT.md`, `report.json`, source
+snapshot hashes, paired probes, test logs and NVML curves. Media:
+`outputs/quality39-int8-flashattn-localrot-20steps/FLASH_ATTN_V100/`.
+**Under 50 seconds, attention 60 TFLOPS, formal per-card 80 TFLOPS and human
+quality acceptance remain incomplete.** GEMM/attention operand reuse remains
+the main optimization target; this small ConvRot gain does not resolve it.
+
 ### Optional FP32 residual row sharding: 58.79 seconds
 
 `--residual-sequence-parallel` enables an experimental TP4 FL2VA INT8 path

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,89 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Attention-focused diagnosis and V prefetch: 69.06 seconds
+
+The user redirects the next optimization to GEMM/attention arithmetic and data
+movement, with **60 useful TFLOPS for D128 attention** as the next operator
+milestone. Preserve the under-50-second complete-denoise and >80 TFLOPS/card
+model targets; none of these targets has passed.
+
+A fresh two-update trace of the 69.92-second native baseline records 2.515795 s
+of GEMM service (94.413296 useful TFLOPS) and 2.580667 s of attention service
+(42.179368 useful TFLOPS) on the critical rank. These are service rates, not
+complete-model throughput. The actual B1/N12323/H14/D128 noncausal attention
+call has 1,088,506,166,272 useful FLOPs; 60 TFLOPS requires 18.141769 ms.
+
+NCU on the same baseline binary finds 234 registers/thread, 26,128 shared
+bytes/block, two resident blocks and 12.5% occupancy. Tensor pipe activity is
+36.99%; HBM throughput is only 1.51%, while the L1/shared data path reaches
+61.64%. SASS-correlated samples identify long-scoreboard consumers at the
+QK/V shared stores after global loads, and short-scoreboard consumers at QK
+HMMA instructions. This supports addressing operand movement and latency
+hiding *inside* attention. It does not establish an HBM bandwidth limit.
+
+The retained change loads the first V fragment before softmax and passes it
+to a small adaptation of the existing SM70 PV software pipeline. Residual
+masks, FP16 rounding, FP32 accumulation and math order are unchanged. It keeps
+234 registers without spills, the same shared footprint and zero persistent
+FP16 cache / zero Lt workspace. The native helper's paired operator median
+is 24.522753 versus 25.702400 ms (44.387601 versus 42.350370 TFLOPS); clocks
+vary, so this is a development microbenchmark, not formal model acceptance.
+
+The new binary's independent NCU run reduces long-scoreboard stalls per
+issued instruction from 0.646730 to 0.342021. Tensor pipe activity rises from
+36.99% to 37.91%; short-scoreboard stalls remain. Do not interpret that stall
+ratio change as an equivalent wall-time reduction. Remaining work should
+address QK's shared-load/HMMA dependencies and input reuse.
+
+The installed CMake build completes the unchanged 39-frame/20-update TP4
+workload in **69.062335 s**, or 3.453117 s/update and 50.154018 useful
+TFLOPS/card: a 1.23% reduction from 69.923404 s. All ranks retain exactly
+6.647851467 GiB peak Torch allocation. Video/audio latents are bitwise equal;
+reuse of the baseline decode is explicit, with MP4 SHA256
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+Automatic media checks inherit the identical baseline output; human scoring
+is pending. The artifact prototype's 68.980006 s is a separate build/run.
+Neither timing is end-to-end or the formal three-run 243-frame acceptance.
+
+Eighteen native GPU tests pass, including newly added 32/33/96/97-key residual
+boundaries, strided storage, poisoned padding, online rescaling and graph
+replay. The standard CMake FlashAttention component builds. Binary SHA256 is
+`540474cfad758d4328ad0e0f00c745be62d3d8caaebea1d4bc19b86354442b9f`.
+
+CUDA12.8 isolated memcheck, racecheck and synccheck each pass thirteen cases
+with zero errors/hazards. Full pytest under memcheck completed its seventeen
+selected tests but reported a CUDA `cuKernelGetFunction` invalid-handle API
+error during module loading, as in the earlier full-environment diagnostic.
+Retain that failed log; the isolated run loads the exact installed extension
+without importing the full vLLM runtime. Ordinary GPU graph replay is covered
+by pytest; the isolated sanitizer harness does not test graph capture.
+
+Rejected or paused probes, all outside production source:
+
+| Probe | Paired candidate / control | Decision |
+| --- | --- | --- |
+| Manual QK shared fill | 44.529663 / 24.239103 ms | Exact but slower; retain original pipeline |
+| QK internal K64 stage | 25.759745 / 25.328640 ms | Exact, no improvement |
+| PV internal K64 stage | 26.507263 / 24.967169 ms | Exact, slower |
+| QK first-tile persistence / next-K prefetch | 25.236481 / 25.414656 ms | Only 0.7%, registers 234 to 254; not retained |
+| Q64/K128 with a 32x64 QK warp | NaN at length 63 | Rejected; grouped version spills, direct indexing removes spills but does not fix numerics |
+
+The wider QK path needs its accumulator/shared-memory mapping and boundary
+behavior fixed before any timing can be admitted. Its split-32 conversion
+attempt also fails length 63; do not repeat these variants unchanged. Earlier
+Q128/K32 wide-PV variants corrupt the length-one output; their direct-store
+workaround spills and slows down. Manual PV fill and larger Q/K tiles remain
+rejected in the retained artifact records.
+
+Evidence is under `flashattention-warp50/`: `report.json`,
+`attention60-root-cause.json`, `native-steps.nsys-rep`, both NCU reports and
+SASS-correlated samples, candidate source/build logs, native tests and quality
+commands. Media, rank/phase CSVs and NVML curves are under
+`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
+Rollback is the kernel parent `8cacbb70219c` plus a rebuild of
+`_h3_flashattn_C`; keep the existing column-major INT8 path.
+
 ### Low-memory follow-up: 69.92 seconds, under-50 target incomplete
 
 The user requires no substantial memory increase. Keep the persistent FP16

--- a/docs/design/minimax_h3/CONTROL.md
+++ b/docs/design/minimax_h3/CONTROL.md
@@ -11,6 +11,115 @@ the existing D256 TensorOp architecture; padding never increases useful FLOPs.
 
 ## 2026-09-08 FlashAttention-V100 D128 native route
 
+### Optional FP32 residual row sharding: 58.79 seconds
+
+`--residual-sequence-parallel` enables an experimental TP4 FL2VA INT8 path
+for either native SM70 attention backend. It defaults to false in both
+`video generate` and `video serve`. This reuses the committed residual dataflow
+from the independent FlashInfer branch at `5b4f0bba31`, adapting its backend
+gate and tests for FlashAttention-V100. No FlashInfer attention code is ported
+or delegated to when FlashAttention is selected.
+
+Each rank retains only its FP32 residual rows through the DiT blocks. The
+existing normalization boundary produces FP16 rows, which are gathered before
+QKV and MLP projection. Output projections retain FP32 partial sums and use
+FP32 reduce-scatter. Final heads receive the gathered FP32 rows. This reduces
+repeated normalization/gating work and intermediate data movement, preserving
+INT8/scale information, all GEMMs, valid attention tokens and denoise updates.
+The feature rejects unsupported TP sizes, BF16 checkpoints, Ref2VA, multiple
+requests and simultaneous Ulysses hooks. The original path remains available
+by omitting the flag; source rollback is kernel parent `9764b6c20259`.
+
+On the unchanged 1344x768, 39-frame/24-FPS, seed42, INT8 ConvRot FL2VA,
+TP4 GPU0-3 request, **20 actual updates take 58.794562 s**:
+**2.939728 s/update and 58.912822 useful model TFLOPS/card**. This is a 6.38%
+time reduction from the 62.804019 s default. Per-card useful FLOPs remain
+3,463,753,579,661,312. Peak denoise Torch allocation falls from 6.566735744 to
+**6.195001125 GiB/card**; NVML peak device-used memory is 8.171386719 GiB/card.
+Persistent FP16 weight cache and cuBLASLt workspace stay zero. This is one
+unprofiled development run with a one-call warmup and prompt-verified cached
+text, not an end-to-end or formal repeated measurement.
+
+Fresh VAE decoding takes 8.478661 s, with 34.904292 s VAE loading reported
+separately. All automatic media checks pass. FP32 reduction order changes:
+video/audio latent relative RMS differences from the 62.80-second baseline
+are 3.87465% /1.20270%. Decoded-video SSIM is 0.983989 and PSNR 38.238221 dB;
+these are auxiliary comparisons, not quality thresholds. Eight sampled frames
+show a consistent red boat, yellow duck and background. Human audiovisual
+scoring remains pending, so the option is not promoted to the default.
+MP4 SHA256 is
+`f00ba75587f58e2a63a105647cb634eebd60b154ab7b3551f385ca2df96e5243`.
+
+Separate two-update Nsight Systems traces explain the gain. Rank0 exclusive
+wall seconds close to each trace's own denoise NVTX span:
+
+| Category | Replicated residual | Sharded residual |
+| --- | ---: | ---: |
+| GEMM | 2.539663 | 2.550870 |
+| Attention | 2.005245 | 2.023926 |
+| TP collectives | 1.076831 | 0.845654 |
+| Other GPU kernels | 0.440786 | 0.237076 |
+| ConvRot | 0.125264 | 0.126346 |
+| Weight dequantization | 0.059483 | 0.059765 |
+| Copies | 0.012490 | 0.012507 |
+| FP16 preparation outside fused kernels | 0.000026 | 0.000025 |
+| No recorded GPU activity | 0.031895 | 0.035798 |
+| Complete trace span | 6.291683 | 5.891967 |
+
+The fused activation's preparation is included in other GPU kernels. GEMM
+and attention still consume about 78% of the new trace. This is not an idle
+optimization. Explicit copies are small; the profile does not establish an
+HBM-copy bottleneck. At 60 useful attention TFLOPS alone, the old trace still
+projects roughly 61 seconds for 20 updates with all other costs held fixed;
+this is an Amdahl illustration, not a measurement or hardware lower bound.
+
+NCU on the unchanged native wide attention reports 246 registers/thread,
+34,304 shared bytes/block, 12.47% achieved occupancy, 49.23% tensor-pipe
+activity, 66.46% L1/shared data-path throughput and 4.57% HBM throughput.
+SASS samples point to QK shared stores waiting for operands, shared-load/HMMA
+dependencies and PV address instructions. Higher occupancy alone is not a
+sufficient fix. Eight isolated paired candidates pass sampled FP32 references
+but fail to establish a speedup; all remain outside the installed extension:
+
+| Candidate | Native control ms | Candidate ms | Decision |
+| --- | ---: | ---: | --- |
+| Pretranspose V to column layout | 20.215809 | 21.629951 | Packing/zeroing loses |
+| Warp/shared row maximum | 20.073471 | 20.227072 | No gain |
+| Q32/K256 | 20.044800 | 24.824833 | Reuse/traffic regression |
+| Unroll fixed QK loop | 20.204544 | 20.252672 | No gain |
+| Unroll fixed PV loop | 19.892223 | 20.021248 | No gain |
+| Eight warps | 20.045824 | 26.279936 | Register spills |
+| Global-load cache policy cg | 20.264959 | 20.225023 | 0.2% noise |
+| Q32/K128, four warps, three CTAs | 20.711424 | 26.468351 | Reuse regression |
+
+A further artifact-only GEMM/reduce-scatter overlap probe uses zero persistent
+cache and workspace, unlike the earlier independent 10-GiB-cache probe. Three
+paired two-update runs give medians 5.872043 ->5.742729 s (2.20%). It preserves
+useful FLOPs and reduces temporary memory, but has nonzero latent differences
+and no complete-video quality validation. Extra packing, streams and GEMM-plan
+APIs are not integrated for this modest prefix gain. Do not report 57.43 s as
+measured full-20 denoise, or repeat these variants without a new hypothesis.
+
+Validation: 70 targeted numerics/service/configuration tests pass. One actual
+four-rank collective test passes on every rank, covering both native attention
+backends, three valid/padded lengths, consecutive blocks, rank-dependent
+weights, FP32 residual values above 65504 and poisoned padding. Pre-commit
+checks pass. No CUDA source or installed binary changes in this follow-up;
+prior attention sanitizer coverage is retained, not presented as a new run.
+The actual full-20 run records all ranks' finite, mutually identical final
+latents and unchanged FLOP counts.
+
+Evidence root: `flashattention-pipeline50/` (exact jobs, NCU/SASS, both Nsight
+traces, candidate source/binaries, negative results, tests, reports and NVML
+curves). Fresh output:
+`outputs/quality39-int8-flashattn-residual-20steps/FLASH_ATTN_V100/`.
+Installed attention SHA256 remains
+`bdb3dcf0eea8c23f992536182a06d26f7b61c7bb6ddefa4b3c88590b81ad0005`.
+
+**Under 50 seconds, attention 60 TFLOPS, formal per-card 80 TFLOPS and human
+quality acceptance remain incomplete.** Keep the arithmetic operand-reuse
+focus; do not mistake 100% NVML utilization for Tensor Core saturation.
+
 ### Wide QK reuse and fused MLP preparation: 62.80 seconds
 
 The retained native implementation completes the unchanged 1344x768,

--- a/docs/design/minimax_h3/GPU_EXPORT.md
+++ b/docs/design/minimax_h3/GPU_EXPORT.md
@@ -1,0 +1,84 @@
+# H3 NVENC export measurement
+
+The opt-in `h264_nvenc` route completed a real GPU export on a
+V100-SXM2-32GB. For this five-second 720p sample, mean export latency fell
+from 1.652 s to 1.377 s (16.6%), while the output file grew by 40.8%.
+This is an export-only result, not an end-to-end H3 generation speedup.
+
+## Workload and environment
+
+- Implementation SHA: `642925223d0a97ac48aa598ef6e0559493f71084` (clean tree).
+- Integration base: `e7fa44deb253746a11b06be1cd3a75ef7dcdb67c`.
+- One V100-SXM2-32GB, physical GPU 0, CUDA-visible device 0. The existing
+  GPU-owner queue ran this bounded test serially under its own lease.
+- Python 3.12.13, PyTorch 2.10.0+cu128, CUDA 12.8, driver 580.173.02.
+- System FFmpeg 6.1.1-3ubuntu5, selected with `IMAGEIO_FFMPEG_EXE`.
+- Common input: 120 RGB24 frames at 1280x720 and 24 FPS, resident on the GPU,
+  plus the same five-second 32-kHz audio tensor. The frames were decoded from
+  the earlier delivered H3 sample, not retained original VAE output tensors.
+- Initial frame upload, model startup, denoising, VAE decoding and VAE output
+  quantization are excluded. Export includes raw-frame device-to-host copying,
+  WAV writing, FFmpeg startup/feed, compression, AAC encoding and MP4 muxing.
+- Two runs per encoder, ordered CPU / NVENC / NVENC / CPU. Torch used four
+  CPU threads; FFmpeg retained its normal encoder thread defaults.
+- CPU: libx264 CRF 18 / medium. GPU: NVENC VBR CQ 18 / p4 / HQ. These are
+  different encoder quality controls, not matched bitrate or matched quality.
+
+## Results
+
+| Metric | CPU libx264 | GPU h264_nvenc |
+| --- | ---: | ---: |
+| Export samples (s) | 1.613, 1.691 | 1.391, 1.363 |
+| Mean export (s) | 1.652 | 1.377 |
+| Mean frame preparation and copy (s) | 0.209 | 0.292 |
+| Mean WAV preparation (s) | 0.017 | 0.016 |
+| Mean FFmpeg startup and feeding (s) | 0.954 | 0.804 |
+| Mean FFmpeg completion (s) | 0.449 | 0.233 |
+| SSIM versus common input | 0.993359 | 0.992695 |
+| MP4 size (bytes) | 3,563,768 | 5,018,993 |
+
+Feeding includes pipe backpressure and overlaps encoding. These are sequential
+wall intervals, not disjoint CPU/GPU kernel timings; small Python/cleanup costs
+remain outside the sub-intervals but inside the export total. RGBA adds GPU
+packing and increases raw transfer volume compared with RGB24; both costs are
+included in the GPU route's preparation/copy interval.
+
+All four outputs passed automatic frame, dimension, FPS, audio, finite-value,
+black-frame and static-frame checks. FFprobe confirms H.264 YUV420P, 120 frames,
+24 FPS, and exactly 5.000 s for both video and AAC audio. NVENC samples had
+identical size and SSIM. Inspection of frames 48 and 119 found no obvious color
+or channel-order corruption; this is not a full human temporal/audio review.
+NVML recorded hardware encoder activity, peaking at 15% during this short test.
+
+The current exporter packs RGBA on the source GPU, then uses a host-memory
+subprocess pipe. NVENC handles RGB-to-YUV420 conversion and H.264 compression.
+This does not eliminate the GPU-to-CPU-to-GPU raw-frame transfer or parallelize
+one video across several GPUs. Audio encoding, muxing and file I/O remain on
+the CPU. The CPU default is retained; use the explicit deployment option in
+[the API guide](API.md#gpu-video-encoding) to select NVENC.
+
+The earlier full-pipeline packaging measurement of 20.56 s was not reproduced
+under this isolated contract. It must not be compared directly with 1.377 s
+as a claimed speedup. An already-CPU-resident input exported through the original
+implementation in 1.298 s and passed checks (SSIM 0.993359), also a different
+timing boundary.
+
+## Reproduction and retained evidence
+
+Artifacts are under `/data/minimax-h3/h3-gpu-export-20260908/`:
+`benchmark_export.py`, `benchmark-contract.json`, `export-ab.json`,
+`encoder-utilization.json`, `quality-comparison.json`, `summary.json`,
+`coordinated-probe.json`, and the four `export-*/` output directories.
+`runtime-binaries.sha256` records the pre-existing native binaries used for
+Python imports; this Python-only change does not claim a new CUDA build.
+
+Run the benchmark only inside an owned GPU lease, with `PYTHONPATH` pointing
+to this worktree and `CUDA_VISIBLE_DEVICES` restricted to the allocated GPU.
+After GPU work completes, `check_quality.py` performs CPU output validation
+and SSIM comparisons. The bounded coordinated job exited successfully and
+returned control to its parent lease; no unrelated process was interrupted.
+
+Validation: 36 targeted tests passed, covering export contracts, a real CPU
+export, and native HTTP API regressions. Local pre-commit and GitHub checks
+passed on the implementation commit; the actual NVENC run provides separate
+hardware evidence beyond the CPU tests' simulated encoder process.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -107,11 +107,15 @@ For the measured TP4 FL2VA INT8 development workload, optionally add
 FP32 residual rows sharded across ranks and gathers normalized FP16 inputs at
 the existing precision boundary. Both native SM70 attention backends support
 this option; it rejects BF16, Ref2VA, adapters and non-TP4 configurations. It defaults to
-false. The native FlashAttention 39-frame/20-update run measures 58.794562 s
+false. Normalized FP16 rows are now rotated locally before all-gather, avoiding
+four copies of the same ConvRot work while preserving gathered bits and GEMMs.
+The native FlashAttention 39-frame/20-update run measures 58.190385 s
 and 6.195001125 GiB peak denoise allocation/card, versus 62.804019 s and
 6.566735744 GiB without the flag, with zero persistent cache in both cases.
-Automatic media checks pass; changed FP32 reduction order requires human
-quality review, which remains pending. Omit the flag to restore the default.
+Its complete audio/video latents equal the earlier 58.794562-second sharded
+run bitwise, so that run's checked decode is reused. Automatic checks pass;
+the sharded route changes FP32 reduction order from the default and its human
+quality review remains pending. Omit the flag to restore the default.
 These are short development measurements, not the 243-frame acceptance run.
 
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -97,6 +97,18 @@ large FP32 activation intermediate without lowering arithmetic precision or
 adding a persistent cache. CPU, unquantized and FP32-input paths keep their
 existing implementation.
 
+For the measured TP4 FL2VA INT8 development workload, optionally add
+`--residual-sequence-parallel` to `video generate` or `video serve`. This keeps
+FP32 residual rows sharded across ranks and gathers normalized FP16 inputs at
+the existing precision boundary. Both native SM70 attention backends support
+this option; it rejects BF16, Ref2VA and non-TP4 configurations. It defaults to
+false. The native FlashAttention 39-frame/20-update run measures 58.794562 s
+and 6.195001125 GiB peak denoise allocation/card, versus 62.804019 s and
+6.566735744 GiB without the flag, with zero persistent cache in both cases.
+Automatic media checks pass; changed FP32 reduction order requires human
+quality review, which remains pending. Omit the flag to restore the default.
+These are short development measurements, not the 243-frame acceptance run.
+
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
 `nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
 replace the five-axis human quality review. Useful TFLOPS use actual local

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,0 +1,75 @@
+# H3 reproducible validation
+
+This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
+Component numerics and a short end-to-end route are working. Keep profiler
+diagnostics separate from the three formal timing runs.
+
+## Fixed workload
+
+The acceptance helper uses the Chinese paper-boat/duck prompt in
+`H3Request`, 1344x768, 243 frames, 24 FPS, seed 42 and 50 sigma positions.
+The checkpoint schedule performs 49 DiT calls. All four ranks must report
+their actual completed call counts.
+
+After installing 1Cat with `.[video]` and building the H3 extensions:
+
+```bash
+python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
+  --output-dir /path/to/reference-fixtures
+python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
+```
+
+The runner performs one warmup and three unprofiled requests in one engine.
+The warmup's automatic media checks must pass before formal timing starts.
+Use `FLASHINFER_SM70` for the independent Volta attention path. A nonzero FP16
+weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
+arguments. The default budget is zero.
+
+## Reports and interpretation
+
+```bash
+python -m pip install matplotlib
+python tools/minimax_h3/report.py /path/to/acceptance/run-1
+```
+
+Each request retains `video.mp4`, the original waveform, sampled screenshots,
+`run.json`, and `nvml.jsonl`. The report helper exports rank throughput and phase
+times as CSV, and six NVML curves as PNG/SVG. Phase times include overlapping
+aggregate and component fields; do not sum all fields indiscriminately.
+
+Useful FLOPs count the actual local model matrices and effective attention
+lengths. Padding, Hadamard rotations, weight dequantization and extra output
+rows do not inflate the numerator. Each rank uses the slowest rank's full
+denoise wall time. Formal evaluation rejects mismatched requests/configurations,
+profiled timing, duplicate ranks and incomplete schedules.
+
+The performance gate requires all four per-rank medians to be strictly above
+80 TFLOPS and the three denoise times' population coefficient of variation to
+be at most 5%. Memory is a separate 30 GiB gate. NVML utilization is never
+interpreted as Tensor Core activity. Retain Nsight Compute counter evidence and
+Nsight Systems communication/stall traces separately.
+
+The evaluator leaves overall `accepted` false. Final review must score prompt
+following, subject consistency, temporal continuity, detail and audio at least
+4/5 each and reject flicker, deformation or audio/video faults.
+
+## Evidence completed so far
+
+- Both fixed INT8 partition files are downloaded and SHA256 manifests saved.
+  The original BF16 DiT partitions and shared components are downloaded; their
+  full file manifest is being generated.
+- Real TP4 text-encoder outputs are finite and bitwise identical between ranks.
+- Real 50-block INT8 DiT single-forward checks pass after preserving large
+  condition projections, residuals, gated products and row-projection outputs
+  in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
+- The native numerical/service suite passed 23 tests before the additional
+  request preflight changes. Six acceptance-contract tests pass.
+- A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
+  passed the automatic media checks. It is not a quality/performance baseline.
+- A full primary FL2VA INT8 / Flash-V100 eager video is running. Full quality,
+  both-backend comparisons, original BF16 comparisons, mixed references,
+  extra seeds and formal timing remain pending.
+- Standard CMake configuration, build and component installation of both H3
+  extensions pass. Complete release-wheel validation remains pending.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -126,7 +126,24 @@ as the full pipeline's memory gate. This single short run does not satisfy the
 primary three-run timing contract or the >80 TFLOPS threshold.
 
 The profiler-only run uses the first two updates of the unchanged 20-update
-schedule. Its critical-rank trace attributes about 52% of the synchronized
+schedule. Its rank-0 trace attributes about 52% of the synchronized
 span to attention, 25% to GEMM and 10% to communication before this optimization.
 Explicit wall coverage and kernel service are retained separately. Profiling
 results never replace unprofiled timing.
+
+The selected cooperative-transpose kernel completes the same 20-update denoise
+in 87.824099 s (4.391205 s/update), with 39.439671 useful TFLOPS on each rank.
+Compared with the original 105.642574 s FlashInfer baseline, throughput improves
+by 20.29%. Both final video and audio latent tensors are bitwise identical to
+the previously decoded prefetch result. Only after checking both tensors and
+the MP4 hash, this run reuses that validated decoder output. Its metadata marks
+`short_clip_denoise_quality_with_reused_decode`; it does not provide a new VAE
+or end-to-end timing measurement. Text embeddings are also cached and verified.
+
+The final binary passes all 47 video tests and the ordinary CMake component
+build. CUDA 12.8 memcheck, racecheck and synccheck each pass all six new
+tail/unaligned cases without errors or hazards. Matched-shape Nsight Compute
+reports 25.091% tensor-pipe activity, up from 16.976% before prefetch. This
+counter is diagnostic, not effective model throughput. The 39-frame result
+remains below 80 TFLOPS/card; primary-load quality, three formal timing runs
+and the full-pipeline memory gate remain incomplete.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -6,45 +6,53 @@ is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
-updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality, without a substantial memory increase. The latest native
-FlashAttention V-prefetch route measures **69.062335 s**, or 3.453117 s/update
-and 50.154018 useful TFLOPS/card. The prior full-tile/column-major INT8 route
-measured 69.923404 s; this is a 1.23% reduction. Both use zero persistent
-FP16 cache and zero Lt workspace. Peak allocated denoise memory remains
-6.647851467 GiB on all four cards; NVML peak device-used memory is 8.583496 GiB.
+updates**, retaining 1344x768, 39 frames/24 FPS, seed42, INT8 ConvRot FL2VA,
+TP4 GPU0-3 and output quality, without a substantial memory increase. The
+latest native wide-QK plus fused MLP route measures **62.804019 s**, or
+**3.140201 s/update and 55.151783 useful model TFLOPS/card**, compared with
+69.062335 s previously (9.06% reduction). Cache and Lt workspace are zero.
+Peak Torch denoise allocation is **6.566735744 GiB/card**, down from
+6.647851467; NVML peak device-used memory is 8.419433594 GiB/card.
 
-Video and audio latents are bitwise equal to the prior route. The baseline
-decode is explicitly reused: MP4 SHA256 remains
-`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
-The identical media retains the automatic checks; human audiovisual scoring
-remains pending. Earlier timing/decoder experiments remain in CONTROL.md.
+The main gain reuses Q operands across a wider K tile and fixes softmax's
+incorrect inferred warp count. A second change fuses FP32 SiLU/product with
+power-of-two FP16 input preparation and releases the gate buffer before GEMM.
+The native B1/N12323/H14/D128 attention paired control is 25.572351 ->20.110336
+ms (42.565744 ->54.126701 useful TFLOPS). The **60 TFLOPS attention** milestone
+requires <=18.141769 ms. A larger-Q prototype improves only 1.48% against the
+new native path and is not enabled. Preserve the arithmetic/data-movement
+focus identified in the earlier NCU/SASS evidence in CONTROL.md.
 
-This is one unprofiled complete native run after a one-call warmup, with
-prompt-verified cached text. The separate V-prefetch prototype measured
-68.980006 s. Do not combine different builds into a formal median or present
-these as end-to-end generation / three-run 243-frame acceptance.
+Wide attention changes online reduction and FP16 probability rounding; its
+64.284648-second native run was freshly decoded. Video/audio latent relative
+RMS deltas against the previous K64 implementation are 10.5741% /1.8484%.
+Automatic media checks pass, and eight sampled frames show no obvious count,
+color or geometry regression. Human audiovisual scoring is still pending.
+The subsequent MLP fusion (62.852804 s) and buffer release (62.804019 s) are
+bitwise equal to the wide-attention latents; their decoder reuse is explicit.
+The output MP4 SHA256 is
+`97b9196c49a8e1bf61cb8368f4db7d7013e99bc107650945dbe92b4b59b0184a`.
 
-The user's next operator milestone is **60 useful TFLOPS for D128 attention**.
-The current workload's B1/N12323/H14/D128 attention requires 18.141769 ms to
-meet that milestone. The native helper's paired microbenchmark measures
-24.522753 ms (44.387601 TFLOPS), so this milestone is also incomplete.
-The old baseline's two-update trace separates GEMM service at 94.413296
-TFLOPS from attention service at 42.179368 TFLOPS. NCU and SASS samples locate
-operand-load/shared-store/HMMA dependencies inside attention; retain the
-arithmetic/data-movement focus. See CONTROL.md for the full evidence and
-failed wider-QK paths.
+There are **103 passing targeted tests** for attention, fused activation,
+INT8 layout/Lt and model numerics. After repository formatting and rebuilding,
+the resulting SASS is byte-for-byte identical and the 41 affected attention
+and activation tests pass again; this is a repeated subset, not 144 distinct
+tests. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass 25
+attention cases with zero errors/hazards. Ordinary pytest covers graph
+replay; isolated sanitizers do not capture graphs. N73483 uses sampled FP32
+reference rows, avoiding a full quadratic allocation. Sixteen lengths retain
+bitwise K64 primitive rollback. Two earlier same-module-name control probes
+are explicitly invalidated because Python reused the candidate extension;
+only `native-verified-results.json` is valid native paired-control evidence.
 
-The standard CMake FlashAttention component builds; 18 native GPU tests pass,
-including the new 32/33/96/97-key residual boundaries, poisoned padding,
-noncontiguous storage, online rescaling and CUDA Graph replay. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass
-thirteen cases without errors/hazards. The full-environment memcheck loader
-error and isolated harness limits are retained in CONTROL.md. Previous INT8
-layout/Lt validation remains recorded. Evidence is in `flashattention-warp50/`;
-media and NVML reports are in
-`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
-**Neither 60 TFLOPS attention, 50-second denoise nor >80 TFLOPS/card model
-acceptance is achieved.**
+These are separate single unprofiled development runs after a one-call warmup,
+with prompt-verified cached text. Do not pool different builds into a formal
+median or present this as end-to-end / three-run 243-frame acceptance.
+Evidence and NVML plots are in `flashattention-qk50/`; media and raw rank/NVML
+reports are in
+`outputs/quality39-int8-flashattn-native-wide-silu-release-20steps/FLASH_ATTN_V100/`.
+**Attention 60 TFLOPS, under-50-second denoise, formal >80 TFLOPS/card and human
+quality gates remain incomplete.**
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -147,3 +147,17 @@ reports 25.091% tensor-pipe activity, up from 16.976% before prefetch. This
 counter is diagnostic, not effective model throughput. The 39-frame result
 remains below 80 TFLOPS/card; primary-load quality, three formal timing runs
 and the full-pipeline memory gate remain incomplete.
+
+Fused FP32 input preparation and warp-shuffle ConvRot subsequently reduce the
+same 20-update denoise to 86.200372 s (4.310019 s/update), or 40.182583 useful
+TFLOPS on every rank. Final video/audio latents remain bitwise identical;
+the run retains explicit cached-text/decoder-reuse labels. The video suite
+passes 58 tests, with a subsequently added nonfinite-input test passing
+separately. All eleven new rotation/scaling cases pass memcheck, racecheck
+and synccheck, and the W8A16 CMake component builds.
+
+A recovered ComfyUI V100 attention source was also audited. On aligned D128
+controls it is about 1.9 times slower than current FlashInfer, and its raw
+unaligned path has query-tail synchronization and numerical failures. Those
+controls do not replace H3 quality or performance acceptance. The mainline
+and >80 TFLOPS/card target remain unchanged; see CONTROL.md for evidence.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,9 +1,28 @@
 # H3 reproducible validation
 
 This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
-Component numerics and short cached-text generation are working. FlashInfer-SM70
+Component numerics and short cached-text generation are working. FlashAttention-V100
 is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
+
+The dedicated D128 FlashAttention-V100 route completes the INT8 FL2VA
+1344x768/39-frame/seed42/20-update development workload in 77.342982 s,
+or 3.867149 s/update and 44.784329 useful TFLOPS on each of GPU0-3.
+The comparison FlashInfer checkpoint takes 86.200372 s with the same W8A16
+preparation and cache-off settings. This is one unprofiled complete denoise
+measurement after a one-call warmup, using verified cached text embeddings.
+Fresh VAE decode takes 5.650908 s, excluding its 35.935474 s load.
+Automatic media checks pass; full human audiovisual quality remains pending.
+Video/audio latents differ from FlashInfer (relative L2 0.107541/0.018019),
+so this route does not claim bitwise equivalence or reuse its decoded output.
+
+The native route, independent memory/synchronization checks, matched operator
+benchmarks and NCU counters are documented in `CONTROL.md`. Source/build logs,
+the per-rank report, NVML curves and generated media are retained under
+`/data/minimax-h3/native-h3-20260908/flashattention-mainline/` and
+`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-fused-20steps/`.
+The primary 243-frame warmup/three-run contract has not been executed for this
+candidate. **80 TFLOPS/card is not achieved.**
 
 ## Short development checks
 
@@ -13,7 +32,7 @@ extent while developing kernels or debugging components:
 ```bash
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
+  --tensor-parallel-size 4 --attention-backend FLASH_ATTN_V100 \
   --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 
@@ -38,12 +57,12 @@ python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
   --output-dir /path/to/reference-fixtures
 python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --attention-backend FLASHINFER_SM70 --output-dir /path/to/acceptance
+  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
 ```
 
 The runner performs one warmup and three unprofiled requests in one engine.
 The warmup's automatic media checks must pass before formal timing starts.
-Use `FLASH_ATTN_V100` for an explicit comparison or rollback. A nonzero FP16
+Use `FLASHINFER_SM70` for an explicit comparison or rollback. A nonzero FP16
 weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
 arguments. The default budget is zero.
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -1,7 +1,8 @@
 # H3 reproducible validation
 
 This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
-Component numerics and a short end-to-end route are working. Keep profiler
+Component numerics and short cached-text generation are working. FlashInfer-SM70
+is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
 ## Short development checks
@@ -37,12 +38,12 @@ python tools/minimax_h3/fixtures.py --model-root /path/to/MiniMax-H3 \
   --output-dir /path/to/reference-fixtures
 python tools/minimax_h3/benchmark.py --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
-  --attention-backend FLASH_ATTN_V100 --output-dir /path/to/acceptance
+  --attention-backend FLASHINFER_SM70 --output-dir /path/to/acceptance
 ```
 
 The runner performs one warmup and three unprofiled requests in one engine.
 The warmup's automatic media checks must pass before formal timing starts.
-Use `FLASHINFER_SM70` for the independent Volta attention path. A nonzero FP16
+Use `FLASH_ATTN_V100` for an explicit comparison or rollback. A nonzero FP16
 weight-cache budget requires an explicit measured list of `--fp16-cache-layer`
 arguments. The default budget is zero.
 
@@ -83,8 +84,9 @@ following, subject consistency, temporal continuity, detail and audio at least
 - Real 50-block INT8 DiT single-forward checks pass after preserving large
   condition projections, residuals, gated products and row-projection outputs
   in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
-- The current numerical/service suite passes 38 tests, including short clips
-  and the optimized FlashInfer kernel. Seven acceptance-contract tests pass, including excluded timing.
+- The current numerical/service suite passes 47 tests, including short clips,
+  the optimized FlashInfer kernel, prefetch tails and unaligned storage views.
+  Seven acceptance-contract tests pass, including excluded timing.
 - A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
   passed the automatic media checks. It is not a quality/performance baseline.
 - The earlier full primary video was interrupted before completion and is
@@ -93,8 +95,10 @@ following, subject consistency, temporal continuity, detail and audio at least
   with Flash-V100 and 10.55566 s with the FlashInfer candidate: 30.6664 versus
   32.8142 useful TFLOPS on each rank. Both produced finite, rank-identical
   latents. These are development results, not full-schedule acceptance.
-- Full quality, original BF16 comparisons, mixed references, extra seeds and
-  formal three-run timing remain pending.
+- Original BF16 FL2VA text-to-video completed 20 updates at 39 frames through
+  Flash-V100 with FP16/FP32 computation. All automatic checks pass; denoise took
+  110.569167 s. Other original-checkpoint backend/partition combinations, mixed
+  references, extra seeds, full quality and formal three-run timing remain pending.
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
 
@@ -110,3 +114,19 @@ longer show the severe two-forward artifacts. Flash-V100 took 113.459387 s
 (5.672969 s/call); FlashInfer took 105.642574 s (5.282129 s/call). Both used the
 same INT8 checkpoint, prompt, seed, 39 frames, cached text and shift rules.
 Full primary acceptance and human audiovisual review remain pending.
+
+The subsequent FlashInfer V-layout/KV-prefetch optimization completes the same
+20-update short request in 90.880784 s (4.544039 s/update), with 38.113157 useful
+TFLOPS on each rank. Video/audio latents and the exported MP4 are bitwise
+identical to the previous FlashInfer result; automatic media checks pass.
+CUDA 12.8 memcheck/synccheck each pass the six new tail/unaligned cases with
+zero errors. The standard CMake FlashInfer component builds successfully.
+The 6.647851 GiB Torch peak is measured during DiT only and must not be treated
+as the full pipeline's memory gate. This single short run does not satisfy the
+primary three-run timing contract or the >80 TFLOPS threshold.
+
+The profiler-only run uses the first two updates of the unchanged 20-update
+schedule. Its critical-rank trace attributes about 52% of the synchronized
+span to attention, 25% to GEMM and 10% to communication before this optimization.
+Explicit wall coverage and kernel service are retained separately. Profiling
+results never replace unprofiled timing.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -5,24 +5,26 @@ Component numerics and short cached-text generation are working. FlashAttention-
 is the user-selected mainline and the default denoiser. Keep profiler
 diagnostics separate from the three formal timing runs.
 
-The dedicated D128 FlashAttention-V100 route completes the INT8 FL2VA
-1344x768/39-frame/seed42/20-update development workload in 77.342982 s,
-or 3.867149 s/update and 44.784329 useful TFLOPS on each of GPU0-3.
-The comparison FlashInfer checkpoint takes 86.200372 s with the same W8A16
-preparation and cache-off settings. This is one unprofiled complete denoise
-measurement after a one-call warmup, using verified cached text embeddings.
-Fresh VAE decode takes 5.650908 s, excluding its 35.935474 s load.
-Automatic media checks pass; full human audiovisual quality remains pending.
-Video/audio latents differ from FlashInfer (relative L2 0.107541/0.018019),
-so this route does not claim bitwise equivalence or reuse its decoded output.
+The current short-development target is **under 50 seconds for 20 actual DiT
+updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
+output quality. QK/RoPE fusion now completes this workload in **74.411059 s**,
+or 3.720553 s/update and 46.548909 useful TFLOPS/card. The prior FlashAttention
+checkpoint took 77.342982 s; FlashInfer took 86.200372 s with the same W8A16
+preparation and cache-off settings. These are individual unprofiled development
+measurements after a one-call warmup, using verified cached text embeddings.
 
-The native route, independent memory/synchronization checks, matched operator
-benchmarks and NCU counters are documented in `CONTROL.md`. Source/build logs,
-the per-rank report, NVML curves and generated media are retained under
-`/data/minimax-h3/native-h3-20260908/flashattention-mainline/` and
-`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-fused-20steps/`.
-The primary 243-frame warmup/three-run contract has not been executed for this
-candidate. **80 TFLOPS/card is not achieved.**
+The fused QK/RoPE result is bitwise equal to the prior FlashAttention checkpoint
+for both video and audio latents. Fresh VAE decoding also produces the identical
+MP4 SHA256, and all automatic media checks pass. Human audiovisual quality
+review remains pending. This equivalence is to the FlashAttention control;
+its earlier difference from FlashInfer is still recorded in CONTROL.md.
+
+The four-rank trace, matched failed probes and retained fusion are documented
+in CONTROL.md and `/data/minimax-h3/native-h3-20260908/flashattention-feeding-round2/`.
+Media, NVML and phase reports are under
+`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-rope-20steps/`.
+24 targeted tests and three isolated CUDA sanitizer checks pass. Neither the
+50-second development goal nor the primary >80 TFLOPS/card gate is achieved.
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -4,6 +4,24 @@ This draft has not passed the full-video quality or per-GPU 80 TFLOPS gates.
 Component numerics and a short end-to-end route are working. Keep profiler
 diagnostics separate from the three formal timing runs.
 
+## Short development checks
+
+Use the native entrypoint with the same spatial canvas and a short temporal
+extent while developing kernels or debugging components:
+
+```bash
+vllm video generate --model /path/to/MiniMax-H3 \
+  --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
+  --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
+  --num-frames 39 --num-inference-steps 3 --output-dir /path/to/development
+```
+
+This produces 1.625 seconds and performs two DiT forwards. It is an execution,
+numerical-range and profiling workload; two forwards cannot establish the
+checkpoint's final video quality. The streaming VAE requires at least 22 frames.
+Keep the requested 50 sigma positions when evaluating final quality. Do not run
+the full acceptance runner for routine development.
+
 ## Fixed workload
 
 The acceptance helper uses the Chinese paper-boat/duck prompt in
@@ -30,7 +48,7 @@ arguments. The default budget is zero.
 ## Reports and interpretation
 
 ```bash
-python -m pip install matplotlib
+uv pip install --python .venv/bin/python matplotlib
 python tools/minimax_h3/report.py /path/to/acceptance/run-1
 ```
 
@@ -58,18 +76,29 @@ following, subject consistency, temporal continuity, detail and audio at least
 ## Evidence completed so far
 
 - Both fixed INT8 partition files are downloaded and SHA256 manifests saved.
-  The original BF16 DiT partitions and shared components are downloaded; their
-  full file manifest is being generated.
+  The original BF16 DiT partitions and shared components are downloaded, and
+  their 98-file checksum manifest is complete.
 - Real TP4 text-encoder outputs are finite and bitwise identical between ranks.
 - Real 50-block INT8 DiT single-forward checks pass after preserving large
   condition projections, residuals, gated products and row-projection outputs
   in FP32. The matrix inputs/weights remain FP16 for Tensor Core execution.
-- The native numerical/service suite passed 23 tests before the additional
-  request preflight changes. Six acceptance-contract tests pass.
+- The current numerical/service suite passes 38 tests, including short clips
+  and the optimized FlashInfer kernel. Seven acceptance-contract tests pass, including excluded timing.
 - A 256x256, 107-frame, one-DiT-call route exported finite video and audio and
   passed the automatic media checks. It is not a quality/performance baseline.
-- A full primary FL2VA INT8 / Flash-V100 eager video is running. Full quality,
-  both-backend comparisons, original BF16 comparisons, mixed references,
-  extra seeds and formal timing remain pending.
+- The earlier full primary video was interrupted before completion and is
+  retained as partial diagnostics only. Development now uses 39-frame clips.
+  Cached-text INT8 TP4 denoise (two forwards after warmup) measured 11.29494 s
+  with Flash-V100 and 10.55566 s with the FlashInfer candidate: 30.6664 versus
+  32.8142 useful TFLOPS on each rank. Both produced finite, rank-identical
+  latents. These are development results, not full-schedule acceptance.
+- Full quality, original BF16 comparisons, mixed references, extra seeds and
+  formal three-run timing remain pending.
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
+
+The final short export contains 39 decoded frames and valid audio, but its
+two-forward image has clear ghosting and grid artifacts. It is not quality
+accepted. Other GPU workers were present during that export run, so its JSON
+marks timing invalid. Both the evaluator and report helper reject explicitly
+excluded timing. The earlier isolated candidate comparison is retained separately.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -13,12 +13,13 @@ extent while developing kernels or debugging components:
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 --attention-backend FLASHINFER_SM70 \
-  --num-frames 39 --num-inference-steps 3 --output-dir /path/to/development
+  --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 
-This produces 1.625 seconds and performs two DiT forwards. It is an execution,
-numerical-range and profiling workload; two forwards cannot establish the
-checkpoint's final video quality. The streaming VAE requires at least 22 frames.
+This produces 1.625 seconds and performs 20 DiT forwards. It is the short
+quality/development workload; the sigma-point convention needs 21 positions
+for 20 actual updates. One- or two-forward runs remain numerical/execution
+diagnostics and must not be used to judge normal model image quality. The streaming VAE requires at least 22 frames.
 Keep the requested 50 sigma positions when evaluating final quality. Do not run
 the full acceptance runner for routine development.
 
@@ -97,8 +98,15 @@ following, subject consistency, temporal continuity, detail and audio at least
 - Standard CMake configuration, build and component installation of both H3
   extensions pass. Complete release-wheel validation remains pending.
 
-The final short export contains 39 decoded frames and valid audio, but its
-two-forward image has clear ghosting and grid artifacts. It is not quality
+The earlier two-forward short export contains 39 decoded frames and valid
+audio, but its image has clear ghosting and grid artifacts. It is not quality
 accepted. Other GPU workers were present during that export run, so its JSON
 marks timing invalid. Both the evaluator and report helper reject explicitly
 excluded timing. The earlier isolated candidate comparison is retained separately.
+
+A subsequent matched 20-forward comparison completed on exclusively leased
+GPUs 0–3. Both backends pass automatic media checks, and inspected frames no
+longer show the severe two-forward artifacts. Flash-V100 took 113.459387 s
+(5.672969 s/call); FlashInfer took 105.642574 s (5.282129 s/call). Both used the
+same INT8 checkpoint, prompt, seed, 39 frames, cached text and shift rules.
+Full primary acceptance and human audiovisual review remain pending.

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -7,33 +7,44 @@ diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
 updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality, without a substantial memory increase. Exact full-tile
-FlashAttention specialization and column-major INT8/Lt now complete this workload
-in **69.923404 s**, or 3.496170 s/update and 49.536398 useful TFLOPS/card.
-The preceding QK/RoPE baseline took 74.411059 s; the new route reduces that time
-by 6.03%. Both use zero persistent FP16 cache. New Lt workspace is also zero.
-Peak allocated denoise memory remains exactly 6.647851467 GiB on all four cards;
-NVML peak device-used memory, including runtime allocations, is 8.583496 GiB.
+output quality, without a substantial memory increase. The latest native
+FlashAttention V-prefetch route measures **69.062335 s**, or 3.453117 s/update
+and 50.154018 useful TFLOPS/card. The prior full-tile/column-major INT8 route
+measured 69.923404 s; this is a 1.23% reduction. Both use zero persistent
+FP16 cache and zero Lt workspace. Peak allocated denoise memory remains
+6.647851467 GiB on all four cards; NVML peak device-used memory is 8.583496 GiB.
 
-Both video and audio latents are bitwise equal to the prior FlashAttention
-baseline. Fresh VAE decoding produces identical PCM samples and MP4 bytes;
-MP4 SHA256 is `17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
-All automatic media checks pass. Human audiovisual quality scoring remains
-pending. Earlier FlashInfer comparisons remain recorded in CONTROL.md.
+Video and audio latents are bitwise equal to the prior route. The baseline
+decode is explicitly reused: MP4 SHA256 remains
+`17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+The identical media retains the automatic checks; human audiovisual scoring
+remains pending. Earlier timing/decoder experiments remain in CONTROL.md.
 
-These are individual unprofiled development measurements after a one-invocation
-warmup with prompt-verified cached text embeddings. Do not interpret them as
-end-to-end generation or the formal three-measurement 243-frame acceptance.
-The separate low-memory prototype took 69.868952 s; combining different builds
-into a formal median is not permitted.
+This is one unprofiled complete native run after a one-call warmup, with
+prompt-verified cached text. The separate V-prefetch prototype measured
+68.980006 s. Do not combine different builds into a formal median or present
+these as end-to-end generation / three-run 243-frame acceptance.
 
-The standard CMake components build. 86 targeted GPU/CPU tests pass, including
-INT8 offsets/scales, padded-M12352 projection equality, fallback and CUDA Graph
-replay. Isolated CUDA12.8 memcheck/racecheck/synccheck pass without errors or
-hazards. Evidence is under `flashattention-lowmem50/`; serialized GPU test logs
-are under `flashattention-under50/`. Media and NVML reports are under
-`outputs/quality39-int8-flashattn-lowmem-native-20steps/FLASH_ATTN_V100/` in the
-recorded artifact root. **Neither 50 seconds nor >80 TFLOPS/card is achieved.**
+The user's next operator milestone is **60 useful TFLOPS for D128 attention**.
+The current workload's B1/N12323/H14/D128 attention requires 18.141769 ms to
+meet that milestone. The native helper's paired microbenchmark measures
+24.522753 ms (44.387601 TFLOPS), so this milestone is also incomplete.
+The old baseline's two-update trace separates GEMM service at 94.413296
+TFLOPS from attention service at 42.179368 TFLOPS. NCU and SASS samples locate
+operand-load/shared-store/HMMA dependencies inside attention; retain the
+arithmetic/data-movement focus. See CONTROL.md for the full evidence and
+failed wider-QK paths.
+
+The standard CMake FlashAttention component builds; 18 native GPU tests pass,
+including the new 32/33/96/97-key residual boundaries, poisoned padding,
+noncontiguous storage, online rescaling and CUDA Graph replay. Isolated CUDA12.8 memcheck, racecheck and synccheck each pass
+thirteen cases without errors/hazards. The full-environment memcheck loader
+error and isolated harness limits are retained in CONTROL.md. Previous INT8
+layout/Lt validation remains recorded. Evidence is in `flashattention-warp50/`;
+media and NVML reports are in
+`outputs/quality39-int8-flashattn-native-prefetch-20steps/FLASH_ATTN_V100/`.
+**Neither 60 TFLOPS attention, 50-second denoise nor >80 TFLOPS/card model
+acceptance is achieved.**
 
 ## Short development checks
 

--- a/docs/design/minimax_h3/VALIDATION.md
+++ b/docs/design/minimax_h3/VALIDATION.md
@@ -7,24 +7,33 @@ diagnostics separate from the three formal timing runs.
 
 The current short-development target is **under 50 seconds for 20 actual DiT
 updates**, retaining 1344x768, 39 frames, seed42, INT8 ConvRot, TP4 GPU0-3 and
-output quality. QK/RoPE fusion now completes this workload in **74.411059 s**,
-or 3.720553 s/update and 46.548909 useful TFLOPS/card. The prior FlashAttention
-checkpoint took 77.342982 s; FlashInfer took 86.200372 s with the same W8A16
-preparation and cache-off settings. These are individual unprofiled development
-measurements after a one-call warmup, using verified cached text embeddings.
+output quality, without a substantial memory increase. Exact full-tile
+FlashAttention specialization and column-major INT8/Lt now complete this workload
+in **69.923404 s**, or 3.496170 s/update and 49.536398 useful TFLOPS/card.
+The preceding QK/RoPE baseline took 74.411059 s; the new route reduces that time
+by 6.03%. Both use zero persistent FP16 cache. New Lt workspace is also zero.
+Peak allocated denoise memory remains exactly 6.647851467 GiB on all four cards;
+NVML peak device-used memory, including runtime allocations, is 8.583496 GiB.
 
-The fused QK/RoPE result is bitwise equal to the prior FlashAttention checkpoint
-for both video and audio latents. Fresh VAE decoding also produces the identical
-MP4 SHA256, and all automatic media checks pass. Human audiovisual quality
-review remains pending. This equivalence is to the FlashAttention control;
-its earlier difference from FlashInfer is still recorded in CONTROL.md.
+Both video and audio latents are bitwise equal to the prior FlashAttention
+baseline. Fresh VAE decoding produces identical PCM samples and MP4 bytes;
+MP4 SHA256 is `17ac6de78b7bc280ce91a0c6ca018785d131b3798856ca3ea3cdc55a10811988`.
+All automatic media checks pass. Human audiovisual quality scoring remains
+pending. Earlier FlashInfer comparisons remain recorded in CONTROL.md.
 
-The four-rank trace, matched failed probes and retained fusion are documented
-in CONTROL.md and `/data/minimax-h3/native-h3-20260908/flashattention-feeding-round2/`.
-Media, NVML and phase reports are under
-`/data/minimax-h3/native-h3-20260908/outputs/quality39-int8-flashattn-rope-20steps/`.
-24 targeted tests and three isolated CUDA sanitizer checks pass. Neither the
-50-second development goal nor the primary >80 TFLOPS/card gate is achieved.
+These are individual unprofiled development measurements after a one-invocation
+warmup with prompt-verified cached text embeddings. Do not interpret them as
+end-to-end generation or the formal three-measurement 243-frame acceptance.
+The separate low-memory prototype took 69.868952 s; combining different builds
+into a formal median is not permitted.
+
+The standard CMake components build. 86 targeted GPU/CPU tests pass, including
+INT8 offsets/scales, padded-M12352 projection equality, fallback and CUDA Graph
+replay. Isolated CUDA12.8 memcheck/racecheck/synccheck pass without errors or
+hazards. Evidence is under `flashattention-lowmem50/`; serialized GPU test logs
+are under `flashattention-under50/`. Media and NVML reports are under
+`outputs/quality39-int8-flashattn-lowmem-native-20steps/FLASH_ATTN_V100/` in the
+recorded artifact root. **Neither 50 seconds nor >80 TFLOPS/card is achieved.**
 
 ## Short development checks
 
@@ -35,6 +44,7 @@ extent while developing kernels or debugging components:
 vllm video generate --model /path/to/MiniMax-H3 \
   --transformer-path /path/to/minimax_h3_fl2va_pruned_int8_convrot.safetensors \
   --tensor-parallel-size 4 --attention-backend FLASH_ATTN_V100 \
+  --int8-weight-layout column --fp16-weight-cache-gib 0 \
   --num-frames 39 --num-inference-steps 21 --output-dir /path/to/development
 ```
 

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from copy import deepcopy
+from dataclasses import asdict
+
+import pytest
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+from vllm.video.metrics import evaluate_performance
+
+
+def measurements():
+    run = {
+        "config": asdict(H3Config()),
+        "request": asdict(H3Request()),
+        "gpus": [0, 1, 2, 3],
+        "measurement": {"profiled": False, "warmup_runs": 1},
+        "ranks": [
+            {
+                "rank": rank,
+                "dit_calls": 49,
+                "useful_denoise_flops": 6_000_000_000_000_000,
+                "peak_allocated_bytes": 29 * 1024**3,
+                "stage_seconds": {"denoise": 60.0 if rank == 3 else 50.0},
+            }
+            for rank in range(4)
+        ],
+    }
+    return [deepcopy(run) for _ in range(3)]
+
+
+def test_all_ranks_use_slowest_rank_wall_time_and_strict_threshold():
+    runs = measurements()
+    report = evaluate_performance(runs)
+    assert report["rank_median_tflops"] == [100.0] * 4
+    assert report["performance_passed"]
+    for run in runs:
+        run["ranks"][2]["useful_denoise_flops"] = 4_800_000_000_000_000
+    assert not evaluate_performance(runs)["performance_passed"]
+
+
+@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls"])
+def test_rejects_incomparable_measurements(invalid):
+    runs = measurements()
+    if invalid == "profiled":
+        runs[1]["measurement"]["profiled"] = True
+    elif invalid == "seed":
+        runs[1]["request"]["sampling"]["seed"] = 2026
+    elif invalid == "rank":
+        runs[1]["ranks"][3]["rank"] = 2
+    else:
+        runs[1]["ranks"][0]["dit_calls"] = 48
+    with pytest.raises(ValueError):
+        evaluate_performance(runs)
+
+
+def test_memory_gate_and_variability_are_reported_separately():
+    runs = measurements()
+    runs[0]["ranks"][1]["peak_allocated_bytes"] = 31 * 1024**3
+    runs[0]["ranks"][3]["stage_seconds"]["denoise"] = 80.0
+    report = evaluate_performance(runs)
+    assert not report["memory_passed"]
+    assert report["denoise_cv"] > 0.05
+    assert not report["performance_passed"]

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -39,7 +39,7 @@ def test_all_ranks_use_slowest_rank_wall_time_and_strict_threshold():
     assert not evaluate_performance(runs)["performance_passed"]
 
 
-@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls"])
+@pytest.mark.parametrize("invalid", ["profiled", "seed", "rank", "calls", "excluded"])
 def test_rejects_incomparable_measurements(invalid):
     runs = measurements()
     if invalid == "profiled":
@@ -48,6 +48,8 @@ def test_rejects_incomparable_measurements(invalid):
         runs[1]["request"]["sampling"]["seed"] = 2026
     elif invalid == "rank":
         runs[1]["ranks"][3]["rank"] = 2
+    elif invalid == "excluded":
+        runs[1]["timing_valid"] = False
     else:
         runs[1]["ranks"][0]["dit_calls"] = 48
     with pytest.raises(ValueError):

--- a/tests/video/test_h3_gpu_export.py
+++ b/tests/video/test_h3_gpu_export.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Export contracts without requiring an unleased GPU during CPU CI."""
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.video import media
+
+
+def test_nvenc_receives_rgba_in_rgb_order_and_preserves_device_selection(
+    monkeypatch, tmp_path
+):
+    class Process:
+        def __init__(self):
+            self.stdin = self
+            self.frames = []
+
+        def write(self, frame):
+            self.frames.append(bytes(frame))
+
+        def close(self):
+            pass
+
+        def wait(self):
+            return 0
+
+    process = Process()
+    commands = []
+
+    def popen(command, **kwargs):
+        commands.append(command)
+        return process
+
+    monkeypatch.setattr(media.subprocess, "Popen", popen)
+    monkeypatch.setenv("IMAGEIO_FFMPEG_EXE", "/test/ffmpeg-nvenc")
+    # Non-contiguous input exposes incorrect stride handling and channel order.
+    video = torch.arange(24, dtype=torch.uint8).reshape(1, 2, 2, 2, 3)
+    video = video.transpose(2, 3)
+    audio = torch.zeros(1, 1, 2667)
+    result = media.export_video(
+        video, audio, tmp_path, encoder="h264_nvenc", gpu_index=2
+    )
+    received = torch.tensor(list(b"".join(process.frames)), dtype=torch.uint8)
+    received = received.reshape(1, 2, 2, 2, 4)
+    assert torch.equal(received[..., :3], video)
+    assert (received[..., 3] == 255).all()
+    command = commands[0]
+    assert command[0] == "/test/ffmpeg-nvenc"
+    assert command[command.index("-gpu") + 1] == "2"
+    assert command[command.index("-c:v") + 1] == "h264_nvenc"
+    assert command[command.index("-rgb_mode") + 1] == "yuv420"
+    # Only the raw input format is declared: an output -pix_fmt yuv420p
+    # would insert a software conversion ahead of NVENC.
+    assert command.count("-pix_fmt") == 1
+    assert command[command.index("-pix_fmt") + 1] == "rgba"
+    assert "-crf" not in command
+    assert result["encoding_device"] == "cuda:2"
+    assert result["preparation_device"] == "cpu"
+    assert result["frames"] == 2
+    assert set(result["export_stage_seconds"]) == {
+        "prepare_and_copy",
+        "audio_wav",
+        "ffmpeg_start_and_feed",
+        "ffmpeg_finish",
+    }
+
+
+def test_nvenc_failure_does_not_silently_switch_to_cpu(monkeypatch, tmp_path):
+    class Process:
+        stdin = None
+        killed = False
+        launches = 0
+
+        def __init__(self, *args, **kwargs):
+            self.stdin = self
+            Process.launches += 1
+
+        def write(self, frame):
+            raise BrokenPipeError("GPU encoder unavailable")
+
+        def kill(self):
+            Process.killed = True
+
+        def wait(self):
+            return 1
+
+    monkeypatch.setattr(media.subprocess, "Popen", Process)
+    monkeypatch.setenv("IMAGEIO_FFMPEG_EXE", "/test/ffmpeg-nvenc")
+    with pytest.raises(RuntimeError, match="h264_nvenc.*encode.log"):
+        media.export_video(
+            torch.zeros(1, 1, 2, 2, 3, dtype=torch.uint8),
+            torch.zeros(1, 1, 1333),
+            tmp_path,
+            encoder="h264_nvenc",
+        )
+    assert Process.killed
+    assert Process.launches == 1
+
+
+def test_unknown_encoder_rejected_in_deployment_contract():
+    with pytest.raises(H3InputError, match="video encoder"):
+        H3Config(video_encoder="unrecognized")

--- a/tests/video/test_h3_local_rotation.py
+++ b/tests/video/test_h3_local_rotation.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact ConvRot-before-gather regression on TP4, with real INT8 projections."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.video import test_h3_residual_parallel as residual_tests
+from vllm.model_executor.models.minimax_h3 import transformer
+from vllm.model_executor.models.minimax_h3.quantization import (
+    DiffusionInt8ConvRotConfig,
+    H3QKVParallelLinear,
+    Int8ConvRotLayerConfig,
+    Int8ConvRotLinearMethod,
+    rotate_local_fp16,
+)
+
+tp4_group = residual_tests.tp4_group
+
+
+def test_cpu_rotation_preserves_original_path_and_rejects_pre_rotated_input():
+    method = Int8ConvRotLinearMethod(
+        DiffusionInt8ConvRotConfig(), Int8ConvRotLayerConfig(True), prefix="blocks.0"
+    )
+    layer = SimpleNamespace(quant_method=method, bias=None, gather_output=False)
+    x = torch.randn(17, 256, dtype=torch.float16)
+    actual, rotated = rotate_local_fp16(layer, x)
+    assert actual is x and not rotated
+    with pytest.raises(ValueError, match="Pre-rotated H3"):
+        H3QKVParallelLinear.forward(layer, x, input_is_rotated=True)
+
+
+@torch.inference_mode()
+def test_gpu_local_rotation_preserves_tp4_blocks_and_hooks(tp4_group, monkeypatch):
+    from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+    from vllm.video.metrics import DenoiseWorkCounter
+
+    group = tp4_group
+    names = ("attn.qkv_proj", "attn.out_proj", "mlp.fc1", "mlp.fc2")
+    quant = DiffusionInt8ConvRotConfig(
+        layer_configs={
+            f"blocks.0.{name}": {"format": "int8_tensorwise", "convrot": True}
+            for name in names
+        }
+    )
+    arch = transformer.MiniMaxH3DiTArchConfig(
+        hidden_size=512,
+        num_attention_heads=8,
+        ffn_hidden_size=1024,
+        adaln_curve_grid=2,
+        adaln_out_features=18 * 512,
+    )
+    token = attention_backend.set("FLASH_ATTN_V100")
+    try:
+        block = (
+            transformer.MiniMaxH3DiTBlock(
+                arch, quant, prefix="blocks.0", residual_sequence_parallel=True
+            )
+            .cuda()
+            .eval()
+        )
+    finally:
+        attention_backend.reset(token)
+    torch.manual_seed(1234 + group.rank_in_group)
+    for name, parameter in block.named_parameters():
+        if parameter.dtype == torch.int8:
+            parameter.random_(-7, 8)
+        elif name.endswith("weight_scale"):
+            parameter.fill_(0.005)
+        elif "norm" in name:
+            parameter.fill_(1)
+        else:
+            parameter.normal_(0, 0.03)
+    for layer in block.modules():
+        method = getattr(layer, "quant_method", None)
+        if isinstance(method, Int8ConvRotLinearMethod):
+            method.process_weights_after_loading(layer)
+    original = rotate_local_fp16
+    observed = []
+
+    def checked_rotation(layer, values):
+        result, selected = original(layer, values)
+        assert selected
+        observed.append(tuple(values.shape))
+        return result, selected
+
+    for cached in (False, True):
+        if cached:
+            for layer in block.modules():
+                if isinstance(
+                    getattr(layer, "quant_method", None), Int8ConvRotLinearMethod
+                ):
+                    layer.h3_fp16_weight = w8a16_extension().dequantize(
+                        layer.weight, layer.weight_scale
+                    )
+        for valid in (33, 131):
+            torch.manual_seed(42)
+            total = (valid + 3) // 4 * 4
+            full = torch.randn(total, 512, device="cuda", dtype=torch.float32)
+            full[::5, 0] = 70000
+            local = full.chunk(4, dim=0)[group.rank_in_group].clone()
+            kwargs = dict(
+                t_emb=torch.randn(1, 8, device="cuda"),
+                combined_indices=torch.arange(total, device="cuda") % 3,
+                rope_table=torch.randn(total, 96, device="cuda"),
+                cu_seqlens=torch.tensor([0, valid], device="cuda", dtype=torch.int32),
+                max_seqlen=valid,
+                packed_total=total,
+            )
+            outputs, counts = [], []
+            for enabled in (False, True):
+                observed.clear()
+                monkeypatch.setattr(
+                    transformer,
+                    "rotate_local_fp16",
+                    checked_rotation if enabled else lambda layer, x: (x, False),
+                )
+                counter = DenoiseWorkCounter(
+                    block, used_length=valid, video_outputs=valid, audio_outputs=0
+                )
+                value = local.clone()
+                try:
+                    for _ in range(2):
+                        value = block(value, **kwargs)
+                    counts.append((counter.flops, dict(counter.by_layer)))
+                finally:
+                    counter.close()
+                outputs.append(value)
+                if enabled:
+                    assert observed == [(total // 4, 512)] * 4
+            assert counts[0] == counts[1]
+            assert torch.isfinite(outputs[1]).all()
+            assert outputs[1].abs().max() > torch.finfo(torch.float16).max
+            torch.testing.assert_close(outputs[0], outputs[1], atol=0, rtol=0)

--- a/tests/video/test_h3_residual_parallel.py
+++ b/tests/video/test_h3_residual_parallel.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TP4 residual tests: launch the GPU cases with torchrun --nproc-per-node=4."""
+
+import argparse
+import os
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.model_executor.models.minimax_h3.transformer import MiniMaxH3DiTBlock
+
+
+@pytest.mark.parametrize("backend", ["FLASH_ATTN_V100", "FLASHINFER_SM70"])
+def test_residual_parallel_accepts_native_sm70_backends(backend):
+    config = H3Config(
+        transformer_path="int8.safetensors",
+        attention_backend=backend,
+        residual_sequence_parallel=True,
+    )
+    assert config.residual_sequence_parallel
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"tensor_parallel_size": 1},
+        {"tensor_parallel_size": 2},
+        {"attention_backend": "TORCH_SDPA"},
+        {"partition": "ref2va"},
+        {"transformer_path": None},
+    ],
+)
+def test_residual_parallel_rejects_unvalidated_deployments(change):
+    config = H3Config(
+        transformer_path="int8.safetensors",
+        attention_backend="FLASHINFER_SM70",
+        residual_sequence_parallel=True,
+    )
+    with pytest.raises(H3InputError, match="residual sequence parallelism"):
+        replace(config, **change)
+
+
+@pytest.mark.parametrize("mode", ["generate", "serve"])
+def test_residual_parallel_is_explicit_in_both_entrypoints(mode):
+    from vllm.entrypoints.cli.video import VideoSubcommand
+
+    parser = argparse.ArgumentParser()
+    VideoSubcommand().subparser_init(parser.add_subparsers())
+    assert not parser.parse_args(["video", mode]).residual_sequence_parallel
+    assert parser.parse_args(
+        ["video", mode, "--residual-sequence-parallel"]
+    ).residual_sequence_parallel
+
+
+@pytest.mark.parametrize(
+    "rows,total,dtype,extra",
+    [
+        (4, 17, torch.float32, {}),
+        (16, 16, torch.float32, {}),
+        (4, 16, torch.float16, {}),
+        (4, 16, torch.float32, {"num_requests": 2}),
+        (4, 16, torch.float32, {"sp_seq_lens": [4] * 4}),
+    ],
+)
+def test_residual_parallel_rejects_invalid_rows_before_collectives(
+    rows, total, dtype, extra
+):
+    block = SimpleNamespace(
+        residual_group=SimpleNamespace(world_size=4, rank_in_group=0)
+    )
+    with pytest.raises(ValueError, match="local FP32 rows"):
+        MiniMaxH3DiTBlock.forward(
+            block,
+            torch.zeros(rows, 8, dtype=dtype),
+            t_emb=torch.zeros(1, 8),
+            combined_indices=torch.zeros(total, dtype=torch.long),
+            rope_table=torch.zeros(total, 8),
+            cu_seqlens=torch.tensor([0, total]),
+            max_seqlen=total,
+            packed_total=total,
+            **extra,
+        )
+
+
+@pytest.fixture
+def tp4_group():
+    if os.environ.get("WORLD_SIZE") != "4":
+        pytest.skip("requires torchrun --nproc-per-node=4 on a leased GPU group")
+    from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed import (
+        cleanup_dist_env_and_memory,
+        get_tp_group,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.accelerator.set_device_index(local_rank)
+    torch.set_num_threads(2)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(tensor_parallel_size=4))
+    ):
+        init_distributed_environment(4, rank, "env://", local_rank, "nccl")
+        initialize_model_parallel(4)
+        try:
+            yield get_tp_group()
+        finally:
+            cleanup_dist_env_and_memory()
+
+
+@torch.inference_mode()
+def test_gpu_residual_parallel_matches_replicated_blocks(tp4_group):
+    # The repository's autouse fixture tears down distributed state after each
+    # test. Keep all collective shapes inside the same torchrun lifetime.
+    for valid in (32, 33, 131):
+        for backend in ("FLASH_ATTN_V100", "FLASHINFER_SM70"):
+            _check_replicated_blocks(tp4_group, valid, backend)
+
+
+def _check_replicated_blocks(group, valid, backend):
+    from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.transformer import (
+        MiniMaxH3DiTArchConfig,
+    )
+
+    arch = MiniMaxH3DiTArchConfig(
+        hidden_size=512,
+        num_attention_heads=8,
+        ffn_hidden_size=1024,
+        adaln_curve_grid=2,
+        adaln_out_features=18 * 512,
+    )
+    token = attention_backend.set(backend)
+    try:
+        baseline = MiniMaxH3DiTBlock(arch, None, prefix="blocks.0").cuda().eval()
+        candidate = (
+            MiniMaxH3DiTBlock(
+                arch, None, prefix="blocks.0", residual_sequence_parallel=True
+            )
+            .cuda()
+            .eval()
+        )
+    finally:
+        attention_backend.reset(token)
+    # Rank-dependent projection weights exercise real TP partial sums.
+    torch.manual_seed(1234 + group.rank_in_group)
+    for name, parameter in baseline.named_parameters():
+        if "norm" in name:
+            parameter.fill_(1)
+        else:
+            parameter.normal_(0, 0.03)
+    candidate.load_state_dict(baseline.state_dict())
+    torch.manual_seed(42)
+    total = (valid + 3) // 4 * 4
+    x = torch.randn(total, 512, device="cuda", dtype=torch.float32)
+    x[::5, 0] = 70000  # Residuals must not pass through an FP16 collective.
+    kwargs = dict(
+        t_emb=torch.randn(1, 8, device="cuda"),
+        combined_indices=torch.arange(total, device="cuda") % 3,
+        rope_table=torch.randn(total, 96, device="cuda"),
+        cu_seqlens=torch.tensor([0, valid], device="cuda", dtype=torch.int32),
+        max_seqlen=valid,
+        packed_total=total,
+    )
+    rows = total // 4
+    actual = x.narrow(0, group.rank_in_group * rows, rows).clone()
+    expected = x.clone()
+    for _ in range(2):
+        expected = baseline(expected, **kwargs)
+        actual = candidate(actual, **kwargs)
+    actual = group.all_gather(actual, dim=0)
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all()
+    assert actual.abs().max() > torch.finfo(torch.float16).max
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=3e-4)
+    # Modifying padding must not change any valid attention output.
+    if valid < total:
+        changed = x.clone()
+        changed[valid:] *= 10
+        altered = candidate(
+            changed.narrow(0, group.rank_in_group * rows, rows), **kwargs
+        )
+        original = candidate(x.narrow(0, group.rank_in_group * rows, rows), **kwargs)
+        torch.testing.assert_close(
+            group.all_gather(altered, dim=0)[:valid],
+            group.all_gather(original, dim=0)[:valid],
+            rtol=0,
+            atol=0,
+        )

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Warm up once, then measure the approved H3 workload three times."""
+
+import argparse
+import json
+from pathlib import Path
+
+from vllm.model_executor.models.minimax_h3.comfy_checkpoint import (
+    inspect_comfy_checkpoint,
+)
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
+from vllm.video.engine import H3Engine
+from vllm.video.metrics import evaluate_performance
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--transformer-path", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--fp16-weight-cache-gib", type=float, default=0)
+    parser.add_argument("--fp16-cache-layer", action="append", default=[])
+    parser.add_argument(
+        "--attention-backend",
+        choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
+        default="FLASH_ATTN_V100",
+    )
+    args = parser.parse_args()
+    inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")
+    config = H3Config(
+        model=args.model,
+        transformer_path=args.transformer_path,
+        attention_backend=args.attention_backend,
+        fp16_weight_cache_gib=args.fp16_weight_cache_gib,
+        fp16_cache_layers=tuple(args.fp16_cache_layer),
+    )
+    results = []
+    with H3Engine(config) as engine:
+        warmup = engine.generate(H3Request(), args.output_dir / "warmup")
+        if not warmup["ranks"][0]["quality"]["automatic_passed"]:
+            raise RuntimeError("warmup media checks failed; fix quality before timing")
+        for index in range(3):
+            result = engine.generate(H3Request(), args.output_dir / f"run-{index + 1}")
+            result["measurement"] = {"profiled": False, "warmup_runs": 1}
+            (args.output_dir / f"run-{index + 1}" / "run.json").write_text(
+                json.dumps(result, indent=2, ensure_ascii=False)
+            )
+            results.append(result)
+    report = evaluate_performance(results)
+    report["quality"] = [run["ranks"][0]["quality"] for run in results]
+    report["accepted"] = False  # Human quality review is always required.
+    (args.output_dir / "acceptance.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument(
         "--attention-backend",
         choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
-        default="FLASHINFER_SM70",
+        default="FLASH_ATTN_V100",
     )
     args = parser.parse_args()
     inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")

--- a/tools/minimax_h3/benchmark.py
+++ b/tools/minimax_h3/benchmark.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument(
         "--attention-backend",
         choices=("FLASH_ATTN_V100", "FLASHINFER_SM70"),
-        default="FLASH_ATTN_V100",
+        default="FLASHINFER_SM70",
     )
     args = parser.parse_args()
     inspect_comfy_checkpoint(args.transformer_path, expected_partition="fl2va")

--- a/tools/minimax_h3/fixtures.py
+++ b/tools/minimax_h3/fixtures.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Extract immutable image/video/audio references from the pinned H3 example."""
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from vllm.model_executor.models.minimax_h3.config import BASE_REVISION
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    source = args.model_root / "assets/ref2va.mp4"
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to prepare reference fixtures")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    for name, options in (
+        ("first.png", ["-frames:v", "1"]),
+        ("reference.mp4", ["-t", "4", "-c:v", "libx264", "-crf", "18", "-c:a", "aac"]),
+        ("reference.wav", ["-t", "4", "-vn", "-ar", "32000", "-c:a", "pcm_f32le"]),
+    ):
+        subprocess.run(
+            [ffmpeg, "-v", "error", "-y", "-i", str(source), *options, str(out / name)],
+            check=True,
+        )
+    subprocess.run(
+        [
+            ffmpeg,
+            "-v",
+            "error",
+            "-y",
+            "-sseof",
+            "-0.1",
+            "-i",
+            str(source),
+            "-frames:v",
+            "1",
+            str(out / "last.png"),
+        ],
+        check=True,
+    )
+    files = []
+    for path in (source, *sorted(out.iterdir())):
+        if not path.is_file() or path.suffix == ".json":
+            continue
+        with path.open("rb") as stream:
+            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+        files.append(
+            {"filename": path.name, "sha256": digest, "bytes": path.stat().st_size}
+        )
+    (out / "manifest.json").write_text(
+        json.dumps({"revision": BASE_REVISION, "files": files}, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3/report.py
+++ b/tools/minimax_h3/report.py
@@ -11,6 +11,11 @@ from pathlib import Path
 def export_report(run_dir):
     run_dir = Path(run_dir)
     run = json.loads((run_dir / "run.json").read_text())
+    if run.get("timing_valid") is False:
+        raise ValueError(
+            "Cannot report excluded timing: "
+            + run.get("timing_exclusion_reason", "run marked invalid")
+        )
     ranks = sorted(run["ranks"], key=lambda rank: rank["rank"])
     denoise_seconds = max(rank["stage_seconds"]["denoise"] for rank in ranks)
     rows = []
@@ -80,7 +85,8 @@ def export_report(run_dir):
     for axis in axes[-1]:
         axis.set_xlabel("Seconds from first NVML sample")
     figure.suptitle(
-        f"H3 {run['config']['attention_backend']} — "
+        f"H3 {run['config']['attention_backend']} "
+        f"({run.get('mode', 'native request')}) — "
         "NVML diagnostics (Tensor Core activity requires Nsight Compute)"
     )
     figure.tight_layout()

--- a/tools/minimax_h3/report.py
+++ b/tools/minimax_h3/report.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Export measured H3 rank throughput, phase times and NVML curves."""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+def export_report(run_dir):
+    run_dir = Path(run_dir)
+    run = json.loads((run_dir / "run.json").read_text())
+    ranks = sorted(run["ranks"], key=lambda rank: rank["rank"])
+    denoise_seconds = max(rank["stage_seconds"]["denoise"] for rank in ranks)
+    rows = []
+    for rank in ranks:
+        rows.append(
+            {
+                "rank": rank["rank"],
+                "gpu": run["gpus"][rank["rank"]],
+                "useful_flops": rank["useful_denoise_flops"],
+                "denoise_seconds": denoise_seconds,
+                "effective_tflops": rank["useful_denoise_flops"]
+                / denoise_seconds
+                / 1e12,
+                "peak_allocated_gib": rank["peak_allocated_bytes"] / 1024**3,
+                "dit_calls": rank["dit_calls"],
+            }
+        )
+    with (run_dir / "rank-performance.csv").open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    with (run_dir / "phase-times.csv").open("w", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["rank", "phase", "seconds"])
+        for rank in ranks:
+            for phase, seconds in rank["stage_seconds"].items():
+                writer.writerow([rank["rank"], phase, seconds])
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    samples = [
+        json.loads(line)
+        for line in (run_dir / "nvml.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    if not samples:
+        raise ValueError("no NVML samples were recorded")
+    start = min(sample["timestamp"] for sample in samples)
+    fields = [
+        ("gpu_util_percent", "GPU utilization (%)", 1),
+        ("memory_used_bytes", "Device memory (GiB)", 1024**3),
+        ("power_watts", "Power (W)", 1),
+        ("sm_clock_mhz", "SM clock (MHz)", 1),
+        ("temperature_c", "Temperature (C)", 1),
+        ("memory_util_percent", "Memory controller utilization (%)", 1),
+    ]
+    figure, axes = plt.subplots(3, 2, figsize=(14, 10), sharex=True)
+    for axis, (key, label, divisor) in zip(axes.flat, fields):
+        for gpu in run["gpus"]:
+            points = [
+                sample
+                for sample in samples
+                if sample["gpu"] == gpu and sample.get(key) is not None
+            ]
+            axis.plot(
+                [point["timestamp"] - start for point in points],
+                [point[key] / divisor for point in points],
+                label=f"GPU {gpu}",
+                linewidth=1,
+            )
+        axis.set_ylabel(label)
+        axis.grid(alpha=0.25)
+    axes[0, 0].legend(ncol=4, fontsize=8)
+    for axis in axes[-1]:
+        axis.set_xlabel("Seconds from first NVML sample")
+    figure.suptitle(
+        f"H3 {run['config']['attention_backend']} — "
+        "NVML diagnostics (Tensor Core activity requires Nsight Compute)"
+    )
+    figure.tight_layout()
+    for extension in ("png", "svg"):
+        figure.savefig(run_dir / f"nvml-curves.{extension}", dpi=160)
+    plt.close(figure)
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(export_report(args.run_dir), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -40,6 +40,11 @@ class VideoSubcommand(CLISubcommand):
             mode.add_argument(
                 "--int8-weight-layout", choices=["row", "column"], default="column"
             )
+            mode.add_argument(
+                "--residual-sequence-parallel",
+                action="store_true",
+                help=("Experimental FP32 residual sharding for TP4 FL2VA INT8"),
+            )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
             if name == "generate":
                 mode.add_argument("--prompt", default=DEFAULT_PROMPT)
@@ -77,6 +82,7 @@ class VideoSubcommand(CLISubcommand):
             fp16_weight_cache_gib=args.fp16_weight_cache_gib,
             fp16_cache_layers=tuple(args.fp16_cache_layer),
             int8_weight_layout=args.int8_weight_layout,
+            residual_sequence_parallel=args.residual_sequence_parallel,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -45,6 +45,12 @@ class VideoSubcommand(CLISubcommand):
                 "--int8-weight-layout", choices=["row", "column"], default="column"
             )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
+            mode.add_argument(
+                "--video-encoder",
+                choices=("libx264", "h264_nvenc"),
+                default="libx264",
+                help="MP4 encoder; NVENC requires a capable IMAGEIO_FFMPEG_EXE",
+            )
             if name == "generate":
                 mode.add_argument("--prompt", default=DEFAULT_PROMPT)
                 mode.add_argument("--width", type=int, default=1344)
@@ -98,6 +104,7 @@ class VideoSubcommand(CLISubcommand):
             fp16_cache_layers=tuple(args.fp16_cache_layer),
             lora_path=args.lora_path,
             int8_weight_layout=args.int8_weight_layout,
+            video_encoder=args.video_encoder,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -41,6 +41,7 @@ class H3Config:
     fp16_weight_cache_gib: float = 0.0
     fp16_cache_layers: tuple[str, ...] = ()
     int8_weight_layout: str = "column"
+    residual_sequence_parallel: bool = False
 
     def __post_init__(self) -> None:
         if self.partition not in ("fl2va", "ref2va"):
@@ -55,6 +56,17 @@ class H3Config:
             "TORCH_SDPA",
         ):
             raise H3InputError(f"unsupported H3 attention: {self.attention_backend}")
+        if self.residual_sequence_parallel and (
+            self.tensor_parallel_size != 4
+            or self.attention_backend not in ("FLASH_ATTN_V100", "FLASHINFER_SM70")
+            or self.partition != "fl2va"
+            or not self.transformer_path
+        ):
+            raise H3InputError(
+                "experimental residual sequence parallelism requires TP4, "
+                "FLASH_ATTN_V100 or FLASHINFER_SM70 and an FL2VA INT8 "
+                "ConvRot checkpoint"
+            )
         if (
             not math.isfinite(self.fp16_weight_cache_gib)
             or self.fp16_weight_cache_gib < 0

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -42,8 +42,11 @@ class H3Config:
     fp16_cache_layers: tuple[str, ...] = ()
     lora_path: str | None = None
     int8_weight_layout: str = "column"
+    video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
 
     def __post_init__(self) -> None:
+        if self.video_encoder not in ("libx264", "h264_nvenc"):
+            raise H3InputError("video encoder must be libx264 or h264_nvenc")
         if self.partition not in ("fl2va", "ref2va"):
             raise H3InputError("partition must be fl2va or ref2va")
         if self.int8_weight_layout not in ("row", "column"):

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -464,7 +464,10 @@ class MiniMaxH3Pipeline(nn.Module):
         token = attention_backend.set(config.attention_backend)
         try:
             self.transformer = MiniMaxH3DiTModel(
-                architecture, quant_config=quant, arch_overrides=overrides
+                architecture,
+                quant_config=quant,
+                arch_overrides=overrides,
+                residual_sequence_parallel=config.residual_sequence_parallel,
             )
         finally:
             attention_backend.reset(token)

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -21,8 +21,11 @@ from torch.nn import Module
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
     LinearBase,
     LinearMethodBase,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
     RowParallelLinear,
     UnquantizedLinearMethod,
 )
@@ -393,13 +396,13 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             output = torch.nn.functional.linear(x, weight, bias)
         return output.reshape(*original_shape[:-1], layer.weight.shape[0])
 
-    def apply_prepared(self, layer, values, scale):
+    def apply_prepared(self, layer, values, scale, *, input_is_rotated=False):
         """Project FP16 rows with an explicit scale restored before TP reduction."""
         from .cuda_ops import fp16_gemm, w8a16_extension
 
         ops = w8a16_extension()
         x = values.reshape(-1, values.shape[-1])
-        if self.layer_config.convrot:
+        if self.layer_config.convrot and not input_is_rotated:
             if self.layer_config.convrot_groupsize != 256:
                 raise ValueError("H3 SM70 ConvRot implements 256-channel groups")
             x = ops.rotate(x)
@@ -412,6 +415,55 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
         if scale is not None:
             output = output * scale
         return output.reshape(*values.shape[:-1], layer.weight.shape[0])
+
+
+def rotate_local_fp16(layer, values):
+    """Rotate local residual rows before their bit-preserving TP all-gather."""
+    method = layer.quant_method
+    if (
+        values.is_cuda
+        and values.dtype == torch.float16
+        and isinstance(method, Int8ConvRotLinearMethod)
+        and method.layer_config.convrot
+        and method.layer_config.convrot_groupsize == 256
+        and layer.bias is None
+        and not layer.gather_output
+    ):
+        from .cuda_ops import w8a16_extension
+
+        return w8a16_extension().rotate(values), True
+    return values, False
+
+
+class _H3RotatedColumnInput(ColumnParallelLinear):
+    def forward(self, input_, *, input_is_rotated=False):
+        if not input_is_rotated:
+            return super().forward(input_)
+        method = self.quant_method
+        if (
+            not input_.is_cuda
+            or input_.dtype != torch.float16
+            or self.bias is not None
+            or self.gather_output
+            or not isinstance(method, Int8ConvRotLinearMethod)
+            or not method.layer_config.convrot
+            or method.layer_config.convrot_groupsize != 256
+        ):
+            raise ValueError(
+                "Pre-rotated H3 columns require bias-free INT8 FP16 inputs"
+            )
+        # The module still receives every gathered row: ordinary forward hooks
+        # and useful-FLOP accounting retain the original full projection shape.
+        output = method.apply_prepared(self, input_, None, input_is_rotated=True)
+        return (output, None) if self.return_bias else output
+
+
+class H3QKVParallelLinear(_H3RotatedColumnInput, QKVParallelLinear):
+    """QKV projection accepting explicitly rotated, gathered FP16 rows."""
+
+
+class H3MergedColumnParallelLinear(_H3RotatedColumnInput, MergedColumnParallelLinear):
+    """Gate/up projection accepting explicitly rotated, gathered FP16 rows."""
 
 
 class H3RowParallelLinear(RowParallelLinear):

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 import torch.nn as nn
 
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import (
@@ -799,6 +799,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        residual_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
@@ -815,6 +816,14 @@ class MiniMaxH3DiTBlock(nn.Module):
             quant_config,
             prefix=f"{prefix}.mlp",
         )
+        self.residual_group = get_tp_group() if residual_sequence_parallel else None
+        if self.residual_group is not None:
+            if self.residual_group.world_size != 4:
+                raise ValueError("H3 residual sequence parallelism requires TP4")
+            # These projections return unreduced FP32 partial sums. Reduce-scatter
+            # keeps that precision and assigns each rank its residual rows.
+            self.attn.out_proj.reduce_results = False
+            self.mlp.fc2.reduce_results = False
         self.adaln_proj = MiniMaxH3AdalnProj(
             arch,
             arch.adaln_out_features,
@@ -845,6 +854,23 @@ class MiniMaxH3DiTBlock(nn.Module):
         norm1 -> scale/shift -> attention -> gated residual, followed by
         norm2 -> scale/shift -> MLP -> gated residual.
         """
+        group = self.residual_group
+        if group is not None:
+            total = combined_indices.shape[0]
+            if (
+                num_requests != 1
+                or sp_seq_lens is not None
+                or total % group.world_size
+                or x.shape[0] != total // group.world_size
+                or x.dtype != _FP32_DTYPE
+            ):
+                raise ValueError(
+                    "H3 residual sequence parallelism needs local FP32 rows, "
+                    "TP-aligned global metadata and a single request without Ulysses"
+                )
+            combined_indices = combined_indices.narrow(
+                0, group.rank_in_group * x.shape[0], x.shape[0]
+            )
         (
             shift_msa,
             scale_msa,
@@ -864,6 +890,9 @@ class MiniMaxH3DiTBlock(nn.Module):
             self.norm1.variance_epsilon,
             output_dtype=_COMPUTE_DTYPE,
         )
+        if group is not None:
+            # Gather only after the existing normalization's FP16 boundary.
+            h = group.all_gather(h, dim=0)
         h = self.attn(
             h,
             rope_table=rope_table,
@@ -874,6 +903,8 @@ class MiniMaxH3DiTBlock(nn.Module):
             sp_seq_lens=sp_seq_lens,
             video_layout=video_layout,
         )
+        if group is not None:
+            h = group.reduce_scatter(h, dim=0)
         x, h = indexed_gate_rms_norm_scale_shift(
             residual,
             gate_msa,
@@ -886,7 +917,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             output_dtype=_COMPUTE_DTYPE,
         )
         residual = x
+        if group is not None:
+            h = group.all_gather(h, dim=0)
         h = self.mlp(h)
+        if group is not None:
+            h = group.reduce_scatter(h, dim=0)
         return indexed_gate(residual, gate_mlp, h, combined_indices)
 
 
@@ -1013,6 +1048,8 @@ class MiniMaxH3DiTModel(nn.Module):
         config: Mapping[str, Any],
         quant_config: QuantizationConfig | None = None,
         arch_overrides: Mapping[str, Any] | None = None,
+        *,
+        residual_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         config_mapping = dict(config)
@@ -1036,6 +1073,15 @@ class MiniMaxH3DiTModel(nn.Module):
         self._qkv_checkpoint_is_runtime_layout = bool(
             getattr(quant_config, "is_checkpoint_int8_convrot_serialized", False)
         )
+        self.residual_sequence_parallel = residual_sequence_parallel
+        if residual_sequence_parallel and (
+            get_tensor_model_parallel_world_size() != 4
+            or not self._qkv_checkpoint_is_runtime_layout
+        ):
+            raise ValueError(
+                "H3 residual sequence parallelism requires TP4 "
+                "and serialized INT8 ConvRot"
+            )
         self.hidden_size = arch.hidden_size
         self.num_attention_heads = arch.num_attention_heads
         self.num_channels_latents = arch.latents_dim
@@ -1100,6 +1146,7 @@ class MiniMaxH3DiTModel(nn.Module):
                     arch,
                     quant_config,
                     prefix=f"blocks.{i}",
+                    residual_sequence_parallel=residual_sequence_parallel,
                 )
                 for i in range(arch.num_layers)
             ]
@@ -1520,6 +1567,23 @@ class MiniMaxH3DiTModel(nn.Module):
                 block_rope,
                 block_combined,
             )
+        residual_group = None
+        if self.residual_sequence_parallel:
+            residual_group = get_tp_group()
+            if (
+                local_len != seq_len
+                or hidden.shape[0] != seq_len
+                or block_combined.shape[0] != seq_len
+                or block_rope.shape[0] != seq_len
+                or seq_len % residual_group.world_size
+                or num_requests != 1
+            ):
+                raise ValueError(
+                    "H3 residual sequence parallelism requires a single request "
+                    "with TP-aligned global rows and no sequence-parallel hooks"
+                )
+            rows = seq_len // residual_group.world_size
+            hidden = hidden.narrow(0, residual_group.rank_in_group * rows, rows)
         for block in self.blocks:
             hidden = block(
                 hidden,
@@ -1532,6 +1596,9 @@ class MiniMaxH3DiTModel(nn.Module):
                 num_requests=num_requests,
                 video_layout=video_layout,
             )
+        if residual_group is not None:
+            # Final heads and the existing padding boundary consume full FP32 rows.
+            hidden = residual_group.all_gather(hidden, dim=0)
         if local_len == seq_len:
             hidden = self.sp_gather(hidden)
             video_logits, audio_logits = self.final_layer(

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -21,8 +21,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -42,9 +40,12 @@ from .modulation import (
 )
 from .ops import RMSNorm, RotaryEmbedding, fused_qk_norm_rope
 from .quantization import (
+    H3MergedColumnParallelLinear,
+    H3QKVParallelLinear,
     H3RowParallelLinear,
     Int8ConvRotLinearMethod,
     preserve_fp32_output,
+    rotate_local_fp16,
 )
 
 if TYPE_CHECKING:
@@ -375,7 +376,7 @@ class MiniMaxH3Attention(nn.Module):
         self.head_dim = arch.attention_head_dim
         inner_dim = self.total_num_heads * self.head_dim
         self.softmax_scale = self.head_dim**-0.5
-        self.qkv_proj = QKVParallelLinear(
+        self.qkv_proj = H3QKVParallelLinear(
             hidden_size=arch.hidden_size,
             head_size=self.head_dim,
             total_num_heads=self.total_num_heads,
@@ -547,6 +548,7 @@ class MiniMaxH3Attention(nn.Module):
         num_requests: int = 1,
         sp_seq_lens: list[int] | None = None,
         video_layout: VideoTokenLayout | None = None,
+        input_is_rotated: bool = False,
     ) -> torch.Tensor:
         """x: [T, hidden] packed thd rows -> [T, hidden].
 
@@ -560,7 +562,10 @@ class MiniMaxH3Attention(nn.Module):
         all-to-all restores the row shard before the output projection.
         """
         total = x.shape[0]
-        qkv, _ = self.qkv_proj(x)
+        if input_is_rotated:
+            qkv, _ = self.qkv_proj(x, input_is_rotated=True)
+        else:
+            qkv, _ = self.qkv_proj(x)
         q_size = self.num_heads * self.head_dim
         kv_size = self.num_kv_heads * self.head_dim
         q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
@@ -610,7 +615,7 @@ class MiniMaxH3MLP(nn.Module):
         prefix: str,
     ) -> None:
         super().__init__()
-        self.fc1 = MergedColumnParallelLinear(
+        self.fc1 = H3MergedColumnParallelLinear(
             arch.hidden_size,
             [arch.ffn_hidden_size, arch.ffn_hidden_size],
             bias=False,
@@ -633,8 +638,11 @@ class MiniMaxH3MLP(nn.Module):
         )
         preserve_fp32_output(self.fc2)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        hidden, _ = self.fc1(x)
+    def forward(self, x: torch.Tensor, *, input_is_rotated=False) -> torch.Tensor:
+        if input_is_rotated:
+            hidden, _ = self.fc1(x, input_is_rotated=True)
+        else:
+            hidden, _ = self.fc1(x)
         if (
             hidden.is_cuda
             and hidden.dtype == torch.float16
@@ -890,8 +898,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             self.norm1.variance_epsilon,
             output_dtype=_COMPUTE_DTYPE,
         )
+        input_is_rotated = False
         if group is not None:
-            # Gather only after the existing normalization's FP16 boundary.
+            # Rotation is row-independent. Compute it once on each row's owner,
+            # after the existing FP16 boundary, then gather its exact FP16 bits.
+            h, input_is_rotated = rotate_local_fp16(self.attn.qkv_proj, h)
             h = group.all_gather(h, dim=0)
         h = self.attn(
             h,
@@ -902,6 +913,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             num_requests=num_requests,
             sp_seq_lens=sp_seq_lens,
             video_layout=video_layout,
+            input_is_rotated=input_is_rotated,
         )
         if group is not None:
             h = group.reduce_scatter(h, dim=0)
@@ -917,9 +929,11 @@ class MiniMaxH3DiTBlock(nn.Module):
             output_dtype=_COMPUTE_DTYPE,
         )
         residual = x
+        input_is_rotated = False
         if group is not None:
+            h, input_is_rotated = rotate_local_fp16(self.mlp.fc1, h)
             h = group.all_gather(h, dim=0)
-        h = self.mlp(h)
+        h = self.mlp(h, input_is_rotated=input_is_rotated)
         if group is not None:
             h = group.reduce_scatter(h, dim=0)
         return indexed_gate(residual, gate_mlp, h, combined_indices)

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -83,7 +83,14 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
 
                     started = time.perf_counter()
                     result.update(
-                        export_video(video, audio, output_dir, fps=request.sampling.fps)
+                        export_video(
+                            video,
+                            audio,
+                            output_dir,
+                            fps=request.sampling.fps,
+                            encoder=config.video_encoder,
+                            gpu_index=rank,
+                        )
                     )
                     result["stage_seconds"]["packaging"] = time.perf_counter() - started
                     from vllm.model_executor.models.minimax_h3.time_request import (

--- a/vllm/video/media.py
+++ b/vllm/video/media.py
@@ -3,6 +3,7 @@
 """Export H3 video and its synchronous 32 kHz audio."""
 
 import subprocess
+import time
 from pathlib import Path
 
 import imageio_ffmpeg
@@ -10,32 +11,82 @@ import numpy as np
 import soundfile as sf
 
 
-def export_video(video, audio, output_dir, *, fps=24):
+def export_video(video, audio, output_dir, *, fps=24, encoder="libx264", gpu_index=0):
+    if encoder not in ("libx264", "h264_nvenc"):
+        raise ValueError(f"unsupported video encoder {encoder!r}")
+    nvenc = encoder == "h264_nvenc"
     root = Path(output_dir)
     root.mkdir(parents=True, exist_ok=True)
+    stages = {}
+    started = time.perf_counter()
     # Pipeline video is B,T,H,W,C, audio is B,C,samples.
-    video = video.detach().cpu()
-    audio = audio.detach().float().cpu()
+    video = video.detach()
     if video.ndim != 5 or video.shape[0] != 1 or video.shape[-1] != 3:
         raise ValueError(f"unexpected H3 video shape {tuple(video.shape)}")
     if audio.ndim != 3 or audio.shape[0] != 1 or audio.shape[1] not in (1, 2):
         raise ValueError(f"unexpected H3 audio shape {tuple(audio.shape)}")
+    preparation_device = str(video.device)
+    if nvenc:
+        # NVENC accepts packed RGBA and converts it to YUV420 on the GPU.
+        # Pack on the source device before the subprocess's host-memory pipe;
+        # do not request FFmpeg's CPU RGB-to-YUV conversion with -pix_fmt.
+        rgba = video.new_full((*video.shape[:-1], 4), 255)
+        rgba[..., :3].copy_(video)
+        video = rgba
+    video = video.cpu().contiguous()
+    audio = audio.detach().float().cpu()
+    stages["prepare_and_copy"] = time.perf_counter() - started
+    started = time.perf_counter()
     if not np.isfinite(audio.numpy()).all():
         raise ValueError("H3 produced non-finite audio")
     waveform = audio[0].numpy().T
     wav = root / "audio.wav"
     sf.write(wav, waveform, 32000, subtype="FLOAT")
+    stages["audio_wav"] = time.perf_counter() - started
     _, frames, height, width, _ = video.shape
     output = root / "video.mp4"
+    ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
+    codec_args = (
+        [
+            "-c:v",
+            "h264_nvenc",
+            "-gpu",
+            str(gpu_index),
+            "-preset",
+            "p4",
+            "-tune",
+            "hq",
+            "-rc",
+            "vbr",
+            "-cq",
+            "18",
+            "-b:v",
+            "0",
+            "-rgb_mode",
+            "yuv420",
+        ]
+        if nvenc
+        else [
+            "-c:v",
+            "libx264",
+            "-crf",
+            "18",
+            "-preset",
+            "medium",
+            "-pix_fmt",
+            "yuv420p",
+        ]
+    )
     command = [
-        imageio_ffmpeg.get_ffmpeg_exe(),
+        ffmpeg,
+        "-nostdin",
         "-y",
         "-v",
         "error",
         "-f",
         "rawvideo",
         "-pix_fmt",
-        "rgb24",
+        "rgba" if nvenc else "rgb24",
         "-s",
         f"{width}x{height}",
         "-r",
@@ -48,14 +99,7 @@ def export_video(video, audio, output_dir, *, fps=24):
         "0:v",
         "-map",
         "1:a",
-        "-c:v",
-        "libx264",
-        "-crf",
-        "18",
-        "-preset",
-        "medium",
-        "-pix_fmt",
-        "yuv420p",
+        *codec_args,
         "-c:a",
         "aac",
         "-b:a",
@@ -64,20 +108,30 @@ def export_video(video, audio, output_dir, *, fps=24):
         "+faststart",
         str(output),
     ]
+    started = time.perf_counter()
     with (root / "encode.log").open("wb") as log:
         process = subprocess.Popen(command, stdin=subprocess.PIPE, stderr=log)
         try:
             assert process.stdin is not None
             for frame in video[0]:
-                process.stdin.write(frame.contiguous().numpy().tobytes())
+                process.stdin.write(memoryview(frame.numpy()).cast("B"))
             process.stdin.close()
+            # Pipe feeding overlaps encoder work and includes backpressure.
+            # These are sequential wall intervals, not CPU/GPU kernel times.
+            stages["ffmpeg_start_and_feed"] = time.perf_counter() - started
+            started = time.perf_counter()
             if process.wait() != 0:
                 raise RuntimeError(
                     f"ffmpeg video export failed; see {root / 'encode.log'}"
                 )
-        except BaseException:
+            stages["ffmpeg_finish"] = time.perf_counter() - started
+        except BaseException as exc:
             process.kill()
             process.wait()
+            if isinstance(exc, BrokenPipeError):
+                raise RuntimeError(
+                    f"ffmpeg {encoder} export failed; see {root / 'encode.log'}"
+                ) from exc
             raise
     return {
         "video": str(output),
@@ -86,4 +140,9 @@ def export_video(video, audio, output_dir, *, fps=24):
         "width": width,
         "height": height,
         "fps": fps,
+        "video_encoder": encoder,
+        "encoding_device": f"cuda:{gpu_index}" if nvenc else "cpu",
+        "preparation_device": preparation_device,
+        "ffmpeg_executable": ffmpeg,
+        "export_stage_seconds": stages,
     }

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -138,6 +138,34 @@ def evaluate_performance(runs):
     """Evaluate three unprofiled post-warmup runs; never use utilization as FLOPs."""
     if len(runs) != 3 or any(len(run["ranks"]) != 4 for run in runs):
         raise ValueError("acceptance requires three four-rank measurements")
+    baseline = runs[0]
+    for run in runs:
+        if sorted(rank["rank"] for rank in run["ranks"]) != list(range(4)):
+            raise ValueError("each measurement must contain four unique TP ranks")
+        if any(run[key] != baseline[key] for key in ("config", "request", "gpus")):
+            raise ValueError("acceptance measurements must use the same configuration")
+        sampling = run["request"]["sampling"]
+        expected = {
+            "width": 1344,
+            "height": 768,
+            "num_frames": 243,
+            "fps": 24,
+            "seed": 42,
+            "num_inference_steps": 50,
+        }
+        if any(sampling.get(key) != value for key, value in expected.items()):
+            raise ValueError("acceptance requires the fixed primary workload")
+        if run.get("measurement", {}).get("profiled") is not False:
+            raise ValueError("formal timing must be explicitly recorded as unprofiled")
+        if any(rank["dit_calls"] != 49 for rank in run["ranks"]):
+            raise ValueError("the primary schedule requires 49 completed DiT calls")
+        if any(
+            type(rank["useful_denoise_flops"]) is not int
+            or rank["useful_denoise_flops"] <= 0
+            for rank in run["ranks"]
+        ):
+            raise ValueError("useful FLOPs must be positive integer counts")
+    ordered = [sorted(run["ranks"], key=lambda rank: rank["rank"]) for run in runs]
     seconds = [
         max(rank["stage_seconds"]["denoise"] for rank in run["ranks"]) for run in runs
     ]
@@ -146,14 +174,20 @@ def evaluate_performance(runs):
     medians = []
     for rank in range(4):
         values = [
-            run["ranks"][rank]["useful_denoise_flops"] / duration / 1e12
-            for run, duration in zip(runs, seconds)
+            ranks[rank]["useful_denoise_flops"] / duration / 1e12
+            for ranks, duration in zip(ordered, seconds)
         ]
         medians.append(statistics.median(values))
     cv = statistics.pstdev(seconds) / statistics.mean(seconds)
+    memory_passed = all(
+        rank["peak_allocated_bytes"] <= 30 * 1024**3
+        for run in runs
+        for rank in run["ranks"]
+    )
     return {
         "rank_median_tflops": medians,
         "denoise_seconds": seconds,
         "denoise_cv": cv,
+        "memory_passed": memory_passed,
         "performance_passed": all(value > 80 for value in medians) and cv <= 0.05,
     }

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -163,6 +163,8 @@ def evaluate_performance(runs):
             raise ValueError("acceptance requires the fixed primary workload")
         if run.get("measurement", {}).get("profiled") is not False:
             raise ValueError("formal timing must be explicitly recorded as unprofiled")
+        if run.get("timing_valid") is False:
+            raise ValueError("run timing was excluded from performance evidence")
         if any(rank["dit_calls"] != 49 for rank in run["ranks"]):
             raise ValueError("the primary schedule requires 49 completed DiT calls")
         if any(


### PR DESCRIPTION
Native H3 currently exports every video through CPU libx264. Add an explicit `--video-encoder h264_nvenc` option to offline generation and HTTP deployments. GPU-resident input is packed as RGBA on its source device; NVENC performs RGB-to-YUV420 conversion and H.264 compression on rank 0's leased GPU. Run metadata records the encoder/device/executable and sequential export timing intervals.

The default remains CPU CRF 18 / medium. NVENC uses VBR CQ 18 / p4 / HQ, with a capable FFmpeg selected through `IMAGEIO_FFMPEG_EXE`. It never silently falls back to CPU. The subprocess still pipes raw frames through host memory; AAC encoding, MP4 muxing and I/O remain on the CPU. This is single-GPU export, not multi-GPU partitioning of one clip. The frontend API is unchanged.

Purpose and measured result: on one V100-SXM2-32GB, exporting the same GPU-resident 120-frame 1280x720 input took 1.652 s with libx264 versus 1.377 s with NVENC (two samples each; 16.6% lower latency). NVENC produced a 40.8% larger MP4 at these settings. The encoder quality controls are not equivalent. See `docs/design/minimax_h3/GPU_EXPORT.md` for the workload, stage table and limitations.

Test Plan and Result:
- `.venv/bin/python -m pytest --confcutdir=tests/video tests/video/test_h3_gpu_export.py tests/video/test_h3_service.py tests/video/test_h3_omni_api.py -q`: 36 passed, including a real CPU export and API regressions. NVENC unit tests cover packing/channel order, stride handling, selected device and explicit failure propagation.
- Actual GPU export completed on clean implementation SHA `642925223d0a97ac48aa598ef6e0559493f71084`: CPU / NVENC / NVENC / CPU samples were 1.613 / 1.391 / 1.363 / 1.691 seconds. NVML recorded hardware encoder activity. Input upload, model startup, denoising, VAE and VAE output quantization were excluded; raw-frame D2H copy, WAV writing, encoding and muxing were included.
- All four outputs passed automatic checks: H.264 YUV420P, 1280x720, 120 frames, 24 FPS, video/audio exactly 5.000 s. SSIM versus common decoded RGB input: CPU 0.993359, NVENC 0.992695. MP4 sizes: CPU 3,563,768 bytes, NVENC 5,018,993 bytes. Frames 48 and 119 were inspected without obvious color/channel corruption; no full temporal/listening review is claimed.
- Targeted pre-commit, mypy/lint/headers, generate/serve CLI help and GitHub checks passed on the implementation. The follow-up evidence commit changes only documentation and passed local hooks.

The earlier full-pipeline packaging interval of 20.56 s was not reproduced under this isolated contract and is not a comparable baseline. No end-to-end H3 generation speedup is claimed. An already-CPU-resident input exported through the original implementation in 1.298 s, also a different timing boundary.

Integration base: `e7fa44deb253746a11b06be1cd3a75ef7dcdb67c`. No overlapping H3 export PR was found. AI assistance was used; this Draft requires human review. Retained artifacts: `/data/minimax-h3/h3-gpu-export-20260908/`. The GPU-owner queue ran the approximately 9.6-second bounded job serially following user-authorized coordination; no unrelated task was interrupted, and no owned GPU process remains. Native import binaries were reused with hashes retained; no new CUDA build is claimed.


### Main integration requested by user

Resolved the current main merge in an isolated integration worktree, retaining both the residual-sequence-parallel option and video-encoder selection. The combined CPU suite (`tests/video/test_h3_gpu_export.py`, `test_h3_service.py`, `test_h3_omni_api.py`, `test_h3_acceptance.py`, with `--confcutdir=tests/video`) passes **44 tests**. Targeted pre-commit hooks pass. Existing GPU-export measurements remain unchanged; no new GPU or end-to-end performance claim is made. Evidence: `/data/minimax-h3/native-h3-20260908/merge-all-20260909/export-integration-tests.log`. The user explicitly authorized main integration; libx264 remains the default encoder.
