### PR TITLE
[Bugfix] Guard sampling indices and empty bad-word tokenization

### DIFF
--- a/docs/design/sm70_sampling_input_guards.md
+++ b/docs/design/sm70_sampling_input_guards.md
@@ -1,0 +1,67 @@
+# Sampling input guards for the Qwen3.8 runtime
+
+This follow-up to PR533 fixes three request-boundary defects on public main
+`4f19ef7a20db60bb0685e599bd3f4dd156202eed`. Only `SamplingParams` production
+code changes; model weights, precision, CUDA kernels and default sampling are
+unchanged.
+
+## Confirmed defects
+
+1. **Stop IDs were not bounded by the model vocabulary.** A negative or
+   out-of-vocab `stop_token_ids` entry passed model-aware verification.
+   MRv2's minimum-token mask uses these IDs as raw logit indices, so enabling
+   `min_tokens` could turn a malformed request into an out-of-row GPU store.
+   Validate user stop IDs and already-merged stop metadata before scheduling.
+   No malformed IDs were deliberately executed on CUDA during the audit.
+2. **Allowed IDs were validated only against the tokenizer.** With
+   `skip_tokenizer_init`/token-ID-only requests, there was no range validation;
+   a tokenizer larger than the model could also admit indices beyond the
+   model's logit width. Validation now uses the model width even without a
+   tokenizer, while retaining the existing tokenizer limit when present.
+3. **Whitespace-only bad words became empty token sequences.** Stripping
+   leading whitespace turned spaces, tabs and newlines into empty strings,
+   and prefix handling then indexed an empty list. Keep literal whitespace
+   sequences. If a tokenizer still produces no tokens, return a structured
+   `VLLMValidationError` instead of an `IndexError` or an empty GPU bad-word
+   sequence. Normal-word prefix handling is unchanged.
+
+The actual local RadixArk Qwen3.8-Flash-Next-NVFP4 tokenizer reproduced
+`IndexError` for space, double space, Tab and newline before the fix.
+After the fix their literal IDs are respectively 220, 256, 197 and 198, with
+nonempty prefix variants. English and Chinese controls retain their old IDs.
+This tokenizer has 248,077 entries; the model logit width is 248,320.
+
+## Validation
+
+The initial CPU suite on the integration base had **24 failures and 11 passing
+controls in 4.25 s**. This includes model vocabulary sizes 128 and 248,320,
+negative and upper-bound IDs, tokenizer absence/mismatch, whitespace, and
+empty encodings. The final CPU suite plus existing state/greedy regressions
+has **67 passes in 6.84 s**, including chat request conversion through actual
+`InputProcessor._validate_params`.
+
+```bash
+CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q --tb=short \
+  --confcutdir=tests/v1/worker \
+  tests/v1/worker/test_sampling_input_guards.py \
+  tests/v1/worker/test_gpu_sampler_runtime_states.py \
+  tests/v1/worker/test_gpu_model_runner_v2_greedy.py
+.venv/bin/python -m pytest -q --tb=short --confcutdir=tests/v1/worker \
+  tests/v1/worker/test_sampling_input_guards_gpu.py
+```
+
+Use the installed source runtime or the repository's source-overlay bootstrap.
+Tests load no model weights. CPU masks compare exact values, valid token lists
+remain unchanged, and invalid IDs are checked on the CPU instead of inducing
+a GPU fault. The GPU suite checks valid minimum-token/allow masks at model
+vocabulary width and bad-word preprocessing against the existing CPU oracle.
+
+At publication, local scoped pre-commit passed. The 11 GPU controls were added
+but not run: the cooperative GPU groups were occupied, so the test launcher
+exited without taking over another task's devices. No full model or service
+was started for this CPU preprocessing change.
+
+This audit is not a new 98 tok/s benchmark or a universal output-quality
+certificate. Validated behavior is the changed input boundary; broader GDN/W13
+numerical auditing, late runner capacity limits and generated EOS configuration
+validation are separate scopes. The no-option fast decode path is untouched.

--- a/tests/v1/worker/test_sampling_input_guards.py
+++ b/tests/v1/worker/test_sampling_input_guards.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-boundary regressions: do not send invalid indices to CUDA."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.ops.bad_words import _apply_bad_words_single_batch
+
+
+class Tokenizer:
+    max_token_id = 127
+
+    def __len__(self):
+        return self.max_token_id + 1
+
+    def encode(self, text, add_special_tokens=False):
+        assert not add_special_tokens
+        return [ord(char) for char in text if char != "\x00"]
+
+
+def verify(params, vocab_size=128, tokenizer=None):
+    config = SimpleNamespace(
+        max_logprobs=20, get_vocab_size=lambda: vocab_size, logits_processors=None
+    )
+    params.verify(config, None, None, tokenizer)
+
+
+@pytest.mark.parametrize("vocab_size", [128, 248320])
+@pytest.mark.parametrize("offset", [-1, 0, 100])
+@pytest.mark.parametrize("minimum", [0, 2])
+def test_stop_ids_are_checked_against_model_vocabulary(vocab_size, offset, minimum):
+    token = offset if offset < 0 else vocab_size + offset
+    params = SamplingParams(stop_token_ids=[token], min_tokens=minimum)
+    with pytest.raises(VLLMValidationError, match="stop_token_ids"):
+        verify(params, vocab_size)
+
+
+@pytest.mark.parametrize("vocab_size", [128, 248320])
+@pytest.mark.parametrize("offset", [-1, 0, 100])
+def test_allowed_ids_are_checked_without_tokenizer(vocab_size, offset):
+    token = offset if offset < 0 else vocab_size + offset
+    params = SamplingParams(allowed_token_ids=[0, token], detokenize=False)
+    with pytest.raises(VLLMValidationError, match="allowed_token_ids"):
+        verify(params, vocab_size)
+
+
+def test_tokenizer_extra_ids_do_not_exceed_model_logits():
+    with pytest.raises(VLLMValidationError, match="allowed_token_ids"):
+        verify(
+            SamplingParams(allowed_token_ids=[100]),
+            vocab_size=64,
+            tokenizer=Tokenizer(),
+        )
+
+
+@pytest.mark.parametrize("ids", [[0], [127], [0, 127, 0]])
+@pytest.mark.parametrize("with_tokenizer", [False, True])
+def test_valid_boundary_ids_are_preserved(ids, with_tokenizer):
+    params = SamplingParams(stop_token_ids=ids, allowed_token_ids=ids, min_tokens=2)
+    verify(params, tokenizer=Tokenizer() if with_tokenizer else None)
+    assert params.stop_token_ids == ids
+    assert params.allowed_token_ids == ids
+    assert params.all_stop_token_ids == set(ids)
+
+
+@pytest.mark.parametrize("ids", [[], [128]])
+def test_existing_tokenizer_limit_is_preserved(ids):
+    with pytest.raises(VLLMValidationError, match="allowed_token_ids"):
+        verify(
+            SamplingParams(allowed_token_ids=ids), vocab_size=256, tokenizer=Tokenizer()
+        )
+
+
+@pytest.mark.parametrize("word", [" ", "  ", "\t", "\n"])
+def test_whitespace_bad_words_remain_literal_sequences(word):
+    tokenizer = Tokenizer()
+    params = SamplingParams(bad_words=[word])
+    params.update_from_tokenizer(tokenizer)
+    expected = tokenizer.encode(word)
+    assert expected in params.bad_words_token_ids
+    assert all(params.bad_words_token_ids)
+    logits = torch.zeros(128)
+    _apply_bad_words_single_batch(logits, params.bad_words_token_ids, expected[:-1])
+    assert torch.isneginf(logits[expected[-1]])
+
+
+@pytest.mark.parametrize("word", ["hello", " hello", "  hello"])
+def test_normal_bad_word_prefix_behavior_is_unchanged(word):
+    params = SamplingParams(bad_words=[word])
+    params.update_from_tokenizer(Tokenizer())
+    assert params.bad_words_token_ids == [Tokenizer().encode("hello")]
+
+
+def test_empty_tokenization_is_a_request_error():
+    params = SamplingParams(bad_words=["\x00"])
+    with pytest.raises(VLLMValidationError, match="bad_words"):
+        params.update_from_tokenizer(Tokenizer())

--- a/tests/v1/worker/test_sampling_input_guards.py
+++ b/tests/v1/worker/test_sampling_input_guards.py
@@ -100,3 +100,36 @@ def test_empty_tokenization_is_a_request_error():
     params = SamplingParams(bad_words=["\x00"])
     with pytest.raises(VLLMValidationError, match="bad_words"):
         params.update_from_tokenizer(Tokenizer())
+
+
+@pytest.mark.parametrize("parameter", ["stop_token_ids", "allowed_token_ids"])
+@pytest.mark.parametrize("token_id", [-1, 248320])
+def test_chat_request_is_rejected_at_engine_admission(parameter, token_id):
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.v1.engine.input_processor import InputProcessor
+
+    request = ChatCompletionRequest(
+        model="qwen38",
+        messages=[{"role": "user", "content": "hello"}],
+        min_tokens=2,
+        **{parameter: [token_id]},
+    )
+    params = request.to_sampling_params(max_tokens=8, default_sampling_params={})
+    processor = object.__new__(InputProcessor)
+    processor.model_config = SimpleNamespace(
+        max_logprobs=20, get_vocab_size=lambda: 248320, logits_processors=None
+    )
+    processor.speculative_config = None
+    processor.structured_outputs_config = None
+    processor.renderer = SimpleNamespace(tokenizer=None)
+    with pytest.raises(VLLMValidationError) as exc:
+        processor._validate_params(params, ("generate",))
+    assert exc.value.parameter == parameter
+
+
+def test_premerged_eos_is_validated_for_min_token_masking():
+    params = SamplingParams(min_tokens=2, ignore_eos=True)
+    params.update_from_generation_config({}, eos_token_id=128)
+    assert params.stop_token_ids == []
+    with pytest.raises(VLLMValidationError, match="stop_token_ids"):
+        verify(params)

--- a/tests/v1/worker/test_sampling_input_guards_gpu.py
+++ b/tests/v1/worker/test_sampling_input_guards_gpu.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Valid input controls through actual GPU masks; invalid IDs stay on CPU."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.ops.bad_words import _apply_bad_words_single_batch
+from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
+from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
+from vllm.v1.worker.gpu.states import RequestState
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+class ByteTokenizer:
+    max_token_id = 127
+
+    def encode(self, text, add_special_tokens=False):
+        return list(text.encode("ascii"))
+
+
+@pytest.mark.parametrize("word", [" ", "  ", "\t", "\n", "hello"])
+def test_bad_word_preprocessing_matches_gpu_mask(word):
+    device = torch.device("cuda")
+    params = SamplingParams(bad_words=[word])
+    params.update_from_tokenizer(ByteTokenizer())
+    tokens = ByteTokenizer().encode(word)
+    history = tokens[:-1]
+    reqs = RequestState(1, 32, 8, 0, 128, device)
+    reqs.add_request("request", 1, [1, *history], len(history), 8)
+    state = BadWordsState(reqs)
+    state.add_request(0, params)
+    reqs.apply_staged_writes()
+    state.apply_staged_writes()
+    logits = torch.arange(128, dtype=torch.float32, device=device).unsqueeze(0)
+    expected = logits.cpu()
+    _apply_bad_words_single_batch(expected[0], params.bad_words_token_ids, history)
+    state.apply_bad_words(
+        logits,
+        torch.zeros(1, dtype=torch.int32, device=device),
+        np.array([0]),
+        torch.tensor([history[-1] if history else 1], dtype=torch.int32, device=device),
+        torch.zeros(1, dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(logits.cpu(), expected, atol=0, rtol=0)
+    assert torch.isneginf(logits[0, tokens[-1]])
+
+
+@pytest.mark.parametrize("vocab_size", [128, 248320])
+@pytest.mark.parametrize("generated", [1, 2, 3])
+def test_valid_token_id_guards_preserve_stop_and_allow_masks(vocab_size, generated):
+    eos = vocab_size - 1
+    params = SamplingParams(
+        min_tokens=2, allowed_token_ids=[42, eos], stop_token_ids=[eos]
+    )
+    config = SimpleNamespace(
+        max_logprobs=20, get_vocab_size=lambda: vocab_size, logits_processors=None
+    )
+    params.verify(config, None, None, None)
+    state = LogitBiasState(1, torch.device("cuda"))
+    state.add_request(0, 8, params)
+    state.apply_staged_writes()
+    logits = torch.zeros(1, vocab_size, device="cuda")
+    logits[0, eos], logits[0, 42] = 10, 5
+    state.apply_logit_bias(
+        logits,
+        torch.zeros(1, dtype=torch.int32, device="cuda"),
+        np.array([0]),
+        torch.tensor([8 + generated - 1], device="cuda"),
+    )
+    expected = torch.full_like(logits, -torch.inf)
+    expected[0, 42] = 5
+    if generated >= 2:
+        expected[0, eos] = 10
+    torch.testing.assert_close(logits, expected, atol=0, rtol=0)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -622,15 +622,24 @@ class SamplingParams(
             return
         self._bad_words_token_ids = []
         for bad_word in self.bad_words:
+            # Preserve literal whitespace-only sequences rather than stripping
+            # them into an empty token list.
+            word = bad_word.lstrip() or bad_word
             # To prohibit words both at the beginning
             # and in the middle of text
             # (related to add_prefix_space tokenizer parameter)
             for add_prefix_space in [False, True]:
                 prefix = " " if add_prefix_space else ""
-                prompt = prefix + bad_word.lstrip()
+                prompt = prefix + word
                 prompt_token_ids = tokenizer.encode(
                     text=prompt, add_special_tokens=False
                 )
+                if not prompt_token_ids:
+                    raise VLLMValidationError(
+                        f"bad_words entry {bad_word!r} encodes to no tokens.",
+                        parameter="bad_words",
+                        value=bad_word,
+                    )
 
                 # If no space at the beginning
                 # or if prefix space produces a new word token
@@ -705,8 +714,9 @@ class SamplingParams(
     ) -> None:
         self._validate_logprobs(model_config)
         self._validate_logit_bias(model_config)
+        self._validate_stop_token_ids(model_config)
         self._validate_logits_processors(model_config)
-        self._validate_allowed_token_ids(tokenizer)
+        self._validate_allowed_token_ids(model_config, tokenizer)
         self._validate_spec_decode(speculative_config)
         self._validate_structured_outputs(structured_outputs_config, tokenizer)
 
@@ -799,7 +809,28 @@ class SamplingParams(
 
         validate_logits_processors_parameters(model_config.logits_processors, self)
 
-    def _validate_allowed_token_ids(self, tokenizer: TokenizerLike | None) -> None:
+    def _validate_stop_token_ids(self, model_config: ModelConfig) -> None:
+        # min_tokens turns these IDs into logit indices, not just stop labels.
+        stop_token_ids = self.all_stop_token_ids.union(self.stop_token_ids or [])
+        if not stop_token_ids:
+            return
+        vocab_size = model_config.get_vocab_size()
+        invalid_token_ids = sorted(
+            token_id
+            for token_id in stop_token_ids
+            if token_id < 0 or token_id >= vocab_size
+        )
+        if invalid_token_ids:
+            raise VLLMValidationError(
+                f"stop_token_ids contains out-of-vocab token ids "
+                f"{invalid_token_ids}. Vocabulary size: {vocab_size}",
+                parameter="stop_token_ids",
+                value=invalid_token_ids,
+            )
+
+    def _validate_allowed_token_ids(
+        self, model_config: ModelConfig, tokenizer: TokenizerLike | None
+    ) -> None:
         allowed_token_ids = self.allowed_token_ids
         if allowed_token_ids is None:
             return
@@ -811,19 +842,22 @@ class SamplingParams(
                 value=allowed_token_ids,
             )
 
+        # Token-ID-only requests may skip the tokenizer entirely. When present,
+        # retain its existing limit as well as the model's logit width.
+        vocab_size = model_config.get_vocab_size()
         if tokenizer is not None:
-            vocab_size = len(tokenizer)
-            invalid_token_ids = [
-                token_id
-                for token_id in allowed_token_ids
-                if token_id < 0 or token_id >= vocab_size
-            ]
-            if invalid_token_ids:
-                raise VLLMValidationError(
-                    "allowed_token_ids contains out-of-vocab token id!",
-                    parameter="allowed_token_ids",
-                    value=invalid_token_ids,
-                )
+            vocab_size = min(vocab_size, len(tokenizer))
+        invalid_token_ids = [
+            token_id
+            for token_id in allowed_token_ids
+            if token_id < 0 or token_id >= vocab_size
+        ]
+        if invalid_token_ids:
+            raise VLLMValidationError(
+                "allowed_token_ids contains out-of-vocab token id!",
+                parameter="allowed_token_ids",
+                value=invalid_token_ids,
+            )
 
     def _validate_spec_decode(
         self,


### PR DESCRIPTION
## Purpose

Continue the Qwen3.8 Flash-Next runtime audit after merged PR533, fixing request-boundary defects in a batch without changing model arithmetic or restarting the full model.

Integration base: public/main `4f19ef7a20db60bb0685e599bd3f4dd156202eed`.
Fixed head: `400acb6c042f59d6d3fc3b8673b207a4115c4f47`. Reproduction-only commit: `3420bde5b8`.

## Reproduced scope

1. Out-of-vocab stop_token_ids pass model-aware request validation. With min_tokens enabled they become unchecked GPU logit stores.
2. allowed_token_ids is unchecked when the tokenizer is skipped, and is bounded only by tokenizer length otherwise, not model logits vocabulary. Invalid IDs can reach GPU loads/stores.
3. Whitespace-only bad words are stripped into empty strings; empty tokenizer output is indexed without checking. Whitespace cases reproduce with this checkpoint's tokenizer.

These are distinct from PR533's custom-logprob validation and prompt/speculative fixes. Open-PR search found no equivalent repair; no unrelated MTP, FlashInfer, H3 or projection experiment is included.

## Test plan / result

Before repair: tests/v1/worker/test_sampling_input_guards.py has 24 failing cases and 11 passing controls on the integration base (4.25 s). Tests invoke public SamplingParams.verify and bad-word preprocessing; invalid indices are not deliberately sent to CUDA.

## Implementation

- Verify stop IDs against the actual model vocabulary (including already-merged stop metadata); report VLLMValidationError before worker execution.
- Verify allowed IDs against model vocabulary even when tokenizer is absent; preserve the existing tokenizer limit when present.
- Preserve literal whitespace-only bad words, and reject empty tokenizer output as a structured request error. Normal-word prefix semantics remain unchanged.

Only `vllm/sampling_params.py` production code changes. No CUDA kernel, model arithmetic, precision, weight, attention, SSM, PLE placement or default per-token dispatch is modified. No new approximately 98 tok/s result is claimed.

## Tests / final results

```bash
CUDA_VISIBLE_DEVICES= .venv/bin/python -m pytest -q --tb=short \
  --confcutdir=tests/v1/worker \
  tests/v1/worker/test_sampling_input_guards.py \
  tests/v1/worker/test_gpu_sampler_runtime_states.py \
  tests/v1/worker/test_gpu_model_runner_v2_greedy.py
pre-commit run
```

Run with the installed source runtime or documented source-overlay bootstrap.

- Final CPU regression: **67 passed in 6.84 s**, including chat protocol conversion through InputProcessor admission, tokenizerless/model-mismatched IDs, valid boundary preservation, literal whitespace masks and previous state/greedy tests.
- All applicable local scoped pre-commit hooks passed, including ruff, mypy and markdownlint.
- Actual local RadixArk Qwen3.8-Flash-Next-NVFP4 cached tokenizer: space/double-space/Tab/newline changed from IndexError to correct nonempty token sequences. English/Chinese controls unchanged. Raw tokenizer metadata loads only; no model weights initialized.
- **GPU controls pending**: `tests/v1/worker/test_sampling_input_guards_gpu.py` contains 11 valid-input mask comparisons. Cooperative GPU groups were busy, so the launcher exited without starting tests. These are not counted as passes; no foreign process was interrupted.
- No full-model restart, dependency upgrade, native rebuild, GPU residency or fresh throughput claim.

Public audit/reproduction notes: `docs/design/sm70_sampling_input_guards.md`. Local raw evidence is retained under the owned worktree's `.artifacts/`: `guards_before.log`, `guards_final_cpu.log`, `tokenizer_wrapped_before.log`, `tokenizer_after.log`, `precommit_fixes.log`, and GPU lease-attempt logs. No weights, caches, secrets or private absolute paths committed.

## Limits / negative results

The first raw HF tokenizer probe bypassed vLLM's required tokenizer wrapper and produced an unrelated missing-max_token_id error on controls; that probe is not evidence of a production defect. The corrected probe uses vLLM get_tokenizer and passes normal-word controls.

This audit does not claim an observed live-service CUDA crash: range validation failures and the unchecked indexing code establish the risk without deliberately executing malformed indices. It also does not certify GDN/W13 numerics, post-validation generation-config EOS data, or late MRv2 request-capacity limits; these remain separate scopes. Draft pending the GPU controls and final remote CI; not merged or deployed.

AI assistance: OpenAI Codex performs this audit and implementation at the repository owner's request. No independent human review is claimed.
