### PR TITLE
[Core][SM70] Enable the qualified Qwen3.8 no-MTP default path

### DIFF
--- a/benchmarks/benchmark_sm70_qwen38_baseline.py
+++ b/benchmarks/benchmark_sm70_qwen38_baseline.py
@@ -37,6 +37,8 @@ def run(args):
     from vllm import LLM, SamplingParams
 
     bundle = validate_bundle(args.runtime_dir)
+    use_defaults = getattr(args, "use_defaults", False)
+    model_args = engine_args(args.model, use_defaults=use_defaults)
     tokenizer = AutoTokenizer.from_pretrained(args.model, local_files_only=True)
     config = json.loads((Path(args.model) / "generation_config.json").read_text())
     natural = SamplingParams(
@@ -68,7 +70,11 @@ def run(args):
             ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
         ).strip(),
         "bundle": bundle,
-        "contract": engine_args(args.model),
+        "contract": model_args,
+        "use_defaults": use_defaults,
+        "launch_vllm_env": {
+            k: v for k, v in os.environ.items() if k.startswith("VLLM_")
+        },
         "gpu_group": os.environ.get("CUDA_VISIBLE_DEVICES"),
         "started_unix": time.time(),
         "health": [],
@@ -102,7 +108,7 @@ def run(args):
     llm = None
     try:
         save()
-        llm = LLM(**engine_args(args.model))
+        llm = LLM(**model_args)
         for name, prompt, pattern in (
             (
                 "arithmetic",
@@ -264,13 +270,21 @@ def main():
     parser.add_argument("--reference-json", type=Path)
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument("--long-context", action="store_true")
+    parser.add_argument(
+        "--use-defaults",
+        action="store_true",
+        help="Use model-aware defaults, without baseline optimization/graph overrides.",
+    )
     parser.add_argument("--configured", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.repeats < 2:
         parser.error("At least two repeats are required")
     if not args.configured:
         configure_environment(
-            args.runtime_dir, args.output.parent / "cache", args.native_extension_dir
+            args.runtime_dir,
+            args.output.parent / "cache",
+            args.native_extension_dir,
+            use_defaults=args.use_defaults,
         )
         # The fresh interpreter installs the same import path in spawned workers.
         os.execv(

--- a/benchmarks/sm70_qwen38_baseline.py
+++ b/benchmarks/sm70_qwen38_baseline.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Explicit, opt-in reproduction contract for the quality-repaired M1 baseline."""
+"""Explicit-baseline and model-default contracts for the quality-repaired M1 lane."""
 
 import hashlib
 import json

--- a/benchmarks/sm70_qwen38_baseline.py
+++ b/benchmarks/sm70_qwen38_baseline.py
@@ -151,13 +151,16 @@ def validate_bundle(bundle: Path) -> dict:
     return manifest
 
 
-def configure_environment(bundle: Path, cache: Path, native_dir: Path | None) -> dict:
+def configure_environment(
+    bundle: Path, cache: Path, native_dir: Path | None, *, use_defaults: bool = False
+) -> dict:
     manifest = validate_bundle(bundle)
     # Do not inherit another experiment's optional VLLM route switches.
     for name in list(os.environ):
         if name.startswith("VLLM_"):
             del os.environ[name]
-    os.environ.update(BASELINE_ENV)
+    if not use_defaults:
+        os.environ.update(BASELINE_ENV)
     for component, name in LIBRARY_ENVS.items():
         os.environ[name] = manifest["libraries"][component]["path"]
     if native_dir is not None:
@@ -203,8 +206,8 @@ def configure_environment(bundle: Path, cache: Path, native_dir: Path | None) ->
     return manifest
 
 
-def engine_args(model: str) -> dict:
-    return {
+def engine_args(model: str, *, use_defaults: bool = False) -> dict:
+    args = {
         "model": model,
         "tensor_parallel_size": 4,
         "dtype": "half",
@@ -251,3 +254,14 @@ def engine_args(model: str) -> dict:
         },
         "worker_extension_cls": "benchmarks.sm70_qwen38_baseline_worker.BaselineWorker",
     }
+    if use_defaults:
+        # Keep model, precision and capacity fixed; let ordinary configuration
+        # select the backend, optimization flags and graph/kernel policy.
+        for name in (
+            "quantization",
+            "attention_backend",
+            "kernel_config",
+            "compilation_config",
+        ):
+            args.pop(name)
+    return args

--- a/benchmarks/sm70_qwen38_baseline_worker.py
+++ b/benchmarks/sm70_qwen38_baseline_worker.py
@@ -48,6 +48,12 @@ class BaselineWorker:
             "max_model_len": int(cfg.model_config.max_model_len),
             "graph_mode": str(cfg.compilation_config.cudagraph_mode),
             "mamba_cache_mode": str(cfg.cache_config.mamba_cache_mode),
+            "resolved_vllm_env": {
+                key: value
+                for key, value in os.environ.items()
+                if key.startswith("VLLM_")
+            },
+            "compilation_config": str(cfg.compilation_config),
             "binaries": binaries,
             "native_dependencies": native,
             "qsa_specialization_version": (

--- a/docs/design/sm70_qwen38_default_fastpath.md
+++ b/docs/design/sm70_qwen38_default_fastpath.md
@@ -5,11 +5,85 @@ with FP16 activations/KV, native FP32 SSM state, NVFP4 expert weights,
 TP4/PP1, 262144 context capacity, an 8192-token prefill chunk and no MTP or
 prefix cache. It used explicit optimization switches.
 
-This task checks whether ordinary model/capacity arguments can select that
-same route. Model-scoped defaults and a default-route benchmark are under
-validation; this document does not yet claim a new speed result.
+This change lets ordinary model/capacity arguments select the missing parts
+of that route. End-to-end validation remains pending; this document does not
+claim a new speed result or that configuration tests reproduce throughput.
 
 The initial audit found checkpoint-FP16 GEMV, fused GDN input and fused HC
 disabled by default. This also prevents the dependent auto dual-compile and
 hybrid PLE route. Most MoE, router, QSA and TP4 push optimizations are already
-enabled. Shared-expert overlap and MoE add/reduce still require opt-in.
+enabled. Shared-expert overlap and MoE add/reduce also required opt-in.
+
+## Model-scoped defaults
+
+The following five switches now default to 1 only for the matching
+Qwen3.8 Flash-Next architecture and dimensions, checkpoint NVFP4
+(`modelopt_fp4`), FP16 activations/KV, native FP32 SSM, all-SM70 local TP4/PP1,
+DP1, no MTP, no LoRA, no expert parallelism and no dual-batch overlap:
+
+- `VLLM_SM70_QWEN38_FP16_GEMV`
+- `VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16`
+- `VLLM_SM70_QWEN38_FUSED_HC_FP16`
+- `VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP`
+- `VLLM_SM70_MOE_ADD_ALLREDUCE`
+
+Existing explicit values are preserved, including 0. Other models, hardware,
+quantizations and speculative configurations do not receive these new
+defaults. Enforce-eager/no-compile-decode-graph requests also skip this
+auto-selection. No kernel arithmetic or precision is changed by this PR.
+
+The existing dependent selectors can then enable dual compilation and hybrid
+PLE automatically. Prefill uses asynchronous disk-mmap lookup; decode uses
+local pinned-UVA lookup. **Hybrid PLE still needs substantial host RAM** and
+must not be described as a disk-only, low-RAM mode.
+
+## Configuration verification
+
+Using the real checkpoint metadata and ordinary engine arguments, with no
+`VLLM_*` launch variables and without loading weights or initializing CUDA:
+
+| Resolved setting | Before this change | With this change |
+|---|---|---|
+| Five switches above | Off | On |
+| Qwen3.8 dual compilation | Off | On |
+| Hybrid PLE / CPU and disk offload | Off | On |
+| Model Runner V2 | On | On |
+| Full + piecewise graphs, native RMSNorm priority | Selected | Selected |
+| SSM cache | FP32 | FP32 |
+
+The configuration regression suite passed 23 tests; the benchmark contract
+and correctness-gate suite passed 12 tests. These establish selection and
+failure-handling behavior, not output equivalence or performance.
+
+## Default-route reproduction
+
+Build the runtime from the current checkout as described in
+[the baseline reproduction guide](sm70_qwen38_reproducible_baseline.md).
+The same public benchmark accepts `--use-defaults`:
+
+```bash
+python benchmarks/benchmark_sm70_qwen38_baseline.py \
+  --model /path/to/Qwen3.8-Flash-Next-NVFP4 \
+  --runtime-dir /path/to/fresh-runtime \
+  --output /path/to/results/defaults.json \
+  --reference-json /path/to/accepted-reference.json \
+  --repeats 2 --long-context --use-defaults
+```
+
+This mode clears inherited `VLLM_*` switches and does not inject the explicit
+baseline optimization map, quantization override, attention-backend override,
+or graph/kernel configuration. Native library paths and isolated build caches
+remain explicit reproduction plumbing. A compatible native vLLM installation
+is still required; source-overlay users can supply
+`--native-extension-dir /path/to/native-vllm`.
+
+The workload still specifies TP4, FP16 activations/KV, 262144 context capacity,
+8192-token prefill chunks, one text-only request, 0.90 GPU memory utilization,
+no prefix cache and no speculative decoding. Default speed must be checked with that
+same workload, not inferred from an unrelated serving concurrency or prompt.
+
+The driver retains natural-output health checks, token-for-token comparison
+with the accepted reference, per-worker runtime hashes and FP32 SSM checks,
+and shutdown after the test. It reports launch settings and resolved worker
+settings so an inherited fast-path flag cannot silently count as a default.
+The long-context option adds 261631+513 and 262143+1 boundary cases.

--- a/docs/design/sm70_qwen38_default_fastpath.md
+++ b/docs/design/sm70_qwen38_default_fastpath.md
@@ -1,0 +1,15 @@
+# Qwen3.8 Flash-Next SM70 default-path audit
+
+The historical approximately 98 tok/s single-request baseline was measured
+with FP16 activations/KV, native FP32 SSM state, NVFP4 expert weights,
+TP4/PP1, 262144 context capacity, an 8192-token prefill chunk and no MTP or
+prefix cache. It used explicit optimization switches.
+
+This task checks whether ordinary model/capacity arguments can select that
+same route. Model-scoped defaults and a default-route benchmark are under
+validation; this document does not yet claim a new speed result.
+
+The initial audit found checkpoint-FP16 GEMV, fused GDN input and fused HC
+disabled by default. This also prevents the dependent auto dual-compile and
+hybrid PLE route. Most MoE, router, QSA and TP4 push optimizations are already
+enabled. Shared-expert overlap and MoE add/reduce still require opt-in.

--- a/docs/design/sm70_qwen38_reproducible_baseline.md
+++ b/docs/design/sm70_qwen38_reproducible_baseline.md
@@ -106,6 +106,11 @@ for every requested fixed-prompt case (missing cases are rejected). The warmup
 and timed repeats must also agree.
 The driver does not change sampling to conceal early EOS or numerical drift.
 
+To test model-aware selection instead of the explicit baseline flag map, add
+`--use-defaults`. See [the default-path audit](sm70_qwen38_default_fastpath.md)
+for its scope and current validation status. The precision, workload,
+reference-token checks and shutdown behavior are unchanged.
+
 ## Accepted historical evidence and fresh-build acceptance
 
 The unprofiled `main` source95205a2d9952 sweep used physical GPUs4-7 with the

--- a/tests/benchmarks/test_sm70_qwen38_baseline.py
+++ b/tests/benchmarks/test_sm70_qwen38_baseline.py
@@ -117,6 +117,26 @@ def test_environment_is_explicit(bundle, tmp_path, monkeypatch):
         assert os.environ[name] == str(output / f"{component}.so")
 
 
+def test_default_route_does_not_inject_optimization_flags(
+    bundle, tmp_path, monkeypatch
+):
+    output, _, _ = bundle
+    monkeypatch.setattr(os, "environ", dict(os.environ))
+    os.environ["VLLM_SM70_QWEN38_FP16_GEMV"] = "0"
+    baseline.configure_environment(output, tmp_path / "cache", None, use_defaults=True)
+    assert set(name for name in os.environ if name.startswith("VLLM_")) == set(
+        baseline.LIBRARY_ENVS.values()
+    ) - {"FLASH_QLA_SM70_PREBUILT_EXTENSION_PATH"} | {"VLLM_CACHE_ROOT"}
+    args = baseline.engine_args("model", use_defaults=True)
+    assert (
+        not {"compilation_config", "kernel_config", "attention_backend", "quantization"}
+        & args.keys()
+    )
+    assert args["tensor_parallel_size"] == 4
+    assert args["mamba_ssm_cache_dtype"] == "auto"
+    assert args["kv_cache_dtype"] == "float16"
+
+
 @pytest.mark.parametrize("failure", [None, "health", "reference"])
 def test_driver_records_failure_and_releases_workers(
     bundle, tmp_path, monkeypatch, failure

--- a/tests/compile/test_sm70_decode_graph.py
+++ b/tests/compile/test_sm70_decode_graph.py
@@ -4,6 +4,7 @@
 import os
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.compilation.sm70_decode_graph import (
@@ -14,6 +15,7 @@ from vllm.compilation.sm70_decode_graph import (
 from vllm.config.parallel import ParallelConfig
 from vllm.config.vllm import (
     _apply_sm70_qwen38_hybrid_ple_defaults,
+    _apply_sm70_qwen38_nomtp_defaults,
     _is_sm70_qwen38_nomtp_dual_compile_contract,
 )
 
@@ -111,6 +113,100 @@ def test_qwen38_nomtp_dual_compile_contract_accepts_awq_lm_only_wrapper() -> Non
     assert not _is_sm70_qwen38_nomtp_dual_compile_contract(
         model_config, None, parallel_config
     )
+
+
+def _nomtp_default_config():
+    return SimpleNamespace(
+        model_config=_qwen38_model_config(
+            "Qwen4ExpForConditionalGeneration",
+            language_model_only=True,
+            quantization="modelopt_fp4",
+        ),
+        speculative_config=None,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4,
+            pipeline_parallel_size=1,
+            enable_expert_parallel=False,
+            enable_dbo=False,
+            data_parallel_size=1,
+            nnodes_within_dp=1,
+        ),
+        cache_config=SimpleNamespace(
+            cache_dtype="float16", mamba_ssm_cache_dtype="float32"
+        ),
+        lora_config=None,
+    )
+
+
+def test_qwen38_nomtp_defaults_preserve_overrides(monkeypatch):
+    monkeypatch.setattr(os, "environ", {})
+    cfg = _nomtp_default_config()
+    disabled = "VLLM_SM70_QWEN38_FP16_GEMV"
+    os.environ[disabled] = "0"
+    applied = _apply_sm70_qwen38_nomtp_defaults(cfg, is_sm70=True)
+    assert disabled not in applied and os.environ[disabled] == "0"
+    assert len(applied) == 4
+    assert os.environ["VLLM_SM70_QWEN38_FUSED_HC_FP16"] == "1"
+    assert _apply_sm70_qwen38_nomtp_defaults(cfg, is_sm70=True) == ()
+    assert "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8" not in os.environ
+    assert "VLLM_SM70_NVFP4_QPN2" not in os.environ
+
+
+@pytest.mark.parametrize(
+    "mismatch",
+    [
+        "device",
+        "model",
+        "dtype",
+        "quantization",
+        "mtp",
+        "tp",
+        "pp",
+        "ep",
+        "dbo",
+        "dp",
+        "nodes",
+        "kv",
+        "ssm",
+        "lora",
+        "multimodal",
+    ],
+)
+def test_qwen38_nomtp_defaults_reject_unqualified_contract(monkeypatch, mismatch):
+    monkeypatch.setattr(os, "environ", {})
+    cfg = _nomtp_default_config()
+    if mismatch == "model":
+        cfg.model_config.hf_text_config.hidden_size = 5120
+    elif mismatch == "dtype":
+        cfg.model_config.dtype = torch.bfloat16
+    elif mismatch == "quantization":
+        cfg.model_config.quantization = "awq"
+    elif mismatch == "mtp":
+        cfg.speculative_config = SimpleNamespace(method="mtp")
+    elif mismatch in ("tp", "pp", "dp", "nodes"):
+        field = {
+            "tp": "tensor_parallel_size",
+            "pp": "pipeline_parallel_size",
+            "dp": "data_parallel_size",
+            "nodes": "nnodes_within_dp",
+        }[mismatch]
+        setattr(cfg.parallel_config, field, 2)
+    elif mismatch in ("ep", "dbo"):
+        setattr(
+            cfg.parallel_config,
+            "enable_expert_parallel" if mismatch == "ep" else "enable_dbo",
+            True,
+        )
+    elif mismatch == "kv":
+        cfg.cache_config.cache_dtype = "fp8_e4m3"
+    elif mismatch == "ssm":
+        cfg.cache_config.mamba_ssm_cache_dtype = "float16"
+    elif mismatch == "lora":
+        cfg.lora_config = SimpleNamespace()
+    elif mismatch == "multimodal":
+        cfg.model_config.multimodal_config.language_model_only = False
+    assert _apply_sm70_qwen38_nomtp_defaults(cfg, is_sm70=mismatch != "device") == ()
+    assert not os.environ
 
 
 def test_parallel_config_initializes_ple_ipc_after_late_auto_enable(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -252,6 +252,42 @@ def _participating_cuda_device_ids(cfg: "VllmConfig") -> tuple[int, ...]:
     return tuple(range(start, start + parallel.local_world_size))
 
 
+def _apply_sm70_qwen38_nomtp_defaults(
+    cfg: "VllmConfig", *, is_sm70: bool
+) -> tuple[str, ...]:
+    """Complete the admitted NVFP4 baseline without global experimental defaults."""
+    if not is_sm70 or not _is_sm70_qwen38_nomtp_dual_compile_contract(
+        cfg.model_config, cfg.speculative_config, cfg.parallel_config
+    ):
+        return ()
+    parallel = cfg.parallel_config
+    if (
+        cfg.model_config.quantization != "modelopt_fp4"
+        or cfg.lora_config is not None
+        or parallel.enable_expert_parallel
+        or parallel.enable_dbo
+        or parallel.data_parallel_size != 1
+        or parallel.nnodes_within_dp != 1
+        or cfg.cache_config.cache_dtype not in ("auto", "float16")
+        or cfg.cache_config.mamba_ssm_cache_dtype not in ("auto", "float32")
+    ):
+        return ()
+
+    defaults = {
+        "VLLM_SM70_QWEN38_FP16_GEMV": "1",
+        "VLLM_SM70_QWEN38_FUSED_GDN_INPUT_FP16": "1",
+        "VLLM_SM70_QWEN38_FUSED_HC_FP16": "1",
+        "VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP": "1",
+        "VLLM_SM70_MOE_ADD_ALLREDUCE": "1",
+    }
+    applied = []
+    for name, value in defaults.items():
+        if name not in os.environ:
+            os.environ[name] = value
+            applied.append(name)
+    return tuple(applied)
+
+
 def _any_participating_device_is_capability(
     cfg: "VllmConfig", capability: tuple[int, int]
 ) -> bool:
@@ -1926,6 +1962,23 @@ class VllmConfig:
                         "baseline. Set it explicitly to override.",
                         env_name,
                         env_value,
+                    )
+            if (
+                not sm70_compile_disabled_by_user
+                and not sm70_no_compile_decode_graph_requested
+                and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+            ):
+                for env_name in _apply_sm70_qwen38_nomtp_defaults(
+                    self,
+                    is_sm70=all(
+                        current_platform.is_device_capability((7, 0), device_id=i)
+                        for i in _participating_cuda_device_ids(self)
+                    ),
+                ):
+                    logger.info_once(
+                        "Auto-setting %s=1 for the quality-qualified SM70 "
+                        "Qwen3.8 NVFP4 TP4 no-MTP path. Set it explicitly to override.",
+                        env_name,
                     )
             if (
                 _is_sm70_qwen38_nomtp_dual_compile_contract(


### PR DESCRIPTION
## Purpose

Make the accepted Qwen3.8 Flash-Next NVFP4 TP4 no-MTP V100 path reproducible with ordinary capacity/model arguments, without a long list of opt-in optimization flags. Only quality-qualified model-scoped defaults are candidates; no precision reduction or experimental MTP path.

Base public/main: `4f19ef7a20db60bb0685e599bd3f4dd156202eed`.

## Audit

MoE, router, QSA and TP4 push paths are already mostly default-on. The checkpoint-FP16 GEMV, fused GDN input and fused HC switches remain off, preventing dependent auto dual-compile/hybrid-PLE selection. Shared-expert overlap and MoE add/reduce also differ from the accepted reproduction contract.

## Implementation

- Added five model-scoped defaults for FP16 GEMV, fused GDN input, fused HC, shared-expert overlap and MoE add/all-reduce. The existing dual-compile/hybrid-PLE selectors can then apply without hand-written launch flags.
- Guarded by the exact model dimensions, SM70 on every participating rank, FP16, checkpoint NVFP4, local TP4/PP1/DP1, no speculative decoding, no EP/DBO/LoRA, FP32 SSM and FP16 KV. Existing explicit values remain authoritative.
- Added `--use-defaults` to the public baseline driver. It clears inherited VLLM flags and omits the baseline flag map, quantization override, attention-backend override, and graph/kernel override. It preserves workload, precision, output-health/token checks and worker shutdown.
- Worker manifests record resolved flags and compilation configuration in addition to native library hashes. Documentation explains hybrid PLE's continued host-RAM requirement.

## Test Plan

One bounded fresh-source TP4/no-MTP run, fixed 8192+513 and 261631+513, natural-output checks, full reference-token comparison and 262143+1 context boundary. No resident API, no precision reduction. Report actual prefill and pure decode separately.

## Test Result

- Configuration regression: **23 passed**.
- Benchmark contract / token-health failure handling: **12 passed**.
- Pre-commit: passed locally; both current GitHub checks passed on functional commit `6a013f7c61ce75771eeff18c16193b6f62851f79`.
- Real checkpoint metadata, zero launch `VLLM_*` variables: all five defaults plus dual compilation and hybrid PLE resolve on; Runner V2, full+piecewise graphs, native RMSNorm priority and FP32 SSM are retained. No model weights loaded; CUDA remained uninitialized.
- Before/after configuration probe: disabling only the new selector in the probe restores all five switches and the dependent dual/hybrid selectors to off. This is configuration evidence, not a speed result.
- Six source-matched HC/QPN/QSA/FlashQLA/Flash-V100/paged-KV libraries built and runtime source/binary hashes validated. Native build from functional commit above, using Torch 2.10.0+cu128, nvcc 12.0.140, Triton 3.6.0 and V100/SM70.
- **Full-model validation not executed:** the bounded five-minute admission attempt expired without an exclusive TP4 group and sufficient host RAM (final MemAvailable20.6 GiB; required90 GiB). No HC/model kernel test was started; no GPU process or queue remains. No new throughput claim. Keep Draft until same-contract end-to-end gates pass.

No equivalent open default-path PR was found. This is separate from PR577 input guards and other MTP/H3/FlashInfer work. AI assistance: OpenAI Codex, at the owner's request; no independent human review is claimed. Draft until measured gates pass.
