### PR TITLE
[Bugfix] Honor explicit H3 GPU selection on mixed display hosts

### DIFF
--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -149,8 +149,13 @@ matrix dimensions and valid attention tokens, exclude padding/rotation/dequant,
 and divide by the maximum complete denoise duration across all four ranks.
 NVML utilization and standalone operator speed are diagnostic evidence only.
 
-The native engine reserves a whole available GPU group (0–3 first, then 4–7)
-with the shared 1Cat V100 per-card and group locks. The lease remains held until
+The native engine reserves a whole available GPU group with the shared 1Cat
+V100 per-card and group locks. An explicit `CUDA_VISIBLE_DEVICES` selection
+(NVML indices or GPU UUIDs) bounds the candidate groups; a busy selected group
+never falls back to unselected devices. UUIDs are recommended for launchers.
+Without a selection, devices with at least 30 GiB capacity form ordered groups,
+so a small display card does not shift the four-V100 grouping. Workers receive
+the leased devices as UUIDs to avoid CUDA/NVML ordinal-order differences. The lease remains held until
 its workers exit. A group reserved by another cooperating task is unavailable
 even while that task is between CUDA processes. If both groups are occupied or
 reserved, startup fails before model loading.

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -157,7 +157,8 @@ Without a selection, devices with at least 30 GiB capacity form ordered groups,
 so a small display card does not shift the four-V100 grouping. Workers receive
 the leased devices as UUIDs to avoid CUDA/NVML ordinal-order differences.
 The NVML platform resolves these UUIDs for physical-device queries before
-pipeline imports, so capability checks use the same selected boards.
+pipeline imports, so capability checks use the same selected boards. Custom
+all-reduce topology checks use this mapping as well.
 The lease remains held until
 its workers exit. A group reserved by another cooperating task is unavailable
 even while that task is between CUDA processes. If both groups are occupied or

--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -155,7 +155,10 @@ V100 per-card and group locks. An explicit `CUDA_VISIBLE_DEVICES` selection
 never falls back to unselected devices. UUIDs are recommended for launchers.
 Without a selection, devices with at least 30 GiB capacity form ordered groups,
 so a small display card does not shift the four-V100 grouping. Workers receive
-the leased devices as UUIDs to avoid CUDA/NVML ordinal-order differences. The lease remains held until
+the leased devices as UUIDs to avoid CUDA/NVML ordinal-order differences.
+The NVML platform resolves these UUIDs for physical-device queries before
+pipeline imports, so capability checks use the same selected boards.
+The lease remains held until
 its workers exit. A group reserved by another cooperating task is unavailable
 even while that task is between CUDA processes. If both groups are occupied or
 reserved, startup fails before model loading.

--- a/tests/video/test_h3_gpu_visibility.py
+++ b/tests/video/test_h3_gpu_visibility.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU lease selection with a CPU-only NVML inventory, including a display card."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "h3_visibility", Path(__file__).resolve().parents[2] / "vllm/video/gpu.py"
+)
+assert spec is not None and spec.loader is not None
+gpu = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gpu)
+
+
+@pytest.fixture
+def inventory(monkeypatch, tmp_path):
+    memory = [2] + [32] * 8
+    busy: set[int] = set()
+    nvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetCount=lambda: len(memory),
+        nvmlDeviceGetHandleByIndex=lambda i: i,
+        nvmlDeviceGetHandleByUUID=lambda u: int(u.removeprefix("GPU-")),
+        nvmlDeviceGetIndex=lambda i: i,
+        nvmlDeviceGetUUID=lambda i: f"GPU-{i}",
+        nvmlDeviceGetMemoryInfo=lambda i: SimpleNamespace(
+            total=memory[i] * 1024**3, free=memory[i] * 1024**3
+        ),
+        nvmlDeviceGetComputeRunningProcesses=lambda i: (
+            [SimpleNamespace(usedGpuMemory=1024**3)] if i in busy else []
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", nvml)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setattr(gpu, "LOCK_ROOT", tmp_path)
+    return memory, busy
+
+
+def test_display_gpu_does_not_hide_four_card_group(inventory):
+    assert gpu._available_gpu_groups(4) == [(1, 2, 3, 4), (5, 6, 7, 8)]
+    assert gpu.worker_device_mask((1, 2, 3, 4)) == "GPU-1,GPU-2,GPU-3,GPU-4"
+
+
+@pytest.mark.parametrize("mask", ["5,6,7,8", "GPU-5,GPU-6,GPU-7,GPU-8"])
+def test_explicit_group_never_falls_back_to_unselected_gpus(
+    inventory, monkeypatch, mask
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    assert gpu._available_gpu_groups(4) == [(5, 6, 7, 8)]
+    inventory[1].add(5)
+    assert gpu._available_gpu_groups(4) == []
+    with pytest.raises(RuntimeError, match="unleased"):
+        gpu.acquire_gpu_group(4)
+
+
+@pytest.mark.parametrize("mask", ["", "-1", "1,2"])
+def test_empty_or_insufficient_visibility_never_expands(inventory, monkeypatch, mask):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    assert gpu._available_gpu_groups(4) == []
+
+
+@pytest.mark.parametrize("mask", ["1,1,2,3", "1,2,3,99", "1,2,3,bad"])
+def test_invalid_masks_are_refused(inventory, monkeypatch, mask):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    with pytest.raises(ValueError):
+        gpu._available_gpu_groups(4)
+
+
+def test_selected_lock_is_respected_even_when_other_gpus_are_idle(
+    inventory, monkeypatch
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,2,3,4")
+    with gpu.GPUGroupLease((1, 2, 3, 4)), pytest.raises(RuntimeError, match="unleased"):
+        gpu.acquire_gpu_group(4)
+    with gpu.acquire_gpu_group(4) as lease:
+        assert lease.gpu_ids == (1, 2, 3, 4)

--- a/tests/video/test_h3_gpu_visibility.py
+++ b/tests/video/test_h3_gpu_visibility.py
@@ -119,3 +119,42 @@ def test_nvml_platform_preserves_integer_and_empty_masks(
     )
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
     assert cuda.NvmlCudaPlatform.device_id_to_physical_device_id(device) == expected
+
+
+@pytest.mark.parametrize("mask", ["GPU-a,GPU-b,GPU-c,GPU-d", "6,2,4,1"])
+def test_custom_allreduce_queries_the_selected_physical_boards(monkeypatch, mask):
+    from vllm.distributed.device_communicators import custom_all_reduce as ar
+
+    physical = [6, 2, 4, 1]
+    observed = []
+
+    def gather(values, tensor, group):
+        assert tensor.item() == 2
+        for value, index in zip(values, physical):
+            value.fill_(index)
+
+    def connected(indices):
+        observed.extend(indices)
+        return False  # Stop after the topology check, before CUDA allocation.
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    monkeypatch.setattr(ar, "custom_ar", True)
+    monkeypatch.setattr(ar, "in_the_same_node_as", lambda *a, **kw: [True] * 4)
+    monkeypatch.setattr(ar.dist, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(ar.dist, "get_rank", lambda **kw: 1)
+    monkeypatch.setattr(ar.dist, "get_world_size", lambda **kw: 4)
+    monkeypatch.setattr(ar.dist, "all_gather", gather)
+    monkeypatch.setattr(
+        ar,
+        "current_platform",
+        SimpleNamespace(
+            get_device_capability=lambda: SimpleNamespace(major=7, minor=0),
+            is_cuda=lambda: True,
+            is_cuda_alike=lambda: True,
+            device_id_to_physical_device_id=lambda index: physical[index],
+            is_fully_connected=connected,
+        ),
+    )
+    communicator = ar.CustomAllreduce(group=object(), device="cuda:1")
+    assert communicator.disabled
+    assert observed == physical

--- a/tests/video/test_h3_gpu_visibility.py
+++ b/tests/video/test_h3_gpu_visibility.py
@@ -80,3 +80,42 @@ def test_selected_lock_is_respected_even_when_other_gpus_are_idle(
         gpu.acquire_gpu_group(4)
     with gpu.acquire_gpu_group(4) as lease:
         assert lease.gpu_ids == (1, 2, 3, 4)
+
+
+def test_nvml_platform_resolves_worker_uuid_order(monkeypatch):
+    from vllm.platforms import cuda
+
+    fake = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByUUID=lambda u: {"GPU-selected-a": 6, "GPU-selected-b": 2}[
+            u
+        ],
+        nvmlDeviceGetIndex=lambda handle: handle,
+    )
+    monkeypatch.setattr(cuda, "pynvml", fake)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-selected-a,GPU-selected-b")
+    assert cuda.NvmlCudaPlatform.device_id_to_physical_device_id(0) == 6
+    assert cuda.NvmlCudaPlatform.device_id_to_physical_device_id(1) == 2
+    with pytest.raises(IndexError):
+        cuda.NvmlCudaPlatform.device_id_to_physical_device_id(2)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-unknown")
+    with pytest.raises(KeyError):
+        cuda.NvmlCudaPlatform.device_id_to_physical_device_id(0)
+
+
+@pytest.mark.parametrize(
+    "mask,device,expected", [("6,2", 0, 6), ("6,2", 1, 2), ("", 1, 1)]
+)
+def test_nvml_platform_preserves_integer_and_empty_masks(
+    monkeypatch, mask, device, expected
+):
+    from vllm.platforms import cuda
+
+    monkeypatch.setattr(
+        cuda,
+        "pynvml",
+        SimpleNamespace(nvmlInit=lambda: None, nvmlShutdown=lambda: None),
+    )
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    assert cuda.NvmlCudaPlatform.device_id_to_physical_device_id(device) == expected

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -194,7 +194,10 @@ class CustomAllreduce:
                 )
         cuda_visible_devices = envs.CUDA_VISIBLE_DEVICES
         if cuda_visible_devices:
-            device_ids = list(map(int, cuda_visible_devices.split(",")))
+            device_ids = [
+                current_platform.device_id_to_physical_device_id(index)
+                for index in range(len(cuda_visible_devices.split(",")))
+            ]
         else:
             device_ids = list(range(current_platform.device_count()))
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -639,6 +639,17 @@ class CudaPlatformBase(Platform):
 # the major benefit of using NVML is that it will not initialize CUDA
 class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
+    @with_nvml_context
+    def device_id_to_physical_device_id(cls, device_id: int):
+        visible = os.environ.get(cls.device_control_env_var, "")
+        if visible:
+            selected = visible.split(",")[device_id].strip()
+            if selected.startswith("GPU-"):
+                handle = pynvml.nvmlDeviceGetHandleByUUID(selected)
+                return pynvml.nvmlDeviceGetIndex(handle)
+        return super().device_id_to_physical_device_id(device_id)
+
+    @classmethod
     @cache
     @with_nvml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -18,12 +18,12 @@ from typing import cast
 
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 
-from .gpu import acquire_gpu_group
+from .gpu import acquire_gpu_group, worker_device_mask
 from .gpu import select_gpu_group as select_gpu_group
 
 
 def _worker(rank, config, gpu_ids, endpoint, connection):
-    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
+    os.environ["CUDA_VISIBLE_DEVICES"] = worker_device_mask(gpu_ids)
     from datetime import timedelta
 
     import torch

--- a/vllm/video/gpu.py
+++ b/vllm/video/gpu.py
@@ -12,15 +12,45 @@ LOCK_ROOT = Path("/tmp")
 def _available_gpu_groups(tp: int) -> list[tuple[int, ...]]:
     import pynvml as nvml
 
+    if tp < 1:
+        raise ValueError("H3 tensor parallel size must be positive")
     groups = []
     nvml.nvmlInit()
     try:
-        for start in (0, 4):
-            indices = tuple(range(start, start + tp))
-            if indices[-1] >= nvml.nvmlDeviceGetCount():
+        count = nvml.nvmlDeviceGetCount()
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if visible is not None:
+            if not visible.strip() or visible.strip() == "-1":
+                return []
+            indices = []
+            for token in visible.split(","):
+                token = token.strip()
+                if token.startswith("GPU-"):
+                    index = nvml.nvmlDeviceGetIndex(
+                        nvml.nvmlDeviceGetHandleByUUID(token)
+                    )
+                elif token.isdecimal() and int(token) < count:
+                    index = int(token)
+                else:
+                    raise ValueError(
+                        "H3 GPU selection must contain NVML indices or GPU UUIDs"
+                    )
+                if index in indices:
+                    raise ValueError("H3 GPU selection contains a duplicate device")
+                indices.append(index)
+        else:
+            # A display GPU must not shift the four-card V100 group boundaries.
+            indices = []
+            for index in range(count):
+                handle = nvml.nvmlDeviceGetHandleByIndex(index)
+                if nvml.nvmlDeviceGetMemoryInfo(handle).total >= 30 * 1024**3:
+                    indices.append(index)
+        for start in range(0, len(indices), tp):
+            group = tuple(indices[start : start + tp])
+            if len(group) != tp:
                 continue
             available = True
-            for index in indices:
+            for index in group:
                 handle = nvml.nvmlDeviceGetHandleByIndex(index)
                 processes = nvml.nvmlDeviceGetComputeRunningProcesses(handle)
                 # Ignore a small desktop CUDA allocation; never displace jobs.
@@ -29,8 +59,22 @@ def _available_gpu_groups(tp: int) -> list[tuple[int, ...]]:
                 if nvml.nvmlDeviceGetMemoryInfo(handle).free < 30 * 1024**3:
                     available = False
             if available:
-                groups.append(indices)
+                groups.append(group)
         return groups
+    finally:
+        nvml.nvmlShutdown()
+
+
+def worker_device_mask(gpu_ids: tuple[int, ...]) -> str:
+    """Use UUIDs when entering CUDA; NVML and CUDA ordinal order may differ."""
+    import pynvml as nvml
+
+    nvml.nvmlInit()
+    try:
+        uuids = [
+            nvml.nvmlDeviceGetUUID(nvml.nvmlDeviceGetHandleByIndex(i)) for i in gpu_ids
+        ]
+        return ",".join(u.decode() if isinstance(u, bytes) else u for u in uuids)
     finally:
         nvml.nvmlShutdown()
 


### PR DESCRIPTION
## Purpose
H3 ignored an explicit GPU selection and considered only groups starting at NVML indices 0 and 4. A display card before four V100s could make both groups unusable; a selected second group could fall back to the first. Passing UUIDs to the workers also exposed integer-only parsing in platform capability and custom all-reduce topology queries.

Bound H3 candidates to the requested NVML indices or full GPU UUIDs, reject invalid/duplicate/insufficient masks, and form automatic groups from capacity-eligible cards. Workers receive the leased UUIDs. NVML capability and custom all-reduce topology queries now resolve those UUIDs to the correct physical boards. Existing capacity rechecks, per-card/group locks, numeric masks, kernels and model arithmetic are preserved.

## Validation
Base `onecat/main`: `4f19ef7a20db60bb0685e599bd3f4dd156202eed`. Tested implementation: `1918716454a292e0492000d974d4b077ec3dada3`.

- 19 focused CPU regressions passed: inventory grouping, selected/busy/locked devices, UUID/numeric masks, capability mapping, and custom all-reduce constructor topology discovery. All applicable hooks and GitHub pre-commit checks passed.
- Full SM70 source wheel compiled and installed on a host with four V100-SXM2-32GB cards plus a display P400. Python3.12.13, Torch2.10.0+cu128, CUDA Toolkit12.8.
- Real TP4 startup under reversed UUID visibility passed. Logical ranks0/1/2/3 resolved to physical boards3/2/1/0. All ranks reduced 4096 FP16 values from rank+1 to exactly10. The existing CUSTOM/PYNCCL dispatch initialized successfully. All test GPU contexts were released.
- Native H3 progressed past device selection and collective initialization into checkpoint loading. This 64GB-RAM host then exhausted host memory in the existing pinned model residency path. This PR does not claim full H3 generation, model quality or a speed improvement; host-memory handling is a separate deployment issue.

Artifact directory: `/home/ymzx/1cat-vllm-deploy/studio-main-20260909`; `check-uuid-tp4.py`, `uuid-tp4.log`, `uuid-tp4-result.json`, and the retained H3 startup logs reproduce the acceptance boundary. Wheel SHA256: `c09bd633f1ad2f1ad16b2c2c1ddd39e8e671febf00342312d43dc4e40eb30a69`.

AI assistance was used. No source changes were made in shared dirty worktrees.
