### PR TITLE
[Video] Bound H3 host weight residency on memory-constrained hosts

### DIFF
--- a/docs/design/minimax_h3/README.md
+++ b/docs/design/minimax_h3/README.md
@@ -27,6 +27,31 @@ CUTLASS v4.4.2 source. It does not rebuild the rest of vLLM. The normal CMake
 build fetches that pinned CUTLASS version automatically.
 The development tests use Transformers 5.15.1 and Diffusers 0.40.0.
 
+## Host memory and temporary disk storage
+
+Four 32-GB GPUs do not imply that the host can retain the complete CPU model.
+Pinned DiT and text-encoder masters exhausted a 64-GiB host during TP4 loading.
+`--host-memory-mode auto` therefore uses reclaimable, disk-backed CPU weights
+on hosts with less than 128 GiB of physical RAM. Larger hosts retain the pinned
+path. `--host-memory-mode mmap` or `pinned` selects a policy explicitly.
+
+The disk-backed path preserves tensor bytes, aliases, strides and dtypes;
+quantization, attention and denoise schedules are unchanged. Parameters are
+mapped before streaming checkpoint writes, avoiding a complete anonymous CPU
+copy before offload. Storage transformed during quantization and adapter
+preparation is mapped again before staging. Device transfers from these CPU
+masters may take longer than transfers from pinned RAM.
+
+Temporary storage defaults to `VLLM_CACHE_ROOT/h3-host`. Use
+`--host-memory-directory /path/on/local-ssd` to select another directory.
+Each allocation reserves disk space before mapping so a full disk reports a
+loading error instead of a later SIGBUS. Files are immediately unlinked after
+mapping; their space remains occupied until the worker releases the tensors,
+including after an abrupt worker exit. Original model files remain read-only.
+Provide enough free SSD space for the selected model's CPU weights. This mode
+reduces weight residency; it does not eliminate activation or media-processing
+memory requirements.
+
 ```bash
 export CUDA_HOME=/path/to/cuda-12.8
 export TORCH_CUDA_ARCH_LIST=7.0

--- a/setup.py
+++ b/setup.py
@@ -896,6 +896,9 @@ class precompiled_wheel_utils:
                 sm70_sampler_ext_regex = re.compile(
                     r"vllm/_sm70_sampler_C(?:\.[^/]+)?\.so$"
                 )
+                h3_ext_regex = re.compile(
+                    r"vllm/_h3_(?:w8a16|flashinfer|flashattn)_C(?:\.[^/]+)?\.so$"
+                )
                 file_members = []
                 for member in wheel.filelist:
                     if member.filename in exact_members:
@@ -916,6 +919,7 @@ class precompiled_wheel_utils:
                         or flash_attn_v100_ext_regex.match(member.filename)
                         or flash_qla_sm70_ext_regex.match(member.filename)
                         or sm70_sampler_ext_regex.match(member.filename)
+                        or h3_ext_regex.match(member.filename)
                     ):
                         file_members.append(member)
 

--- a/tests/video/test_h3_host_memory.py
+++ b/tests/video/test_h3_host_memory.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+import errno
+import os
+import shutil
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import regex as re
+import torch
+from torch import nn
+
+from vllm.model_executor.models.minimax_h3.config import H3Config, H3InputError
+from vllm.model_executor.models.minimax_h3.residency import (
+    MMapHostWeights,
+    PinnedModuleStager,
+)
+
+
+def aliased_module():
+    module = nn.Module()
+    values = torch.arange(128, dtype=torch.float32).reshape(16, 8)
+    module.weight = nn.Parameter(values)
+    module.register_buffer("view", values[3:7, 1:5])
+    module.register_buffer("raw", values.view(torch.uint8))
+    module.register_buffer("empty", torch.empty((0, 3)))
+    return module
+
+
+def test_mapped_weights_keep_bytes_views_and_restore(tmp_path):
+    module = aliased_module()
+    expected = {name: value.clone() for name, value in module.state_dict().items()}
+    backing = MMapHostWeights(tmp_path)
+    PinnedModuleStager.map_cpu_weights(module, backing)
+    filename = module.weight.untyped_storage().filename
+    assert filename and not Path(filename).exists()
+    assert not list(tmp_path.iterdir())
+    assert not module.weight.is_pinned()
+    assert module.view.stride() == (8, 1) and module.view.storage_offset() == 25
+    assert (
+        module.weight.untyped_storage().data_ptr()
+        == module.raw.untyped_storage().data_ptr()
+    )
+    reserved = backing.bytes_reserved
+    stager = object.__new__(PinnedModuleStager)
+    stager._groups = stager._snapshot_groups(
+        (module,), pin_memory=True, host_backing=backing
+    )
+    assert backing.bytes_reserved == reserved  # Existing mappings are reused.
+    module.weight.data = torch.zeros_like(module.weight)
+    stager._restore_masters()
+    for name, value in module.state_dict().items():
+        torch.testing.assert_close(value, expected[name], rtol=0, atol=0)
+
+
+def test_map_before_fused_loading_preserves_buffers(tmp_path):
+    module = nn.Module()
+    module.weight = nn.Parameter(torch.empty(12, 8, dtype=torch.float16))
+    module.register_buffer("scale", torch.tensor([0.125, 3.0], dtype=torch.float32))
+    PinnedModuleStager.map_cpu_weights(
+        module, MMapHostWeights(tmp_path), preserve_parameters=False
+    )
+    with torch.no_grad():
+        for part in range(3):
+            module.weight[part * 4 : (part + 1) * 4].copy_(torch.full((4, 8), part + 1))
+    torch.testing.assert_close(module.scale, torch.tensor([0.125, 3.0]), rtol=0, atol=0)
+    expected = (
+        torch.arange(1, 4, dtype=torch.float16)
+        .repeat_interleave(4)[:, None]
+        .expand(12, 8)
+    )
+    torch.testing.assert_close(module.weight, expected, rtol=0, atol=0)
+
+
+def test_disk_reservation_failure_preserves_original_storage(monkeypatch, tmp_path):
+    module = nn.Linear(8, 4)
+    before = module.weight.detach().clone()
+
+    def full_disk(*args):
+        raise OSError(errno.ENOSPC, "disk full")
+
+    monkeypatch.setattr(os, "posix_fallocate", full_disk)
+    with pytest.raises(RuntimeError, match="reserve disk storage"):
+        PinnedModuleStager.map_cpu_weights(module, MMapHostWeights(tmp_path))
+    torch.testing.assert_close(module.weight, before, rtol=0, atol=0)
+    assert not list(tmp_path.iterdir())
+
+
+def test_invalid_host_memory_policy_is_rejected():
+    with pytest.raises(H3InputError, match="host memory mode"):
+        H3Config(host_memory_mode="invalid")
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires an explicitly selected idle GPU"
+)
+def test_disk_backed_gpu_roundtrip_keeps_storage_aliases(tmp_path):
+    module = aliased_module()
+    expected = module.view.clone()
+    stager = PinnedModuleStager(
+        module, torch.device("cuda"), host_backing=MMapHostWeights(tmp_path)
+    )
+    for _ in range(3):
+        stager.load()
+        assert module.weight.is_cuda
+        assert (
+            module.weight.untyped_storage().data_ptr()
+            == module.raw.untyped_storage().data_ptr()
+        )
+        torch.testing.assert_close(module.view.cpu(), expected, rtol=0, atol=0)
+        stager.offload()
+        assert module.weight.device.type == "cpu" and not module.weight.is_pinned()
+        assert module.weight.untyped_storage().filename
+        torch.testing.assert_close(module.view, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("extensions", [True, False])
+def test_source_wheel_reuse_keeps_h3_native_operators(
+    tmp_path, monkeypatch, extensions
+):
+    # Execute only the extraction method, avoiding setup() and build/network work.
+    source = Path(__file__).resolve().parents[2] / "setup.py"
+    tree = ast.parse(source.read_text())
+    function = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef)
+        and n.name == "extract_precompiled_and_patch_package"
+    )
+    function.decorator_list = []
+    scope: dict[str, Any] = {"os": os, "re": re, "shutil": shutil, "Path": Path}
+    exec(
+        compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"),
+        scope,
+    )
+    wheel = tmp_path / "native.whl"
+    names = [
+        f"_h3_{kind}_C.cpython-312-x86_64-linux-gnu.so"
+        for kind in ("w8a16", "flashinfer", "flashattn")
+    ]
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for name in names:
+            archive.writestr("vllm/" + name, b"native-test-bytes")
+    monkeypatch.chdir(tmp_path)
+    result = scope["extract_precompiled_and_patch_package"](
+        str(wheel), None, extract_extensions=extensions, extract_rust_frontend=False
+    )
+    assert result == ({"vllm": names} if extensions else {})
+    for name in names:
+        path = tmp_path / "vllm" / name
+        assert path.exists() == extensions
+        if extensions:
+            assert path.read_bytes() == b"native-test-bytes"

--- a/vllm/entrypoints/cli/video.py
+++ b/vllm/entrypoints/cli/video.py
@@ -51,6 +51,13 @@ class VideoSubcommand(CLISubcommand):
             )
             mode.add_argument("--output-dir", type=Path, default=Path("h3-output"))
             mode.add_argument(
+                "--host-memory-mode",
+                choices=("auto", "pinned", "mmap"),
+                default="auto",
+                help="Use disk-backed CPU weights on hosts below 128 GiB RAM",
+            )
+            mode.add_argument("--host-memory-directory")
+            mode.add_argument(
                 "--video-encoder",
                 choices=("libx264", "h264_nvenc"),
                 default="libx264",
@@ -111,6 +118,8 @@ class VideoSubcommand(CLISubcommand):
             int8_weight_layout=args.int8_weight_layout,
             residual_sequence_parallel=args.residual_sequence_parallel,
             video_encoder=args.video_encoder,
+            host_memory_mode=args.host_memory_mode,
+            host_memory_directory=args.host_memory_directory,
         )
         if args.video_mode == "serve":
             from vllm.video.server import serve

--- a/vllm/model_executor/models/minimax_h3/config.py
+++ b/vllm/model_executor/models/minimax_h3/config.py
@@ -44,8 +44,12 @@ class H3Config:
     int8_weight_layout: str = "column"
     residual_sequence_parallel: bool = False
     video_encoder: Literal["libx264", "h264_nvenc"] = "libx264"
+    host_memory_mode: Literal["auto", "pinned", "mmap"] = "auto"
+    host_memory_directory: str | None = None
 
     def __post_init__(self) -> None:
+        if self.host_memory_mode not in ("auto", "pinned", "mmap"):
+            raise H3InputError("host memory mode must be auto, pinned or mmap")
         if self.video_encoder not in ("libx264", "h264_nvenc"):
             raise H3InputError("video encoder must be libx264 or h264_nvenc")
         if self.partition not in ("fl2va", "ref2va"):

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager, nullcontext
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -22,8 +23,10 @@ from torch import nn
 from tqdm.auto import tqdm
 from transformers import Qwen2TokenizerFast, Qwen3VLProcessor
 
+from vllm import envs
 from vllm.distributed import get_tp_group, get_world_group
 from vllm.logger import init_logger
+from vllm.utils.mem_utils import get_cpu_memory
 from vllm.video.metrics import DenoiseWorkCounter
 
 from .attention import attention_backend
@@ -81,7 +84,7 @@ from .reference_video import (
     validate_reference_audio_files,
     validate_reference_audio_waveforms,
 )
-from .residency import PinnedModuleStager
+from .residency import MMapHostWeights, PinnedModuleStager
 from .sigma_schedule import DMD2SigmaSchedule
 from .time_request import (
     MINIMAX_H3_SHAPE_PLANNER,
@@ -428,6 +431,22 @@ class MiniMaxH3Pipeline(nn.Module):
         self.config = config
         self.partition = config.partition
         self.device = torch.device("cuda", torch.accelerator.current_device_index())
+        use_mmap = config.host_memory_mode == "mmap" or (
+            config.host_memory_mode == "auto" and get_cpu_memory() < 128 * 1024**3
+        )
+        self._host_backing = (
+            MMapHostWeights(
+                config.host_memory_directory or Path(envs.VLLM_CACHE_ROOT) / "h3-host"
+            )
+            if use_mmap
+            else None
+        )
+        if self._host_backing is not None:
+            logger.info(
+                "H3 uses reclaimable disk-backed host weights at %s; "
+                "weights and compute precision are unchanged",
+                self._host_backing.directory,
+            )
         from .fasth3 import FastH3Fusion, FastH3Spec
         from .flashgen import FlashGenSpec, restore_dense_adaln_weights
         from .lora import inspect_deployment_adapter, select_adapter_file
@@ -497,6 +516,10 @@ class MiniMaxH3Pipeline(nn.Module):
             )
         finally:
             attention_backend.reset(token)
+        if self._host_backing is not None:
+            PinnedModuleStager.map_cpu_weights(
+                self.transformer, self._host_backing, preserve_parameters=False
+            )
         weights = iter_checkpoint_weights(transformer_path)
         if restore_adaln:
             weights = restore_dense_adaln_weights(weights, path / "transformer")
@@ -521,6 +544,8 @@ class MiniMaxH3Pipeline(nn.Module):
             method = getattr(layer, "quant_method", None)
             if method is not None:
                 method.process_weights_after_loading(layer)
+                if self._host_backing is not None:
+                    PinnedModuleStager.map_cpu_weights(layer, self._host_backing)
         self.transformer.post_load_weights()
         self.turbo_spec = None
         if fusion is not None:
@@ -531,7 +556,9 @@ class MiniMaxH3Pipeline(nn.Module):
             self.turbo_spec = install_adapter(
                 self.transformer, config.lora_path, self.partition
             )
-        self._dit_stager = PinnedModuleStager(self.transformer, self.device)
+        self._dit_stager = PinnedModuleStager(
+            self.transformer, self.device, host_backing=self._host_backing
+        )
         self._weight_cache = FP16WeightCache(
             self.transformer,
             budget_gib=config.fp16_weight_cache_gib,
@@ -552,8 +579,14 @@ class MiniMaxH3Pipeline(nn.Module):
             load_model=True,
             encoder_group=self.text_encoder_group,
         )
+        if self._host_backing is not None:
+            PinnedModuleStager.map_cpu_weights(
+                self.text_encoder, self._host_backing, preserve_parameters=False
+            )
         self.text_encoder.load_weights(iter_checkpoint_weights(shared / "text_encoder"))
-        self._encoder_stager = PinnedModuleStager(self.text_encoder, self.device)
+        self._encoder_stager = PinnedModuleStager(
+            self.text_encoder, self.device, host_backing=self._host_backing
+        )
         self.video_vae = MiniMaxH3VideoVAE(
             str(shared / "video_vae"),
             device=self.device,

--- a/vllm/model_executor/models/minimax_h3/residency.py
+++ b/vllm/model_executor/models/minimax_h3/residency.py
@@ -5,9 +5,13 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
+import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import chain
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -29,6 +33,49 @@ def set_tensor_storage(target, value):
 
 
 logger = init_logger(__name__)
+
+
+class MMapHostWeights:
+    """Reclaimable CPU masters with disk space reserved before mapping.
+
+    Files are unlinked once mapped. The kernel keeps storage alive while tensors
+    reference it, and releases it even if a worker is killed. No model files are
+    modified and no stale offload files need to be recovered after a crash.
+    """
+
+    def __init__(self, directory: str | Path):
+        self.directory = Path(directory).expanduser().resolve()
+        self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.prefix = f"h3-{os.getpid()}-{uuid.uuid4().hex}-"
+        self.bytes_reserved = 0
+
+    def snapshot(self, source: torch.Tensor, *, preserve: bool = True) -> torch.Tensor:
+        if source.device.type != "cpu" or source.dtype != torch.uint8:
+            raise ValueError("Host backing requires a CPU storage byte view")
+        if not source.numel():
+            return source.detach()
+        filename = source.untyped_storage().filename
+        if filename and str(filename).startswith(str(self.directory / self.prefix)):
+            return source.detach()
+        fd, filename = tempfile.mkstemp(prefix=self.prefix, dir=self.directory)
+        try:
+            # ftruncate alone can SIGBUS later if the disk fills during loading.
+            os.posix_fallocate(fd, 0, source.numel())
+            master = torch.from_file(
+                filename, shared=True, size=source.numel(), dtype=torch.uint8
+            )
+            if preserve:
+                master.copy_(source)
+            self.bytes_reserved += source.numel()
+            return master
+        except OSError as error:
+            raise RuntimeError(
+                "H3 host offload could not reserve disk storage at "
+                f"{self.directory}: {error}"
+            ) from error
+        finally:
+            os.close(fd)
+            Path(filename).unlink(missing_ok=True)
 
 
 class BoundedAllocatorCache:
@@ -125,6 +172,7 @@ class PinnedModuleStager:
         device: torch.device,
         *,
         pin_memory: bool = True,
+        host_backing: MMapHostWeights | None = None,
         copy_stream: Any | None = None,
         cache_retention: BoundedAllocatorCache | None = None,
     ) -> None:
@@ -139,7 +187,9 @@ class PinnedModuleStager:
         self._ready_event = torch.cuda.Event()
         self.cache_retention = cache_retention
         self.loaded = False
-        self._groups = self._snapshot_groups(modules, pin_memory=pin_memory)
+        self._groups = self._snapshot_groups(
+            modules, pin_memory=pin_memory, host_backing=host_backing
+        )
         self._device_storages: list[torch.Tensor] = []
         self._restore_masters()
 
@@ -153,6 +203,8 @@ class PinnedModuleStager:
         modules: tuple[nn.Module, ...],
         *,
         pin_memory: bool,
+        host_backing: MMapHostWeights | None = None,
+        preserve_parameters: bool = True,
     ) -> list[_StorageGroup]:
         targets: list[torch.Tensor] = []
         seen_targets: set[int] = set()
@@ -204,7 +256,12 @@ class PinnedModuleStager:
                 if storage_view.device.type == "cpu"
                 else storage_view.to("cpu")
             )
-            if pin_memory and not master.is_pinned():
+            if host_backing is not None:
+                preserve = preserve_parameters or any(
+                    not isinstance(binding.target, nn.Parameter) for binding in bindings
+                )
+                master = host_backing.snapshot(master, preserve=preserve)
+            elif pin_memory and not master.is_pinned():
                 master = master.pin_memory()
             groups.append(_StorageGroup(master=master, bindings=bindings))
             # Release each pageable allocation as soon as its pinned master is
@@ -213,6 +270,22 @@ class PinnedModuleStager:
             for binding in bindings:
                 set_tensor_storage(binding.target, cls._view(master, binding))
         return groups
+
+    @classmethod
+    def map_cpu_weights(
+        cls,
+        module: nn.Module,
+        backing: MMapHostWeights,
+        *,
+        preserve_parameters: bool = True,
+    ) -> None:
+        """Bind CPU storage before streaming writes, avoiding a full anonymous copy."""
+        cls._snapshot_groups(
+            (module,),
+            pin_memory=False,
+            host_backing=backing,
+            preserve_parameters=preserve_parameters,
+        )
 
     @staticmethod
     def _view(backing: torch.Tensor, binding: _TensorBinding) -> torch.Tensor:


### PR DESCRIPTION
## Purpose

H3 TP4 loading exhausted the four-V100 host's 64 GiB system RAM after GPU selection and collectives succeeded. Store DiT and encoder CPU masters in reclaimable file mappings on smaller hosts, while preserving weight bytes, tensor aliases, GPU kernels and sampling. Reserve disk before mapping and immediately unlink mapped files so worker crashes cannot leave large offload files behind. Explicit pinned/mmap options remain available.

The source-wheel extraction path also retains all three H3 native operators, allowing this Python-only change to reuse the exact native libraries compiled from the current source during the same deployment.

Base: `a9cfe620127f04888400f7fba91c23699174832f`. Head: `9f111147204b55d35eb11b3c188842af55ed01bb`.

## Test Plan and Result

- Host-memory and FastH3 CPU suites: 35 passed, 1 GPU test skipped, 1 CUDA case deselected.
- Staged pre-commit hooks passed, including mypy and documentation lint.
- Covers byte-exact storage aliases/strides, fused checkpoint writes, buffer preservation, disk reservation failure/cleanup, and packaging of H3 native operators.
- Isolated candidate wheel installed; all 13 native libraries are SHA256-identical to the campaign’s full SM70 source build. `python -m pip check` passed.
- Actual V100 test: `python -m pytest src/tests/video/test_h3_host_memory.py -q` — 7 passed, including three byte-exact GPU load/offload cycles.
- Studio-managed H3 Turbo4, TP4 / 4×V100-SXM2-32GB / 64 GiB host: loading and generation completed without a new kernel OOM. ModelScope FL2VA INT8 plus original Turbo4 adapter, FP16 staging, Flash-V100, seed 42, 107 frames, 1344×768, 4 denoiser updates.
- Saved MP4 verified: 107 frames, 24 FPS, 4.458333 seconds, AAC stereo. Four-frame visual check shows coherent boat/duck/water imagery; this is an operational smoke, not a full temporal or prompt-adherence quality benchmark.
- Generation-to-save elapsed 147.93 s; native denoising 67.5 s. No same-contract pinned baseline exists on this 64 GiB host because it OOMs, so no speedup is claimed. The runtime keeps H3 experimental.

Original OOM and raw deployment evidence are retained in `/home/ymzx/1cat-vllm-deploy/studio-main-20260909/`; candidate evidence is retained in `/home/ymzx/1cat-vllm-deploy/h3-host-memory-20260909/`.

## Scope and Limitations

Open-PR checks found kernel/workflow changes (#571/#578), but no duplicate host-weight residency fix. This scope does not change those kernels. File-backed staging needs local disk capacity and can slow CPU→GPU transfers; transient activations still require RAM. Automatic mode uses physical host RAM, with an explicit override for constrained containers.

AI assistance: implementation and tests prepared with OpenAI Codex at the maintainer's request.
