### PR TITLE
[Core] Generalize H3 SM70 execution and weight residency

### DIFF
--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -77,8 +77,9 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
   `git archive` of that SHA. Generated extension aliases are confined to the
   artifact bootstrap, preserving package ABI names without copying stale H3
   binaries from another task.
-- `prepared-linear-v2.log`: 28 GPU tests passed (shared GEMM, scaling, LoRA,
-  activation, column-major plans). Prepared LoRA equals normal execution
+- `prepared-linear-v2.log`: 28 checks passed in the leased GPU batch (24 GPU
+  checks and four CPU layout checks: shared GEMM, scaling, LoRA, activation,
+  column-major plans). Prepared LoRA equals normal execution
   bitwise for original FP16 and W8A16, scales 0/0.75/-0.5, including explicit
   unrotated inputs beside rotated base operands.
 - `candidate-tp2.log` and `candidate-tp4.log`: the complete distributed block
@@ -134,3 +135,15 @@ the unqualified reduce-scatter communication saving. The distributed oracle
 is tightened from a tolerance to bitwise equality; complete-model revalidation
 is still required. Tensor-parallel GEMM, local normalization/residual ownership
 and adapter support remain active. No >80 result or human acceptance exists.
+
+`candidate-720p-exact-reduction` validates code `9623a9adb2`: complete video
+and audio latents are **bitwise equal** to the frozen mainline baseline, all
+124 pre-encoding frames match (SSIM 1.0), and all audio numerical gates pass.
+See `exact-reduction-quality.json`. This was a single no-warmup quality request
+(66.954238 s denoise); it is not a qualified performance comparison.
+
+The tightened bitwise block oracle also passes on both TP2 ranks
+(`exact-reduction-tp2-v3.log`) and all TP4 ranks (`exact-reduction-tp4.log`).
+These results establish the sampled four-step route's numerical preservation,
+not all adapters/partitions or human audiovisual acceptance. Draft PR #571
+contains the implementation and remains Draft.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -1,0 +1,108 @@
+# General SM70 H3 acceleration campaign
+
+Integration: `onecat/main`, base `4f19ef7a20db60bb0685e599bd3f4dd156202eed`.
+Owned branch: `codex/v100-h3-general-sm70-20260908-165458`.
+Raw evidence: `/data/minimax-h3/sm70-general-20260909/`.
+
+## Accepted objective
+
+Accelerate every supported H3 generation task across original floating-point
+weights, W8A16, all eight LightX2V four/eight-step adapters, FlashGen, FastH3
+Dense/VSA, TeaCache and Cache-DiT. Keep official task, adapter and sigma
+contracts. Extract reusable SM70 DiT operators; a second complete model is
+outside this campaign. Frontends continue to call the native vLLM API.
+
+Use hardware, tensor layout/dtype, precision, adapter and collective capabilities
+for dispatch. Preserve FP32 accumulation, residuals and wide-range scaling.
+ConvRot applies only to matching rotated weights. LoRA receives the unrotated
+activation and joins TP partial sums before reduction. Extend residual sequence
+sharding to original weights, Ref2VA, adapters and TP2/TP4; TP1 remains ordinary
+execution. AUTO may select only qualified routes.
+
+Primary performance cases are the original 720p five-second four-step sample,
+1344x768/243-frame official workload, and the 15-second boundary on TP4.
+Count actual useful rank-local model work over the slowest rank's complete
+denoise wall time, excluding padding, redundant work and skipped operations.
+Sparse attention counts selected pairs and its actual compression projections;
+cache savings are reported separately from arithmetic throughput. Record
+actual denoiser calls, executed blocks and per-step/stage timing.
+
+Acceptance requires one full warmup then three unprofiled measurements,
+each rank's median above 80 TFLOP/s and denoise CV <= 5%, plus measured request
+latency and memory. Smaller shapes and TP1/TP2 require compatibility checks.
+The old 43.914752 TFLOP/s/card sample had 71.315842 s denoise and no warmup;
+its equal-work 80 TFLOP/s budget is 39.147719 s. The old 39-frame/20-step
+FA/FI diagnostics are not matching speed baselines.
+
+Quality compares each variant against the same weights, initial noise and
+official algorithm, including full sampling. Default numerical gates are
+video/audio final-latent relative L2 <= 0.01, pre-encoding video PSNR >= 40 dB
+and SSIM >= 0.99, audio spectral cosine >= 0.99 and RMS ratio in [0.99, 1.01].
+Complete audiovisual and reference-consistency review remains a separate gate.
+Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
+
+## Progress and required evidence
+
+| Requirement | Implementation | Validation / evidence |
+| --- | --- | --- |
+| Common FP16 input/GEMM, dense column-major path | Shared operator and explicit dense layout | GPU operator checks pass; full original-weight generation pending |
+| Prepared LoRA input and collective ordering | Implemented, including explicit original basis | GPU prepared/normal results bitwise equal; TP2/TP4 block comparisons pass |
+| General residual sequence sharding | TP2/TP4, original/INT8, matching adapters; TP1 no-op | Both backends and wide residual/padding block checks pass; full Ref2VA pending |
+| FA and FI kernel optimization | Existing narrower routes | Matched baselines pending |
+| All dense task/weight/adapter combinations | Partial mainline support | Full matrix pending |
+| FastH3 VSA on SM70 | Pending | Pending |
+| TeaCache and Cache-DiT | Pending | Pending |
+| AUTO and native variant APIs | Pending | Pending |
+| Workflow-specific performance accounting | Fixed primary case only | Pending |
+| Non-H3 DiT operator reuse | Shared GEMM/input preparation | Two non-H3 GEMM shapes pass; Attention reuse pending |
+| >80 TFLOP/s/card, full quality, memory | Not achieved | No qualifying results |
+| Draft PRs, matrix report and playable samples | Pending | Pending |
+
+## Development record
+
+- Baseline and active PRs inspected; no overlapping H3 PR is open. Both prior
+  attention directions and NVENC are merged at the declared base.
+- All eight V100s were idle at preflight. Every GPU launch must acquire the
+  native GPU lease and recheck actual processes; idle observations do not
+  reserve a device.
+- The attachment and complete accepted plan were read. No previous execution
+  turn existed: the preceding turn produced a plan, not implementation evidence.
+- Next: rebuild owned baseline extensions, prove the current numerical route,
+  then implement shared prepared linear execution and residual sharding.
+
+### First implementation checkpoint
+
+- Fresh SM70 extensions built from the integration base; immutable paths and
+  SHA256 recorded in `baseline-binaries.json`. The baseline runtime is a clean
+  `git archive` of that SHA. Generated extension aliases are confined to the
+  artifact bootstrap, preserving package ABI names without copying stale H3
+  binaries from another task.
+- `prepared-linear-v2.log`: 28 GPU tests passed (shared GEMM, scaling, LoRA,
+  activation, column-major plans). Prepared LoRA equals normal execution
+  bitwise for original FP16 and W8A16, scales 0/0.75/-0.5, including explicit
+  unrotated inputs beside rotated base operands.
+- `candidate-tp2.log` and `candidate-tp4.log`: the complete distributed block
+  case passes on all respective ranks. Cases include both attention backends,
+  original and INT8 adapted blocks, consecutive blocks, padding and residuals
+  exceeding FP16 range. This is not complete-model quality evidence.
+- `core-regressions-v2.log`: 133 CPU adapter/config/API/conversion checks passed,
+  one skipped and eight GPU cases deselected. Earlier export/import failures
+  were missing video-extra dependencies in the new isolated environment.
+  The environment now matches the retained native model-component versions;
+  Torch remains 2.10.0+cu128. Both dynamic VAE classes import successfully.
+- Failed setup paths retained: combining two distributed fixture lifetimes in
+  one torchrun produced a Gloo rendezvous error after the first case passed;
+  separate torchrun invocations resolve it. The first prepared run caught a
+  removed compatibility export; the alias is restored and all 28 tests pass.
+- The first full baseline stopped during VAE construction because the new
+  environment lacked `diffusers`; no generated result or speed is claimed.
+  Align the video dependencies with the retained native environment before retry.
+- Active LoRA retains the normal unrotated gather in residual sharding. Its
+  prepared row projections are enabled, and explicit dual-basis column input
+  is supported, but reducing adapter input/gather overhead remains work.
+- Original checkpoint loading rejects non-finite FP16 conversion, while keeping
+  wide-range FP32 parameters intact. Tests cover BF16 overflow, infinity and NaN.
+- Current full baseline: `baseline-720p-v2`, frozen integration Python source,
+  fresh owned kernels, FA backend, no residual sharding, four-step v1.2 adapter,
+  no FP16 weight cache, full warmup then one captured quality/timing request.
+  This is a baseline acquisition, not the formal three-run acceptance.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -48,15 +48,15 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
 | Common FP16 input/GEMM, dense column-major path | Shared operator and explicit dense layout | GPU operator checks pass; original/W8A16 four-step complete controls match bitwise |
 | Prepared LoRA input and collective ordering | Implemented, including explicit original basis | GPU prepared/normal results bitwise equal; TP2/TP4 block comparisons pass |
 | General residual sequence sharding | TP2/TP4, original/INT8, matching adapters; TP1 no-op | Both backends and wide residual/padding block checks pass; full Ref2VA pending |
-| FA and FI kernel optimization | Existing narrower routes | Matched baselines pending |
+| FA and FI kernel optimization | Explicit query-128 and shared epilogues in #581 | Audited FA 47.092, FI 43.990, candidate FA 51.939 TFLOP/s/card; >80 fails |
 | All dense task/weight/adapter combinations | Partial mainline support | Full matrix pending |
-| FastH3 VSA on SM70 | Pending | Pending |
-| TeaCache and Cache-DiT | Pending | Pending |
-| AUTO and native variant APIs | Pending | Pending |
-| Workflow-specific performance accounting | Fixed primary case only | Pending |
+| FastH3 VSA on SM70 | True block-sparse native API in #583 | Full generation completes; final FP32-math diagnostic fails latent/video gates |
+| TeaCache and Cache-DiT | Request-scoped official policies in #584 | TP1/2/4 small forwards and full native cached/lossless/cached lifecycle pass; official quality pending |
+| AUTO and native variant APIs | Variant APIs in #583/#584; AUTO pending | No configuration qualified for automatic selection |
+| Workflow-specific performance accounting | Actual intervals, blocks, sparse pairs and cache hits in #578/#583/#584 | Strict validators pass; skipped/padded/duplicate work excluded |
 | Non-H3 DiT operator reuse | Shared GEMM/input preparation | Two non-H3 GEMM shapes pass; Attention reuse pending |
 | >80 TFLOP/s/card, full quality, memory | Not achieved | No qualifying results |
-| Draft PRs, matrix report and playable samples | Common interface Draft PR #571 | First original/W8A16 four-step samples retained; full matrix pending |
+| Draft PRs, matrix report and playable samples | Draft PRs #571/#578/#581/#583/#584 | Original/W8A16 Light4, W8A16 Light8, FlashGen, FastH3 and cache samples retained; full matrix pending |
 
 ## Development record
 
@@ -186,3 +186,39 @@ checks pass. The full original-weight native-flag run is still pending.
 The separate workflow-metrics branch replaces fixed 49-call validation with
 actual sigma intervals and step/block counts. Its results and formal FA/FI
 comparisons will be recorded independently. No >80 configuration is qualified.
+
+### Current shared storage and campaign checkpoints
+
+The later native-flag run at `324f2463c78fb0f69d1546c817e67f3802e52342`
+also enables explicit shared VAE host storage. Full original-weight Light4
+latents, RGB and PCM match the original column-weight control bitwise.
+TP4 VAE mappings total 11.02 GB physical PSS instead of four physical replicas,
+and the engine cleans up its owned files. See [shared host weights](SHARED_HOST_WEIGHTS.md).
+This supersedes the pending native-flag status above; warmed request speed
+and automatic memory budgeting remain unqualified.
+
+The accounting branch corrects duplicate column-LoRA A projections. For the
+four-step W8A16 sample, useful rank-zero FLOPs are now
+3,103,284,010,387,456; the equal-work 80 TFLOP/s budget is approximately
+38.79 seconds. Earlier TFLOP/s values in this historical record use the old
+numerator and must not be mixed with corrected results.
+
+The kernel branch's full warmup plus three unprofiled query-128 requests take
+59.743807 / 59.748563 / 59.748666 seconds, median 51.939 TFLOP/s/card and
+CV 0.003793%. Light4 and Light8 complete native-control comparisons pass
+bitwise for video/audio latents, RGB and PCM. Neither establishes independent
+official-model or human quality acceptance. The >80 gate still fails.
+
+The variants branch completes native FlashGen, FastH3 Dense and true VSA
+generation. VSA's full FP32 selected-key attention control produces final
+video/audio latent L2 errors 0.390670/0.088636, PSNR 24.277 dB and SSIM
+0.769774: it is unqualified despite small local operator errors. Unmodified
+official FastVideo Triton cannot compile FP16 inputs on this V100 setup;
+an independent compatible official runtime remains required.
+
+Both request caches complete original-weight TP4 cached/lossless/cached
+generation at 256x448, 107 internal frames and 49 intervals. TeaCache records
+5/0/5 hits and Cache-DiT 34/0/34, with repeated latents/RGB bitwise and PCM
+within the declared gates. These are lifecycle checks, not full official
+quality or the primary performance matrix. Subsequent branch documents hold
+the detailed records; their APIs are not all present in this common-base PR.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -45,7 +45,7 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
 
 | Requirement | Implementation | Validation / evidence |
 | --- | --- | --- |
-| Common FP16 input/GEMM, dense column-major path | Shared operator and explicit dense layout | GPU operator checks pass; full original-weight generation pending |
+| Common FP16 input/GEMM, dense column-major path | Shared operator and explicit dense layout | GPU operator checks pass; original/W8A16 four-step complete controls match bitwise |
 | Prepared LoRA input and collective ordering | Implemented, including explicit original basis | GPU prepared/normal results bitwise equal; TP2/TP4 block comparisons pass |
 | General residual sequence sharding | TP2/TP4, original/INT8, matching adapters; TP1 no-op | Both backends and wide residual/padding block checks pass; full Ref2VA pending |
 | FA and FI kernel optimization | Existing narrower routes | Matched baselines pending |
@@ -56,7 +56,7 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
 | Workflow-specific performance accounting | Fixed primary case only | Pending |
 | Non-H3 DiT operator reuse | Shared GEMM/input preparation | Two non-H3 GEMM shapes pass; Attention reuse pending |
 | >80 TFLOP/s/card, full quality, memory | Not achieved | No qualifying results |
-| Draft PRs, matrix report and playable samples | Pending | Pending |
+| Draft PRs, matrix report and playable samples | Common interface Draft PR #571 | First original/W8A16 four-step samples retained; full matrix pending |
 
 ## Development record
 
@@ -147,3 +147,42 @@ The tightened bitwise block oracle also passes on both TP2 ranks
 These results establish the sampled four-step route's numerical preservation,
 not all adapters/partitions or human audiovisual acceptance. Draft PR #571
 contains the implementation and remains Draft.
+
+### Original floating-weight control and host memory
+
+The first original checkpoint run was interrupted by a host restart and has no
+result. The retry (`baseline-720p-original-v2`) was stopped during startup after
+host usage reached 187 GiB with less than 1 GiB available and heavy swapping.
+No denoise performance was recorded. Original-weight CPU masters per rank are
+17,252,698,560 bytes DiT, 13,770,235,360 bytes encoder, 10,415,484,160 bytes video
+VAE and 605,306,340 bytes audio VAE, before loader/allocator overhead.
+
+Two complete controls therefore used identical **pageable** CPU masters for
+all four components, with otherwise unchanged sampling, original BF16 checkpoint
+converted through the existing FP16/FP32 runtime, LightX2V four-step v1.2 and FA:
+
+| Quality control | Denoise seconds | Useful TFLOP/s/card |
+| --- | ---: | ---: |
+| Frozen mainline, ordinary residuals and row layout | 69.044838 | 45.359844 |
+| General prepared path, column layout, exact residual sharding | 66.426983 | 47.147453 |
+
+These are single no-warmup quality requests; the timing difference is **not an
+accepted speedup**. Full video/audio latents match bitwise, all 124 decoded RGB
+frames match (SSIM 1.0), spectral cosine is effectively 1 and RMS ratio is 1.
+See `baseline-720p-original-pageable`, `candidate-720p-original-column` and
+`original-column-quality.json`. These prove preservation of frozen mainline for
+this original-weight workflow, not independent official or human acceptance.
+
+The corresponding native deployment option is `host_weight_pin_memory=False`
+or `--disable-host-weight-pinning`, applied to the DiT, encoder and both VAEs.
+It preserves values, aliases and layouts and changes host residency/transfers
+only. Automatic host/GPU memory budgeting remains further work. The recorded
+complete controls used an artifact-local stager option before the native flag
+was added; they must not be presented as full native-flag generation evidence.
+`host-memory-cpu-v1.log`: 43 config/VAE/workflow/API checks pass.
+`host-memory-gpu-v1.log`: two pinned/pageable alias-preserving repeated transfer
+checks pass. The full original-weight native-flag run is still pending.
+
+The separate workflow-metrics branch replaces fixed 49-call validation with
+actual sigma intervals and step/block counts. Its results and formal FA/FI
+comparisons will be recorded independently. No >80 configuration is qualified.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -222,3 +222,34 @@ generation at 256x448, 107 internal frames and 49 intervals. TeaCache records
 within the declared gates. These are lifecycle checks, not full official
 quality or the primary performance matrix. Subsequent branch documents hold
 the detailed records; their APIs are not all present in this common-base PR.
+
+### Original projection conversion audit
+
+`float-matrix-conversion-audit.json` scans every original attention/MLP matrix
+that the native model executes in FP16, including the token refiners: 208
+matrices and 20,038,287,360 values per partition. Protected FP32 normalization,
+AdaLN and embedding parameters are outside this conversion. The audit retains
+each source tensor's SHA256, shape/dtype, conversion error and underflow count.
+Checkpoint revision is `42ed227ee7df40d41602854ae760620d6eb651fe`.
+
+| Partition | Aggregate relative L2 | Maximum matrix relative L2 | Nonzero values underflowed to zero | Overflow / non-finite input |
+| --- | ---: | ---: | ---: | ---: |
+| FL2VA | 9.000060e-10 | 4.256286e-9 | 4,055 | 0 / 0 |
+| Ref2VA | 9.004251e-10 | 4.208590e-9 | 4,058 | 0 / 0 |
+
+This explicitly records FP16 subnormal-range loss; conversion is not claimed
+to preserve every source bit. No value clipping is performed. The loading
+guard still rejects FP16 overflow. These weight-only measurements do not
+replace the final latent, video and audio quality gates.
+
+The official eight LightX2V files are now present and hash-verified against
+repository revision `2f015e66b37c585cea9dc4ae6f1850ea8788e742`. Native header
+inspection accepts all eight with the recipe's task families, four/eight
+intervals, five/nine sigma points, flow shifts and alpha values; see
+`official-variants/all-lightx2v-inventory.json`. Download/header validation is
+not full GPU generation or acceptance for the remaining adapter versions.
+
+The kernel branch's Ref2VA eight-step mixed image/video/audio control also
+passes frozen-native latent/RGB/PCM comparison bitwise, with 69,325 valid DiT
+tokens. Its single captured denoise is 366.799932 seconds; no formal three-run
+or independent official quality qualification is claimed.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -106,3 +106,31 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
   fresh owned kernels, FA backend, no residual sharding, four-step v1.2 adapter,
   no FP16 weight cache, full warmup then one captured quality/timing request.
   This is a baseline acquisition, not the formal three-run acceptance.
+
+### Complete four-step quality localization
+
+The baseline completed on GPUs 0-3: one full warmup, then 66.206537 s denoise,
+47.303750 TFLOP/s/card, four calls and 3,131,817,518,663,680 useful FLOPs/rank.
+The first request took 83.139160 s denoise including fresh-cache startup; it is
+excluded. Complete-request memory peaked at 18.162186 GiB allocated/card.
+The baseline captured all latents and unencoded RGB/PCM; capture overhead is
+outside denoise but included in VAE/end-to-end wall time.
+
+`candidate-720p-residual` took 62.624739 s / 50.009271 TFLOP/s/card after one
+warmup. **Rejected:** video/audio latent relative L2 is 0.2957225/0.0565235,
+video PSNR 28.312 dB and SSIM 0.878025. Finite media and a 5.41% time reduction
+do not satisfy the accepted quality gate. This is not a qualified speedup.
+
+`candidate-720p-prepared-only` disables residual sharding while retaining every
+new prepared/dense execution change. Complete video/audio latents match the
+baseline bitwise; pre-encoding RGB matches exactly (SSIM 1.0), and all audio
+gates pass. Its single cold request is a quality control, not a speed baseline.
+This isolates the full-sampling regression to the residual route rather than
+the newly generalized prepared matrix/LoRA path.
+
+The residual implementation now uses the same full FP32 all-reduce as the
+replicated path, then selects local residual rows. This intentionally gives up
+the unqualified reduce-scatter communication saving. The distributed oracle
+is tightened from a tolerance to bitwise equality; complete-model revalidation
+is still required. Tensor-parallel GEMM, local normalization/residual ownership
+and adapter support remain active. No >80 result or human acceptance exists.

--- a/docs/design/minimax_h3/GENERAL_SM70.md
+++ b/docs/design/minimax_h3/GENERAL_SM70.md
@@ -34,6 +34,11 @@ The old 43.914752 TFLOP/s/card sample had 71.315842 s denoise and no warmup;
 its equal-work 80 TFLOP/s budget is 39.147719 s. The old 39-frame/20-step
 FA/FI diagnostics are not matching speed baselines.
 
+After auditing duplicated column-LoRA A work, the current four-step numerator
+is 3,103,284,010,387,456 useful FLOPs on rank 0. Its corrected 80-TFLOP/s budget
+is 38.791050 seconds. Historical numbers above retain their original accounting
+and must not be mixed with the corrected formal results below.
+
 Quality compares each variant against the same weights, initial noise and
 official algorithm, including full sampling. Default numerical gates are
 video/audio final-latent relative L2 <= 0.01, pre-encoding video PSNR >= 40 dB
@@ -47,14 +52,15 @@ Unaccepted drift is not a new oracle; thresholds must not be relaxed to pass.
 | --- | --- | --- |
 | Common FP16 input/GEMM, dense column-major path | Shared operator and explicit dense layout | GPU operator checks pass; original/W8A16 four-step complete controls match bitwise |
 | Prepared LoRA input and collective ordering | Implemented, including explicit original basis | GPU prepared/normal results bitwise equal; TP2/TP4 block comparisons pass |
-| General residual sequence sharding | TP2/TP4, original/INT8, matching adapters; TP1 no-op | Both backends and wide residual/padding block checks pass; full Ref2VA pending |
+| General residual sequence sharding | TP2/TP4, original/INT8, matching adapters; TP1 no-op | TP2 original Light4 small full control and TP4 Ref8 mixed-reference control match bitwise; broader matrix pending |
 | FA and FI kernel optimization | Explicit query-128 and shared epilogues in #581 | Audited FA 47.092, FI 43.990, candidate FA 51.939 TFLOP/s/card; >80 fails |
 | All dense task/weight/adapter combinations | Partial mainline support | Full matrix pending |
 | FastH3 VSA on SM70 | True block-sparse native API in #583 | Full generation completes; final FP32-math diagnostic fails latent/video gates |
 | TeaCache and Cache-DiT | Request-scoped official policies in #584 | TP1/2/4 small forwards and full native cached/lossless/cached lifecycle pass; official quality pending |
 | AUTO and native variant APIs | Variant APIs in #583/#584; AUTO pending | No configuration qualified for automatic selection |
 | Workflow-specific performance accounting | Actual intervals, blocks, sparse pairs and cache hits in #578/#583/#584 | Strict validators pass; skipped/padded/duplicate work excluded |
-| Non-H3 DiT operator reuse | Shared GEMM/input preparation | Two non-H3 GEMM shapes pass; Attention reuse pending |
+| Non-H3 DiT operator reuse | Shared GEMM/input preparation and explicit dense attention | GEMM and non-H3 BSHD attention shapes pass; no second complete model added |
+| TP1/TP2 original-weight capacity | Explicit DiT/encoder layer staging | Full small original Light4 generations pass; pinned/pageable TP1 and ordinary/sharded TP2 final media match bitwise |
 | >80 TFLOP/s/card, full quality, memory | Not achieved | No qualifying results |
 | Draft PRs, matrix report and playable samples | Draft PRs #571/#578/#581/#583/#584 | Original/W8A16 Light4, W8A16 Light8, FlashGen, FastH3 and cache samples retained; full matrix pending |
 

--- a/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
+++ b/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
@@ -38,5 +38,21 @@ Evidence: `/data/minimax-h3/sm70-general-20260909/`.
   adapter buffers, cross-component aliases and 65-row tails reproduce
   whole-resident results bitwise across three load/forward/offload cycles.
 
-Full TP1/TP2 H3 generation and peak-memory measurements remain pending. These
-operator tests do not establish full-model quality or performance acceptance.
+`layer-staging-cpu-v2.log` additionally passes 35 checks, including explicit
+resident consumers and both CLI modes, with three GPU cases deselected.
+
+Source `aea5a0fc35` completes a TP1 original-weight LightX2V four-step request
+on one V100, using column-major matrices and pageable host masters. The first
+capacity check uses the smallest legal temporal extent (22 frames) on a
+256x448 canvas; it is not a primary performance workload. The full request
+passes basic media validation and peaks at 15,473,571,328 allocated GPU bytes.
+Denoise takes 126.274887 seconds and the complete request 152.031041 seconds.
+Recorded DiT weight loading takes 123.212966 seconds including the initial
+3.769427-second resident setup outside denoise. This identifies pageable
+layer transfers as the dominant cost, not a useful fast configuration.
+
+The full contract, source/binary hashes, raw latents/RGB/PCM and stages are in
+`/home/ymzx/h3-sm70-artifacts-20260909/runs/layer-offload-tp1-original-minimal/`.
+Pinned-host full-output comparison, larger TP1 and full TP2 generation remain
+pending. Neither the operator tests nor this basic media check establishes
+independent official full-model quality or performance acceptance.

--- a/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
+++ b/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
@@ -23,8 +23,11 @@ bounded. This mode does not support a fixed persistent FP16 weight-cache list.
 
 All transfers inside sampling remain in the full denoise denominator.
 `dit_layer_weight_staging` / `dit_layer_weight_offload` and the corresponding
-encoder fields report subsets of the enclosing denoise/encode wall times;
-they must not be summed again into request latency. This is a capacity option,
+encoder fields are host boundary measurements, not isolated GPU transfer
+durations. Loading includes host submission and any blocking copies; offload
+waits for pending H2D and compute before releasing storage, with no D2H copy.
+DiT loading also includes the initial resident setup outside denoise. These
+fields must not be summed again into request latency. This is a capacity option,
 not an automatic or >80-TFLOP/s configuration.
 
 ## Development validation
@@ -48,11 +51,19 @@ capacity check uses the smallest legal temporal extent (22 frames) on a
 passes basic media validation and peaks at 15,473,571,328 allocated GPU bytes.
 Denoise takes 126.274887 seconds and the complete request 152.031041 seconds.
 Recorded DiT weight loading takes 123.212966 seconds including the initial
-3.769427-second resident setup outside denoise. This identifies pageable
-layer transfers as the dominant cost, not a useful fast configuration.
+3.769427-second resident setup outside denoise. Pageable staging accounts for
+most host boundary time in this run.
 
 The full contract, source/binary hashes, raw latents/RGB/PCM and stages are in
 `/home/ymzx/h3-sm70-artifacts-20260909/runs/layer-offload-tp1-original-minimal/`.
-Pinned-host full-output comparison, larger TP1 and full TP2 generation remain
-pending. Neither the operator tests nor this basic media check establishes
-independent official full-model quality or performance acceptance.
+The matching pinned-host run completes denoise in 53.840319 seconds and the
+request in 67.370839 seconds, with the same GPU peak. Final video/audio latents,
+all 22 pre-encoding frames and decoded PCM match the pageable run bitwise;
+SSIM is 1 and audio RMS ratio is 1 (`layer-tp1-pinned-quality.json`). Recorded
+DiT load/offload boundaries take 35.957164/15.261954 seconds; the latter includes
+waiting for asynchronous copies and compute, not device-to-host weight traffic.
+Both are captured cold capacity checks, not formal warmed speed measurements.
+
+Larger TP1 and full TP2 generation remain pending. Neither these residency-mode
+comparisons nor the operator tests establish independent official full-model
+quality or performance acceptance.

--- a/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
+++ b/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
@@ -1,0 +1,42 @@
+# Layer weight offload for capacity-limited H3 execution
+
+The original model's attention/MLP FP16 matrices alone occupy 40,076,574,720
+bytes globally. A 32-GB V100 cannot hold that complete DiT, even before FP32
+protected weights and activations. The explicit `--weight-offload layer`
+deployment option stages individual DiT blocks and Qwen text/vision layers.
+`H3Config(weight_offload="layer")` is the Python equivalent. The default
+remains whole-component staging for the existing TP4 execution path.
+
+The plan partitions the existing immutable host snapshot by actual storage
+ownership. Private block storage moves to the GPU before its forward and is
+released afterwards. Storage shared with other blocks or outer consumers stays
+resident for the component context, preserving offsets, strides and aliases.
+The first DiT block's normalization and AdaLN projection stay resident because
+cache decision probes may call them outside the block's forward. Adapter
+buffers follow their owning block. No weight precision or reduction changes.
+
+Both normal and failed forwards release block storage. The context removes its
+hooks on exit, rejects overlapping use and prevents a whole-component load
+during layer staging. GPU copy streams/events are reused sequentially from the
+original snapshot; block boundaries synchronize. Allocator retention stays
+bounded. This mode does not support a fixed persistent FP16 weight-cache list.
+
+All transfers inside sampling remain in the full denoise denominator.
+`dit_layer_weight_staging` / `dit_layer_weight_offload` and the corresponding
+encoder fields report subsets of the enclosing denoise/encode wall times;
+they must not be summed again into request latency. This is a capacity option,
+not an automatic or >80-TFLOP/s configuration.
+
+## Development validation
+
+Python 3.12.13, Torch 2.10.0+cu128, CUDA 12.8.93, V100 SXM2 32GB.
+Evidence: `/data/minimax-h3/sm70-general-20260909/`.
+
+- `layer-staging-cpu-v1.log`: 22 ownership, lifetime, failure cleanup,
+  configuration and service checks pass, three GPU cases deselected.
+- `layer-staging-gpu-v1.log`: FP16 and FP32 models with column-major weights,
+  adapter buffers, cross-component aliases and 65-row tails reproduce
+  whole-resident results bitwise across three load/forward/offload cycles.
+
+Full TP1/TP2 H3 generation and peak-memory measurements remain pending. These
+operator tests do not establish full-model quality or performance acceptance.

--- a/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
+++ b/docs/design/minimax_h3/LAYER_WEIGHT_OFFLOAD.md
@@ -64,6 +64,21 @@ DiT load/offload boundaries take 35.957164/15.261954 seconds; the latter include
 waiting for asynchronous copies and compute, not device-to-host weight traffic.
 Both are captured cold capacity checks, not formal warmed speed measurements.
 
-Larger TP1 and full TP2 generation remain pending. Neither these residency-mode
+The full TP2 original-weight DiT also exceeds 32-GB/card capacity in component
+mode: loading fails before denoise after the allocator's bounded retry. No
+timing or output is claimed for that failed run. The matching layer policy
+completes a full request with exact residual sharding, peaking at
+15,449,646,080 allocated bytes/card. Denoise is 90.431030 seconds and request
+latency 110.419366 seconds. A separate layer-mode control disables residual
+sharding while preserving TP2, original weights, adapter, seed and sampling.
+Final video/audio latents, all 22 RGB frames and decoded PCM match bitwise
+(`layer-tp2-quality.json`). Both controls use shared pageable VAE masters.
+The ordinary-residual cold request takes 166.482792 seconds denoise; variable
+host paging and captures preclude a formal performance comparison.
+
+Artifacts are `layer-offload-tp2-original-component/`,
+`layer-offload-tp2-original-layer/` and
+`layer-offload-tp2-original-layer-ordinary/` under the same `runs/` root.
+Larger TP1/TP2 shapes remain pending. Neither these residency/sharding
 comparisons nor the operator tests establish independent official full-model
 quality or performance acceptance.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -123,16 +123,27 @@ For INT8 MLPs, the native path combines FP32 SiLU/product evaluation and
 power-of-two FP16 input preparation in one kernel. The following projection
 restores the scale in FP32 before the normal TP reduction. This removes the
 large FP32 activation intermediate without lowering arithmetic precision or
-adding a persistent cache. CPU, unquantized and FP32-input paths keep their
-existing implementation.
+adding a persistent cache. Prepared inputs now also support original floating
+weights and active LoRA. LoRA restores the first A projection's row scale before
+preparing B, retaining both rounding boundaries and pre-reduction delta addition.
+The shared FP16 GEMM and preparation operators live outside the H3 model package.
+Original floating projections can opt into `--fp16-weight-layout column`; the
+default remains `row`. Layout preparation preserves logical weight coordinates
+and storage size. Full-workflow qualification is tracked in [GENERAL_SM70.md](GENERAL_SM70.md).
 
 For the measured TP4 FL2VA INT8 development workload, optionally add
 `--residual-sequence-parallel` to `video generate` or `video serve`. This keeps
 FP32 residual rows sharded across ranks and gathers normalized FP16 inputs at
 the existing precision boundary. Both native SM70 attention backends support
-this option; it rejects BF16, Ref2VA, adapters and non-TP4 configurations. It defaults to
-false. Normalized FP16 rows are now rotated locally before all-gather, avoiding
+this option. It now accepts original weights, Ref2VA and matching adapters on
+TP2/TP4; TP1 uses ordinary execution. It defaults to false. Runtime guards still
+require one request, FP32 residuals, aligned metadata and no Ulysses hooks.
+For projections that can consume only a rotated input, normalized FP16 rows
+are rotated locally before all-gather, avoiding
 four copies of the same ConvRot work while preserving gathered bits and GEMMs.
+An active adapter also needs the unrotated input, so the ordinary gather is
+retained there until a validated combined preparation removes that dependency.
+The following measurements predate the generalized route and do not qualify it:
 The native FlashAttention 39-frame/20-update run measures 58.190385 s
 and 6.195001125 GiB peak denoise allocation/card, versus 62.804019 s and
 6.566735744 GiB without the flag, with zero persistent cache in both cases.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -58,6 +58,15 @@ its downloaded model directory. Frozen revisions and port licenses are recorded
 in the model package's `UPSTREAM.md`. FFmpeg and FFprobe must be on `PATH` for
 reference-video/audio processing.
 
+For hosts that cannot hold every component's pinned CPU copy, use
+`--disable-host-weight-pinning` (Python: `host_weight_pin_memory=False`). This
+keeps pageable immutable masters for the DiT, text encoder and both VAEs.
+It preserves weights, layouts and computation, while allowing the OS to page
+inactive components; transfers and request startup can be slower. The original
+TP4 deployment holds about 157 GiB of CPU masters before loader temporaries and
+allocator caches, so all-pinned startup exhausted the tested 188 GiB host.
+See [GENERAL_SM70.md](GENERAL_SM70.md) for the complete floating-weight control.
+
 Use `--image first.png --keyframe-indices 0`, `--image last.png
 --keyframe-indices -1`, or two `--image` arguments with `--keyframe-indices 0 -1`
 for FL2VA. A Ref2VA instance uses `--partition ref2va` and the matching transformer
@@ -98,13 +107,13 @@ The measured 39-frame/20-update cache list and native cuBLASLt configuration
 are documented in [FLASHINFER_TO50.md](FLASHINFER_TO50.md), including exact
 commands, output comparison and the still-incomplete 50-second target.
 
-For the experimental FlashInfer TP4 INT8 FL2VA route, add
-`--residual-sequence-parallel` to shard FP32 residual rows and reduce TP
-communication. It defaults off and changes floating-point reduction order.
-The unchanged 39-frame/20-update denoise measures 66.863312 seconds; automatic
-checks pass, while five-axis human quality review and the 50-second target
-remain open. See [FLASHINFER_RESIDUAL.md](FLASHINFER_RESIDUAL.md) for output
-differences, GPU tests, current hardware counters and rollback.
+The earlier experimental FlashInfer residual route changed reduction order;
+its historical results and unaccepted differences are recorded in
+[FLASHINFER_RESIDUAL.md](FLASHINFER_RESIDUAL.md). Current residual sharding uses
+the ordinary full FP32 all-reduce before selecting local residual rows. It
+preserves the complete four-step control bitwise, and does not claim the old
+reduce-scatter communication saving. It remains explicitly enabled with
+`--residual-sequence-parallel` and requires wider quality/performance validation.
 
 The subsequent probability-tile layout change reduces this same optional
 route to 65.804661 seconds and preserves its video/audio outputs bitwise.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -153,6 +153,12 @@ the sharded route changes FP32 reduction order from the default and its human
 quality review remains pending. Omit the flag to restore the default.
 These are short development measurements, not the 243-frame acceptance run.
 
+The generalized four-step/full-canvas check exposed substantial latent drift
+from reduce-scatter's FP32 addition order. Residual sharding now performs the
+same full all-reduce as the replicated path before selecting each rank's rows.
+This preserves the reference sum order and does not claim a communication-volume
+reduction. The old reduce-scatter speed figures above are not qualified outputs.
+
 Outputs include `video.mp4`, original decoded `audio.wav`, `run.json`, sampled
 `nvml.jsonl`, `quality.json` and frame screenshots. Automatic checks do not
 replace the five-axis human quality review. Useful TFLOPS use actual local

--- a/docs/design/minimax_h3/SHARED_HOST_WEIGHTS.md
+++ b/docs/design/minimax_h3/SHARED_HOST_WEIGHTS.md
@@ -1,0 +1,47 @@
+# Shared immutable host VAE weights
+
+`--share-host-vae-weights --disable-host-weight-pinning` enables an explicit
+TP2/TP4 memory policy. The Python equivalent is
+`H3Config(share_host_vae_weights=True, host_weight_pin_memory=False)` through
+`H3Engine`. TP1 uses ordinary storage. The option is off by default.
+
+The native video and audio VAEs keep replicated FP32 host masters even though
+their computation is distributed. In the measured original-weight TP4 setup,
+each rank retains 10,415,484,160 video-VAE bytes and 605,306,340 audio-VAE bytes.
+Sharing one physical replica instead of four can remove 33,062,371,500 bytes
+of duplicated host storage. This does not change GPU weights, arithmetic,
+reference encoding or the VAE compute topology.
+
+Each engine creates an owned temporary directory under `/dev/shm`. Rank zero
+writes aligned storage groups and checksums; every worker validates its own
+weights/layouts against the snapshot and maps the bytes privately. Private
+mappings share clean physical pages and isolate accidental CPU writes.
+Shapes, strides, storage offsets, mixed-dtype aliases and empty tensors are
+preserved. GPU load/offload still copies the exact original storage bytes.
+The parent removes its directory only after its workers stop, including failed
+startup. Unrelated shared-memory files are not modified.
+
+The policy requires pageable masters: ordinary PyTorch pinning would copy the
+mapping into a separate pinned allocation per rank, defeating the memory
+saving. CUDA host registration and automatic policy selection are not added.
+The measured VAE snapshot needs approximately 11.02 GB of tmpfs capacity plus
+small alignment/metadata overhead. Space is reserved before mapping writes.
+
+## Evidence and current limits
+
+The original-weight Cache-DiT lifecycle trace separates allocation and copies.
+First DiT device allocation takes 0.18–0.19 s, while copies take 27.7–43.2 s
+with 142,577–268,365 major faults/rank. Later copies take 6.5–8.2 s. The memory
+policy targets duplicated host storage and cold paging; it is not evidence of
+higher denoising TFLOP/s.
+
+`shared-host-cpu-v1.log`: 19 host-storage and native service checks pass,
+including nonzero offsets, transposed and strided views, mixed-dtype aliases,
+private writes, mismatched replicas, corrupt snapshots and owned cleanup.
+`shared-host-gpu.log`: exact storage roundtrips pass across three GPU
+load/offload cycles. Full TP4 generation, measured physical host-memory savings
+and final media comparison remain pending. Do not qualify this option for
+AUTO or claim an end-to-end speed improvement yet.
+
+Evidence root: `/data/minimax-h3/sm70-general-20260909/`. Runtime:
+Python 3.12.13, Torch 2.10.0+cu128, CUDA 12.8.93, V100 SXM2 32GB.

--- a/docs/design/minimax_h3/SHARED_HOST_WEIGHTS.md
+++ b/docs/design/minimax_h3/SHARED_HOST_WEIGHTS.md
@@ -39,9 +39,34 @@ higher denoising TFLOP/s.
 including nonzero offsets, transposed and strided views, mixed-dtype aliases,
 private writes, mismatched replicas, corrupt snapshots and owned cleanup.
 `shared-host-gpu.log`: exact storage roundtrips pass across three GPU
-load/offload cycles. Full TP4 generation, measured physical host-memory savings
-and final media comparison remain pending. Do not qualify this option for
-AUTO or claim an end-to-end speed improvement yet.
+load/offload cycles.
+
+Source `324f2463c78fb0f69d1546c817e67f3802e52342` additionally completes a full
+TP4 original-weight LightX2V four-step request: column-major FP16 weights,
+FP32 residual sharding, frozen FA binaries, 1280x736/124 internal frames,
+seed 42, five sigma points and no persistent FP16 weight cache. All final
+video/audio latents, 124 RGB frames and decoded PCM match the prior original
+column-weight control bitwise (`shared-host-quality.json`). PSNR is infinity,
+SSIM and audio RMS ratio are 1; all numerical preservation gates pass.
+
+The four workers' VAE mappings total 44,083,544,064 RSS bytes but only
+11,020,886,016 PSS bytes, with zero private mapped pages at startup. Each rank
+maps the same two files and accounts for one quarter of their physical pages.
+This verifies sharing of the approximately 11.02 GB replica and eliminates
+the three redundant replicas; mapping alignment adds small overhead to the
+raw tensor sizes above. The engine removes its owned directory after shutdown.
+
+The single captured cold request takes 66.365689 s in denoise and 126.846697 s
+overall, with 21,979,466,240 peak allocated GPU bytes/card. DiT staging still
+takes 8.44–26.53 s across ranks after startup paging. This is not a warmed
+speed comparison or proof that all host paging has been eliminated. Full
+independent official quality, human review and performance qualification
+remain pending; AUTO is not enabled.
+
+`shared-host-summary.json` records the physical mapping totals and stages.
+The complete contract, source/binary hashes, startup smaps snapshot and raw
+media are retained under
+`/home/ymzx/h3-sm70-artifacts-20260909/runs/shared-host-original-light4/`.
 
 Evidence root: `/data/minimax-h3/sm70-general-20260909/`. Runtime:
 Python 3.12.13, Torch 2.10.0+cu128, CUDA 12.8.93, V100 SXM2 32GB.

--- a/tests/video/test_h3_column_major.py
+++ b/tests/video/test_h3_column_major.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.model_executor.layers import sm70_diffusion
 from vllm.model_executor.models.minimax_h3 import cuda_ops
 from vllm.model_executor.models.minimax_h3.quantization import (
     DiffusionInt8ConvRotConfig,
@@ -73,7 +74,9 @@ def test_real_tp4_projection_uses_exact_zero_workspace_plan(n, k, fp32):
 @cuda
 def test_missing_plan_falls_back_without_changing_math(monkeypatch):
     monkeypatch.setattr(
-        cuda_ops, "_column_major_plan", lambda *args: SimpleNamespace(supported=False)
+        sm70_diffusion,
+        "_column_major_plan",
+        lambda *args: SimpleNamespace(supported=False),
     )
     x = torch.randn(17, 256, dtype=torch.float16, device="cuda")
     w = torch.randn(65, 256, dtype=torch.float16, device="cuda")

--- a/tests/video/test_h3_host_memory.py
+++ b/tests/video/test_h3_host_memory.py
@@ -51,3 +51,123 @@ def test_both_vae_stagers_honor_the_host_policy(monkeypatch, pin_memory, kind):
     assert calls == [(remote, torch.device("cuda"), {"pin_memory": pin_memory})]
     assert wrapper.model.weight.dtype == torch.float32
     torch.testing.assert_close(wrapper.model.weight, expected, rtol=0, atol=0)
+
+
+def _alias_module():
+    raw = torch.arange(257, dtype=torch.float32)
+    module = nn.Module()
+    module.weight = nn.Parameter(raw[8:104].reshape(8, 12).t())
+    module.register_buffer("strided", raw[31:67:2])
+    module.register_buffer("byte_alias", raw.view(torch.uint8)[9:63])
+    module.other = nn.Parameter(
+        torch.arange(77, dtype=torch.float16).reshape(7, 11).t()
+    )
+    module.register_buffer("empty", torch.empty(0))
+    return module
+
+
+def _cpu_snapshot(module):
+    from vllm.model_executor.models.minimax_h3.residency import PinnedModuleStager
+
+    stager = PinnedModuleStager.__new__(PinnedModuleStager)
+    stager._groups = stager._snapshot_groups((module,), pin_memory=False)
+    stager.loaded = False
+    return stager
+
+
+def test_shared_snapshot_preserves_offsets_aliases_and_private_writes(tmp_path):
+    left, right = _alias_module(), _alias_module()
+    a, b = _cpu_snapshot(left), _cpu_snapshot(right)
+    before = {name: value.clone() for name, value in left.state_dict().items()}
+    directory = tmp_path / "snapshot"
+    a._write_shared_groups(directory)
+    a._read_shared_groups(directory)
+    b._read_shared_groups(directory)
+    for module in (left, right):
+        for name, value in module.state_dict().items():
+            torch.testing.assert_close(value, before[name], atol=0, rtol=0)
+        assert module.weight.stride() == (1, 12)
+        assert module.strided.stride() == (2,)
+        assert (
+            module.weight.untyped_storage().data_ptr()
+            == module.strided.untyped_storage().data_ptr()
+        )
+    with torch.no_grad():
+        right.weight.add_(7)
+    torch.testing.assert_close(left.weight, before["weight"], atol=0, rtol=0)
+    # A private mapping must not modify a later reader or the shared snapshot.
+    third = _alias_module()
+    _cpu_snapshot(third)._read_shared_groups(directory)
+    torch.testing.assert_close(third.weight, before["weight"], atol=0, rtol=0)
+    a._restore_masters()
+    for name, value in left.state_dict().items():
+        torch.testing.assert_close(value, before[name], atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("corrupt", ["layout", "weights", "file"])
+def test_shared_snapshot_rejects_different_replicas(tmp_path, corrupt):
+    left, right = _alias_module(), _alias_module()
+    a = _cpu_snapshot(left)
+    directory = tmp_path / "snapshot"
+    a._write_shared_groups(directory)
+    if corrupt == "layout":
+        right.weight = nn.Parameter(right.weight.t())
+    elif corrupt == "weights":
+        with torch.no_grad():
+            right.other.add_(1)
+    else:
+        data = directory / "weights.bin"
+        with data.open("r+b") as f:
+            f.seek(257)
+            f.write(b"\xff")
+    with pytest.raises(ValueError, match="shared component"):
+        _cpu_snapshot(right)._read_shared_groups(directory)
+
+
+def test_shared_vae_configuration_requires_pageable_storage():
+    with pytest.raises(H3InputError, match="pageable"):
+        H3Config(share_host_vae_weights=True)
+    assert H3Config(
+        share_host_vae_weights=True, host_weight_pin_memory=False
+    ).share_host_vae_weights
+    assert not H3Config().share_host_vae_weights
+
+
+def test_engine_cleans_only_its_shared_directory(tmp_path):
+    import tempfile
+
+    from vllm.video.engine import H3Engine
+
+    untouched = tmp_path / "other"
+    untouched.mkdir()
+    engine = H3Engine.__new__(H3Engine)
+    engine._closed = False
+    engine.workers = []
+    engine.connections = []
+    engine._gpu_lease = None
+    engine._shared_weights = tempfile.TemporaryDirectory(dir=tmp_path, prefix="owned-")
+    directory = engine._shared_weights.name
+    engine.close()
+    from pathlib import Path
+
+    assert not Path(directory).exists()
+    assert untouched.is_dir()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a leased GPU")
+def test_gpu_shared_snapshot_roundtrips_all_storage_views(tmp_path):
+    from vllm.model_executor.models.minimax_h3.residency import PinnedModuleStager
+
+    model = _alias_module()
+    before = {name: value.clone() for name, value in model.state_dict().items()}
+    stager = PinnedModuleStager(model, torch.device("cuda"), pin_memory=False)
+    stager.share_cpu_storage(tmp_path / "shared")
+    for _ in range(3):
+        stager.load()
+        for name, value in model.state_dict().items():
+            assert value.device.type == "cuda"
+            torch.testing.assert_close(value.cpu(), before[name], atol=0, rtol=0)
+        stager.offload()
+        for name, value in model.state_dict().items():
+            assert value.device.type == "cpu"
+            torch.testing.assert_close(value, before[name], atol=0, rtol=0)

--- a/tests/video/test_h3_host_memory.py
+++ b/tests/video/test_h3_host_memory.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+
+
+@pytest.mark.parametrize("mode", ["generate", "serve"])
+def test_pageable_weight_masters_are_an_explicit_deployment_option(mode):
+    from vllm.entrypoints.cli.video import VideoSubcommand
+
+    parser = argparse.ArgumentParser()
+    VideoSubcommand().subparser_init(parser.add_subparsers())
+    assert parser.parse_args(["video", mode]).host_weight_pin_memory
+    assert not parser.parse_args(
+        ["video", mode, "--disable-host-weight-pinning"]
+    ).host_weight_pin_memory
+    assert not H3Config(host_weight_pin_memory=False).host_weight_pin_memory
+    with pytest.raises(H3InputError, match="boolean"):
+        H3Config(host_weight_pin_memory="false")
+
+
+@pytest.mark.parametrize("pin_memory", [True, False])
+@pytest.mark.parametrize("kind", ["MiniMaxH3VideoVAE", "MiniMaxH3AudioVAE"])
+def test_both_vae_stagers_honor_the_host_policy(monkeypatch, pin_memory, kind):
+    from vllm.model_executor.models.minimax_h3 import vae
+
+    remote = nn.Module()
+    remote.model = nn.Linear(2, 2)
+    expected = remote.model.weight.clone()
+    calls = []
+    monkeypatch.setattr(
+        vae, "_load_component_config", lambda path: {"sample_rate": 44100}
+    )
+    monkeypatch.setattr(vae, "_load_remote_component", lambda *args: remote)
+    monkeypatch.setattr(
+        vae,
+        "PinnedModuleStager",
+        lambda module, device, **kwargs: calls.append((module, device, kwargs)),
+    )
+    wrapper = getattr(vae, kind)(
+        "test",
+        device=torch.device("cuda"),
+        load_device=torch.device("cpu"),
+        pin_memory=pin_memory,
+    )
+    assert calls == [(remote, torch.device("cuda"), {"pin_memory": pin_memory})]
+    assert wrapper.model.weight.dtype == torch.float32
+    torch.testing.assert_close(wrapper.model.weight, expected, rtol=0, atol=0)

--- a/tests/video/test_h3_layer_staging.py
+++ b/tests/video/test_h3_layer_staging.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bounded layer ownership, failure cleanup and exact device transitions."""
+
+import argparse
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.model_executor.models.minimax_h3.residency import (
+    BoundedAllocatorCache,
+    LayerwiseModuleStager,
+    PinnedModuleStager,
+)
+
+
+class Block(nn.Module):
+    def __init__(self, size=8):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(size, size) / size)
+        self.register_buffer("adapter_a", torch.randn(2, size) / size)
+        self.register_buffer("adapter_b", torch.randn(size, 2) / size)
+        self.fail = False
+
+    def forward(self, x):
+        if self.fail:
+            raise RuntimeError("block failure")
+        return nn.functional.linear(x, self.weight) + 0.25 * nn.functional.linear(
+            nn.functional.linear(x, self.adapter_a), self.adapter_b
+        )
+
+
+class Model(nn.Module):
+    def __init__(self, size=8):
+        super().__init__()
+        self.blocks = nn.ModuleList([Block(size), Block(size)])
+        # Aliased storage spanning a block and the outer model stays resident.
+        self.register_buffer("shared", self.blocks[0].adapter_a[0])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x + self.shared
+
+
+def cpu_snapshot(model):
+    snapshot = PinnedModuleStager.__new__(PinnedModuleStager)
+    snapshot._groups = snapshot._snapshot_groups((model,), pin_memory=False)
+    snapshot.loaded = False
+    snapshot._device_storages = []
+    snapshot.device = torch.device("cpu")
+    snapshot.cache_retention = None
+    return snapshot
+
+
+def test_layer_storage_partition_and_rejected_overlap():
+    model = Model()
+    snapshot = cpu_snapshot(model)
+    plan = LayerwiseModuleStager(snapshot, model.blocks)
+    groups = [g for s in (*plan.stagers, plan.resident) for g in s._groups]
+    assert len(groups) == len({id(g) for g in groups}) == len(snapshot._groups)
+    shared = [g for g in plan.resident._groups if len(g.bindings) == 2]
+    assert len(shared) == 1
+    assert {id(b.target) for b in shared[0].bindings} == {
+        id(model.shared),
+        id(model.blocks[0].adapter_a),
+    }
+    with pytest.raises(ValueError, match="unique"):
+        LayerwiseModuleStager(snapshot, [model.blocks[0]] * 2)
+    with pytest.raises(ValueError, match="nested"):
+        LayerwiseModuleStager(snapshot, [model, model.blocks[0]])
+    protected = LayerwiseModuleStager(
+        snapshot, model.blocks, resident_modules=(model.blocks[1],)
+    )
+    assert not protected.stagers[1]._groups
+    assert {id(b.target) for g in protected.resident._groups for b in g.bindings} >= {
+        id(t) for t in model.blocks[1].parameters()
+    }
+
+
+def test_layer_forward_lifetime_failure_and_reentry(monkeypatch):
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        BoundedAllocatorCache, "release_if_needed", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        PinnedModuleStager, "_load_once", lambda self: setattr(self, "loaded", True)
+    )
+    model = Model().eval()
+    snapshot = cpu_snapshot(model)
+    plan = LayerwiseModuleStager(snapshot, model.blocks)
+    seen = []
+    for index, block in enumerate(model.blocks):
+        # Observe after the plan's pre-hook runs, inside the actual forward.
+        original = block.forward
+
+        def observe(x, index=index, original=original):
+            assert plan.resident.loaded
+            assert [s.loaded for s in plan.stagers] == [i == index for i in range(2)]
+            seen.append(index)
+            return original(x)
+
+        block.forward = observe
+    for fail in (False, True, False):
+        model.blocks[1].fail = fail
+        with plan.on_device():
+            with pytest.raises(RuntimeError, match="idle host"), plan.on_device():
+                pass
+            with pytest.raises(RuntimeError, match="overlaps"):
+                snapshot.load()
+            if fail:
+                with pytest.raises(RuntimeError, match="block failure"):
+                    model(torch.ones(3, 8))
+            else:
+                assert torch.isfinite(model(torch.ones(3, 8))).all()
+        assert not snapshot._layerwise_active
+        assert all(not s.loaded for s in (*plan.stagers, plan.resident))
+        assert all(
+            not b._forward_pre_hooks and not b._forward_hooks for b in model.blocks
+        )
+    assert seen == [0, 1] * 3
+    assert plan.loaded_bytes > 0
+
+
+def test_layer_policy_rejects_incompatible_fixed_cache():
+    assert H3Config().weight_offload == "component"
+    assert H3Config(weight_offload="layer").weight_offload == "layer"
+    with pytest.raises(H3InputError, match="offload"):
+        H3Config(weight_offload="automatic")
+    with pytest.raises(H3InputError, match="fixed GPU weight cache"):
+        H3Config(weight_offload="layer", fp16_cache_layers=("blocks.0",))
+
+
+@pytest.mark.parametrize("mode", ["generate", "serve"])
+def test_layer_policy_cli(mode):
+    from vllm.entrypoints.cli.video import VideoSubcommand
+
+    parser = argparse.ArgumentParser()
+    VideoSubcommand().subparser_init(parser.add_subparsers())
+    assert parser.parse_args(["video", mode]).weight_offload == "component"
+    assert (
+        parser.parse_args(["video", mode, "--weight-offload", "layer"]).weight_offload
+        == "layer"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_gpu_layerwise_adapter_and_alias_roundtrips(dtype):
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+    torch.manual_seed(96)
+    model = Model(128).to(device="cuda", dtype=dtype).eval()
+    # Module.to can split aliases; establish the actual mixed-owner alias on GPU.
+    model.shared = model.blocks[0].adapter_a[0]
+    for block in model.blocks:
+        block.weight.data = block.weight.t().contiguous().t()
+    inputs = [torch.randn(65, 128, device="cuda", dtype=dtype) for _ in range(3)]
+    with torch.inference_mode():
+        expected = [model(x).clone() for x in inputs]
+        snapshot = PinnedModuleStager(model, torch.device("cuda"), pin_memory=False)
+        plan = LayerwiseModuleStager(snapshot, model.blocks)
+        for x, reference in zip(inputs, expected):
+            with plan.on_device():
+                actual = model(x)
+            torch.testing.assert_close(actual, reference, atol=0, rtol=0)
+            assert all(p.device.type == "cpu" for p in model.parameters())
+            assert (
+                model.shared.untyped_storage().data_ptr()
+                == model.blocks[0].adapter_a.untyped_storage().data_ptr()
+            )

--- a/tests/video/test_h3_numerics.py
+++ b/tests/video/test_h3_numerics.py
@@ -435,7 +435,8 @@ def test_encoder_uses_functional_all_reduce_return():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
-def test_staging_preserves_aliased_weights_across_repeated_transfers():
+@pytest.mark.parametrize("pin_memory", [True, False])
+def test_staging_preserves_aliased_weights_across_repeated_transfers(pin_memory):
     from torch import nn
 
     from vllm.model_executor.models.minimax_h3.residency import PinnedModuleStager
@@ -445,7 +446,7 @@ def test_staging_preserves_aliased_weights_across_repeated_transfers():
     module.weight = nn.Parameter(backing)
     module.register_buffer("view", backing[3:7, 1:5])
     expected = module.view.clone()
-    stager = PinnedModuleStager(module, torch.device("cuda"))
+    stager = PinnedModuleStager(module, torch.device("cuda"), pin_memory=pin_memory)
     for _ in range(2):
         stager.load()
         assert module.weight.is_cuda and module.view.is_cuda
@@ -455,7 +456,8 @@ def test_staging_preserves_aliased_weights_across_repeated_transfers():
         )
         torch.testing.assert_close(module.view.cpu(), expected)
         stager.offload()
-        assert module.weight.is_pinned() and module.view.is_pinned()
+        assert module.weight.is_pinned() is pin_memory
+        assert module.view.is_pinned() is pin_memory
         torch.testing.assert_close(module.view, expected)
 
 

--- a/tests/video/test_h3_prepared_linear.py
+++ b/tests/video/test_h3_prepared_linear.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Independent operand, adapter and output-precision checks for shared GEMM."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.sm70_diffusion import (
+    fp16_gemm_input,
+    fp16_linear_prepared,
+)
+from vllm.model_executor.models.minimax_h3.lora import TurboLinearMethod, lora_scale
+from vllm.model_executor.models.minimax_h3.quantization import (
+    DiffusionInt8ConvRotConfig,
+    FP32OutputLinearMethod,
+    Int8ConvRotLayerConfig,
+    Int8ConvRotLinearMethod,
+)
+
+
+@pytest.mark.parametrize("value", [100000.0, float("inf"), float("nan")])
+def test_original_weight_loader_rejects_fp16_overflow(value):
+    from vllm.model_executor.models.minimax_h3.transformer import MiniMaxH3DiTModel
+
+    model = torch.nn.Module()
+    model.register_parameter(
+        "weight", torch.nn.Parameter(torch.empty(2, 3, dtype=torch.float16), False)
+    )
+    checkpoint = torch.full((2, 3), value, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="finite FP16"):
+        MiniMaxH3DiTModel.load_weights(model, [("weight", checkpoint)])
+
+
+def test_original_weight_loader_keeps_sensitive_fp32_parameters():
+    from vllm.model_executor.models.minimax_h3.transformer import MiniMaxH3DiTModel
+
+    model = torch.nn.Module()
+    model.register_parameter("weight", torch.nn.Parameter(torch.empty(2, 3), False))
+    checkpoint = torch.full((2, 3), 100000.0, dtype=torch.bfloat16)
+    MiniMaxH3DiTModel.load_weights(model, [("weight", checkpoint)])
+    torch.testing.assert_close(model.weight, checkpoint.float(), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("layout", ["row", "column"])
+def test_dense_layout_keeps_logical_weights_and_wide_output(layout):
+    torch.manual_seed(7)
+    # Deliberately not an H3 projection shape.
+    weight = torch.randn(96, 192, dtype=torch.float16)
+    layer = SimpleNamespace(weight=weight.clone(), h3_fp16_weight_layout=layout)
+    method = FP32OutputLinearMethod()
+    for _ in range(2):
+        method.process_weights_after_loading(layer)
+        torch.testing.assert_close(layer.weight, weight, atol=0, rtol=0)
+        assert layer.weight.untyped_storage().nbytes() == weight.numel() * 2
+    x = torch.randn(33, 192) * 100000
+    values, scale = fp16_gemm_input(x)
+    result = method.apply_prepared(layer, values, scale)
+    reference = (values.float() @ weight.float().T) * scale
+    torch.testing.assert_close(result, reference, atol=0, rtol=0)
+    assert torch.isfinite(result).all()
+    assert result.abs().max() > torch.finfo(torch.float16).max
+    with pytest.raises(ValueError, match="unrotated"):
+        method.apply_prepared(layer, values, scale, input_is_rotated=True)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires SM70")
+@pytest.mark.parametrize("quantized", [False, True])
+@pytest.mark.parametrize("adapter_scale", [0.0, 0.75, -0.5])
+def test_gpu_prepared_adapter_preserves_wide_intermediates(quantized, adapter_scale):
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+
+    torch.manual_seed(42)
+    ops = w8a16_extension()
+    if quantized:
+        base = Int8ConvRotLinearMethod(
+            DiffusionInt8ConvRotConfig(), Int8ConvRotLayerConfig(True), prefix="probe"
+        )
+        weight = torch.randint(-7, 8, (384, 256), device="cuda", dtype=torch.int8)
+    else:
+        base = FP32OutputLinearMethod()
+        weight = torch.randn(384, 256, device="cuda", dtype=torch.float16) * 0.03
+    layer = SimpleNamespace(
+        weight=weight,
+        weight_scale=torch.full((384,), 0.01, device="cuda"),
+        h3_output_fp32=True,
+        h3_lora_a_0=torch.randn(8, 256, device="cuda", dtype=torch.float16),
+        h3_lora_b_0=torch.randn(384, 8, device="cuda", dtype=torch.float16),
+    )
+    method = TurboLinearMethod(base, [(0, 0, 384)], 0.125)
+    x = torch.randn(33, 256, device="cuda") * 100000
+    values, scale = fp16_gemm_input(x)
+    token = lora_scale.set(adapter_scale)
+    try:
+        expected = method.apply(layer, x)
+        actual = method.apply_prepared(layer, values, scale)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        assert actual.dtype == torch.float32 and torch.isfinite(actual).all()
+        if quantized:
+            rotated = ops.rotate(values)
+            actual = method.apply_prepared(
+                layer, rotated, scale, input_is_rotated=True, original_input=values
+            )
+            torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+            if adapter_scale:
+                with pytest.raises(ValueError, match="original unrotated"):
+                    method.apply_prepared(layer, rotated, scale, input_is_rotated=True)
+    finally:
+        lora_scale.reset(token)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires SM70")
+def test_gpu_shared_linear_handles_non_h3_shapes_and_fp32_outputs():
+    from vllm.model_executor.models.minimax_h3.cuda_ops import w8a16_extension
+
+    torch.manual_seed(2026)
+    for m, n, k in ((33, 96, 192), (257, 1024, 768)):
+        x = torch.randn(m, k, device="cuda", dtype=torch.float16)
+        w = torch.randn(n, k, device="cuda", dtype=torch.float16)
+        expected = w8a16_extension().gemm(x, w, True)
+        for weight in (w, w.T.contiguous().T):
+            actual = fp16_linear_prepared(x, weight, output_fp32=True)
+            torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/video/test_h3_residual_parallel.py
+++ b/tests/video/test_h3_residual_parallel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""TP4 residual tests: launch the GPU cases with torchrun --nproc-per-node=4."""
+"""Residual tests: launch the GPU cases with torchrun --nproc-per-node=2 or 4."""
 
 import argparse
 import os
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.model_executor.models.minimax_h3.config import H3Config
 from vllm.model_executor.models.minimax_h3.transformer import MiniMaxH3DiTBlock
 
 
@@ -35,14 +35,13 @@ def test_residual_parallel_accepts_native_sm70_backends(backend):
         {"lora_path": "adapter.safetensors"},
     ],
 )
-def test_residual_parallel_rejects_unvalidated_deployments(change):
+def test_residual_parallel_accepts_compatible_deployments(change):
     config = H3Config(
         transformer_path="int8.safetensors",
         attention_backend="FLASHINFER_SM70",
         residual_sequence_parallel=True,
     )
-    with pytest.raises(H3InputError, match="residual sequence parallelism"):
-        replace(config, **change)
+    assert replace(config, **change).residual_sequence_parallel
 
 
 @pytest.mark.parametrize("mode", ["generate", "serve"])
@@ -89,8 +88,9 @@ def test_residual_parallel_rejects_invalid_rows_before_collectives(
 
 @pytest.fixture
 def tp4_group():
-    if os.environ.get("WORLD_SIZE") != "4":
-        pytest.skip("requires torchrun --nproc-per-node=4 on a leased GPU group")
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size not in (2, 4):
+        pytest.skip("requires torchrun with TP2/TP4 on a leased GPU group")
     from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
     from vllm.distributed import (
         cleanup_dist_env_and_memory,
@@ -104,10 +104,10 @@ def tp4_group():
     torch.accelerator.set_device_index(local_rank)
     torch.set_num_threads(2)
     with set_current_vllm_config(
-        VllmConfig(parallel_config=ParallelConfig(tensor_parallel_size=4))
+        VllmConfig(parallel_config=ParallelConfig(tensor_parallel_size=world_size))
     ):
-        init_distributed_environment(4, rank, "env://", local_rank, "nccl")
-        initialize_model_parallel(4)
+        init_distributed_environment(world_size, rank, "env://", local_rank, "nccl")
+        initialize_model_parallel(world_size)
         try:
             yield get_tp_group()
         finally:
@@ -121,10 +121,20 @@ def test_gpu_residual_parallel_matches_replicated_blocks(tp4_group):
     for valid in (32, 33, 131):
         for backend in ("FLASH_ATTN_V100", "FLASHINFER_SM70"):
             _check_replicated_blocks(tp4_group, valid, backend)
+    for quantized in (False, True):
+        for backend in ("FLASH_ATTN_V100", "FLASHINFER_SM70"):
+            _check_replicated_blocks(
+                tp4_group, 131, backend, quantized=quantized, adapted=True
+            )
 
 
-def _check_replicated_blocks(group, valid, backend):
+def _check_replicated_blocks(group, valid, backend, *, quantized=False, adapted=False):
     from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.lora import TurboLinearMethod, lora_scale
+    from vllm.model_executor.models.minimax_h3.quantization import (
+        DiffusionInt8ConvRotConfig,
+        Int8ConvRotLinearMethod,
+    )
     from vllm.model_executor.models.minimax_h3.transformer import (
         MiniMaxH3DiTArchConfig,
     )
@@ -137,11 +147,19 @@ def _check_replicated_blocks(group, valid, backend):
         adaln_out_features=18 * 512,
     )
     token = attention_backend.set(backend)
+    quant = None
+    if quantized:
+        quant = DiffusionInt8ConvRotConfig(
+            layer_configs={
+                f"blocks.0.{name}": {"format": "int8_tensorwise", "convrot": True}
+                for name in ("attn.qkv_proj", "attn.out_proj", "mlp.fc1", "mlp.fc2")
+            }
+        )
     try:
-        baseline = MiniMaxH3DiTBlock(arch, None, prefix="blocks.0").cuda().eval()
+        baseline = MiniMaxH3DiTBlock(arch, quant, prefix="blocks.0").cuda().eval()
         candidate = (
             MiniMaxH3DiTBlock(
-                arch, None, prefix="blocks.0", residual_sequence_parallel=True
+                arch, quant, prefix="blocks.0", residual_sequence_parallel=True
             )
             .cuda()
             .eval()
@@ -151,13 +169,41 @@ def _check_replicated_blocks(group, valid, backend):
     # Rank-dependent projection weights exercise real TP partial sums.
     torch.manual_seed(1234 + group.rank_in_group)
     for name, parameter in baseline.named_parameters():
-        if "norm" in name:
+        if parameter.dtype == torch.int8:
+            parameter.random_(-7, 8)
+        elif name.endswith("weight_scale"):
+            parameter.fill_(0.005)
+        elif "norm" in name:
             parameter.fill_(1)
         else:
             parameter.normal_(0, 0.03)
+    if adapted:
+        for block in (baseline, candidate):
+            for layer in block.modules():
+                method = getattr(layer, "quant_method", None)
+                if not getattr(method, "supports_prepared_fp16", False):
+                    continue
+                n, k = layer.weight.shape
+                layer.register_buffer(
+                    "h3_lora_a_0",
+                    torch.randn(8, k, dtype=torch.float16, device="cuda") * 0.01,
+                )
+                layer.register_buffer(
+                    "h3_lora_b_0",
+                    torch.randn(n, 8, dtype=torch.float16, device="cuda") * 0.01,
+                )
+                layer._sm70_f16_forbidden = True
+                layer.quant_method = TurboLinearMethod(method, [(0, 0, n)], 1.0)
     candidate.load_state_dict(baseline.state_dict())
+    for block in (baseline, candidate):
+        for layer in block.modules():
+            method = getattr(layer, "quant_method", None)
+            if isinstance(method, TurboLinearMethod):
+                method = method.base
+            if isinstance(method, Int8ConvRotLinearMethod):
+                method.process_weights_after_loading(layer)
     torch.manual_seed(42)
-    total = (valid + 3) // 4 * 4
+    total = (valid + group.world_size - 1) // group.world_size * group.world_size
     x = torch.randn(total, 512, device="cuda", dtype=torch.float32)
     x[::5, 0] = 70000  # Residuals must not pass through an FP16 collective.
     kwargs = dict(
@@ -168,12 +214,16 @@ def _check_replicated_blocks(group, valid, backend):
         max_seqlen=valid,
         packed_total=total,
     )
-    rows = total // 4
+    rows = total // group.world_size
     actual = x.narrow(0, group.rank_in_group * rows, rows).clone()
     expected = x.clone()
-    for _ in range(2):
-        expected = baseline(expected, **kwargs)
-        actual = candidate(actual, **kwargs)
+    scale_token = lora_scale.set(0.75 if adapted else 0.0)
+    try:
+        for _ in range(2):
+            expected = baseline(expected, **kwargs)
+            actual = candidate(actual, **kwargs)
+    finally:
+        lora_scale.reset(scale_token)
     actual = group.all_gather(actual, dim=0)
     assert actual.dtype == torch.float32
     assert torch.isfinite(actual).all()

--- a/tests/video/test_h3_residual_parallel.py
+++ b/tests/video/test_h3_residual_parallel.py
@@ -228,7 +228,7 @@ def _check_replicated_blocks(group, valid, backend, *, quantized=False, adapted=
     assert actual.dtype == torch.float32
     assert torch.isfinite(actual).all()
     assert actual.abs().max() > torch.finfo(torch.float16).max
-    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=3e-4)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
     # Modifying padding must not change any valid attention output.
     if valid < total:
         changed = x.clone()

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -40,6 +40,12 @@ class VideoSubcommand(CLISubcommand):
                 default="FLASH_ATTN_V100",
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
+            mode.add_argument(
+                "--disable-host-weight-pinning",
+                dest="host_weight_pin_memory",
+                action="store_false",
+                help="Keep weight masters pageable when pinned copies exceed host RAM",
+            )
             mode.add_argument("--fp16-cache-layer", action="append", default=[])
             mode.add_argument(
                 "--int8-weight-layout", choices=["row", "column"], default="column"
@@ -115,6 +121,7 @@ class VideoSubcommand(CLISubcommand):
             fp16_weight_layout=args.fp16_weight_layout,
             residual_sequence_parallel=args.residual_sequence_parallel,
             video_encoder=args.video_encoder,
+            host_weight_pin_memory=args.host_weight_pin_memory,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -45,9 +45,12 @@ class VideoSubcommand(CLISubcommand):
                 "--int8-weight-layout", choices=["row", "column"], default="column"
             )
             mode.add_argument(
+                "--fp16-weight-layout", choices=["row", "column"], default="row"
+            )
+            mode.add_argument(
                 "--residual-sequence-parallel",
                 action="store_true",
-                help=("Experimental FP32 residual sharding for TP4 FL2VA INT8"),
+                help="Experimental FP32 residual sharding for TP2/TP4; TP1 is a no-op",
             )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
             mode.add_argument(
@@ -109,6 +112,7 @@ class VideoSubcommand(CLISubcommand):
             fp16_cache_layers=tuple(args.fp16_cache_layer),
             lora_path=args.lora_path,
             int8_weight_layout=args.int8_weight_layout,
+            fp16_weight_layout=args.fp16_weight_layout,
             residual_sequence_parallel=args.residual_sequence_parallel,
             video_encoder=args.video_encoder,
         )

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -41,6 +41,12 @@ class VideoSubcommand(CLISubcommand):
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
             mode.add_argument(
+                "--weight-offload",
+                choices=("component", "layer"),
+                default="component",
+                help="Stage complete components or individual DiT/encoder layers",
+            )
+            mode.add_argument(
                 "--share-host-vae-weights",
                 action="store_true",
                 help="Share immutable pageable VAE masters across TP workers",
@@ -128,6 +134,7 @@ class VideoSubcommand(CLISubcommand):
             video_encoder=args.video_encoder,
             host_weight_pin_memory=args.host_weight_pin_memory,
             share_host_vae_weights=args.share_host_vae_weights,
+            weight_offload=args.weight_offload,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -41,6 +41,11 @@ class VideoSubcommand(CLISubcommand):
             )
             mode.add_argument("--fp16-weight-cache-gib", type=float, default=0)
             mode.add_argument(
+                "--share-host-vae-weights",
+                action="store_true",
+                help="Share immutable pageable VAE masters across TP workers",
+            )
+            mode.add_argument(
                 "--disable-host-weight-pinning",
                 dest="host_weight_pin_memory",
                 action="store_false",
@@ -122,6 +127,7 @@ class VideoSubcommand(CLISubcommand):
             residual_sequence_parallel=args.residual_sequence_parallel,
             video_encoder=args.video_encoder,
             host_weight_pin_memory=args.host_weight_pin_memory,
+            share_host_vae_weights=args.share_host_vae_weights,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/model_executor/layers/sm70_diffusion.py
+++ b/vllm/model_executor/layers/sm70_diffusion.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-independent SM70 FP16 GEMM with FP32 scaling and accumulation.
+
+The extension ABI retains its historical H3 name. Dispatch depends on tensor
+properties, not checkpoint names, quantization labels or model families.
+"""
+
+from functools import lru_cache
+from importlib import import_module
+from pathlib import Path
+
+import torch
+
+
+@lru_cache(maxsize=1)
+def sm70_extension():
+    try:
+        return import_module("vllm._h3_w8a16_C")
+    except ImportError:
+        pass
+    from torch.utils.cpp_extension import load
+
+    root = Path(__file__).resolve().parents[3]
+    source = root / "csrc/sm70_turbomind/ops/h3_w8a16.cu"
+    if not source.is_file():
+        raise RuntimeError("SM70 diffusion operators require the 1Cat source build")
+    return load(
+        name="onecat_h3_w8a16",
+        sources=[str(source)],
+        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
+        extra_ldflags=["-lcublas", "-lcublasLt"],
+        verbose=False,
+    )
+
+
+@lru_cache(maxsize=32)
+def _column_major_plan(device, m, n, k, output_fp32):
+    return sm70_extension().ColumnMajorGemmPlan(device, m, n, k, output_fp32)
+
+
+def fp16_gemm(input, weight, output_fp32=False):
+    """Use a zero-workspace Volta plan for dense column-major H3 weights.
+
+    Plan entries contain host descriptors only. Unaligned inputs, empty shapes
+    and library versions without the validated algorithm use the original
+    row-major GEMM. Warm up each shape before capturing a CUDA graph.
+    """
+    ops = sm70_extension()
+    if weight.is_contiguous():
+        return ops.gemm(input, weight, output_fp32)
+    if (
+        input.is_cuda
+        and weight.device == input.device
+        and input.dim() == weight.dim() == 2
+        and input.is_contiguous()
+        and input.dtype == weight.dtype == torch.float16
+        and weight.stride() == (1, weight.shape[0])
+        and input.shape[1] == weight.shape[1]
+        and min(*input.shape, weight.shape[0]) > 0
+        and input.data_ptr() % 16 == weight.data_ptr() % 16 == 0
+    ):
+        plan = _column_major_plan(
+            input.device.index,
+            input.shape[0],
+            weight.shape[0],
+            input.shape[1],
+            bool(output_fp32),
+        )
+        if plan.supported:
+            return plan.run(input, weight)
+    return ops.gemm(input, weight.contiguous(), output_fp32)
+
+
+def fp16_gemm_input(x):
+    """Scale wide-range activations by exact powers of two before FP16 GEMM.
+
+    Leave headroom for the 256-channel rotation's worst-case amplification.
+    Row scaling is restored in FP32 after the projection.
+    """
+    flat = x.reshape(-1, x.shape[-1]).contiguous()
+    if flat.dtype == torch.float16:
+        return flat, None
+    if flat.dtype != torch.float32:
+        raise ValueError("SM70 GEMM activations must be FP16 or FP32")
+    if flat.is_cuda:
+        return sm70_extension().prepare_fp16(flat)
+    maximum = flat.abs().amax(-1, keepdim=True)
+    _, exponent = torch.frexp(maximum)
+    scale = torch.ldexp(torch.ones_like(maximum), (exponent - 11).clamp_min(0))
+    return (flat / scale).half(), scale
+
+
+def fp16_linear_prepared(values, weight, scale=None, *, output_fp32=False):
+    """Restore per-row scales in FP32 before any distributed reduction."""
+    if values.dtype != torch.float16 or weight.dtype != torch.float16:
+        raise ValueError("Prepared SM70 linear operands must be FP16")
+    output_fp32 = output_fp32 or scale is not None
+    flat = values.reshape(-1, values.shape[-1]).contiguous()
+    if flat.is_cuda:
+        output = fp16_gemm(flat, weight, output_fp32)
+    else:
+        output = torch.nn.functional.linear(flat.float(), weight.float())
+        if not output_fp32:
+            output = output.half()
+    if scale is not None:
+        output = output * scale
+    return output.reshape(*values.shape[:-1], weight.shape[0])

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -44,9 +44,12 @@ class H3Config:
     int8_weight_layout: str = "column"
     fp16_weight_layout: Literal["row", "column"] = "row"
     residual_sequence_parallel: bool = False
+    host_weight_pin_memory: bool = True
     video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
 
     def __post_init__(self) -> None:
+        if not isinstance(self.host_weight_pin_memory, bool):
+            raise H3InputError("host weight pinning must be a boolean")
         if self.video_encoder not in ("libx264", "h264_nvenc"):
             raise H3InputError("video encoder must be libx264 or h264_nvenc")
         if self.partition not in ("fl2va", "ref2va"):

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -46,9 +46,14 @@ class H3Config:
     residual_sequence_parallel: bool = False
     host_weight_pin_memory: bool = True
     share_host_vae_weights: bool = False
+    weight_offload: Literal["component", "layer"] = "component"
     video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
 
     def __post_init__(self) -> None:
+        if self.weight_offload not in ("component", "layer"):
+            raise H3InputError("weight offload must be component or layer")
+        if self.weight_offload == "layer" and self.fp16_cache_layers:
+            raise H3InputError("layer offload cannot retain a fixed GPU weight cache")
         if not isinstance(self.host_weight_pin_memory, bool):
             raise H3InputError("host weight pinning must be a boolean")
         if not isinstance(self.share_host_vae_weights, bool):

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -42,6 +42,7 @@ class H3Config:
     fp16_cache_layers: tuple[str, ...] = ()
     lora_path: str | None = None
     int8_weight_layout: str = "column"
+    fp16_weight_layout: Literal["row", "column"] = "row"
     residual_sequence_parallel: bool = False
     video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
 
@@ -52,6 +53,8 @@ class H3Config:
             raise H3InputError("partition must be fl2va or ref2va")
         if self.int8_weight_layout not in ("row", "column"):
             raise H3InputError("H3 INT8 weight layout must be row or column")
+        if self.fp16_weight_layout not in ("row", "column"):
+            raise H3InputError("H3 FP16 weight layout must be row or column")
         if self.tensor_parallel_size not in (1, 2, 4):
             raise H3InputError("native H3 supports TP1, TP2, or TP4")
         if self.attention_backend not in (
@@ -60,18 +63,6 @@ class H3Config:
             "TORCH_SDPA",
         ):
             raise H3InputError(f"unsupported H3 attention: {self.attention_backend}")
-        if self.residual_sequence_parallel and (
-            self.tensor_parallel_size != 4
-            or self.attention_backend not in ("FLASH_ATTN_V100", "FLASHINFER_SM70")
-            or self.partition != "fl2va"
-            or not self.transformer_path
-            or self.lora_path is not None
-        ):
-            raise H3InputError(
-                "experimental residual sequence parallelism requires TP4, "
-                "FLASH_ATTN_V100 or FLASHINFER_SM70 and an FL2VA INT8 "
-                "ConvRot checkpoint without an adapter"
-            )
         if (
             not math.isfinite(self.fp16_weight_cache_gib)
             or self.fp16_weight_cache_gib < 0

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -45,11 +45,20 @@ class H3Config:
     fp16_weight_layout: Literal["row", "column"] = "row"
     residual_sequence_parallel: bool = False
     host_weight_pin_memory: bool = True
+    share_host_vae_weights: bool = False
     video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
 
     def __post_init__(self) -> None:
         if not isinstance(self.host_weight_pin_memory, bool):
             raise H3InputError("host weight pinning must be a boolean")
+        if not isinstance(self.share_host_vae_weights, bool):
+            raise H3InputError("shared host VAE weights must be a boolean")
+        if (
+            self.share_host_vae_weights
+            and self.tensor_parallel_size > 1
+            and self.host_weight_pin_memory
+        ):
+            raise H3InputError("shared host VAE weights require pageable host masters")
         if self.video_encoder not in ("libx264", "h264_nvenc"):
             raise H3InputError("video encoder must be libx264 or h264_nvenc")
         if self.partition not in ("fl2va", "ref2va"):

--- a/vllm/model_executor/models/minimax_h3/cuda_ops.py
+++ b/vllm/model_executor/models/minimax_h3/cuda_ops.py
@@ -6,68 +6,15 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-import torch
+from vllm.model_executor.layers.sm70_diffusion import (
+    _column_major_plan as _column_major_plan,
+)
+from vllm.model_executor.layers.sm70_diffusion import (
+    fp16_gemm as fp16_gemm,
+)
+from vllm.model_executor.layers.sm70_diffusion import sm70_extension
 
-
-@lru_cache(maxsize=1)
-def w8a16_extension():
-    try:
-        from vllm import _h3_w8a16_C
-
-        return _h3_w8a16_C
-    except ImportError:
-        pass
-    from torch.utils.cpp_extension import load
-
-    root = Path(__file__).resolve().parents[4]
-    source = root / "csrc/sm70_turbomind/ops/h3_w8a16.cu"
-    if not source.is_file():
-        raise RuntimeError("H3 W8A16 extension requires the 1Cat source build")
-    return load(
-        name="onecat_h3_w8a16",
-        sources=[str(source)],
-        extra_cuda_cflags=["-O3", "-gencode=arch=compute_70,code=sm_70"],
-        extra_ldflags=["-lcublas", "-lcublasLt"],
-        verbose=False,
-    )
-
-
-@lru_cache(maxsize=32)
-def _column_major_plan(device, m, n, k, output_fp32):
-    return w8a16_extension().ColumnMajorGemmPlan(device, m, n, k, output_fp32)
-
-
-def fp16_gemm(input, weight, output_fp32=False):
-    """Use a zero-workspace Volta plan for dense column-major H3 weights.
-
-    Plan entries contain host descriptors only. Unaligned inputs, empty shapes
-    and library versions without the validated algorithm use the original
-    row-major GEMM. Warm up each shape before capturing a CUDA graph.
-    """
-    ops = w8a16_extension()
-    if weight.is_contiguous():
-        return ops.gemm(input, weight, output_fp32)
-    if (
-        input.is_cuda
-        and weight.device == input.device
-        and input.dim() == weight.dim() == 2
-        and input.is_contiguous()
-        and input.dtype == weight.dtype == torch.float16
-        and weight.stride() == (1, weight.shape[0])
-        and input.shape[1] == weight.shape[1]
-        and min(*input.shape, weight.shape[0]) > 0
-        and input.data_ptr() % 16 == weight.data_ptr() % 16 == 0
-    ):
-        plan = _column_major_plan(
-            input.device.index,
-            input.shape[0],
-            weight.shape[0],
-            input.shape[1],
-            bool(output_fp32),
-        )
-        if plan.supported:
-            return plan.run(input, weight)
-    return ops.gemm(input, weight.contiguous(), output_fp32)
+w8a16_extension = sm70_extension
 
 
 @lru_cache(maxsize=1)

--- a/vllm/model_executor/models/minimax_h3/lora.py
+++ b/vllm/model_executor/models/minimax_h3/lora.py
@@ -21,6 +21,7 @@ from safetensors import safe_open
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.layers.sm70_diffusion import fp16_linear_prepared
 
 from .config import H3InputError
 from .fasth3 import FASTH3_FILENAME, FastH3Spec
@@ -275,6 +276,46 @@ class TurboLinearMethod(LinearMethodBase):
 
     def create_weights(self, *args, **kwargs):
         raise RuntimeError("Turbo is installed after base checkpoint loading")
+
+    @property
+    def supports_prepared_fp16(self):
+        return bool(getattr(self.base, "supports_prepared_fp16", False))
+
+    @property
+    def supports_rotated_input(self):
+        return bool(getattr(self.base, "supports_rotated_input", False))
+
+    @property
+    def requires_original_input(self):
+        return lora_scale.get() != 0
+
+    def apply_prepared(
+        self, layer, values, input_scale, *, input_is_rotated=False, original_input=None
+    ):
+        if not self.supports_prepared_fp16:
+            raise ValueError("LoRA base does not support prepared FP16 operands")
+        if input_is_rotated and self.requires_original_input and original_input is None:
+            raise ValueError("Active LoRA requires the original unrotated input")
+        output = self.base.apply_prepared(
+            layer, values, input_scale, input_is_rotated=input_is_rotated
+        )
+        scale = lora_scale.get() * self.alpha_over_rank
+        if scale == 0:
+            return output
+        original = original_input if input_is_rotated else values
+        dtype = output.dtype
+        output = output.float()
+        for index, offset, width in self.parts:
+            a = getattr(layer, f"h3_lora_a_{index}")
+            b = getattr(layer, f"h3_lora_b_{index}")
+            # Restore the first projection's row scale before preparing B's
+            # input, retaining the established intermediate rounding boundary.
+            intermediate = fp16_linear_prepared(
+                original, a, input_scale, output_fp32=True
+            )
+            delta = _linear_fp32(intermediate, b)
+            output[..., offset : offset + width].add_(delta, alpha=scale)
+        return output.to(dtype)
 
     def apply(self, layer, x, bias=None):
         output = self.base.apply(layer, x, bias)

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -81,7 +81,7 @@ from .reference_video import (
     validate_reference_audio_files,
     validate_reference_audio_waveforms,
 )
-from .residency import PinnedModuleStager
+from .residency import LayerwiseModuleStager, PinnedModuleStager
 from .sigma_schedule import DMD2SigmaSchedule
 from .time_request import (
     MINIMAX_H3_SHAPE_PLANNER,
@@ -567,6 +567,25 @@ class MiniMaxH3Pipeline(nn.Module):
         self._encoder_stager = PinnedModuleStager(
             self.text_encoder, self.device, pin_memory=config.host_weight_pin_memory
         )
+        self._dit_layer_stager: LayerwiseModuleStager | None = None
+        self._encoder_layer_stager: LayerwiseModuleStager | None = None
+        if config.weight_offload == "layer":
+            self._dit_layer_stager = LayerwiseModuleStager(
+                self._dit_stager,
+                (*self.transformer.token_refiner.blocks, *self.transformer.blocks),
+                # Cache decision probes may consume these outside block.forward.
+                resident_modules=(
+                    self.transformer.blocks[0].norm1,
+                    self.transformer.blocks[0].adaln_proj,
+                ),
+            )
+            self._encoder_layer_stager = LayerwiseModuleStager(
+                self._encoder_stager,
+                (
+                    *self.text_encoder.vision.blocks,
+                    *self.text_encoder.text_model.layers,
+                ),
+            )
         self.video_vae = MiniMaxH3VideoVAE(
             str(shared / "video_vae"),
             device=self.device,
@@ -609,6 +628,20 @@ class MiniMaxH3Pipeline(nn.Module):
 
     @contextmanager
     def _component_on_device(self, component):
+        if (
+            component is self.text_encoder
+            and getattr(self, "_encoder_layer_stager", None) is not None
+        ):
+            plan = self._encoder_layer_stager
+            try:
+                with plan.on_device():
+                    yield
+            finally:
+                self.stage_durations["encoder_layer_weight_staging"] = plan.load_seconds
+                self.stage_durations["encoder_layer_weight_offload"] = (
+                    plan.offload_seconds
+                )
+            return
         stager = self._encoder_stager if component is self.text_encoder else None
         if stager is not None:
             stager.load()
@@ -625,6 +658,18 @@ class MiniMaxH3Pipeline(nn.Module):
     @contextmanager
     def _resident_dit_layers_on_device(self, *, enabled=True):
         started = time.perf_counter()
+        if getattr(self, "_dit_layer_stager", None) is not None:
+            plan = self._dit_layer_stager
+            try:
+                with plan.on_device():
+                    self.stage_durations["dit_staging_and_weight_cache"] = (
+                        time.perf_counter() - started
+                    )
+                    yield
+            finally:
+                self.stage_durations["dit_layer_weight_staging"] = plan.load_seconds
+                self.stage_durations["dit_layer_weight_offload"] = plan.offload_seconds
+            return
         self._dit_stager.load()
         try:
             self._weight_cache.prepare()

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -423,8 +423,16 @@ def _broadcast_tensor(
 
 
 class MiniMaxH3Pipeline(nn.Module):
-    def __init__(self, config: H3Config):
+    def __init__(self, config: H3Config, *, shared_weights_dir: str | None = None):
         super().__init__()
+        if (
+            config.share_host_vae_weights
+            and config.tensor_parallel_size > 1
+            and shared_weights_dir is None
+        ):
+            raise H3InputError(
+                "shared host VAE weights require an engine-owned directory"
+            )
         self.config = config
         self.partition = config.partition
         self.device = torch.device("cuda", torch.accelerator.current_device_index())
@@ -564,6 +572,7 @@ class MiniMaxH3Pipeline(nn.Module):
             device=self.device,
             load_device=torch.device("cpu"),
             pin_memory=config.host_weight_pin_memory,
+            shared_weights_dir=shared_weights_dir,
         )
         self.video_vae.set_parallel_size(config.tensor_parallel_size)
         self.audio_vae = MiniMaxH3AudioVAE(
@@ -571,6 +580,7 @@ class MiniMaxH3Pipeline(nn.Module):
             device=self.device,
             load_device=torch.device("cpu"),
             pin_memory=config.host_weight_pin_memory,
+            shared_weights_dir=shared_weights_dir,
         )
         self.stage_durations = {}
         self.actual_dit_calls = 0

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -520,6 +520,7 @@ class MiniMaxH3Pipeline(nn.Module):
         for layer in self.transformer.modules():
             method = getattr(layer, "quant_method", None)
             if method is not None:
+                layer.h3_fp16_weight_layout = config.fp16_weight_layout
                 method.process_weights_after_loading(layer)
         self.transformer.post_load_weights()
         self.turbo_spec = None

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -532,7 +532,9 @@ class MiniMaxH3Pipeline(nn.Module):
             self.turbo_spec = install_adapter(
                 self.transformer, config.lora_path, self.partition
             )
-        self._dit_stager = PinnedModuleStager(self.transformer, self.device)
+        self._dit_stager = PinnedModuleStager(
+            self.transformer, self.device, pin_memory=config.host_weight_pin_memory
+        )
         self._weight_cache = FP16WeightCache(
             self.transformer,
             budget_gib=config.fp16_weight_cache_gib,
@@ -554,17 +556,21 @@ class MiniMaxH3Pipeline(nn.Module):
             encoder_group=self.text_encoder_group,
         )
         self.text_encoder.load_weights(iter_checkpoint_weights(shared / "text_encoder"))
-        self._encoder_stager = PinnedModuleStager(self.text_encoder, self.device)
+        self._encoder_stager = PinnedModuleStager(
+            self.text_encoder, self.device, pin_memory=config.host_weight_pin_memory
+        )
         self.video_vae = MiniMaxH3VideoVAE(
             str(shared / "video_vae"),
             device=self.device,
             load_device=torch.device("cpu"),
+            pin_memory=config.host_weight_pin_memory,
         )
         self.video_vae.set_parallel_size(config.tensor_parallel_size)
         self.audio_vae = MiniMaxH3AudioVAE(
             str(shared / "audio_vae"),
             device=self.device,
             load_device=torch.device("cpu"),
+            pin_memory=config.host_weight_pin_memory,
         )
         self.stage_durations = {}
         self.actual_dit_calls = 0

--- a/vllm/model_executor/models/minimax_h3/quantization.py
+++ b/vllm/model_executor/models/minimax_h3/quantization.py
@@ -37,6 +37,12 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
 )
+from vllm.model_executor.layers.sm70_diffusion import (
+    fp16_gemm_input as fp16_gemm_input,
+)
+from vllm.model_executor.layers.sm70_diffusion import (
+    fp16_linear_prepared,
+)
 from vllm.model_executor.parameter import (
     ChannelQuantScaleParameter,
     ModelWeightParameter,
@@ -63,45 +69,48 @@ logger = init_logger(__name__)
 _FORMAT = "int8_tensorwise"
 
 
-def fp16_gemm_input(x):
-    """Scale wide-range activations by exact powers of two before FP16 GEMM.
+class FP16LinearMethod(UnquantizedLinearMethod):
+    """Dense Tensor Core operands with explicit preparation and output precision."""
 
-    Leave headroom for the 256-channel rotation's worst-case amplification.
-    Row scaling is restored in FP32 after the projection.
-    """
-    flat = x.reshape(-1, x.shape[-1]).contiguous()
-    if flat.dtype == torch.float16:
-        return flat, None
-    if flat.dtype != torch.float32:
-        raise ValueError("H3 GEMM activations must be FP16 or FP32")
-    if flat.is_cuda:
-        from .cuda_ops import w8a16_extension
-
-        return w8a16_extension().prepare_fp16(flat)
-    maximum = flat.abs().amax(-1, keepdim=True)
-    _, exponent = torch.frexp(maximum)
-    scale = torch.ldexp(torch.ones_like(maximum), (exponent - 11).clamp_min(0))
-    return (flat / scale).half(), scale
-
-
-class FP32OutputLinearMethod(UnquantizedLinearMethod):
-    """Keep wide-range projection outputs in FP32 with FP16 Tensor Core inputs."""
+    output_fp32 = False
+    supports_prepared_fp16 = True
+    supports_rotated_input = False
 
     def process_weights_after_loading(self, layer):
-        layer.weight.data = layer.weight.data.contiguous()
+        if getattr(layer, "h3_fp16_weight_layout", "row") == "column":
+            layer.weight.data = layer.weight.data.t().contiguous().t()
+        else:
+            layer.weight.data = layer.weight.data.contiguous()
 
     def apply(self, layer, x, bias=None):
         if x.is_cuda:
-            from .cuda_ops import w8a16_extension
-
             values, scale = fp16_gemm_input(x)
-            output = w8a16_extension().gemm(values, layer.weight, True)
-            if scale is not None:
-                output = output * scale
+            output = self.apply_prepared(layer, values, scale)
             output = output.reshape(*x.shape[:-1], layer.weight.shape[0])
         else:
             output = torch.nn.functional.linear(x.float(), layer.weight.float())
-        return output if bias is None else output + bias.float()
+            if not self.output_fp32:
+                output = output.to(x.dtype)
+        return output if bias is None else output + bias.to(output.dtype)
+
+    def apply_prepared(
+        self, layer, values, scale, *, input_is_rotated=False, original_input=None
+    ):
+        if input_is_rotated:
+            raise ValueError("Dense weights require unrotated activations")
+        return fp16_linear_prepared(
+            values, layer.weight, scale, output_fp32=self.output_fp32
+        )
+
+
+class FP32OutputLinearMethod(FP16LinearMethod):
+    """Keep wide-range projection outputs in FP32 with FP16 Tensor Core inputs."""
+
+    output_fp32 = True
+
+
+def supports_prepared_fp16(layer):
+    return bool(getattr(layer.quant_method, "supports_prepared_fp16", False))
 
 
 def preserve_fp32_output(layer):
@@ -396,10 +405,20 @@ class Int8ConvRotLinearMethod(LinearMethodBase):
             output = torch.nn.functional.linear(x, weight, bias)
         return output.reshape(*original_shape[:-1], layer.weight.shape[0])
 
-    def apply_prepared(self, layer, values, scale, *, input_is_rotated=False):
+    supports_prepared_fp16 = True
+
+    @property
+    def supports_rotated_input(self):
+        return self.layer_config.convrot and self.layer_config.convrot_groupsize == 256
+
+    def apply_prepared(
+        self, layer, values, scale, *, input_is_rotated=False, original_input=None
+    ):
         """Project FP16 rows with an explicit scale restored before TP reduction."""
         from .cuda_ops import fp16_gemm, w8a16_extension
 
+        if input_is_rotated and not self.supports_rotated_input:
+            raise ValueError("Pre-rotated input requires matching ConvRot weights")
         ops = w8a16_extension()
         x = values.reshape(-1, values.shape[-1])
         if self.layer_config.convrot and not input_is_rotated:
@@ -423,9 +442,8 @@ def rotate_local_fp16(layer, values):
     if (
         values.is_cuda
         and values.dtype == torch.float16
-        and isinstance(method, Int8ConvRotLinearMethod)
-        and method.layer_config.convrot
-        and method.layer_config.convrot_groupsize == 256
+        and getattr(method, "supports_rotated_input", False)
+        and not getattr(method, "requires_original_input", False)
         and layer.bias is None
         and not layer.gather_output
     ):
@@ -436,7 +454,12 @@ def rotate_local_fp16(layer, values):
 
 
 class _H3RotatedColumnInput(ColumnParallelLinear):
-    def forward(self, input_, *, input_is_rotated=False):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if type(self.quant_method) is UnquantizedLinearMethod:
+            self.quant_method = FP16LinearMethod()
+
+    def forward(self, input_, *, input_is_rotated=False, original_input=None):
         if not input_is_rotated:
             return super().forward(input_)
         method = self.quant_method
@@ -445,16 +468,20 @@ class _H3RotatedColumnInput(ColumnParallelLinear):
             or input_.dtype != torch.float16
             or self.bias is not None
             or self.gather_output
-            or not isinstance(method, Int8ConvRotLinearMethod)
-            or not method.layer_config.convrot
-            or method.layer_config.convrot_groupsize != 256
+            or not getattr(method, "supports_rotated_input", False)
         ):
             raise ValueError(
                 "Pre-rotated H3 columns require bias-free INT8 FP16 inputs"
             )
         # The module still receives every gathered row: ordinary forward hooks
         # and useful-FLOP accounting retain the original full projection shape.
-        output = method.apply_prepared(self, input_, None, input_is_rotated=True)
+        output = method.apply_prepared(
+            self,
+            input_,
+            None,
+            input_is_rotated=True,
+            original_input=original_input,
+        )
         return (output, None) if self.return_bias else output
 
 
@@ -475,10 +502,10 @@ class H3RowParallelLinear(RowParallelLinear):
         if (
             not self.input_is_parallel
             or self.bias is not None
-            or not isinstance(self.quant_method, Int8ConvRotLinearMethod)
+            or not supports_prepared_fp16(self)
         ):
             raise ValueError(
-                "Prepared H3 rows require a bias-free INT8 local projection"
+                "Prepared H3 rows require a bias-free local FP16-capable projection"
             )
         output = self.quant_method.apply_prepared(self, input_, input_scale)
         if self.reduce_results and self.tp_size > 1:

--- a/vllm/model_executor/models/minimax_h3/residency.py
+++ b/vllm/model_executor/models/minimax_h3/residency.py
@@ -5,9 +5,13 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import chain
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -216,12 +220,108 @@ class PinnedModuleStager:
 
     @staticmethod
     def _view(backing: torch.Tensor, binding: _TensorBinding) -> torch.Tensor:
+        element_size = binding.dtype.itemsize
+        backing_offset = backing.storage_offset() * backing.element_size()
+        if backing_offset % element_size:
+            raise ValueError("shared weight storage must preserve dtype alignment")
         return torch.empty(0, dtype=binding.dtype, device=backing.device).set_(
             backing.untyped_storage(),
-            binding.storage_offset,
+            backing_offset // element_size + binding.storage_offset,
             binding.shape,
             binding.stride,
         )
+
+    def share_cpu_storage(self, directory: str | Path) -> None:
+        """Share a checked immutable replica across this engine's TP workers.
+
+        The engine owns the temporary directory and removes it after workers
+        stop. Private mappings prevent accidental CPU writes from affecting a
+        different rank. Only identical complete storage groups may be shared.
+        """
+        import torch.distributed as dist
+
+        if self.loaded or any(group.master.is_pinned() for group in self._groups):
+            raise ValueError("shared host storage requires unloaded pageable masters")
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        directory = Path(directory)
+        if rank == 0:
+            self._write_shared_groups(directory)
+        if dist.is_initialized():
+            dist.barrier()
+        self._read_shared_groups(directory)
+
+    @staticmethod
+    def _group_description(group: _StorageGroup) -> dict:
+        return {
+            "bytes": group.master.numel(),
+            "bindings": [
+                {
+                    "dtype": str(binding.dtype),
+                    "shape": list(binding.shape),
+                    "stride": list(binding.stride),
+                    "storage_offset": binding.storage_offset,
+                }
+                for binding in group.bindings
+            ],
+        }
+
+    @staticmethod
+    def _storage_digest(master: torch.Tensor) -> str:
+        return hashlib.sha256(memoryview(master.numpy())).hexdigest()
+
+    def _write_shared_groups(self, directory: Path) -> None:
+        directory.mkdir(mode=0o700)
+        records, total = [], 0
+        for group in self._groups:
+            total = (total + 255) // 256 * 256
+            records.append({**self._group_description(group), "offset": total})
+            total += group.master.numel()
+        data_path = directory / "weights.bin"
+        fd = os.open(data_path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            # Reserve tmpfs space before mapping so a later write cannot SIGBUS
+            # because unrelated processes consume the remaining free space.
+            if total:
+                os.posix_fallocate(fd, 0, total)
+        finally:
+            os.close(fd)
+        shared = torch.from_file(
+            str(data_path), shared=True, size=total, dtype=torch.uint8
+        )
+        for group, record in zip(self._groups, records):
+            target = shared.narrow(0, record["offset"], record["bytes"])
+            target.copy_(group.master)
+            record["sha256"] = self._storage_digest(target)
+        (directory / "metadata.json").write_text(
+            json.dumps({"version": 1, "bytes": total, "groups": records})
+        )
+
+    def _read_shared_groups(self, directory: Path) -> None:
+        metadata = json.loads((directory / "metadata.json").read_text())
+        records = metadata["groups"]
+        if metadata["version"] != 1 or len(records) != len(self._groups):
+            raise ValueError("shared component storage inventory differs across ranks")
+        # COW mappings share physical pages while keeping the file immutable.
+        shared = torch.from_file(
+            str(directory / "weights.bin"),
+            shared=False,
+            size=metadata["bytes"],
+            dtype=torch.uint8,
+        )
+        for group, record in zip(self._groups, records):
+            if any(
+                record[key] != value
+                for key, value in self._group_description(group).items()
+            ):
+                raise ValueError("shared component tensor layouts differ across ranks")
+            if self._storage_digest(group.master) != record["sha256"]:
+                raise ValueError("shared component weights differ across ranks")
+            target = shared.narrow(0, record["offset"], record["bytes"])
+            if self._storage_digest(target) != record["sha256"]:
+                raise ValueError("shared component snapshot failed its checksum")
+            group.master = target
+            for binding in group.bindings:
+                set_tensor_storage(binding.target, self._view(target, binding))
 
     def _bind(self, storages: list[torch.Tensor]) -> None:
         for storage, group in zip(storages, self._groups):

--- a/vllm/model_executor/models/minimax_h3/residency.py
+++ b/vllm/model_executor/models/minimax_h3/residency.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import time
 from collections.abc import Iterable
+from contextlib import contextmanager
+from copy import copy
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
@@ -143,6 +146,7 @@ class PinnedModuleStager:
         self._ready_event = torch.cuda.Event()
         self.cache_retention = cache_retention
         self.loaded = False
+        self._layerwise_active = False
         self._groups = self._snapshot_groups(modules, pin_memory=pin_memory)
         self._device_storages: list[torch.Tensor] = []
         self._restore_masters()
@@ -374,6 +378,8 @@ class PinnedModuleStager:
         self._release_cache(force=True)
 
     def load(self) -> None:
+        if getattr(self, "_layerwise_active", False):
+            raise RuntimeError("whole-module load overlaps layerwise weight staging")
         if self.loaded:
             return
         try:
@@ -408,6 +414,117 @@ class PinnedModuleStager:
         self._device_storages.clear()
         self.loaded = False
         self._release_cache()
+
+
+class LayerwiseModuleStager:
+    """Execute disjoint blocks from the same immutable host snapshot.
+
+    Storage shared across blocks, or between a block and the outer module,
+    remains resident throughout the context. Other block storage is loaded
+    immediately before its forward and released afterwards, including errors.
+    Transfers synchronize at block boundaries; this is a capacity policy.
+    """
+
+    def __init__(
+        self,
+        snapshot: PinnedModuleStager,
+        blocks: Iterable[nn.Module],
+        *,
+        resident_modules: Iterable[nn.Module] = (),
+    ):
+        self.snapshot = snapshot
+        self.blocks = tuple(blocks)
+        if len({id(block) for block in self.blocks}) != len(self.blocks):
+            raise ValueError("layerwise staging blocks must be unique")
+        block_ids = {id(block) for block in self.blocks}
+        for block in self.blocks:
+            if any(id(child) in block_ids for child in tuple(block.modules())[1:]):
+                raise ValueError("layerwise staging blocks must not be nested")
+        owners: dict[int, set[int]] = {}
+        for index, block in enumerate(self.blocks):
+            for target in chain(block.parameters(), block.buffers()):
+                owners.setdefault(id(target), set()).add(index)
+        for module in resident_modules:
+            for target in chain(module.parameters(), module.buffers()):
+                owners.setdefault(id(target), set()).add(-1)
+        grouped: list[list[_StorageGroup]] = [[] for _ in self.blocks]
+        resident = []
+        for group in snapshot._groups:
+            group_owners: set[int] = set().union(
+                *(owners.get(id(binding.target), {-1}) for binding in group.bindings)
+            )
+            if len(group_owners) == 1 and -1 not in group_owners:
+                grouped[next(iter(group_owners))].append(group)
+            else:
+                resident.append(group)
+
+        def subset(groups: list[_StorageGroup]) -> PinnedModuleStager:
+            stager = copy(snapshot)
+            stager._groups = groups
+            stager._device_storages = []
+            stager.loaded = False
+            stager.cache_retention = snapshot.cache_retention or BoundedAllocatorCache(
+                snapshot.device
+            )
+            return stager
+
+        self.resident = subset(resident)
+        self.stagers = tuple(subset(groups) for groups in grouped)
+        self.load_seconds = 0.0
+        self.offload_seconds = 0.0
+        self.loaded_bytes = 0
+
+    def _load(self, stager):
+        started = time.perf_counter()
+        stager.load()
+        torch.accelerator.synchronize()
+        self.load_seconds += time.perf_counter() - started
+        self.loaded_bytes += sum(group.master.numel() for group in stager._groups)
+
+    def _offload(self, stager):
+        started = time.perf_counter()
+        stager.offload()
+        self.offload_seconds += time.perf_counter() - started
+
+    @contextmanager
+    def on_device(self):
+        if self.snapshot.loaded or getattr(self.snapshot, "_layerwise_active", False):
+            raise RuntimeError("layerwise staging requires an idle host snapshot")
+        self.snapshot._layerwise_active = True
+        self.load_seconds = self.offload_seconds = 0.0
+        self.loaded_bytes = 0
+        hooks = []
+        try:
+            self._load(self.resident)
+            for block, stager in zip(self.blocks, self.stagers):
+                hooks.append(
+                    block.register_forward_pre_hook(
+                        lambda module, args, stager=stager: self._load(stager)
+                    )
+                )
+                hooks.append(
+                    block.register_forward_hook(
+                        lambda module, args, result, stager=stager: self._offload(
+                            stager
+                        ),
+                        always_call=True,
+                    )
+                )
+            yield
+        finally:
+            for hook in hooks:
+                hook.remove()
+            errors = []
+            try:
+                for stager in (*self.stagers, self.resident):
+                    try:
+                        self._offload(stager)
+                    except Exception as exc:
+                        errors.append(exc)
+            finally:
+                self.snapshot._layerwise_active = False
+            if errors:
+                raise errors[0]
 
 
 __all__ = ["BoundedAllocatorCache", "PinnedModuleStager"]

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -832,8 +832,9 @@ class MiniMaxH3DiTBlock(nn.Module):
         if self.residual_group is not None:
             if self.residual_group.world_size not in (2, 4):
                 raise ValueError("H3 residual sequence parallelism requires TP2 or TP4")
-            # These projections return unreduced FP32 partial sums. Reduce-scatter
-            # keeps that precision and assigns each rank its residual rows.
+            # Keep the replicated path's FP32 sum order before selecting local
+            # residual rows. NCCL reduce-scatter uses a different reduction
+            # order and fails the full four-step latent quality gate.
             self.attn.out_proj.reduce_results = False
             self.mlp.fc2.reduce_results = False
         self.adaln_proj = MiniMaxH3AdalnProj(
@@ -920,7 +921,9 @@ class MiniMaxH3DiTBlock(nn.Module):
             input_is_rotated=input_is_rotated,
         )
         if group is not None:
-            h = group.reduce_scatter(h, dim=0)
+            h = group.all_reduce(h).narrow(
+                0, group.rank_in_group * residual.shape[0], residual.shape[0]
+            )
         x, h = indexed_gate_rms_norm_scale_shift(
             residual,
             gate_msa,
@@ -939,7 +942,9 @@ class MiniMaxH3DiTBlock(nn.Module):
             h = group.all_gather(h, dim=0)
         h = self.mlp(h, input_is_rotated=input_is_rotated)
         if group is not None:
-            h = group.reduce_scatter(h, dim=0)
+            h = group.all_reduce(h).narrow(
+                0, group.rank_in_group * residual.shape[0], residual.shape[0]
+            )
         return indexed_gate(residual, gate_mlp, h, combined_indices)
 
 

--- a/vllm/model_executor/models/minimax_h3/transformer.py
+++ b/vllm/model_executor/models/minimax_h3/transformer.py
@@ -43,9 +43,9 @@ from .quantization import (
     H3MergedColumnParallelLinear,
     H3QKVParallelLinear,
     H3RowParallelLinear,
-    Int8ConvRotLinearMethod,
     preserve_fp32_output,
     rotate_local_fp16,
+    supports_prepared_fp16,
 )
 
 if TYPE_CHECKING:
@@ -647,7 +647,7 @@ class MiniMaxH3MLP(nn.Module):
             hidden.is_cuda
             and hidden.dtype == torch.float16
             and 0 < hidden.shape[-1] <= 32768
-            and isinstance(self.fc2.quant_method, Int8ConvRotLinearMethod)
+            and supports_prepared_fp16(self.fc2)
         ):
             from .activation import silu_prepare_fp16
 
@@ -824,10 +824,14 @@ class MiniMaxH3DiTBlock(nn.Module):
             quant_config,
             prefix=f"{prefix}.mlp",
         )
-        self.residual_group = get_tp_group() if residual_sequence_parallel else None
+        self.residual_group = (
+            get_tp_group()
+            if residual_sequence_parallel and get_tensor_model_parallel_world_size() > 1
+            else None
+        )
         if self.residual_group is not None:
-            if self.residual_group.world_size != 4:
-                raise ValueError("H3 residual sequence parallelism requires TP4")
+            if self.residual_group.world_size not in (2, 4):
+                raise ValueError("H3 residual sequence parallelism requires TP2 or TP4")
             # These projections return unreduced FP32 partial sums. Reduce-scatter
             # keeps that precision and assigns each rank its residual rows.
             self.attn.out_proj.reduce_results = False
@@ -1087,15 +1091,9 @@ class MiniMaxH3DiTModel(nn.Module):
         self._qkv_checkpoint_is_runtime_layout = bool(
             getattr(quant_config, "is_checkpoint_int8_convrot_serialized", False)
         )
-        self.residual_sequence_parallel = residual_sequence_parallel
-        if residual_sequence_parallel and (
-            get_tensor_model_parallel_world_size() != 4
-            or not self._qkv_checkpoint_is_runtime_layout
-        ):
-            raise ValueError(
-                "H3 residual sequence parallelism requires TP4 "
-                "and serialized INT8 ConvRot"
-            )
+        self.residual_sequence_parallel = (
+            residual_sequence_parallel and get_tensor_model_parallel_world_size() > 1
+        )
         self.hidden_size = arch.hidden_size
         self.num_attention_heads = arch.num_attention_heads
         self.num_channels_latents = arch.latents_dim
@@ -1322,6 +1320,11 @@ class MiniMaxH3DiTModel(nn.Module):
                 weight_loader(param, up, 1)
             else:
                 weight_loader(param, loaded_weight)
+            if param.dtype == _COMPUTE_DTYPE and not torch.isfinite(param).all():
+                raise ValueError(
+                    f"H3 weight {name} cannot be represented as finite FP16; "
+                    "checkpoint conversion must not silently overflow"
+                )
             loaded.add(name)
         return loaded
 

--- a/vllm/model_executor/models/minimax_h3/vae.py
+++ b/vllm/model_executor/models/minimax_h3/vae.py
@@ -137,6 +137,7 @@ class MiniMaxH3VideoVAE(nn.Module):
         device: torch.device,
         load_device: torch.device | None = None,
         pin_memory: bool = True,
+        shared_weights_dir: str | None = None,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -158,6 +159,8 @@ class MiniMaxH3VideoVAE(nn.Module):
                 device,
                 pin_memory=pin_memory,
             )
+            if shared_weights_dir is not None:
+                self._stager.share_cpu_storage(Path(shared_weights_dir) / "video")
         self.model = self.remote.model
         self.use_tiling = True
         self.use_slicing = False
@@ -425,6 +428,7 @@ class MiniMaxH3AudioVAE(nn.Module):
         device: torch.device,
         load_device: torch.device | None = None,
         pin_memory: bool = True,
+        shared_weights_dir: str | None = None,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -444,6 +448,8 @@ class MiniMaxH3AudioVAE(nn.Module):
                 device,
                 pin_memory=pin_memory,
             )
+            if shared_weights_dir is not None:
+                self._stager.share_cpu_storage(Path(shared_weights_dir) / "audio")
         self.model = self.remote.model
         self.sample_rate = int(self.config_dict["sample_rate"])
 

--- a/vllm/model_executor/models/minimax_h3/vae.py
+++ b/vllm/model_executor/models/minimax_h3/vae.py
@@ -136,6 +136,7 @@ class MiniMaxH3VideoVAE(nn.Module):
         *,
         device: torch.device,
         load_device: torch.device | None = None,
+        pin_memory: bool = True,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -155,7 +156,7 @@ class MiniMaxH3VideoVAE(nn.Module):
             self._stager = PinnedModuleStager(
                 self.remote,
                 device,
-                pin_memory=True,
+                pin_memory=pin_memory,
             )
         self.model = self.remote.model
         self.use_tiling = True
@@ -423,6 +424,7 @@ class MiniMaxH3AudioVAE(nn.Module):
         *,
         device: torch.device,
         load_device: torch.device | None = None,
+        pin_memory: bool = True,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -440,7 +442,7 @@ class MiniMaxH3AudioVAE(nn.Module):
             self._stager = PinnedModuleStager(
                 self.remote,
                 device,
-                pin_memory=True,
+                pin_memory=pin_memory,
             )
         self.model = self.remote.model
         self.sample_rate = int(self.config_dict["sample_rate"])

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -8,6 +8,7 @@ import contextlib
 import multiprocessing as mp
 import os
 import socket
+import tempfile
 import threading
 import time
 import traceback
@@ -22,7 +23,7 @@ from .gpu import acquire_gpu_group
 from .gpu import select_gpu_group as select_gpu_group
 
 
-def _worker(rank, config, gpu_ids, endpoint, connection):
+def _worker(rank, config, gpu_ids, endpoint, connection, shared_weights_dir=None):
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
     from datetime import timedelta
 
@@ -55,7 +56,7 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
             )
             initialize_model_parallel(config.tensor_parallel_size)
             started = time.perf_counter()
-            pipeline = MiniMaxH3Pipeline(config)
+            pipeline = MiniMaxH3Pipeline(config, shared_weights_dir=shared_weights_dir)
             connection.send(
                 {
                     "ready": True,
@@ -129,6 +130,7 @@ class H3Engine:
     def __init__(self, config: H3Config):
         self.config = config
         self._gpu_lease = None
+        self._shared_weights = None
         self._lock = threading.Lock()
         self._closed = False
         self.workers = []
@@ -138,15 +140,20 @@ class H3Engine:
         try:
             self._gpu_lease = acquire_gpu_group(config.tensor_parallel_size)
             self.gpu_ids = self._gpu_lease.gpu_ids
+            if config.share_host_vae_weights and config.tensor_parallel_size > 1:
+                self._shared_weights = tempfile.TemporaryDirectory(
+                    prefix="vllm-h3-vae-", dir="/dev/shm"
+                )
             with socket.socket() as sock:
                 sock.bind(("127.0.0.1", 0))
                 port = sock.getsockname()[1]
             endpoint = f"tcp://127.0.0.1:{port}"
             for rank in range(config.tensor_parallel_size):
                 parent, child = context.Pipe()
-                worker = context.Process(
-                    target=_worker, args=(rank, config, self.gpu_ids, endpoint, child)
-                )
+                args: tuple = (rank, config, self.gpu_ids, endpoint, child)
+                if self._shared_weights is not None:
+                    args = (*args, self._shared_weights.name)
+                worker = context.Process(target=_worker, args=args)
                 worker.start()
                 child.close()
                 self.workers.append(worker)
@@ -234,6 +241,9 @@ class H3Engine:
                 worker.join()
         for connection in self.connections:
             connection.close()
+        if self._shared_weights is not None:
+            self._shared_weights.cleanup()
+            self._shared_weights = None
         if self._gpu_lease is not None:
             self._gpu_lease.close()
             self._gpu_lease = None


### PR DESCRIPTION
## Purpose

H3's residual sharding rejected original floating weights, Ref2VA and every
adapter, while fused FP16 input preparation only recognized an INT8 method.
This change routes preparation through execution capabilities and supports
original FP16/W8A16 projections, active LoRA and opt-in TP2/TP4 residual sharding.
FP32 residuals and outputs, row-scale restoration and adapter addition before
TP reduction are preserved. TP1 keeps ordinary execution.

The shared SM70 GEMM/preparation module is independent of the H3 model package.
Original floating projections can explicitly select column-major storage with
`--fp16-weight-layout column`; the default is row-major. Original weight loading
rejects FP16 overflow instead of silently producing non-finite parameters.

Integration base: `4f19ef7a20db60bb0685e599bd3f4dd156202eed` (`onecat/main`).
Implementation checkpoints: `1031bb70cf`, `9623a9adb2`. Duplicate-work check found no open H3
PR after the prior FA/FI/workflow/export changes were merged. This is the common
execution portion of the broader H3 >80 useful TFLOP/s/card campaign.

## Test Plan

- GPU: prepared/normal LoRA equality, signed W8A16, original FP16, wide-range
  activation scaling, column-major/cuBLASLt, graph replay and non-H3 shapes.
- Distributed: compare repeated blocks on TP2/TP4, both native attention
  backends, original/INT8 adapted projections, padding and FP32 residuals
  larger than 65504. Run each distributed module in a separate torchrun.
- CPU: configuration, adapter loaders/schedules, FP16 overflow and FP32
  preservation, API and media export regressions.
- Full-model: matched mainline/candidate 720p five-second four-step generation,
  then the remaining workflow/precision/adapter quality and performance matrix.

## Test Result

Using Python 3.12 and Torch 2.10.0+cu128 on V100 SXM2 32GB:

```text
python -m pytest -q tests/video/test_h3_prepared_linear.py tests/video/test_h3_activation.py tests/video/test_h3_column_major.py
  28 passed in the GPU batch (24 GPU + 4 CPU layout checks; before the additional conversion checks)
torchrun --standalone --nproc-per-node=2 -m pytest -q tests/video/test_h3_residual_parallel.py -k test_gpu
  1 composite case passed on each of 2 ranks
torchrun --standalone --nproc-per-node=4 -m pytest -q tests/video/test_h3_residual_parallel.py -k test_gpu
  1 composite case passed on each of 4 ranks
CUDA_VISIBLE_DEVICES='' python -m pytest -q tests/video/test_h3_residual_parallel.py tests/video/test_h3_lora.py tests/video/test_h3_flashgen.py tests/video/test_h3_fasth3.py tests/video/test_h3_service.py tests/video/test_h3_prepared_linear.py -k 'not test_gpu'
  133 passed, 1 skipped, 8 deselected
```

Commands used the owned `.venv/bin/python`, native exclusive GPU leases,
task-built SM70 binaries and task-specific caches. Ruff and all commit hooks,
including mypy, passed. Raw commands, environments, binary hashes and logs:
`/data/minimax-h3/sm70-general-20260909/`; campaign status is retained in
`docs/design/minimax_h3/GENERAL_SM70.md`.

Prepared LoRA matches normal execution bitwise in the GPU operator tests.
The complete 720p/four-step control without residual sharding also matches
mainline video/audio latents bitwise, pre-encoding video SSIM is 1.0 and every
audio numerical gate passes.

The initial reduce-scatter residual path **failed full quality**: video/audio
latent relative L2 0.2957225/0.0565235, video PSNR 28.312 dB, SSIM 0.878025.
Its 62.624739 s / 50.009271 TFLOP/s/card result is rejected; the same-contract
post-warmup mainline baseline is 66.206537 s / 47.303750 TFLOP/s/card.

The fix preserves the replicated path's full FP32 all-reduce before selecting
local residual rows. It gives up the unqualified communication saving. The TP4
block oracle now passes bitwise on every TP2/TP4 rank (including both backends
and adapted original/INT8 blocks). Complete four-step validation of the fixed
residual path also passes: video/audio latents match frozen mainline bitwise,
all 124 pre-encoding frames match with SSIM 1.0, and all audio numerical gates
pass. This was a no-warmup quality control, not a performance comparison.
Original BF16 checkpoint through FP16/FP32 runtime, with LightX2V4 v1.2,
column layout and exact residual sharding also completes the 720p five-second
control: video/audio latents match frozen original-weight mainline bitwise,
all 124 decoded frames match (SSIM 1.0), audio spectral cosine is effectively 1
and RMS ratio is 1. See `original-column-quality.json`.

Both original-weight controls used pageable CPU masters: all-pinned startup
exhausted the 188 GiB host before denoise. The native deployment now exposes
`--disable-host-weight-pinning` / `host_weight_pin_memory=False` for all four
components. Additional tests: 43 config/VAE/workflow/API checks and two real
pinned/pageable alias-preserving transfer tests pass. The complete controls
used an artifact-local equivalent before this native flag was added. A later native-flag TP4 run at 324f2463 also enables explicit shared VAE host storage and passes full latent/RGB/PCM comparison bitwise. Default pinning remains unchanged.

No >80 or formal three-run result is claimed. Original controls had no warmup
(69.044838 s ordinary vs 66.426983 s candidate), so no speedup is claimed.
Preservation against frozen mainline does not establish independent official
algorithm quality or human audiovisual acceptance.

The explicit `--share-host-vae-weights --disable-host-weight-pinning` policy shares checked immutable VAE CPU storage between this engine's TP workers. Layouts, mixed-dtype aliases, strides and offsets are preserved; private mappings isolate accidental writes, and the parent removes its owned tmpfs directory after workers stop. CPU coverage passes 19 checks and GPU storage roundtrips pass three load/offload cycles. Full original-weight Light4 generation at 1280x736/124 internal frames preserves final video/audio latents, all RGB frames and decoded PCM bitwise (`shared-host-quality.json`). Mapped physical PSS is 11,020,886,016 bytes versus four replicas (44,083,544,064 summed RSS), with zero private mapped pages at startup; owned cleanup succeeds. The single captured cold request is 66.365689 seconds denoise and 126.846697 seconds overall, not a warmed speed result. See `SHARED_HOST_WEIGHTS.md`.

The stacked accounting branch excludes duplicate column-LoRA A work; earlier throughput numbers above use the historical numerator and are not directly comparable to corrected results. The combined kernel branch currently measures 51.939 useful TFLOP/s/card, still below 80.

The explicit `--weight-offload layer` capacity policy stages disjoint DiT and encoder blocks from the existing host snapshot. Outer/shared storage and first-block normalization/AdaLN cache-probe consumers remain resident. Hooks release storage on success/failure and preserve column layouts, aliases and adapter buffers. Whole-component staging remains the default; fixed FP16 cache lists are incompatible with layer mode. CPU coverage passes 35 checks and GPU FP16/FP32 ownership/alias/tail tests pass three cycles. A complete TP1 original-weight Light4 request at 256x448/22 frames peaks at 15,473,571,328 bytes. Pageable and pinned masters produce bitwise-equal final latents, RGB and PCM; cold denoise is 126.274887/53.840319 seconds and request latency 152.031041/67.370839 seconds. These establish capacity and residency parity, not primary performance or independent official quality. Boundary timing includes async waits; offload discards GPU copies and performs no D2H weight transfer. See `LAYER_WEIGHT_OFFLOAD.md`.

Original FP16 projection conversion was independently scanned for all 208 attention/MLP matrices in each partition: no overflow/nonfinite values, aggregate relative L2 about 9e-10 with 4055/4058 tiny underflows. Protected FP32 tensors are excluded from conversion. All eight official Turbo artifacts are downloaded and hash/header verified; GPU coverage remains a separate gate.

## Remaining gates

Keep this PR Draft. Remaining original-weight/Ref2VA/adapter generations, three-run
performance, full audiovisual review and AUTO qualification remain pending.
VSA, cross-step caches and subsequent attention-kernel optimization are separate
campaign changes. Active LoRA still gathers its unrotated input in the residual
path; the prepared row projections and explicit dual-basis column interface are
implemented, but adapter gather optimization remains work.

AI assistance: implementation and initial validation were performed with
OpenAI Codex. Human line-by-line review and independent validation remain
required before promotion from Draft.

Complete TP2 original-weight Light4 capacity/sharding check: whole-component DiT loading exceeds 32 GB/card and fails before denoise. Layer mode completes at 256x448/22 frames with 15,449,646,080 allocated bytes/card. Matched layer-mode ordinary/sharded residual controls reproduce final video/audio latents, all RGB and PCM bitwise (`layer-tp2-quality.json`). Captured cold denoise is 166.482792/90.431030 seconds, affected by host paging; no warmed speed comparison or primary-shape acceptance is claimed.
