### PR TITLE
[Video] Measure H3 workflows with actual denoise schedules

### DIFF
--- a/docs/design/minimax_h3/WORKFLOW_METRICS.md
+++ b/docs/design/minimax_h3/WORKFLOW_METRICS.md
@@ -61,6 +61,15 @@ Cache-DiT support. Padding, ConvRot, dequantization and repeated output rows rem
 excluded from useful FLOPs. Algorithmic work savings must be accounted separately
 when those variants are implemented.
 
+Column-parallel LoRA A projections have the same weights and input on every
+rank. `dense_tp_lora_v2` attributes those input rows once across the TP group,
+including uneven tails. Identical replicas are reported in
+`redundant_denoise_flops`, `redundant_flops_by_layer` and each step's
+`redundant_flops`; they never increase useful throughput. Row-parallel A consumes
+distinct input shards, so its resulting partial B products remain useful work.
+Legacy records without an accounting version are rejected until explicitly
+audited; the measurement source/time must remain unchanged in any such audit.
+
 ## Development evidence
 
 Integration base: `4f19ef7a20db60bb0685e599bd3f4dd156202eed` (`onecat/main`).
@@ -77,3 +86,36 @@ Artifacts: `/data/minimax-h3/sm70-general-20260909/`.
   acquired after the original-weight control released it.
 - Full model instrumentation validation and performance measurements are pending.
   No configuration has met the campaign's >80 TFLOP/s and full quality gates.
+
+### Complete four-step controls and first three-run baseline
+
+`metrics-720p-quality` validates runtime `82362a4312`, W8A16 + LightX2V4 v1.2,
+TP4 GPUs0-3, internal 1280x736/124 frames for the five-second 720p sample.
+All four ranks recorded four complete calls and 52 blocks/call. Full video/audio
+latents and decoded RGB/PCM match frozen mainline bitwise; SSIM is 1.0 and the
+audio numerical gates pass (`metrics-quality.json`). This is instrumentation
+regression evidence, not independent official or human quality acceptance.
+
+`fa-720p-three-runs` completes one full native warmup and three unprofiled
+requests with the same deployment/sampling on `82362a4312`. Denoise times are
+65.880184, 65.898529 and 65.965556 seconds; CV is 0.055668%. End-to-end times
+are 93.173206, 95.494415 and 88.343595 seconds. Peak allocation is
+19,501,498,880 bytes/card. Warmup alone also retained fresh encoder/denoise input
+tensors for later independent diagnostics; measured requests contain no captures.
+
+The original counter included identical column-A replicas. Its reported
+47.524847 TFLOP/s/card is superseded by the explicit header-shape audit in
+`fa-720p-three-runs/audited-counts/`. Original files, times and source fingerprints
+are retained. Rank0 useful work is 3,103,284,010,387,456 FLOPs after excluding
+28,533,508,276,224 replicated A FLOPs (0.9111% of the old numerator).
+Audited median throughput is **47.091839–47.091855 TFLOP/s/card**, depending on
+the uneven row tail. Performance remains below 80. The audit script checks all
+retained per-layer counts against immutable LightX2V A/B header shapes; it is
+not a new run of the revised runtime counter.
+
+`metrics-lora-count-cpu.log`: 49 CPU tests pass, including unique logical column
+adapter FLOPs across TP1/2/4 and one-row/97-row/34551-row tails. Two additional
+legacy/inconsistent-redundancy rejection cases pass in
+`metrics-legacy-rejection.log`. The revised counter will be exercised in the
+matching FlashInfer full measurements. Sparse/cache and complete official
+workflow/quality/performance coverage remain open.

--- a/docs/design/minimax_h3/WORKFLOW_METRICS.md
+++ b/docs/design/minimax_h3/WORKFLOW_METRICS.md
@@ -1,0 +1,79 @@
+# H3 workflow performance measurements
+
+The native engine records the actual video/audio sigma sequences, selected
+attention backends, useful unpadded sequence length and completed block calls.
+The evaluator derives denoiser calls from the runtime intervals. LightX2V's
+5/9 API points and FlashGen/FastH3's four-interval API therefore share the same
+accounting without a hardcoded 49-call assumption. Normal request validation
+still enforces each adapter's legal tasks and sampling settings.
+
+Each rank reports `denoise_steps` with useful FLOPs, completed DiT calls,
+executed blocks, CUDA event time and CPU enqueue time. CUDA event spans include
+dependent communication, stream waits and host feeding gaps; they are not sums
+of individual kernel execution times. No per-step synchronization is added.
+GEMM/attention/communication service attribution still requires a separate
+profiler run. The complete synchronized denoise wall time remains the throughput
+denominator, using the slowest rank for every rank's numerator.
+
+For a complete measurement, reuse a native run's `config` and `request` JSON:
+
+```bash
+.venv/bin/python -m vllm.video.benchmark \
+  --contract h3-contract.json --output h3-measurements-new
+```
+
+Run this command without a profiler. It acquires the native GPU lease, uses one
+persistent engine, generates one complete warmup video/audio request and three
+consecutive measured requests, and saves all four results plus
+`performance.json`. The output directory must be new. NVML records memory,
+power, clocks, temperature, utilization and running processes alongside each
+request. Source revision/file hashes, Torch/CUDA versions and actual loaded H3
+kernel paths/SHA256 hashes accompany the results. Deployment and request JSON
+retain model revision, checkpoint/adapter identifiers, sampling and TP settings.
+
+The evaluator requires a complete warmup from the same engine session, exact
+configuration/shape consistency, all TP ranks and all scheduled steps. Missing
+blocks, inconsistent per-step/per-layer/total work, profiled runs and quality
+captures are rejected. For existing result files:
+
+```python
+import json
+from pathlib import Path
+from vllm.video.metrics import evaluate_performance
+
+root = Path("h3-measurements-new")
+warmup = json.loads((root / "warmup/run.json").read_text())
+runs = [json.loads((root / f"run-{i}/run.json").read_text()) for i in (1, 2, 3)]
+report = evaluate_performance(runs, warmup=warmup)
+```
+
+Passing performance means every rank's three-run median is strictly above
+80 useful TFLOP/s and complete-denoise CV is at most 5%. Peak memory (30 GiB
+allocated/card budget), end-to-end latency and quality status are reported
+separately. The selected shape and TP size remain in the report; passing a
+shorter workload or TP1 does not complete the 243-frame TP4 or 15-second cases.
+Quality must separately pass the accepted numerical and audiovisual review.
+
+This checkpoint counts **dense uncached execution**. It records zero sparse
+blocks/cache hits for those actual routes and rejects sparse/cache descriptors
+until the corresponding execution counter exists. This is not VSA, TeaCache or
+Cache-DiT support. Padding, ConvRot, dequantization and repeated output rows remain
+excluded from useful FLOPs. Algorithmic work savings must be accounted separately
+when those variants are implemented.
+
+## Development evidence
+
+Integration base: `4f19ef7a20db60bb0685e599bd3f4dd156202eed` (`onecat/main`).
+Owned branch: `codex/v100-h3-workflow-metrics-20260909-031302`.
+Artifacts: `/data/minimax-h3/sm70-general-20260909/`.
+
+- `metrics-regressions-v2.log`: 81 CPU acceptance/service/workflow/API checks
+  pass. These include four/eight/base/DMD2 schedule semantics, TP1/2/4 and
+  rejection of incomplete warmup, missing steps and inconsistent work counts.
+- `metrics-block-gpu-v2.log`: real SM70 DiT block test passes, with an independent
+  FLOP formula that excludes suffix padding, two measured calls,
+  bitwise output preservation and hook cleanup before another request. The first
+  GPU5 attempt was rejected by an existing lease and ran no GPU test; GPU0 was
+  acquired after the original-weight control released it.
+- Full model instrumentation validation and performance measurements are pending.
+  No configuration has met the campaign's >80 TFLOP/s and full quality gates.

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -9,62 +9,170 @@ from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 from vllm.video.metrics import evaluate_performance
 
 
-def measurements():
-    run = {
-        "config": asdict(H3Config()),
+def measurements(calls=49, api_steps=50, tp=4):
+    workload = {
+        "partition": "fl2va",
+        "task": "t2va",
+        "adapter": None,
+        "video_sigmas": [1 - i / calls for i in range(calls + 1)],
+        "audio_sigmas": [1 - i / calls for i in range(calls + 1)],
+        "blocks_per_call": 52,
+        "used_length": 34551,
+        "attention_algorithm": "dense",
+        "cache_algorithm": None,
+        "actual_backends": ["FLASH_ATTN_V100"],
+    }
+    total = 6_000_000_000_000_000
+    quot, rem = divmod(total, calls)
+    run: dict = {
+        "config": asdict(H3Config(tensor_parallel_size=tp)),
         "request": asdict(H3Request()),
-        "gpus": [0, 1, 2, 3],
-        "measurement": {"profiled": False, "warmup_runs": 1},
+        "gpus": list(range(tp)),
+        "engine_session_id": "test-session",
+        "request_index": 0,
+        "measurement": {"profiled": False, "warmup": False, "capture": False},
+        "end_to_end_seconds": 90.0,
         "ranks": [
             {
                 "rank": rank,
-                "dit_calls": 49,
-                "useful_denoise_flops": 6_000_000_000_000_000,
+                "dit_calls": calls,
+                "useful_denoise_flops": total,
+                "denoise_flops_by_layer": {"example": total},
+                "denoise_workload": deepcopy(workload),
+                "denoise_executed_blocks": {str(i): calls for i in range(52)},
+                "denoise_steps": [
+                    {
+                        "index": i,
+                        "dit_calls": 1,
+                        "executed_blocks": 52,
+                        "useful_flops": quot + (i < rem),
+                        "gpu_seconds": 1.0,
+                        "cpu_enqueue_seconds": 0.1,
+                        "sparse_blocks": 0,
+                        "cache_hits": 0,
+                    }
+                    for i in range(calls)
+                ],
                 "peak_allocated_bytes": 29 * 1024**3,
-                "stage_seconds": {"denoise": 60.0 if rank == 3 else 50.0},
+                "stage_seconds": {"denoise": 60.0 if rank == tp - 1 else 50.0},
             }
-            for rank in range(4)
+            for rank in range(tp)
         ],
     }
-    return [deepcopy(run) for _ in range(3)]
+    run["request"]["sampling"]["num_inference_steps"] = api_steps
+    runs = [deepcopy(run) for _ in range(3)]
+    for index, measurement in enumerate(runs, 1):
+        measurement["request_index"] = index
+    warmup = deepcopy(run)
+    warmup["measurement"]["warmup"] = True
+    return warmup, runs
 
 
 def test_all_ranks_use_slowest_rank_wall_time_and_strict_threshold():
-    runs = measurements()
-    report = evaluate_performance(runs)
+    warmup, runs = measurements()
+    report = evaluate_performance(runs, warmup=warmup)
     assert report["rank_median_tflops"] == [100.0] * 4
     assert report["performance_passed"]
     for run in runs:
-        run["ranks"][2]["useful_denoise_flops"] = 4_800_000_000_000_000
-    assert not evaluate_performance(runs)["performance_passed"]
+        run["ranks"][-1]["stage_seconds"]["denoise"] = 75.0
+    assert not evaluate_performance(runs, warmup=warmup)["performance_passed"]
+
+
+@pytest.mark.parametrize("calls,api_steps", [(49, 50), (4, 5), (8, 9), (4, 4)])
+@pytest.mark.parametrize("tp", [1, 2, 4])
+def test_uses_actual_intervals_for_all_dense_schedules(calls, api_steps, tp):
+    warmup, runs = measurements(calls, api_steps, tp)
+    for run in (warmup, *runs):
+        run["request"]["sampling"].update(width=1280, height=736, num_frames=120)
+    report = evaluate_performance(runs, warmup=warmup)
+    assert len(report["rank_median_tflops"]) == tp
+    assert len(report["workflow"]["video_sigmas"]) == calls + 1
+    assert report["performance_passed"]
+    assert report["quality_status"] == "requires_separate_numerical_and_human_review"
 
 
 @pytest.mark.parametrize(
-    "invalid", ["profiled", "seed", "rank", "calls", "excluded", "residual"]
+    "invalid",
+    [
+        "profiled",
+        "seed",
+        "rank",
+        "calls",
+        "excluded",
+        "residual",
+        "capture",
+        "warmup",
+        "session",
+        "index",
+        "missing_step",
+        "work",
+        "block",
+        "layer_work",
+        "negative_rank_time",
+        "nan_sigma",
+        "short_audio",
+        "sparse",
+        "cache",
+        "missing_memory",
+        "warmup_incomplete",
+        "missing_warmup",
+        "nan_step_time",
+    ],
 )
-def test_rejects_incomparable_measurements(invalid):
-    runs = measurements()
-    if invalid == "profiled":
-        runs[1]["measurement"]["profiled"] = True
+def test_rejects_incomplete_or_incomparable_measurements(invalid):
+    warmup, runs = measurements(4, 5)
+    run, rank = runs[1], runs[1]["ranks"][0]
+    if invalid in ("profiled", "capture", "warmup"):
+        run["measurement"][invalid] = True
     elif invalid == "seed":
-        runs[1]["request"]["sampling"]["seed"] = 2026
+        run["request"]["sampling"]["seed"] = 2026
     elif invalid == "rank":
-        runs[1]["ranks"][3]["rank"] = 2
+        run["ranks"][3]["rank"] = 2
     elif invalid == "excluded":
-        runs[1]["timing_valid"] = False
+        run["timing_valid"] = False
     elif invalid == "residual":
-        runs[1]["config"]["residual_sequence_parallel"] = True
+        run["config"]["residual_sequence_parallel"] = True
+    elif invalid == "session":
+        run["engine_session_id"] = "restarted"
+    elif invalid == "index":
+        run["request_index"] = 0
+    elif invalid == "missing_step":
+        rank["denoise_steps"].pop()
+    elif invalid == "work":
+        rank["useful_denoise_flops"] += 1
+    elif invalid == "block":
+        rank["denoise_executed_blocks"]["0"] -= 1
+    elif invalid == "layer_work":
+        rank["denoise_flops_by_layer"]["example"] += 1
+    elif invalid == "negative_rank_time":
+        rank["stage_seconds"]["denoise"] = -1.0
+    elif invalid == "nan_sigma":
+        rank["denoise_workload"]["video_sigmas"][1] = float("nan")
+    elif invalid == "short_audio":
+        rank["denoise_workload"]["audio_sigmas"].pop()
+    elif invalid == "sparse":
+        rank["denoise_workload"]["attention_algorithm"] = "vsa"
+    elif invalid == "cache":
+        rank["denoise_workload"]["cache_algorithm"] = "teacache"
+    elif invalid == "missing_memory":
+        rank["peak_allocated_bytes"] = 0
+    elif invalid == "warmup_incomplete":
+        warmup["ranks"][0]["dit_calls"] = 3
+    elif invalid == "missing_warmup":
+        warmup["measurement"]["warmup"] = False
+    elif invalid == "nan_step_time":
+        rank["denoise_steps"][0]["gpu_seconds"] = float("nan")
     else:
-        runs[1]["ranks"][0]["dit_calls"] = 48
+        rank["dit_calls"] = 48
     with pytest.raises(ValueError):
-        evaluate_performance(runs)
+        evaluate_performance(runs, warmup=warmup)
 
 
 def test_memory_gate_and_variability_are_reported_separately():
-    runs = measurements()
+    warmup, runs = measurements()
     runs[0]["ranks"][1]["peak_allocated_bytes"] = 31 * 1024**3
     runs[0]["ranks"][3]["stage_seconds"]["denoise"] = 80.0
-    report = evaluate_performance(runs)
+    report = evaluate_performance(runs, warmup=warmup)
     assert not report["memory_passed"]
     assert report["denoise_cv"] > 0.05
     assert not report["performance_passed"]

--- a/tests/video/test_h3_acceptance.py
+++ b/tests/video/test_h3_acceptance.py
@@ -11,6 +11,7 @@ from vllm.video.metrics import evaluate_performance
 
 def measurements(calls=49, api_steps=50, tp=4):
     workload = {
+        "work_accounting": "dense_tp_lora_v2",
         "partition": "fl2va",
         "task": "t2va",
         "adapter": None,
@@ -38,6 +39,8 @@ def measurements(calls=49, api_steps=50, tp=4):
                 "dit_calls": calls,
                 "useful_denoise_flops": total,
                 "denoise_flops_by_layer": {"example": total},
+                "redundant_denoise_flops": 0,
+                "redundant_flops_by_layer": {},
                 "denoise_workload": deepcopy(workload),
                 "denoise_executed_blocks": {str(i): calls for i in range(52)},
                 "denoise_steps": [
@@ -46,6 +49,7 @@ def measurements(calls=49, api_steps=50, tp=4):
                         "dit_calls": 1,
                         "executed_blocks": 52,
                         "useful_flops": quot + (i < rem),
+                        "redundant_flops": 0,
                         "gpu_seconds": 1.0,
                         "cpu_enqueue_seconds": 0.1,
                         "sparse_blocks": 0,
@@ -117,6 +121,8 @@ def test_uses_actual_intervals_for_all_dense_schedules(calls, api_steps, tp):
         "warmup_incomplete",
         "missing_warmup",
         "nan_step_time",
+        "legacy_work",
+        "redundant_work",
     ],
 )
 def test_rejects_incomplete_or_incomparable_measurements(invalid):
@@ -162,6 +168,10 @@ def test_rejects_incomplete_or_incomparable_measurements(invalid):
         warmup["measurement"]["warmup"] = False
     elif invalid == "nan_step_time":
         rank["denoise_steps"][0]["gpu_seconds"] = float("nan")
+    elif invalid == "legacy_work":
+        rank["denoise_workload"].pop("work_accounting")
+    elif invalid == "redundant_work":
+        rank["redundant_denoise_flops"] = 1
     else:
         rank["dit_calls"] = 48
     with pytest.raises(ValueError):

--- a/tests/video/test_h3_provenance.py
+++ b/tests/video/test_h3_provenance.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import hashlib
+
+import vllm
+from vllm.video.benchmark import source_provenance
+
+
+def test_provenance_tracks_shared_operators_outside_model_directory(
+    tmp_path, monkeypatch
+):
+    package = tmp_path / "vllm"
+    layers = package / "model_executor/layers"
+    layers.mkdir(parents=True)
+    monkeypatch.setattr(vllm, "__file__", str(package / "__init__.py"))
+    contents = {
+        "sm70_diffusion.py": b"gemm revision 1",
+        "sm70_attention.py": b"dense attention revision 1",
+        "sm70_sparse_attention.py": b"sparse attention revision 1",
+    }
+    for name, content in contents.items():
+        (layers / name).write_bytes(content)
+    before = source_provenance()["sources_sha256"]
+    for name, content in contents.items():
+        assert (
+            before[f"model_executor/layers/{name}"]
+            == hashlib.sha256(content).hexdigest()
+        )
+
+    changed = "model_executor/layers/sm70_attention.py"
+    (package / changed).write_bytes(b"dense attention revision 2")
+    after = source_provenance()["sources_sha256"]
+    assert after[changed] != before[changed]
+    assert {k: v for k, v in before.items() if k != changed} == {
+        k: v for k, v in after.items() if k != changed
+    }

--- a/tests/video/test_h3_work_counter.py
+++ b/tests/video/test_h3_work_counter.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+from torch import nn
+
+from vllm.video.metrics import DenoiseWorkCounter
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a leased GPU")
+@torch.inference_mode()
+def test_real_block_work_excludes_padding_and_preserves_outputs(
+    dist_init, default_vllm_config
+):
+    from vllm.model_executor.models.minimax_h3.attention import attention_backend
+    from vllm.model_executor.models.minimax_h3.transformer import (
+        MiniMaxH3DiTArchConfig,
+        MiniMaxH3DiTBlock,
+    )
+
+    arch = MiniMaxH3DiTArchConfig(
+        hidden_size=512,
+        num_attention_heads=4,
+        ffn_hidden_size=1024,
+        adaln_curve_grid=2,
+        adaln_out_features=18 * 512,
+    )
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.block = MiniMaxH3DiTBlock(arch, None, prefix="block")
+
+        def forward(self, x, **kwargs):
+            return self.block(x, **kwargs)
+
+    token = attention_backend.set("FLASH_ATTN_V100")
+    try:
+        model = Model().cuda().eval()
+    finally:
+        attention_backend.reset(token)
+    torch.manual_seed(412)
+    for name, parameter in model.named_parameters():
+        if "norm" in name:
+            parameter.fill_(1)
+        else:
+            parameter.normal_(0, 0.02)
+    valid, padded = 33, 64
+    x = torch.randn(padded, 512, device="cuda")
+    kwargs = dict(
+        t_emb=torch.randn(1, 8, device="cuda"),
+        combined_indices=torch.arange(padded, device="cuda") % 3,
+        rope_table=torch.randn(padded, 96, device="cuda"),
+        cu_seqlens=torch.tensor([0, valid], device="cuda", dtype=torch.int32),
+        max_seqlen=valid,
+        packed_total=padded,
+    )
+    expected = model(x, **kwargs)
+    # Independent geometry: QKV + output + gate/up + down + AdaLN + QK/PV.
+    flops = (
+        2 * valid * (3 * 512 * 512 + 512 * 512 + 2 * 1024 * 512 + 512 * 1024)
+        + 2 * 8 * (18 * 512)
+        + 4 * 4 * valid * valid * 128
+    )
+    with DenoiseWorkCounter(
+        model, used_length=valid, video_outputs=valid, audio_outputs=1
+    ) as counter:
+        for index in range(2):
+            with counter.step(index):
+                actual = model(x, **kwargs)
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.accelerator.synchronize()
+        steps = counter.finish_steps()
+        assert counter.calls == 2
+        assert counter.blocks == {"block": 2}
+        assert counter.flops == 2 * flops
+        assert sum(counter.by_layer.values()) == counter.flops
+        assert [step["useful_flops"] for step in steps] == [flops, flops]
+        assert all(step["gpu_seconds"] > 0 for step in steps)
+    model(x, **kwargs)
+    assert counter.calls == 2  # Hooks must not leak into the following request.

--- a/tests/video/test_h3_work_counter.py
+++ b/tests/video/test_h3_work_counter.py
@@ -1,10 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
 from torch import nn
 
-from vllm.video.metrics import DenoiseWorkCounter
+from vllm.video.metrics import DenoiseWorkCounter, lora_work
+
+
+@pytest.mark.parametrize("rows", [1, 97, 34551])
+@pytest.mark.parametrize("tp", [1, 2, 4])
+def test_column_lora_a_is_counted_once_across_ranks_including_tails(rows, tp):
+    useful = redundant = 0
+    for rank in range(tp):
+        layer = SimpleNamespace(
+            tp_size=tp,
+            tp_rank=rank,
+            h3_lora_a_0=torch.empty(3, 7),
+            h3_lora_b_0=torch.empty(8 // tp, 3),
+        )
+        work, repeated = lora_work(layer, [(0, 0, 8 // tp)], rows, replicated_a=True)
+        useful += work
+        redundant += repeated
+    # The logical adapter is one 7->3->8 projection regardless of TP size.
+    assert useful == 2 * rows * (7 * 3 + 3 * 8)
+    assert redundant == 2 * rows * (7 * 3) * (tp - 1)
+
+
+@pytest.mark.parametrize("tp", [1, 2, 4])
+def test_row_lora_partial_products_are_distinct_work(tp):
+    layer = SimpleNamespace(
+        tp_size=tp,
+        tp_rank=0,
+        h3_lora_a_0=torch.empty(3, 8 // tp),
+        h3_lora_b_0=torch.empty(11, 3),
+    )
+    work, redundant = lora_work(layer, [(0, 0, 11)], 13, replicated_a=False)
+    assert work == 2 * 13 * (3 * (8 // tp) + 11 * 3)
+    assert redundant == 0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a leased GPU")

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -26,7 +26,7 @@ from vllm.distributed import get_tp_group, get_world_group
 from vllm.logger import init_logger
 from vllm.video.metrics import DenoiseWorkCounter
 
-from .attention import attention_backend
+from .attention import Attention, attention_backend
 from .comfy_checkpoint import inspect_comfy_checkpoint, resolve_comfy_checkpoint_path
 from .condition_noise import (
     minimax_h3_audio_cond_noise_aug_rows,
@@ -1521,7 +1521,27 @@ class MiniMaxH3Pipeline(nn.Module):
             video_outputs=int(branch.update_mask.sum()),
             audio_outputs=int(branch.audio_update_mask.sum()),
         )
-        with self._resident_dit_layers_on_device(enabled=True):
+        self.denoise_workload = {
+            "partition": self.partition,
+            "task": task,
+            "adapter": (
+                type(self.turbo_spec).__name__ if self.turbo_spec is not None else None
+            ),
+            "video_sigmas": list(inputs["sigmas_video"]),
+            "audio_sigmas": list(inputs["sigmas_audio"]),
+            "used_length": branch.used_len,
+            "blocks_per_call": counter.blocks_per_call,
+            "attention_algorithm": "dense",
+            "cache_algorithm": None,
+            "actual_backends": sorted(
+                {
+                    module.backend
+                    for module in transformer.modules()
+                    if isinstance(module, Attention)
+                }
+            ),
+        }
+        with counter, self._resident_dit_layers_on_device(enabled=True):
             torch.accelerator.synchronize()
             dist.barrier()
             torch.accelerator.synchronize()
@@ -1544,6 +1564,7 @@ class MiniMaxH3Pipeline(nn.Module):
                         MINIMAX_H3_AUDIO_REF_COND_TIMESTEP
                     ),
                     on_step=lambda step, video, audio: progress.update(),
+                    step_profiler=counter.step,
                 )
             torch.accelerator.synchronize()
             dist.barrier()
@@ -1552,7 +1573,8 @@ class MiniMaxH3Pipeline(nn.Module):
             self.useful_denoise_flops = counter.flops
             self.actual_dit_calls = counter.calls
             self.denoise_flops_by_layer = counter.by_layer
-            counter.close()
+            self.denoise_steps = counter.finish_steps()
+            self.denoise_executed_blocks = dict(counter.blocks)
 
         return self._unpack_denoised_rows(
             branch,

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -1522,6 +1522,7 @@ class MiniMaxH3Pipeline(nn.Module):
             audio_outputs=int(branch.audio_update_mask.sum()),
         )
         self.denoise_workload = {
+            "work_accounting": "dense_tp_lora_v2",
             "partition": self.partition,
             "task": task,
             "adapter": (
@@ -1573,6 +1574,8 @@ class MiniMaxH3Pipeline(nn.Module):
             self.useful_denoise_flops = counter.flops
             self.actual_dit_calls = counter.calls
             self.denoise_flops_by_layer = counter.by_layer
+            self.redundant_denoise_flops = counter.redundant_flops
+            self.redundant_flops_by_layer = counter.redundant_by_layer
             self.denoise_steps = counter.finish_steps()
             self.denoise_executed_blocks = dict(counter.blocks)
 

--- a/vllm/video/benchmark.py
+++ b/vllm/video/benchmark.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Complete native H3 warmup and three-run performance measurements.
+
+Run with ``python -m vllm.video.benchmark --contract contract.json --output DIR``.
+The contract contains the same ``config`` and ``request`` as native run.json.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+from vllm.model_executor.models.minimax_h3.config import (
+    H3Config,
+    H3Request,
+    H3SamplingParams,
+)
+from vllm.video.engine import H3Engine
+from vllm.video.metrics import evaluate_performance
+
+
+def source_provenance():
+    import torch
+
+    import vllm
+
+    package = Path(vllm.__file__).resolve().parent
+    root = package.parent
+    provenance = {
+        "torch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "vllm": vllm.__version__,
+        "package_path": str(package),
+        "sources_sha256": {},
+    }
+    paths = [
+        *package.joinpath("video").glob("*.py"),
+        *package.joinpath("model_executor/models/minimax_h3").glob("*.py"),
+        package / "model_executor/layers/linear.py",
+        package / "model_executor/layers/sm70_diffusion.py",
+    ]
+    for path in sorted(paths):
+        if path.is_file():
+            provenance["sources_sha256"][str(path.relative_to(package))] = (
+                hashlib.sha256(path.read_bytes()).hexdigest()
+            )
+    try:
+        provenance["git_head"] = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        provenance["git_status"] = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=root, text=True
+        ).splitlines()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        provenance["git_head"] = None
+    return provenance
+
+
+def benchmark(config, request, output):
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=False)
+    provenance = source_provenance()
+    contract = {
+        "config": asdict(config),
+        "request": asdict(request),
+        "provenance": provenance,
+        "state": "running",
+        "started": time.time(),
+    }
+    (output / "contract.json").write_text(json.dumps(contract, indent=2))
+    try:
+        runs = []
+        with H3Engine(config) as engine:
+            for index in range(4):
+                directory = output / ("warmup" if index == 0 else f"run-{index}")
+                result = engine.generate(request, directory)
+                result["measurement"] = {
+                    "warmup": index == 0,
+                    "profiled": False,
+                    "capture": False,
+                }
+                result["provenance"] = provenance
+                (directory / "run.json").write_text(json.dumps(result, indent=2))
+                runs.append(result)
+        report = evaluate_performance(runs[1:], warmup=runs[0])
+        (output / "performance.json").write_text(json.dumps(report, indent=2))
+        contract["state"] = "completed"
+        return report
+    except BaseException as exc:
+        contract.update(state="failed", error=repr(exc))
+        raise
+    finally:
+        contract["finished"] = time.time()
+        (output / "contract.json").write_text(json.dumps(contract, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    contract = json.loads(args.contract.read_text())
+    config = H3Config(**contract["config"])
+    request = dict(contract["request"])
+    request["sampling"] = H3SamplingParams(**request["sampling"])
+    report = benchmark(config, H3Request(**request), args.output)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/video/benchmark.py
+++ b/vllm/video/benchmark.py
@@ -41,7 +41,7 @@ def source_provenance():
         *package.joinpath("video").glob("*.py"),
         *package.joinpath("model_executor/models/minimax_h3").glob("*.py"),
         package / "model_executor/layers/linear.py",
-        package / "model_executor/layers/sm70_diffusion.py",
+        *package.joinpath("model_executor/layers").glob("sm70_*.py"),
     ]
     for path in sorted(paths):
         if path.is_file():

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -11,6 +11,7 @@ import socket
 import threading
 import time
 import traceback
+import uuid
 from dataclasses import asdict
 from multiprocessing.connection import Connection
 from pathlib import Path
@@ -56,6 +57,7 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
             initialize_model_parallel(config.tensor_parallel_size)
             started = time.perf_counter()
             pipeline = MiniMaxH3Pipeline(config)
+            kernel_provenance = None
             connection.send(
                 {
                     "ready": True,
@@ -70,12 +72,20 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
                 request, output_dir = command
                 torch.accelerator.reset_peak_memory_stats()
                 video, audio = pipeline(request)
+                if kernel_provenance is None:
+                    from .metrics import loaded_kernel_provenance
+
+                    kernel_provenance = loaded_kernel_provenance()
                 result = {
                     "rank": rank,
                     "stage_seconds": pipeline.stage_durations,
                     "dit_calls": pipeline.actual_dit_calls,
                     "useful_denoise_flops": pipeline.useful_denoise_flops,
                     "denoise_flops_by_layer": pipeline.denoise_flops_by_layer,
+                    "denoise_workload": pipeline.denoise_workload,
+                    "denoise_steps": pipeline.denoise_steps,
+                    "denoise_executed_blocks": pipeline.denoise_executed_blocks,
+                    "kernel_provenance": kernel_provenance,
                     "peak_allocated_bytes": torch.accelerator.max_memory_allocated(),
                 }
                 if rank == 0:
@@ -128,6 +138,8 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
 class H3Engine:
     def __init__(self, config: H3Config):
         self.config = config
+        self.session_id = str(uuid.uuid4())
+        self.request_index = 0
         self._gpu_lease = None
         self._lock = threading.Lock()
         self._closed = False
@@ -205,6 +217,8 @@ class H3Engine:
                 self.close()
                 raise
             result = {
+                "engine_session_id": self.session_id,
+                "request_index": self.request_index,
                 "config": asdict(self.config),
                 "request": asdict(request),
                 "gpus": self.gpu_ids,
@@ -215,6 +229,7 @@ class H3Engine:
             (output_dir / "run.json").write_text(
                 json.dumps(result, indent=2, ensure_ascii=False)
             )
+            self.request_index += 1
             return result
 
     def close(self):

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -82,6 +82,8 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
                     "dit_calls": pipeline.actual_dit_calls,
                     "useful_denoise_flops": pipeline.useful_denoise_flops,
                     "denoise_flops_by_layer": pipeline.denoise_flops_by_layer,
+                    "redundant_denoise_flops": pipeline.redundant_denoise_flops,
+                    "redundant_flops_by_layer": pipeline.redundant_flops_by_layer,
                     "denoise_workload": pipeline.denoise_workload,
                     "denoise_steps": pipeline.denoise_steps,
                     "denoise_executed_blocks": pipeline.denoise_executed_blocks,

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -13,6 +13,23 @@ import time
 from pathlib import Path
 
 
+def loaded_kernel_provenance():
+    """Identify actual loaded native binaries, including task-owned JIT builds."""
+    import hashlib
+    import sys
+
+    paths = {
+        str(Path(filename).resolve())
+        for name, module in list(sys.modules.items())
+        if name.startswith(("vllm._h3_", "onecat_h3_"))
+        and (filename := getattr(module, "__file__", None))
+    }
+    return {
+        path: hashlib.sha256(Path(path).read_bytes()).hexdigest()
+        for path in sorted(paths)
+    }
+
+
 class DenoiseWorkCounter:
     """Count actual TP-local matrix shapes, excluding structural padding.
 
@@ -30,6 +47,9 @@ class DenoiseWorkCounter:
 
         self.flops = 0
         self.calls = 0
+        self.blocks: dict[str, int] = {}
+        self.steps: list[dict] = []
+        self._step_events = []
         self.by_layer: dict[str, int] = {}
         self.handles = []
 
@@ -37,8 +57,23 @@ class DenoiseWorkCounter:
             self.calls += 1
 
         self.handles.append(model.register_forward_hook(completed_call))
+        from vllm.model_executor.models.minimax_h3.transformer import (
+            MiniMaxH3DiTBlock,
+            MiniMaxH3TokenRefinerBlock,
+        )
+
+        self.blocks_per_call = sum(
+            isinstance(module, (MiniMaxH3DiTBlock, MiniMaxH3TokenRefinerBlock))
+            for module in model.modules()
+        )
         for name, module in model.named_modules():
-            if isinstance(module, LinearBase):
+            if isinstance(module, (MiniMaxH3DiTBlock, MiniMaxH3TokenRefinerBlock)):
+
+                def block_hook(layer, inputs, output, name=name):
+                    self.blocks[name] = self.blocks.get(name, 0) + 1
+
+                self.handles.append(module.register_forward_hook(block_hook))
+            elif isinstance(module, LinearBase):
 
                 def linear_hook(layer, inputs, output, name=name):
                     rows = inputs[0].numel() // inputs[0].shape[-1]
@@ -77,6 +112,47 @@ class DenoiseWorkCounter:
                     self.by_layer[name] = self.by_layer.get(name, 0) + count
 
                 self.handles.append(module.register_forward_hook(attention_hook))
+
+    @contextlib.contextmanager
+    def step(self, index):
+        """Record stream spans without introducing per-step synchronization.
+
+        GPU events include dependent communication and stream waits. CPU enqueue
+        time is separate; neither replaces complete synchronized denoise wall time.
+        """
+        import torch
+
+        start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+        before = self.flops, self.calls, sum(self.blocks.values())
+        start.record()
+        started = time.perf_counter()
+        yield
+        end.record()
+        self.steps.append(
+            {
+                "index": index,
+                "cpu_enqueue_seconds": time.perf_counter() - started,
+                "useful_flops": self.flops - before[0],
+                "dit_calls": self.calls - before[1],
+                "executed_blocks": sum(self.blocks.values()) - before[2],
+                # This counter currently instruments dense, uncached execution.
+                "sparse_blocks": 0,
+                "cache_hits": 0,
+            }
+        )
+        self._step_events.append((start, end))
+
+    def finish_steps(self):
+        """Read events only after the caller's complete-denoise synchronization."""
+        for record, (start, end) in zip(self.steps, self._step_events):
+            record["gpu_seconds"] = start.elapsed_time(end) / 1000
+        return self.steps
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
 
     def close(self):
         for handle in self.handles:
@@ -166,52 +242,123 @@ class NVMLMonitor:
             self.thread.join(timeout=5)
 
 
-def evaluate_performance(runs):
-    """Evaluate three unprofiled post-warmup runs; never use utilization as FLOPs."""
-    if len(runs) != 3 or any(len(run["ranks"]) != 4 for run in runs):
-        raise ValueError("acceptance requires three four-rank measurements")
+def _validate_dense_workload(rank):
+    workload = rank["denoise_workload"]
+    if (
+        workload["attention_algorithm"] != "dense"
+        or workload["cache_algorithm"] is not None
+    ):
+        raise ValueError(
+            "sparse/cache workflows require their own measured work accounting"
+        )
+    schedules = [workload[key] for key in ("video_sigmas", "audio_sigmas")]
+    for schedule in schedules:
+        if (
+            len(schedule) < 2
+            or any(not math.isfinite(s) or not 0 <= s <= 1 for s in schedule)
+            or any(a <= b for a, b in zip(schedule, schedule[1:]))
+            or schedule[-1] != 0
+        ):
+            raise ValueError("invalid measured sigma schedule")
+    if len(schedules[0]) != len(schedules[1]):
+        raise ValueError("video/audio schedules must have equal length")
+    calls = len(schedules[0]) - 1
+    blocks = workload["blocks_per_call"]
+    if type(blocks) is not int or blocks <= 0 or rank["dit_calls"] != calls:
+        raise ValueError("incomplete denoiser execution for the measured schedule")
+    steps = rank["denoise_steps"]
+    if len(steps) != calls or [step["index"] for step in steps] != list(range(calls)):
+        raise ValueError("missing, duplicate or unordered denoise steps")
+    for step in steps:
+        if (
+            step["dit_calls"] != 1
+            or step["executed_blocks"] != blocks
+            or step["cache_hits"] != 0
+            or step["sparse_blocks"] != 0
+        ):
+            raise ValueError("dense step work does not match the workflow")
+        if type(step["useful_flops"]) is not int or step["useful_flops"] <= 0:
+            raise ValueError("useful FLOPs must be positive integer counts")
+        for key in ("gpu_seconds", "cpu_enqueue_seconds"):
+            if not math.isfinite(step[key]) or step[key] <= 0:
+                raise ValueError("invalid measured step duration")
+    if (
+        sum(step["useful_flops"] for step in steps) != rank["useful_denoise_flops"]
+        or sum(rank["denoise_flops_by_layer"].values()) != rank["useful_denoise_flops"]
+        or len(rank["denoise_executed_blocks"]) != blocks
+        or any(value != calls for value in rank["denoise_executed_blocks"].values())
+    ):
+        raise ValueError("step, layer and complete-denoise work counts disagree")
+    return workload
+
+
+def evaluate_performance(runs, *, warmup):
+    """Evaluate three full requests after a completed, same-session warmup.
+
+    The runtime descriptor supplies the actual sigma intervals. API step counts
+    are deliberately not interpreted here: LightX2V and DMD2 differ. Passing a
+    shape does not establish coverage of other workloads or their quality.
+    """
+    if len(runs) != 3:
+        raise ValueError("acceptance requires three post-warmup measurements")
     baseline = runs[0]
-    for run in runs:
-        if sorted(rank["rank"] for rank in run["ranks"]) != list(range(4)):
-            raise ValueError("each measurement must contain four unique TP ranks")
-        if any(run[key] != baseline[key] for key in ("config", "request", "gpus")):
-            raise ValueError("acceptance measurements must use the same configuration")
-        sampling = run["request"]["sampling"]
-        expected = {
-            "width": 1344,
-            "height": 768,
-            "num_frames": 243,
-            "fps": 24,
-            "seed": 42,
-            "num_inference_steps": 50,
-        }
-        if any(sampling.get(key) != value for key, value in expected.items()):
-            raise ValueError("acceptance requires the fixed primary workload")
-        if run.get("measurement", {}).get("profiled") is not False:
+    tp = baseline["config"]["tensor_parallel_size"]
+    if tp not in (1, 2, 4):
+        raise ValueError("invalid H3 tensor parallel size")
+    if not baseline.get("engine_session_id"):
+        raise ValueError("completed same-session warmup evidence is required")
+    indices = [run["request_index"] for run in (warmup, *runs)]
+    if indices != list(range(indices[0], indices[0] + 4)):
+        raise ValueError(
+            "warmup and measurements must be consecutive complete requests"
+        )
+    descriptor = baseline["ranks"][0]["denoise_workload"]
+    for index, run in enumerate((warmup, *runs)):
+        if sorted(rank["rank"] for rank in run["ranks"]) != list(range(tp)):
+            raise ValueError("each measurement must contain every unique TP rank")
+        for key in ("config", "request", "gpus", "engine_session_id"):
+            if run[key] != baseline[key]:
+                raise ValueError(
+                    "acceptance measurements must use the same configuration"
+                )
+        if len(run["gpus"]) != tp or len(set(run["gpus"])) != tp:
+            raise ValueError("invalid physical GPU group")
+        measurement = run.get("measurement", {})
+        if measurement.get("profiled") is not False:
             raise ValueError("formal timing must be explicitly recorded as unprofiled")
+        if measurement.get("warmup") is not (index == 0):
+            raise ValueError("warmup must be complete and excluded from measurements")
+        if measurement.get("capture") is not False:
+            raise ValueError("quality captures must be separate from performance runs")
         if run.get("timing_valid") is False:
             raise ValueError("run timing was excluded from performance evidence")
-        if any(rank["dit_calls"] != 49 for rank in run["ranks"]):
-            raise ValueError("the primary schedule requires 49 completed DiT calls")
-        if any(
-            type(rank["useful_denoise_flops"]) is not int
-            or rank["useful_denoise_flops"] <= 0
-            for rank in run["ranks"]
+        if (
+            not math.isfinite(run["end_to_end_seconds"])
+            or run["end_to_end_seconds"] <= 0
         ):
-            raise ValueError("useful FLOPs must be positive integer counts")
+            raise ValueError("invalid end-to-end duration")
+        for rank in run["ranks"]:
+            if _validate_dense_workload(rank) != descriptor:
+                raise ValueError(
+                    "all ranks and requests must execute the same workflow"
+                )
+            seconds = rank["stage_seconds"]["denoise"]
+            if not math.isfinite(seconds) or seconds <= 0:
+                raise ValueError("invalid denoise duration")
+            memory = rank["peak_allocated_bytes"]
+            if type(memory) is not int or memory <= 0:
+                raise ValueError("invalid peak memory measurement")
     ordered = [sorted(run["ranks"], key=lambda rank: rank["rank"]) for run in runs]
     seconds = [
-        max(rank["stage_seconds"]["denoise"] for rank in run["ranks"]) for run in runs
+        max(rank["stage_seconds"]["denoise"] for rank in ranks) for ranks in ordered
     ]
-    if any(not math.isfinite(value) or value <= 0 for value in seconds):
-        raise ValueError("invalid denoise duration")
-    medians = []
-    for rank in range(4):
-        values = [
+    medians = [
+        statistics.median(
             ranks[rank]["useful_denoise_flops"] / duration / 1e12
             for ranks, duration in zip(ordered, seconds)
-        ]
-        medians.append(statistics.median(values))
+        )
+        for rank in range(tp)
+    ]
     cv = statistics.pstdev(seconds) / statistics.mean(seconds)
     memory_passed = all(
         rank["peak_allocated_bytes"] <= 30 * 1024**3
@@ -219,9 +366,18 @@ def evaluate_performance(runs):
         for rank in run["ranks"]
     )
     return {
+        "workflow": descriptor,
+        "sampling": baseline["request"]["sampling"],
+        "tensor_parallel_size": tp,
         "rank_median_tflops": medians,
         "denoise_seconds": seconds,
         "denoise_cv": cv,
+        "end_to_end_seconds": [run["end_to_end_seconds"] for run in runs],
+        "peak_allocated_bytes": [
+            max(ranks[rank]["peak_allocated_bytes"] for ranks in ordered)
+            for rank in range(tp)
+        ],
         "memory_passed": memory_passed,
         "performance_passed": all(value > 80 for value in medians) and cv <= 0.05,
+        "quality_status": "requires_separate_numerical_and_human_review",
     }

--- a/vllm/video/metrics.py
+++ b/vllm/video/metrics.py
@@ -30,6 +30,28 @@ def loaded_kernel_provenance():
     }
 
 
+def lora_work(layer, parts, rows, *, replicated_a):
+    """Separate identical column-A replicas from useful TP partial products.
+
+    Column-parallel A has identical weights and full input rows on every rank.
+    Attribute each row once, balanced by rank, including non-divisible tails.
+    Row-parallel A instead consumes distinct input shards; its B products are
+    distinct partial contributions and are not identical replicas.
+    """
+    a_elements = sum(
+        getattr(layer, f"h3_lora_a_{index}").numel() for index, _, _ in parts
+    )
+    b_elements = sum(
+        getattr(layer, f"h3_lora_b_{index}").numel() for index, _, _ in parts
+    )
+    executed = 2 * rows * (a_elements + b_elements)
+    redundant = 0
+    if replicated_a:
+        owner_rows = rows // layer.tp_size + (layer.tp_rank < rows % layer.tp_size)
+        redundant = 2 * (rows - owner_rows) * a_elements
+    return executed - redundant, redundant
+
+
 class DenoiseWorkCounter:
     """Count actual TP-local matrix shapes, excluding structural padding.
 
@@ -38,7 +60,7 @@ class DenoiseWorkCounter:
     """
 
     def __init__(self, model, *, used_length, video_outputs, audio_outputs):
-        from vllm.model_executor.layers.linear import LinearBase
+        from vllm.model_executor.layers.linear import ColumnParallelLinear, LinearBase
         from vllm.model_executor.models.minimax_h3.attention import Attention
         from vllm.model_executor.models.minimax_h3.lora import (
             TurboLinearMethod,
@@ -46,11 +68,13 @@ class DenoiseWorkCounter:
         )
 
         self.flops = 0
+        self.redundant_flops = 0
         self.calls = 0
         self.blocks: dict[str, int] = {}
         self.steps: list[dict] = []
         self._step_events = []
         self.by_layer: dict[str, int] = {}
+        self.redundant_by_layer: dict[str, int] = {}
         self.handles = []
 
         def completed_call(module, inputs, output):
@@ -88,18 +112,19 @@ class DenoiseWorkCounter:
                     self.by_layer[name] = self.by_layer.get(name, 0) + count
                     method = layer.quant_method
                     if isinstance(method, TurboLinearMethod) and lora_scale.get() != 0:
-                        work = sum(
-                            2
-                            * effective
-                            * (
-                                getattr(layer, f"h3_lora_a_{index}").numel()
-                                + getattr(layer, f"h3_lora_b_{index}").numel()
-                            )
-                            for index, _, _ in method.parts
+                        work, redundant = lora_work(
+                            layer,
+                            method.parts,
+                            effective,
+                            replicated_a=isinstance(layer, ColumnParallelLinear),
                         )
                         self.flops += work
                         key = name + ".lora"
                         self.by_layer[key] = self.by_layer.get(key, 0) + work
+                        self.redundant_flops += redundant
+                        self.redundant_by_layer[key] = (
+                            self.redundant_by_layer.get(key, 0) + redundant
+                        )
 
                 self.handles.append(module.register_forward_hook(linear_hook))
             elif isinstance(module, Attention):
@@ -123,7 +148,7 @@ class DenoiseWorkCounter:
         import torch
 
         start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
-        before = self.flops, self.calls, sum(self.blocks.values())
+        before = self.flops, self.calls, sum(self.blocks.values()), self.redundant_flops
         start.record()
         started = time.perf_counter()
         yield
@@ -133,6 +158,7 @@ class DenoiseWorkCounter:
                 "index": index,
                 "cpu_enqueue_seconds": time.perf_counter() - started,
                 "useful_flops": self.flops - before[0],
+                "redundant_flops": self.redundant_flops - before[3],
                 "dit_calls": self.calls - before[1],
                 "executed_blocks": sum(self.blocks.values()) - before[2],
                 # This counter currently instruments dense, uncached execution.
@@ -244,6 +270,8 @@ class NVMLMonitor:
 
 def _validate_dense_workload(rank):
     workload = rank["denoise_workload"]
+    if workload.get("work_accounting") != "dense_tp_lora_v2":
+        raise ValueError("legacy work counts may include replicated LoRA projections")
     if (
         workload["attention_algorithm"] != "dense"
         or workload["cache_algorithm"] is not None
@@ -279,6 +307,8 @@ def _validate_dense_workload(rank):
             raise ValueError("dense step work does not match the workflow")
         if type(step["useful_flops"]) is not int or step["useful_flops"] <= 0:
             raise ValueError("useful FLOPs must be positive integer counts")
+        if type(step["redundant_flops"]) is not int or step["redundant_flops"] < 0:
+            raise ValueError("redundant work must be a nonnegative integer count")
         for key in ("gpu_seconds", "cpu_enqueue_seconds"):
             if not math.isfinite(step[key]) or step[key] <= 0:
                 raise ValueError("invalid measured step duration")
@@ -287,6 +317,10 @@ def _validate_dense_workload(rank):
         or sum(rank["denoise_flops_by_layer"].values()) != rank["useful_denoise_flops"]
         or len(rank["denoise_executed_blocks"]) != blocks
         or any(value != calls for value in rank["denoise_executed_blocks"].values())
+        or sum(step["redundant_flops"] for step in steps)
+        != rank["redundant_denoise_flops"]
+        or sum(rank["redundant_flops_by_layer"].values())
+        != rank["redundant_denoise_flops"]
     ):
         raise ValueError("step, layer and complete-denoise work counts disagree")
     return workload


### PR DESCRIPTION
## Purpose

The H3 acceptance evaluator hardcodes 49 denoiser calls and one shape, so it cannot validate official four/eight-step adapters or other legal workflows. Native requests now retain actual video/audio sigmas, selected attention backends, completed step/block counts and per-step CUDA/CPU timing. Throughput still divides each rank's useful, unpadded FLOPs by the slowest rank's full synchronized denoise time.

A native benchmark command performs one complete warmup plus three consecutive full requests on one leased GPU group. Evaluation rejects incomplete warmup, changed engine/configuration, missing blocks/steps, inconsistent work counts, profiler timings and quality-capture runs. Results retain source/kernel fingerprints, end-to-end latency, memory and existing NVML measurements. Sparse/cache variants are explicitly rejected until their real execution accounting is implemented.

Stacked on #571 (`codex/v100-h3-general-sm70-20260908-165458`), which owns common prepared execution and residual changes. Integration commit `5195f31b8d` retains both tested parent histories; the PR diff contains the acceptance/measurement scope. The campaign root is `onecat/main` at `4f19ef7a20db60bb0685e599bd3f4dd156202eed`. The open-PR search found no overlapping workflow-accounting PR.

## Test Plan

- CPU: actual 49/4/8-call and DMD2 schedules, TP1/2/4, strict >80 and CV thresholds, completed same-session warmup, invalid/inconsistent execution records, native service/API regressions.
- GPU: independently count a real dense DiT block with suffix padding; verify event instrumentation preserves outputs and removes hooks after a request.
- Full model: compare instrumented 720p five-second four-step outputs to frozen mainline, then collect matching unprofiled FA/FI measurements.

## Test Result

Python 3.12.13, Torch 2.10.0+cu128, V100 SXM2 32GB, task-owned binaries/caches and native GPU leases:

```text
.venv/bin/python -m pytest tests/video/test_h3_acceptance.py tests/video/test_h3_service.py tests/video/test_h3_workflows.py tests/video/test_h3_omni_api.py -q
81 passed
.venv/bin/python -m pytest tests/video/test_h3_work_counter.py -q
1 GPU test passed: exact useful FLOPs, two steps, bitwise outputs, hook cleanup
```

All commit hooks pass, including mypy and ruff. The first GPU5 attempt was rejected by an existing lease before launching a test; the successful test used GPU0 after the owned generation released it. Raw evidence and exact launch environments: `/data/minimax-h3/sm70-general-20260909/`; see `docs/design/minimax_h3/WORKFLOW_METRICS.md`.

Full 720p five-second four-step instrumentation validation passed against frozen mainline: video/audio latents and all 124 pre-encoding frames match bitwise, video SSIM 1.0 and all audio numerical gates pass (`metrics-quality.json`).

FA completed one full warmup plus three full requests at source `82362a4312`: denoise 65.880184 / 65.898529 / 65.965556 seconds, CV 0.055668%, peak allocation 19,501,498,880 bytes/card. An audit found the legacy counter included identical column-parallel LoRA A replicas. Commit `9bcde29ada` excludes those replicas and reports them separately with balanced per-rank row ownership. Row-A/B partial products remain distinct work. Added CPU tests validate logical adapter work across TP1/2/4 and uneven tails; legacy/inconsistent counters are rejected.

The retained FA files are unchanged. `fa-720p-three-runs/audited-counts/` records a header-shape audit with original JSON/source hashes and unchanged times: corrected median 47.091839–47.091855 useful TFLOP/s/card. This supersedes the overcounted 47.524847 figure. It is not a new run of the revised counter. Matching FI measurements completed on `9bcde29ada` with the revised runtime counter: 70.625556 / 70.545638 / 70.525989 seconds, median 43.989720–43.989736 useful TFLOP/s/card, CV 0.061019%. All rank work counts match the audited FA records exactly. No >80 TFLOP/s, full coverage or independent official/human quality acceptance is claimed. Keep Draft pending those gates. GPU event spans include stream dependencies and host feeding gaps; separate Nsight Systems profiles now retain exact exclusive-wall closure and overlapping service attribution (`fa-profile-breakdown/`, `fi-profile-breakdown/`). FA attention/GEMM/communication consume 31.439/16.041/8.453 seconds; FI 36.119/15.919/8.527 seconds. These profiled runs are excluded from performance acceptance. The two backend full latents are not interchangeable under the 1% gate, despite small single-operator reference error; independent official quality remains required.

AI assistance: implemented and initially validated with OpenAI Codex. Human line-by-line review and independent validation are required before promotion.
