### PR TITLE
[Feature] Native Z-Image jobs and true H3 creation progress

### DIFF
--- a/docs/design/native_media/CREATIVE_JOBS.md
+++ b/docs/design/native_media/CREATIVE_JOBS.md
@@ -21,8 +21,12 @@ for authenticated asset storage and model lifecycle confirmation.
 Z-Image's tokenizer, Qwen encoder, diffusion transformer, scheduler and VAE are
 loaded exclusively from a local directory downloaded and verified by ModelScope.
 No remote model code or automatic Hub fallback is enabled. The transformer and
-text encoder use FP16; latents, classifier-free guidance and VAE decoding use
-FP32. Turbo uses eight nonzero sampler updates; base uses fifty with CFG 4.
+text encoder use FP16 weights; latents, classifier-free guidance and VAE decoding
+use FP32. Projection accumulators and SwiGLU gating retain FP32 range before
+normalization. Base additionally keeps attention, AdaLN scaling and residuals in
+FP32 because its learned modulation exceeds FP16 range. It retains FP16 weights
+and fits one V100 32 GB, but is slower than Turbo. No outlier clamping is used.
+Turbo uses eight nonzero sampler updates; base uses fifty with CFG 4.
 Component implementations are pinned to Diffusers 0.40.0 and Transformers 5.15.1.
 The reference sampler is Tongyi-MAI/Z-Image commit
 26f23eda626ffadda020b04ff79488e1d72004cd (Apache-2.0).

--- a/docs/design/native_media/CREATIVE_JOBS.md
+++ b/docs/design/native_media/CREATIVE_JOBS.md
@@ -34,10 +34,43 @@ The reference sampler is Tongyi-MAI/Z-Image commit
 Image editing is deliberately outside this capability. The model registry must
 not advertise image editing, unsupported output sizes or unverified GPU quality.
 
-## Acceptance status
+## Acceptance — 2026-09-09
 
-CPU protocol and cancellation tests are included. V100 generation quality,
-fixed-seed progress on/off parity and Studio frontend acceptance are pending.
-This document does not establish model or workflow availability. Record source
-and model hashes, explicit GPU scope, dimensions, sampler recipe, output hashes,
-quality review, elapsed time and UI run IDs before promoting this integration.
+53 CPU media tests pass, covering protocol compatibility, real step counting,
+queued/running cancellation, restart idempotency, FP16 outlier handling, corrupt
+saved records and disk failure without a stalled queue. Pre-commit and CI pass.
+
+Actual Studio frontend runs on V100 SXM2 32 GB / PyTorch 2.10 / CUDA 12.8 produced:
+
+- Z-Image Turbo and Base: 1024 × 1024 PNG, seed 42, respectively 8 and 50 updates.
+- H3 Turbo 4: text, first/last-frame and image-reference videos, each 1344 × 768,
+  107 frames at 24 fps (4.458333 s), with synchronous 32 kHz stereo audio.
+- The image run uses one explicitly selected V100; H3 uses four. Display GPU is
+  excluded. ABI-matching SM70 extensions from `b6d91d61ff` are reused; this PR
+  changes no CUDA/C++ source and makes no power-policy changes.
+
+Z-Image Base now retains FP32 attention/modulation/residual range after measured
+FP16 overflow in layer 25 Q/K/V and later AdaLN scaling. It fits one 32 GB V100,
+but its 50-update original recipe takes roughly ten minutes in this setup.
+Turbo is the default for interactive creation. Images were visually checked;
+video playback/download and keyframe/reference consistency were checked in UI.
+
+Progress parity with fixed inputs/recipes/seeds:
+
+| Output | Enabled/disabled reporting |
+| --- | --- |
+| Z-Image Turbo PNG | Byte-identical (`a08ca43be383426e…`) |
+| Z-Image Base PNG | Byte-identical (`1d9db6d2e332c65a…`) |
+| Warm H3 keyframe MP4 | Byte-identical (`fb9dc41853af7778…`), including raw audio |
+
+First-run H3 audio has a maximum 5.44e-7 sample difference from warm runs, also
+present with reporting enabled in both runs; enabled/disabled warm outputs
+match exactly. Video frames match in all three cases. These are correctness
+checks, not a throughput benchmark or exhaustive validation of every allowed
+output dimension/duration.
+
+Weights and component code came from the checksum-verified ModelScope catalog:
+`Tongyi-MAI/Z-Image-Turbo`, `Tongyi-MAI/Z-Image`, `MiniMax/MiniMax-H3`,
+`Comfy-Org/MiniMax-H3`, and `lightx2v/Minimax-h3-Turbo`. The original model revision
+and complete manifest hashes are retained in deployment acceptance records.
+No Hub fallback is used by the native image path. Image editing remains disabled.

--- a/docs/design/native_media/CREATIVE_JOBS.md
+++ b/docs/design/native_media/CREATIVE_JOBS.md
@@ -1,0 +1,39 @@
+# Native creative jobs
+
+This change adds a native single-device Z-Image FP16 sampler and asynchronous
+image jobs alongside the existing H3 video engine. Studio remains responsible
+for authenticated asset storage and model lifecycle confirmation.
+
+- Image CLI: `vllm image --model /local/model --checkpoint z-image-turbo --output-dir /local/output`.
+- Image jobs: `POST /v1/images/jobs`, `GET /v1/images/jobs/{id}`, content at
+  `/v1/images/jobs/{id}/content`. Synchronous `/v1/images/generations` remains
+  compatible with URL and base64 results. Queued cancellation is supported;
+  running jobs finish and retain outputs.
+- H3 jobs now report `stage`, `stage_started_at`, `updated_at`, `stage_progress`
+  and `denoise_progress`. Counts are sampler iterations, not output counts.
+  Existing top-level video `progress` retains its legacy output-count meaning.
+- `POST /v1/videos/{id}/cancel` never deletes an already completed output.
+- Progress crosses the existing worker pipe on rank zero. Reporting introduces
+  no tensor transfer, device synchronization, or additional collective.
+
+## Recipes and precision
+
+Z-Image's tokenizer, Qwen encoder, diffusion transformer, scheduler and VAE are
+loaded exclusively from a local directory downloaded and verified by ModelScope.
+No remote model code or automatic Hub fallback is enabled. The transformer and
+text encoder use FP16; latents, classifier-free guidance and VAE decoding use
+FP32. Turbo uses eight nonzero sampler updates; base uses fifty with CFG 4.
+Component implementations are pinned to Diffusers 0.40.0 and Transformers 5.15.1.
+The reference sampler is Tongyi-MAI/Z-Image commit
+26f23eda626ffadda020b04ff79488e1d72004cd (Apache-2.0).
+
+Image editing is deliberately outside this capability. The model registry must
+not advertise image editing, unsupported output sizes or unverified GPU quality.
+
+## Acceptance status
+
+CPU protocol and cancellation tests are included. V100 generation quality,
+fixed-seed progress on/off parity and Studio frontend acceptance are pending.
+This document does not establish model or workflow availability. Record source
+and model hashes, explicit GPU scope, dimensions, sampler recipe, output hashes,
+quality review, elapsed time and UI run IDs before promoting this integration.

--- a/setup.py
+++ b/setup.py
@@ -1411,6 +1411,7 @@ setup(
             "soundfile",
             "mistral_common[audio]",
         ],  # Required for audio processing
+        "image": ["diffusers==0.40.0", "accelerate>=1.12", "nvidia-ml-py"],
         "video": [
             "diffusers==0.40.0",
             "av>=14",

--- a/tests/image/test_jobs.py
+++ b/tests/image/test_jobs.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+from pydantic import ValidationError
+
+from vllm.image.config import ImageConfig, ImageRequest
+from vllm.image.server import create_app
+
+
+class RecordingEngine:
+    def __init__(self, config):
+        self.config = config
+        self.requests = []
+        self.release = threading.Event()
+        self.entered = threading.Event()
+
+    def generate(self, request, output_dir, *, on_progress):
+        self.requests.append(request)
+        on_progress({"stage": "denoising", "completed": 1, "total": 8})
+        self.entered.set()
+        assert self.release.wait(5)
+        output_dir.mkdir(exist_ok=True, parents=True)
+        Image.new("RGB", (request.width, request.height), "orange").save(
+            output_dir / "image.png"
+        )
+        return {"width": request.width, "height": request.height}
+
+    def close(self):
+        pass
+
+
+def wait(client, identity):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        record = client.get(f"/v1/images/jobs/{identity}").json()
+        if record["status"] in {"completed", "failed", "cancelled"}:
+            return record
+        time.sleep(0.01)
+    pytest.fail("Image task did not settle")
+
+
+def test_async_counts_cancel_queue_keep_running_result_and_restart(tmp_path):
+    engine = RecordingEngine(ImageConfig(str(tmp_path)))
+    app = create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    with TestClient(app) as client:
+        try:
+            first = client.post(
+                "/v1/images/jobs",
+                json={"prompt": "A cat"},
+                headers={"Idempotency-Key": "same-key"},
+            ).json()
+            identity = first["id"]
+            assert engine.entered.wait(5)
+            again = client.post(
+                "/v1/images/jobs",
+                json={"prompt": "A cat"},
+                headers={"Idempotency-Key": "same-key"},
+            ).json()
+            assert again["id"] == identity
+            assert again["denoise_progress"] == {"completed": 1, "total": 8}
+            assert client.delete(f"/v1/images/jobs/{identity}").status_code == 409
+            queued = client.post("/v1/images/jobs", json={"prompt": "A dog"}).json()
+            assert (
+                client.delete(f"/v1/images/jobs/{queued['id']}").json()["status"]
+                == "cancelled"
+            )
+        finally:
+            engine.release.set()
+        assert wait(client, identity)["status"] == "completed"
+        assert (
+            client.delete(f"/v1/images/jobs/{identity}").json()["status"] == "completed"
+        )
+        assert (
+            client.get(f"/v1/images/jobs/{identity}/content").headers["content-type"]
+            == "image/png"
+        )
+        assert len(engine.requests) == 1
+    with TestClient(
+        create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    ) as client:
+        assert client.get(f"/v1/images/jobs/{identity}").json()["status"] == "completed"
+        assert client.get(f"/v1/images/jobs/{identity}/content").status_code == 200
+
+
+def test_invalid_model_and_dimensions_do_not_allocate_a_task(tmp_path):
+    engine = RecordingEngine(ImageConfig(str(tmp_path)))
+    with TestClient(
+        create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    ) as client:
+        for body in (
+            {"prompt": " "},
+            {"prompt": "cat", "model": "different"},
+            {"prompt": "cat", "size": "1x1"},
+            {"prompt": "cat", "width": 257},
+            {"prompt": "cat", "size": "1024x768", "height": 1024},
+        ):
+            assert client.post("/v1/images/jobs", json=body).status_code == 422
+    assert not engine.requests
+
+
+def test_sync_compatibility_and_size_alias(tmp_path):
+    engine = RecordingEngine(ImageConfig(str(tmp_path)))
+    engine.release.set()
+    with TestClient(
+        create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    ) as client:
+        response = client.post(
+            "/v1/images/generations",
+            json={"prompt": "A cat", "size": "512x512", "response_format": "b64_json"},
+        )
+        assert response.status_code == 200
+        assert response.json()["data"][0]["b64_json"].startswith("iVBOR")
+        assert engine.requests[0].width == 512
+
+
+@pytest.mark.parametrize(
+    "size", ["0x0", "4096x4096", "1024", "one x two", "256x256x256"]
+)
+def test_size_alias_is_revalidated(size):
+    with pytest.raises(ValidationError):
+        ImageRequest(prompt="cat", size=size)

--- a/tests/image/test_jobs.py
+++ b/tests/image/test_jobs.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import threading
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -123,6 +124,47 @@ def test_sync_compatibility_and_size_alias(tmp_path):
         assert response.status_code == 200
         assert response.json()["data"][0]["b64_json"].startswith("iVBOR")
         assert engine.requests[0].width == 512
+
+
+def test_bad_saved_record_does_not_block_other_image_jobs(tmp_path):
+    broken = tmp_path / ("image_" + "a" * 32) / "job.json"
+    broken.parent.mkdir()
+    broken.write_text('{"unfinished":')
+    engine = RecordingEngine(ImageConfig(str(tmp_path)))
+    engine.release.set()
+    with TestClient(
+        create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    ) as client:
+        assert client.get("/health").status_code == 200
+        identity = client.post("/v1/images/jobs", json={"prompt": "cat"}).json()["id"]
+        assert wait(client, identity)["status"] == "completed"
+        assert broken.read_text() == '{"unfinished":'
+
+
+def test_terminal_disk_failure_releases_waiter_and_does_not_kill_queue(
+    tmp_path, monkeypatch
+):
+    engine = RecordingEngine(ImageConfig(str(tmp_path)))
+    with TestClient(
+        create_app(engine.config, tmp_path, engine_factory=lambda _: engine)
+    ) as client:
+        identity = client.post("/v1/images/jobs", json={"prompt": "cat"}).json()["id"]
+        assert engine.entered.wait(5)
+        replace = Path.replace
+
+        def full(path, target):
+            if path.name == "job.json.tmp":
+                raise OSError("No space left on device")
+            return replace(path, target)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(Path, "replace", full)
+            engine.release.set()
+            failed = wait(client, identity)
+            assert failed["status"] == "failed"
+            assert failed["error"]["code"] == "persistence_failed"
+        following = client.post("/v1/images/jobs", json={"prompt": "dog"}).json()["id"]
+        assert wait(client, following)["status"] == "completed"
 
 
 @pytest.mark.parametrize(

--- a/tests/image/test_jobs.py
+++ b/tests/image/test_jobs.py
@@ -85,6 +85,13 @@ def test_async_counts_cancel_queue_keep_running_result_and_restart(tmp_path):
     ) as client:
         assert client.get(f"/v1/images/jobs/{identity}").json()["status"] == "completed"
         assert client.get(f"/v1/images/jobs/{identity}/content").status_code == 200
+        replay = client.post(
+            "/v1/images/jobs",
+            json={"prompt": "A cat"},
+            headers={"Idempotency-Key": "same-key"},
+        )
+        assert replay.json()["id"] == identity
+        assert len(engine.requests) == 1
 
 
 def test_invalid_model_and_dimensions_do_not_allocate_a_task(tmp_path):

--- a/tests/image/test_precision.py
+++ b/tests/image/test_precision.py
@@ -5,6 +5,7 @@ import torch
 from vllm.model_executor.models.z_image.precision import (
     FP32FeedForward,
     FP32OutputLinear,
+    preserve_projection_range,
 )
 
 
@@ -31,3 +32,47 @@ def test_gating_retains_values_above_fp16_range():
     expected = torch.nn.functional.silu(value.float()) * value.float()
     assert torch.equal(result, expected)
     assert result[0, 0, 0] > torch.finfo(torch.float16).max
+
+
+def test_qk_projection_is_normalized_before_returning_to_half():
+    from diffusers.models.normalization import RMSNorm
+
+    block = torch.nn.Module()
+    block.attention = attention = torch.nn.Module()
+    attention.to_out = torch.nn.ModuleList([torch.nn.Linear(2, 2)])
+    for projection, norm in (("to_q", "norm_q"), ("to_k", "norm_k")):
+        linear = torch.nn.Linear(2, 2, bias=False, dtype=torch.float16)
+        linear.weight.data.fill_(400)
+        setattr(attention, projection, linear)
+        setattr(attention, norm, RMSNorm(2, eps=1e-5).half())
+    preserve_projection_range(block)
+    value = torch.full((1, 3, 2), 400, dtype=torch.float16)
+    for projection, norm in (("to_q", "norm_q"), ("to_k", "norm_k")):
+        projected = getattr(attention, projection)(value)
+        assert projected.max() > torch.finfo(torch.float16).max
+        normalized = getattr(attention, norm)(projected)
+        assert normalized.dtype == torch.float16
+        assert torch.equal(normalized, torch.ones_like(value))
+
+
+def test_base_retains_modulation_and_residual_range_through_final_layer():
+    from diffusers.models.transformers.transformer_z_image import (
+        FinalLayer,
+        ZImageTransformerBlock,
+    )
+
+    torch.manual_seed(42)
+    block = ZImageTransformerBlock(0, 16, 1, 1, 1e-5, True).half()
+    final = FinalLayer(16, 4).half()
+    block.attention_norm1.weight.data.fill_(500)
+    block.adaLN_modulation[0].weight.data.zero_()
+    block.adaLN_modulation[0].bias.data.fill_(500)
+    value = torch.randn(1, 4, 16).half()
+    conditioning = torch.ones(1, 16).half()
+    frequencies = torch.ones(1, 4, 8, dtype=torch.complex64)
+    assert not torch.isfinite(block.attention_norm1(value) * 501).all()
+    preserve_projection_range(torch.nn.ModuleList([block, final]), attention_fp32=True)
+    result = final(block(value, None, frequencies, conditioning), conditioning)
+    assert result.shape == (1, 4, 4)
+    assert result.dtype == torch.float32
+    assert torch.isfinite(result).all()

--- a/tests/image/test_precision.py
+++ b/tests/image/test_precision.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+from vllm.model_executor.models.z_image.precision import (
+    FP32FeedForward,
+    FP32OutputLinear,
+)
+
+
+def test_projection_preserves_outliers_for_following_normalization():
+    linear = torch.nn.Linear(4, 2, bias=False, dtype=torch.float16)
+    linear.weight.data.fill_(400)
+    value = torch.full((1, 3, 4), 400, dtype=torch.float16)
+    result = FP32OutputLinear(linear)(value)
+    assert result.dtype == torch.float32
+    assert torch.isfinite(result).all()
+    assert torch.equal(result, torch.full((1, 3, 2), 640000.0))
+    assert not torch.isfinite(result.half()).all()
+
+
+def test_gating_retains_values_above_fp16_range():
+    original = torch.nn.Module()
+    original.w1 = torch.nn.Linear(2, 2, bias=False, dtype=torch.float16)
+    original.w2 = torch.nn.Linear(2, 2, bias=False, dtype=torch.float16)
+    original.w3 = torch.nn.Linear(2, 2, bias=False, dtype=torch.float16)
+    for layer in (original.w1, original.w2, original.w3):
+        layer.weight.data.copy_(torch.eye(2))
+    value = torch.tensor([[[400.0, -400.0]]], dtype=torch.float16)
+    result = FP32FeedForward(original)(value)
+    expected = torch.nn.functional.silu(value.float()) * value.float()
+    assert torch.equal(result, expected)
+    assert result[0, 0, 0] > torch.finfo(torch.float16).max

--- a/tests/video/test_h3_omni_api.py
+++ b/tests/video/test_h3_omni_api.py
@@ -23,7 +23,7 @@ class RecordingEngine:
         self.requests = []
         self._closed = False
 
-    def generate(self, request, output):
+    def generate(self, request, output, *, on_progress=None):
         for paths in request.media.values():
             assert all(Path(path).is_file() for path in paths)
         self.requests.append(request)

--- a/tests/video/test_h3_progress.py
+++ b/tests/video/test_h3_progress.py
@@ -105,3 +105,34 @@ def test_api_reports_progress_before_output_exists(tmp_path):
                 break
             time.sleep(0.01)
         assert snapshot["stage"] == "completed"
+
+
+def test_queued_device_work_is_not_reported_as_a_completed_step():
+    from vllm.media.progress import DeviceProgress
+
+    ready = threading.Event()
+    arrived = threading.Event()
+    observed: list[dict] = []
+
+    class Fence:
+        def record(self):
+            pass
+
+        def query(self):
+            return ready.is_set()
+
+        def synchronize(self):
+            pytest.fail("Progress must not synchronize the device")
+
+    def callback(event):
+        observed.append(event)
+        arrived.set()
+
+    with DeviceProgress(callback, event_factory=Fence) as observer:
+        observer({"stage": "denoising", "completed": 1, "total": 4})
+        observer({"stage": "decoding"})
+        assert not arrived.wait(0.03)
+        assert not observed
+        ready.set()
+        assert arrived.wait(1)
+    assert [e["stage"] for e in observed] == ["denoising", "decoding"]

--- a/tests/video/test_h3_progress.py
+++ b/tests/video/test_h3_progress.py
@@ -136,3 +136,37 @@ def test_queued_device_work_is_not_reported_as_a_completed_step():
         ready.set()
         assert arrived.wait(1)
     assert [e["stage"] for e in observed] == ["denoising", "decoding"]
+
+
+def test_progress_can_be_disabled_without_changing_the_model_request(tmp_path):
+    captured = []
+
+    class Engine:
+        _closed = False
+
+        def generate(self, request, output, *, on_progress):
+            captured.append((request, on_progress))
+            output.mkdir(parents=True)
+            (output / "video.mp4").write_bytes(b"video")
+            return {"ranks": []}
+
+        def close(self):
+            self._closed = True
+
+    app = create_app(H3Config(), tmp_path, engine_factory=lambda _: Engine())
+    with TestClient(app) as client:
+        for enabled in (True, False):
+            response = client.post(
+                "/v1/videos",
+                json={"prompt": "A cat", "seed": 42},
+                headers={"X-1Cat-Progress": str(enabled).lower()},
+            )
+            identity = response.json()["id"]
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if client.get(f"/v1/videos/{identity}").json()["status"] == "completed":
+                    break
+                time.sleep(0.01)
+        assert captured[0][0] == captured[1][0]
+        assert callable(captured[0][1])
+        assert captured[1][1] is None

--- a/tests/video/test_h3_progress.py
+++ b/tests/video/test_h3_progress.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Progress is request-local and never consumes a worker's terminal reply."""
+
+import multiprocessing
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vllm.media.progress import report, reporting, update_metadata
+from vllm.model_executor.models.minimax_h3.config import H3Config
+from vllm.video.engine import H3Engine
+from vllm.video.server import create_app
+
+
+def test_progress_scope_restores_after_errors():
+    events: list[dict] = []
+    with pytest.raises(ValueError), reporting(events.append):
+        report("encoding")
+        with reporting(None):
+            report("invisible")
+        report("denoising", completed=1, total=4)
+        raise ValueError("failed inference")
+    report("not part of the request")
+    assert events == [
+        {"stage": "encoding"},
+        {"stage": "denoising", "completed": 1, "total": 4},
+    ]
+
+
+def test_receive_consumes_all_progress_before_terminal_reply():
+    parent, child = multiprocessing.Pipe()
+    engine = object.__new__(H3Engine)
+    engine.connections = [parent]
+    engine.workers = []
+    events: list[dict] = []
+    try:
+        child.send({"event": "progress", "stage": "encoding"})
+        child.send(
+            {"event": "progress", "stage": "denoising", "completed": 1, "total": 4}
+        )
+        child.send({"rank": 0, "video": "output.mp4"})
+        assert engine._receive_all(timeout=2, on_progress=events.append) == [
+            {"rank": 0, "video": "output.mp4"}
+        ]
+        assert len(events) == 2
+        assert events[-1]["total"] == 4
+    finally:
+        parent.close()
+        child.close()
+
+
+def test_stage_clock_is_preserved_within_stage_and_counts_are_not_percentages():
+    record: dict = {}
+    update_metadata(record, {"stage": "denoising", "completed": 1, "total": 4}, 10)
+    update_metadata(record, {"stage": "denoising", "completed": 2, "total": 4}, 15)
+    assert record["stage_started_at"] == 10
+    assert record["updated_at"] == 15
+    assert record["denoise_progress"] == {"completed": 2, "total": 4}
+    assert "progress" not in record
+    update_metadata(record, {"stage": "decoding"}, 20)
+    assert record["stage_started_at"] == 20
+    assert record["stage_progress"] is None
+
+
+def test_api_reports_progress_before_output_exists(tmp_path):
+    at_step = threading.Event()
+    finish = threading.Event()
+
+    class Engine:
+        _closed = False
+
+        def generate(self, request, output, *, on_progress):
+            on_progress({"stage": "denoising", "completed": 1, "total": 4})
+            at_step.set()
+            assert finish.wait(5)
+            on_progress({"stage": "decoding"})
+            output.mkdir(parents=True)
+            (output / "video.mp4").write_bytes(b"video")
+            return {"ranks": []}
+
+        def close(self):
+            self._closed = True
+
+    app = create_app(H3Config(), tmp_path, engine_factory=lambda _: Engine())
+    with TestClient(app) as client:
+        try:
+            identity = client.post(
+                "/v1/videos", json={"prompt": "A running cat"}
+            ).json()["id"]
+            assert at_step.wait(5)
+            snapshot = client.get(f"/v1/videos/{identity}").json()
+            assert snapshot["status"] == "in_progress"
+            assert snapshot["stage"] == "denoising"
+            assert snapshot["denoise_progress"] == {"completed": 1, "total": 4}
+            assert client.get(f"/v1/videos/{identity}/content").status_code == 409
+        finally:
+            finish.set()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            snapshot = client.get(f"/v1/videos/{identity}").json()
+            if snapshot["status"] == "completed":
+                break
+            time.sleep(0.01)
+        assert snapshot["stage"] == "completed"

--- a/tests/video/test_h3_service.py
+++ b/tests/video/test_h3_service.py
@@ -17,7 +17,7 @@ class RecordingEngine:
     def __init__(self, config):
         self.config = config
 
-    def generate(self, request, output):
+    def generate(self, request, output, *, on_progress=None):
         self.requests.append(request)
         Path(output).mkdir(parents=True)
         (Path(output) / "video.mp4").write_bytes(b"test video")

--- a/vllm/entrypoints/cli/image.py
+++ b/vllm/entrypoints/cli/image.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Serve the native Z-Image job API from verified local ModelScope components."""
+
+from vllm.entrypoints.cli.types import CLISubcommand
+
+
+class ImageSubcommand(CLISubcommand):
+    name = "image"
+
+    @staticmethod
+    def cmd(args):
+        import uvicorn
+
+        from vllm.image.config import ImageConfig
+        from vllm.image.server import create_app
+
+        app = create_app(ImageConfig(args.model, args.checkpoint), args.output_dir)
+        uvicorn.run(app, host=args.host, port=args.port)
+
+    def subparser_init(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help="Native image generation service"
+        )
+        parser.add_argument(
+            "--model", required=True, help="Verified local Z-Image directory"
+        )
+        parser.add_argument(
+            "--checkpoint",
+            choices=["z-image-turbo", "z-image"],
+            default="z-image-turbo",
+        )
+        parser.add_argument("--output-dir", required=True)
+        parser.add_argument("--host", default="127.0.0.1")
+        parser.add_argument("--port", type=int, default=8090)
+        return parser
+
+
+def cmd_init():
+    return [ImageSubcommand()]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    command = ImageSubcommand()
+    command.subparser_init(parser.add_subparsers(required=True))
+    command.cmd(parser.parse_args())

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -17,6 +17,7 @@ logger = init_logger(__name__)
 def main():
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
+    import vllm.entrypoints.cli.image
     import vllm.entrypoints.cli.launch
     import vllm.entrypoints.cli.openai
     import vllm.entrypoints.cli.run_batch
@@ -33,6 +34,7 @@ def main():
         vllm.entrypoints.cli.collect_env,
         vllm.entrypoints.cli.run_batch,
         vllm.entrypoints.cli.video,
+        vllm.entrypoints.cli.image,
     ]
 
     cli_env_setup()

--- a/vllm/image/__init__.py
+++ b/vllm/image/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native image generation and asynchronous image jobs."""

--- a/vllm/image/config.py
+++ b/vllm/image/config.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RECIPES = {
+    "z-image-turbo": {"steps": 8, "guidance_scale": 0.0, "cfg_truncation": 1.0},
+    "z-image": {"steps": 50, "guidance_scale": 4.0, "cfg_truncation": 1.0},
+}
+RECIPE_VERSION = "z-image-fp16-v1"
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    model: str
+    checkpoint: Literal["z-image-turbo", "z-image"] = "z-image-turbo"
+
+    def __post_init__(self):
+        if self.checkpoint not in RECIPES:
+            raise ValueError("Unsupported native image checkpoint")
+
+
+class ImageRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    prompt: str = Field(min_length=1, max_length=20000)
+    model: str | None = None
+    width: int = Field(default=1024, ge=256, le=2048)
+    height: int = Field(default=1024, ge=256, le=2048)
+    size: str | None = None
+    seed: int = Field(default=42, ge=0, lt=2**63)
+    n: Literal[1] = 1
+    response_format: Literal["url", "b64_json"] = "url"
+
+    @model_validator(mode="after")
+    def validate_size(self):
+        if not self.prompt.strip():
+            raise ValueError("Prompt must contain text")
+        if self.size:
+            try:
+                width, height = (int(x) for x in self.size.split("x"))
+            except ValueError as exc:
+                raise ValueError("Image size must be WIDTHxHEIGHT") from exc
+            for name, value in (("width", width), ("height", height)):
+                if name in self.model_fields_set and getattr(self, name) != value:
+                    raise ValueError("Conflicting image dimensions")
+                setattr(self, name, value)
+        if any(x < 256 or x > 2048 or x % 16 for x in (self.width, self.height)):
+            raise ValueError(
+                "Image dimensions must be multiples of 16 from 256 to 2048"
+            )
+        if self.width * self.height > 2048 * 1024:
+            raise ValueError("Requested image exceeds the native pixel budget")
+        return self

--- a/vllm/image/engine.py
+++ b/vllm/image/engine.py
@@ -6,7 +6,7 @@ import threading
 import time
 from pathlib import Path
 
-from vllm.media.progress import ProgressCallback, report, reporting
+from vllm.media.progress import DeviceProgress, ProgressCallback, report, reporting
 
 from .config import RECIPE_VERSION, RECIPES, ImageConfig, ImageRequest
 
@@ -36,7 +36,7 @@ class ImageEngine:
         *,
         on_progress: ProgressCallback | None = None,
     ):
-        with self._lock, reporting(on_progress):
+        with self._lock, DeviceProgress(on_progress) as observer, reporting(observer):
             if self._closed:
                 raise RuntimeError("Native image engine is closed")
             started = time.perf_counter()

--- a/vllm/image/engine.py
+++ b/vllm/image/engine.py
@@ -58,7 +58,11 @@ class ImageEngine:
                 "model": self.config.checkpoint,
                 "recipe_version": RECIPE_VERSION,
                 "recipe": RECIPES[self.config.checkpoint],
-                "precision": "fp16-fp32-projection-output-and-vae",
+                "precision": (
+                    "fp16-weights-fp32-attention-residual-and-vae"
+                    if self.config.checkpoint == "z-image"
+                    else "fp16-fp32-projection-output-and-vae"
+                ),
                 "stage_seconds": self.pipeline.stage_seconds,
                 "end_to_end_seconds": time.perf_counter() - started,
             }

--- a/vllm/image/engine.py
+++ b/vllm/image/engine.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import os
+import threading
+import time
+from pathlib import Path
+
+from vllm.media.progress import ProgressCallback, report, reporting
+
+from .config import RECIPE_VERSION, RECIPES, ImageConfig, ImageRequest
+
+
+class ImageEngine:
+    def __init__(self, config: ImageConfig):
+        from vllm.video.gpu import GPUGroupLease, acquire_gpu_group, worker_device_mask
+
+        self.config = config
+        self._closed = False
+        self._lock = threading.Lock()
+        self._gpu_lease: GPUGroupLease | None = acquire_gpu_group(1)
+        self.gpu_ids = self._gpu_lease.gpu_ids
+        os.environ["CUDA_VISIBLE_DEVICES"] = worker_device_mask(self.gpu_ids)
+        try:
+            from vllm.model_executor.models.z_image.pipeline import ZImagePipeline
+
+            self.pipeline = ZImagePipeline(config)
+        except BaseException:
+            self.close()
+            raise
+
+    def generate(
+        self,
+        request: ImageRequest,
+        output_dir: Path,
+        *,
+        on_progress: ProgressCallback | None = None,
+    ):
+        with self._lock, reporting(on_progress):
+            if self._closed:
+                raise RuntimeError("Native image engine is closed")
+            started = time.perf_counter()
+            image = self.pipeline(request)
+            report("saving")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            path = output_dir / "image.png"
+            temporary = output_dir / "image.png.tmp"
+            image.save(temporary, format="PNG")
+            from PIL import Image
+
+            with Image.open(temporary) as saved:
+                saved.verify()
+            temporary.replace(path)
+            result = {
+                "width": image.width,
+                "height": image.height,
+                "seed": request.seed,
+                "model": self.config.checkpoint,
+                "recipe_version": RECIPE_VERSION,
+                "recipe": RECIPES[self.config.checkpoint],
+                "precision": "fp16-vae-fp32",
+                "stage_seconds": self.pipeline.stage_seconds,
+                "end_to_end_seconds": time.perf_counter() - started,
+            }
+            (output_dir / "run.json").write_text(json.dumps(result, indent=2))
+            return result
+
+    def close(self):
+        self._closed = True
+        if hasattr(self, "pipeline"):
+            del self.pipeline
+        if self._gpu_lease is not None:
+            self._gpu_lease.close()
+            self._gpu_lease = None

--- a/vllm/image/engine.py
+++ b/vllm/image/engine.py
@@ -58,7 +58,7 @@ class ImageEngine:
                 "model": self.config.checkpoint,
                 "recipe_version": RECIPE_VERSION,
                 "recipe": RECIPES[self.config.checkpoint],
-                "precision": "fp16-vae-fp32",
+                "precision": "fp16-fp32-projection-output-and-vae",
                 "stage_seconds": self.pipeline.stage_seconds,
                 "end_to_end_seconds": time.perf_counter() - started,
             }

--- a/vllm/image/server.py
+++ b/vllm/image/server.py
@@ -119,6 +119,9 @@ def create_app(config: ImageConfig, output_dir: str | Path, *, engine_factory=No
                     },
                 )
                 save(record)
+            jobs[record["id"]] = record
+            done[record["id"]] = asyncio.Event()
+            done[record["id"]].set()
         state["engine"] = await asyncio.to_thread(engine_factory or ImageEngine, config)
         state["ready"] = True
         task = asyncio.create_task(process())

--- a/vllm/image/server.py
+++ b/vllm/image/server.py
@@ -5,6 +5,7 @@
 import asyncio
 import hashlib
 import json
+import logging
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -18,6 +19,8 @@ from fastapi.responses import FileResponse
 from vllm.media.progress import update_metadata
 
 from .config import RECIPE_VERSION, ImageConfig, ImageRequest
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(config: ImageConfig, output_dir: str | Path, *, engine_factory=None):
@@ -66,7 +69,6 @@ def create_app(config: ImageConfig, output_dir: str | Path, *, engine_factory=No
             def apply(event, record=record):
                 if record["status"] == "in_progress":
                     update_metadata(record, event, time.time())
-                    save(record)
 
             def callback(event, loop=loop, apply=apply):
                 loop.call_soon_threadsafe(apply, event)
@@ -98,16 +100,40 @@ def create_app(config: ImageConfig, output_dir: str | Path, *, engine_factory=No
                     },
                 )
             finally:
-                save(record)
-                done[identity].set()
-                queue.task_done()
+                try:
+                    save(record)
+                except OSError:
+                    logger.exception("Could not persist image job %s", identity)
+                    update_metadata(record, {"stage": "failed"}, time.time())
+                    record.update(
+                        status="failed",
+                        error={
+                            "code": "persistence_failed",
+                            "message": "Could not save image job state; "
+                            "check free disk space and permissions",
+                        },
+                    )
+                finally:
+                    done[identity].set()
+                    queue.task_done()
 
     @asynccontextmanager
     async def lifespan(app):
         root.mkdir(parents=True, exist_ok=True)
         # A process restart cannot replay a submitted request without consent.
         for path in root.glob("image_*/job.json"):
-            record = json.loads(path.read_text())
+            try:
+                record = json.loads(path.read_text())
+                if (
+                    not isinstance(record, dict)
+                    or record.get("id") != path.parent.name
+                    or record.get("status")
+                    not in {"queued", "in_progress", "completed", "failed", "cancelled"}
+                ):
+                    raise ValueError("Invalid saved image job")
+            except (OSError, ValueError, TypeError):
+                logger.warning("Skipping unreadable image job: %s", path)
+                continue
             if record["status"] in {"queued", "in_progress"}:
                 update_metadata(record, {"stage": "failed"}, time.time())
                 record.update(

--- a/vllm/image/server.py
+++ b/vllm/image/server.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native image jobs with persisted terminal state and synchronous compatibility."""
+
+import asyncio
+import hashlib
+import json
+import time
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pybase64 as base64
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import FileResponse
+
+from vllm.media.progress import update_metadata
+
+from .config import RECIPE_VERSION, ImageConfig, ImageRequest
+
+
+def create_app(config: ImageConfig, output_dir: str | Path, *, engine_factory=None):
+    from .engine import ImageEngine
+
+    root = Path(output_dir).absolute()
+    queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=32)
+    jobs: dict[str, dict] = {}
+    done: dict[str, asyncio.Event] = {}
+    state: dict[str, Any] = {"ready": False, "closing": False, "engine": None}
+
+    def save(record):
+        folder = root / record["id"]
+        folder.mkdir(parents=True, exist_ok=True)
+        temporary = folder / "job.json.tmp"
+        temporary.write_text(json.dumps(record, ensure_ascii=False))
+        temporary.replace(folder / "job.json")
+
+    def get(identity):
+        if (
+            not identity.startswith("image_")
+            or len(identity) != 38
+            or not all(c in "0123456789abcdef" for c in identity[6:])
+        ):
+            raise HTTPException(404, "Image job not found")
+        if identity not in jobs:
+            try:
+                jobs[identity] = json.loads((root / identity / "job.json").read_text())
+            except (OSError, ValueError) as exc:
+                raise HTTPException(404, "Image job not found") from exc
+        return jobs[identity]
+
+    async def process():
+        while True:
+            identity = await queue.get()
+            if identity is None:
+                queue.task_done()
+                return
+            record = jobs[identity]
+            if record["status"] != "queued":
+                queue.task_done()
+                continue
+            record.update(status="in_progress", started_at=time.time())
+            loop = asyncio.get_running_loop()
+
+            def apply(event, record=record):
+                if record["status"] == "in_progress":
+                    update_metadata(record, event, time.time())
+                    save(record)
+
+            def callback(event, loop=loop, apply=apply):
+                loop.call_soon_threadsafe(apply, event)
+
+            try:
+                result = await asyncio.to_thread(
+                    state["engine"].generate,
+                    ImageRequest.model_validate(record["request"]),
+                    root / identity,
+                    on_progress=callback,
+                )
+                if not (root / identity / "image.png").is_file():
+                    raise RuntimeError("Native engine returned without an image")
+                update_metadata(record, {"stage": "completed"}, time.time())
+                record.update(
+                    status="completed",
+                    completed_at=time.time(),
+                    result=result,
+                    content_url=f"/v1/images/jobs/{identity}/content",
+                )
+            except Exception as exc:
+                update_metadata(record, {"stage": "failed"}, time.time())
+                record.update(
+                    status="failed",
+                    completed_at=time.time(),
+                    error={
+                        "code": "generation_failed",
+                        "message": str(exc),
+                    },
+                )
+            finally:
+                save(record)
+                done[identity].set()
+                queue.task_done()
+
+    @asynccontextmanager
+    async def lifespan(app):
+        root.mkdir(parents=True, exist_ok=True)
+        # A process restart cannot replay a submitted request without consent.
+        for path in root.glob("image_*/job.json"):
+            record = json.loads(path.read_text())
+            if record["status"] in {"queued", "in_progress"}:
+                update_metadata(record, {"stage": "failed"}, time.time())
+                record.update(
+                    status="failed",
+                    error={
+                        "code": "interrupted",
+                        "message": "Native image service restarted; "
+                        "retry creates a new job",
+                    },
+                )
+                save(record)
+        state["engine"] = await asyncio.to_thread(engine_factory or ImageEngine, config)
+        state["ready"] = True
+        task = asyncio.create_task(process())
+        try:
+            yield
+        finally:
+            state.update(ready=False, closing=True)
+            while not queue.empty():
+                identity = queue.get_nowait()
+                queue.task_done()
+                if identity:
+                    record = jobs[identity]
+                    record.update(
+                        status="cancelled", stage="cancelled", updated_at=time.time()
+                    )
+                    save(record)
+                    done[identity].set()
+            await queue.put(None)
+            await task  # Do not release the GPU lease while its worker still runs.
+            await asyncio.to_thread(state["engine"].close)
+
+    app = FastAPI(title="1Cat native image API", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health():
+        if not state["ready"]:
+            raise HTTPException(503, "Native image engine unavailable")
+        return {
+            "status": "ok",
+            "kind": "image",
+            "checkpoint": config.checkpoint,
+            "recipe_version": RECIPE_VERSION,
+        }
+
+    @app.get("/v1/models")
+    async def models():
+        return {
+            "object": "list",
+            "data": [{"id": config.checkpoint, "object": "model", "owned_by": "1Cat"}],
+        }
+
+    def submit(body: ImageRequest, request_key: str | None):
+        if not state["ready"]:
+            raise HTTPException(503, "Native image engine unavailable")
+        if body.model and body.model not in {config.checkpoint, config.model}:
+            raise HTTPException(422, "Requested checkpoint is not loaded")
+        if request_key and len(request_key) > 128:
+            raise HTTPException(422, "Idempotency key is too long")
+        body_hash = hashlib.sha256(body.model_dump_json().encode()).hexdigest()
+        if request_key:
+            for record in jobs.values():
+                if record.get("request_key") == request_key:
+                    if record["request_hash"] != body_hash:
+                        raise HTTPException(
+                            409, "Idempotency key already used with different input"
+                        )
+                    return record
+        if queue.full():
+            raise HTTPException(429, "Native image queue is full")
+        identity = "image_" + uuid.uuid4().hex
+        now = time.time()
+        record = {
+            "id": identity,
+            "object": "image.job",
+            "model": config.checkpoint,
+            "status": "queued",
+            "stage": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "stage_started_at": now,
+            "stage_progress": None,
+            "denoise_progress": None,
+            "request": body.model_dump(),
+            "request_key": request_key,
+            "request_hash": body_hash,
+        }
+        save(record)
+        jobs[identity] = record
+        done[identity] = asyncio.Event()
+        queue.put_nowait(identity)
+        return record
+
+    @app.post("/v1/images/jobs", status_code=202)
+    async def create(
+        body: ImageRequest, idempotency_key: str | None = Header(default=None)
+    ):
+        return submit(body, idempotency_key)
+
+    @app.get("/v1/images/jobs/{identity}")
+    async def status(identity: str):
+        return get(identity)
+
+    @app.get("/v1/images/jobs/{identity}/content")
+    async def content(identity: str):
+        record = get(identity)
+        if record["status"] != "completed":
+            raise HTTPException(409, "Image is not ready")
+        path = root / identity / "image.png"
+        if not path.is_file():
+            raise HTTPException(410, "Image output is missing")
+        return FileResponse(path, media_type="image/png", filename=identity + ".png")
+
+    @app.delete("/v1/images/jobs/{identity}")
+    async def cancel(identity: str):
+        record = get(identity)
+        if record["status"] == "in_progress":
+            raise HTTPException(
+                409,
+                "Running image generation cannot be interrupted; "
+                "its output will be saved",
+            )
+        if record["status"] == "queued":
+            update_metadata(record, {"stage": "cancelled"}, time.time())
+            record["status"] = "cancelled"
+            save(record)
+            done[identity].set()
+        return record
+
+    @app.post("/v1/images/generations")
+    async def compatible(body: ImageRequest):
+        record = submit(body, None)
+        await done[record["id"]].wait()
+        if record["status"] != "completed":
+            raise HTTPException(
+                500, record.get("error", {"message": "Image job cancelled"})
+            )
+        if body.response_format == "b64_json":
+            encoded = await asyncio.to_thread(
+                (root / record["id"] / "image.png").read_bytes
+            )
+            output = {"b64_json": base64.b64encode(encoded).decode()}
+        else:
+            output = {"url": record["content_url"]}
+        return {"created": record["created_at"], "data": [output]}
+
+    return app

--- a/vllm/media/__init__.py
+++ b/vllm/media/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared native image and video task utilities."""

--- a/vllm/media/progress.py
+++ b/vllm/media/progress.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-local progress without device synchronization or tensor transfers."""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+ProgressCallback = Callable[[dict[str, Any]], None]
+_callback: ContextVar[ProgressCallback | None] = ContextVar(
+    "media_progress_callback", default=None
+)
+
+
+@contextmanager
+def reporting(callback: ProgressCallback | None) -> Iterator[None]:
+    token = _callback.set(callback)
+    try:
+        yield
+    finally:
+        _callback.reset(token)
+
+
+def report(stage: str, *, completed: int | None = None, total: int | None = None):
+    callback = _callback.get()
+    if callback is None:
+        return
+    event: dict[str, Any] = {"stage": stage}
+    if completed is not None and total is not None:
+        if not 0 <= completed <= total or total <= 0:
+            raise ValueError("Invalid media stage count")
+        event["completed"] = completed
+        event["total"] = total
+    callback(event)
+
+
+def update_metadata(metadata: dict, event: dict, now: float):
+    """Apply events on the API event loop; never infer an overall percentage."""
+    stage = event["stage"]
+    if metadata.get("stage") != stage:
+        metadata.update(stage=stage, stage_started_at=now)
+    metadata["updated_at"] = now
+    metadata["stage_progress"] = (
+        {"completed": event["completed"], "total": event["total"]}
+        if "completed" in event and "total" in event
+        else None
+    )
+    if stage == "denoising":
+        metadata["denoise_progress"] = metadata["stage_progress"]

--- a/vllm/media/progress.py
+++ b/vllm/media/progress.py
@@ -13,6 +13,27 @@ _callback: ContextVar[ProgressCallback | None] = ContextVar(
 )
 
 
+def report_loading(completed, total, component, *, rank=0, world_size=1):
+    """Startup progress travels via the existing owned process log."""
+    import json
+
+    print(
+        "ONECAT_MEDIA_PROGRESS "
+        + json.dumps(
+            {
+                "stage": "loading_weights",
+                "completed": completed,
+                "total": total,
+                "component": component,
+                "unit": "components",
+                "rank": rank,
+                "world_size": world_size,
+            }
+        ),
+        flush=True,
+    )
+
+
 @contextmanager
 def reporting(callback: ProgressCallback | None) -> Iterator[None]:
     token = _callback.set(callback)

--- a/vllm/media/progress.py
+++ b/vllm/media/progress.py
@@ -48,3 +48,89 @@ def update_metadata(metadata: dict, event: dict, now: float):
     )
     if stage == "denoising":
         metadata["denoise_progress"] = metadata["stage_progress"]
+
+
+class DeviceProgress:
+    """Publish steps only after their stream events complete, without waiting on GPU.
+
+    A model forward may only enqueue kernels. A small reporting thread polls
+    recorded events, preserving stage order without adding a device/TP barrier.
+    Disabled reporting records no events and starts no thread.
+    """
+
+    def __init__(
+        self, callback: ProgressCallback | None, *, device=0, event_factory=None
+    ):
+        import threading
+        from collections import deque
+
+        self.callback = callback
+        self.device = device
+        self.event_factory = event_factory
+        self.pending: deque[tuple[dict, Any]] = deque()
+        self.condition = threading.Condition()
+        self.closing = False
+        self.stopping = False
+        self.thread: threading.Thread | None = None
+
+    def __enter__(self):
+        import threading
+
+        if self.callback is None:
+            return None
+        self.thread = threading.Thread(
+            target=self._publish, daemon=True, name="media-progress"
+        )
+        self.thread.start()
+        return self.emit
+
+    def emit(self, event):
+        fence = None
+        if event.get("stage") == "denoising" and event.get("completed", 0) > 0:
+            if self.event_factory is not None:
+                fence = self.event_factory()
+            else:
+                import torch
+
+                fence = torch.Event(device=f"cuda:{self.device}", enable_timing=False)
+            fence.record()
+        with self.condition:
+            self.pending.append((dict(event), fence))
+            self.condition.notify()
+
+    def _publish(self):
+        try:
+            while True:
+                with self.condition:
+                    if self.stopping or (self.closing and not self.pending):
+                        return
+                    if not self.pending:
+                        self.condition.wait(0.01)
+                        continue
+                    event, fence = self.pending[0]
+                    if fence is not None and not fence.query():
+                        self.condition.wait(0.01)
+                        continue
+                    self.pending.popleft()
+                if self.callback is not None:
+                    self.callback(event)
+        except Exception:
+            # A broken observer is not a reason to change inference or discard pixels.
+            import logging
+
+            logging.getLogger(__name__).exception("Media progress observer failed")
+
+    def __exit__(self, error_type, *_):
+        if self.thread is None:
+            return
+        with self.condition:
+            self.closing = True
+            if error_type is not None:
+                self.pending.clear()
+            self.condition.notify()
+        # A successful pipeline has already copied the final output to host. Its
+        # step fences are ready. Bound shutdown in case a failed observer blocks.
+        self.thread.join(timeout=5)
+        with self.condition:
+            self.stopping = True
+            self.condition.notify()

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -658,8 +658,11 @@ class MiniMaxH3Pipeline(nn.Module):
 
     @torch.inference_mode()
     def forward(self, request: H3Request):
+        from vllm.media.progress import report
+
         self.stage_durations = {}
         self.actual_dit_calls = 0
+        report("encoding")
         started = time.perf_counter()
         context = self._prepare_request_inputs(
             prompt=request.prompt,
@@ -681,6 +684,7 @@ class MiniMaxH3Pipeline(nn.Module):
             time.perf_counter() - started
         )
         started = time.perf_counter()
+        report("decoding")
         video, audio = self.decode(
             video_latent, audio_latent, height=context["height"], width=context["width"]
         )
@@ -1554,12 +1558,22 @@ class MiniMaxH3Pipeline(nn.Module):
             video_outputs=int(branch.update_mask.sum()),
             audio_outputs=int(branch.audio_update_mask.sum()),
         )
+        from vllm.media.progress import report
+
+        report("loading_weights")
         with self._resident_dit_layers_on_device(enabled=True):
             torch.accelerator.synchronize()
             dist.barrier()
             torch.accelerator.synchronize()
             started = time.perf_counter()
-            with self.progress_bar(total=len(inputs["sigmas_video"]) - 1) as progress:
+            total = len(inputs["sigmas_video"]) - 1
+            report("denoising", completed=0, total=total)
+            with self.progress_bar(total=total) as progress:
+
+                def on_step(step, video, audio):
+                    progress.update()
+                    report("denoising", completed=step + 1, total=total)
+
                 video_rows, audio_rows = minimax_h3_denoise_loop(
                     model=transformer,
                     positive=branch,
@@ -1576,7 +1590,7 @@ class MiniMaxH3Pipeline(nn.Module):
                     audio_cond_noise_aug_for_inference=(
                         MINIMAX_H3_AUDIO_REF_COND_TIMESTEP
                     ),
-                    on_step=lambda step, video, audio: progress.update(),
+                    on_step=on_step,
                 )
             torch.accelerator.synchronize()
             dist.barrier()

--- a/vllm/model_executor/models/minimax_h3/pipeline.py
+++ b/vllm/model_executor/models/minimax_h3/pipeline.py
@@ -430,6 +430,19 @@ class MiniMaxH3Pipeline(nn.Module):
         super().__init__()
         self.config = config
         self.partition = config.partition
+        from vllm.media.progress import report_loading
+
+        def loading(done, component):
+            group = get_tp_group()
+            report_loading(
+                done,
+                4,
+                component,
+                rank=group.rank_in_group,
+                world_size=group.world_size,
+            )
+
+        loading(0, "transformer")
         self.device = torch.device("cuda", torch.accelerator.current_device_index())
         use_mmap = config.host_memory_mode == "mmap" or (
             config.host_memory_mode == "auto" and get_cpu_memory() < 128 * 1024**3
@@ -565,6 +578,7 @@ class MiniMaxH3Pipeline(nn.Module):
             layers=config.fp16_cache_layers,
         )
         self.text_encoder_group = get_tp_group()
+        loading(1, "text_encoder")
         self.text_encoder_tp_size = self.text_encoder_group.world_size
         self._dit_rank = self.text_encoder_group.rank_in_group
         self.tokenizer = Qwen2TokenizerFast.from_pretrained(
@@ -587,12 +601,14 @@ class MiniMaxH3Pipeline(nn.Module):
         self._encoder_stager = PinnedModuleStager(
             self.text_encoder, self.device, host_backing=self._host_backing
         )
+        loading(2, "video_vae")
         self.video_vae = MiniMaxH3VideoVAE(
             str(shared / "video_vae"),
             device=self.device,
             load_device=torch.device("cpu"),
         )
         self.video_vae.set_parallel_size(config.tensor_parallel_size)
+        loading(3, "audio_vae")
         self.audio_vae = MiniMaxH3AudioVAE(
             str(shared / "audio_vae"),
             device=self.device,
@@ -601,6 +617,7 @@ class MiniMaxH3Pipeline(nn.Module):
         self.stage_durations = {}
         self.actual_dit_calls = 0
         self.eval()
+        loading(4, "ready")
 
     def _transformer_for_task(self, task):
         return self.transformer
@@ -1560,7 +1577,7 @@ class MiniMaxH3Pipeline(nn.Module):
         )
         from vllm.media.progress import report
 
-        report("loading_weights")
+        report("staging_model")
         with self._resident_dit_layers_on_device(enabled=True):
             torch.accelerator.synchronize()
             dist.barrier()

--- a/vllm/model_executor/models/z_image/__init__.py
+++ b/vllm/model_executor/models/z_image/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Z-Image FP16 inference with FP32 latents and VAE decoding."""

--- a/vllm/model_executor/models/z_image/pipeline.py
+++ b/vllm/model_executor/models/z_image/pipeline.py
@@ -70,7 +70,9 @@ class ZImagePipeline:
         )
         from .precision import preserve_projection_range
 
-        preserve_projection_range(self.transformer)
+        preserve_projection_range(
+            self.transformer, attention_fp32=config.checkpoint == "z-image"
+        )
         loading(1, "text_encoder")
         self.text_encoder = AutoModel.from_pretrained(
             str(root / "text_encoder"),

--- a/vllm/model_executor/models/z_image/pipeline.py
+++ b/vllm/model_executor/models/z_image/pipeline.py
@@ -138,6 +138,8 @@ class ZImagePipeline:
         report("encoding")
         started = time.perf_counter()
         embeddings = self.encode(request.prompt, recipe["guidance_scale"] > 0)
+        if not all(torch.isfinite(value).all() for value in embeddings):
+            raise RuntimeError("Z-Image text encoder produced non-finite conditioning")
         self.stage_seconds["encoding"] = time.perf_counter() - started
         generator = torch.Generator(self.device).manual_seed(request.seed)
         latents = torch.randn(
@@ -199,6 +201,8 @@ class ZImagePipeline:
                 )[0]
                 report("denoising", completed=index + 1, total=len(times))
         self.stage_seconds["denoising"] = time.perf_counter() - started
+        if not torch.isfinite(latents).all():
+            raise RuntimeError("Z-Image denoiser produced non-finite latents")
         report("decoding")
         started = time.perf_counter()
         self.vae.to(self.device)

--- a/vllm/model_executor/models/z_image/pipeline.py
+++ b/vllm/model_executor/models/z_image/pipeline.py
@@ -68,6 +68,9 @@ class ZImagePipeline:
             .eval()
             .to(self.device)
         )
+        from .precision import preserve_projection_range
+
+        preserve_projection_range(self.transformer)
         loading(1, "text_encoder")
         self.text_encoder = AutoModel.from_pretrained(
             str(root / "text_encoder"),

--- a/vllm/model_executor/models/z_image/pipeline.py
+++ b/vllm/model_executor/models/z_image/pipeline.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Sampler adapted from Tongyi-MAI/Z-Image (Apache-2.0), commit
+# 26f23eda626ffadda020b04ff79488e1d72004cd, src/zimage/pipeline.py.
+"""Native single-device Z-Image sampler using local, versioned components.
+
+Diffusers supplies checkpoint-compatible building blocks, not a separate service.
+The native runtime owns conditioning, sampling, precision and progress. There
+are no Hub downloads, remote model code, or BF16/FlashAttention requirements.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import torch
+from PIL import Image
+
+from vllm.image.config import RECIPES, ImageConfig, ImageRequest
+from vllm.media.progress import report
+
+
+class ZImagePipeline:
+    def __init__(self, config: ImageConfig, device="cuda:0"):
+        from diffusers import (
+            AutoencoderKL,
+            FlowMatchEulerDiscreteScheduler,
+            ZImageTransformer2DModel,
+        )
+        from transformers import AutoModel, AutoTokenizer
+
+        self.config = config
+        self.device = torch.device(device)
+        root = Path(config.model).expanduser().resolve(strict=True)
+        for component in (
+            "transformer",
+            "text_encoder",
+            "tokenizer",
+            "vae",
+            "scheduler",
+        ):
+            if not (root / component).is_dir():
+                raise ValueError(f"Missing local Z-Image component: {component}")
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def loading(completed, component):
+            print(
+                "ONECAT_MEDIA_PROGRESS "
+                + json.dumps(
+                    {
+                        "stage": "loading_weights",
+                        "completed": completed,
+                        "total": 3,
+                        "unit": "components",
+                        "component": component,
+                    }
+                ),
+                flush=True,
+            )
+
+        loading(0, "transformer")
+        self.transformer = (
+            ZImageTransformer2DModel.from_pretrained(
+                str(root / "transformer"),
+                torch_dtype=torch.float16,
+                local_files_only=True,
+            )
+            .eval()
+            .to(self.device)
+        )
+        loading(1, "text_encoder")
+        self.text_encoder = AutoModel.from_pretrained(
+            str(root / "text_encoder"),
+            dtype=torch.float16,
+            local_files_only=True,
+            trust_remote_code=False,
+            attn_implementation="sdpa",
+        ).eval()
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(root / "tokenizer"),
+            local_files_only=True,
+            trust_remote_code=False,
+        )
+        loading(2, "vae")
+        # Official recipe decodes in FP32. FP16 VAE can produce blank images.
+        self.vae = AutoencoderKL.from_pretrained(
+            str(root / "vae"),
+            torch_dtype=torch.float32,
+            local_files_only=True,
+        ).eval()
+        self.vae.enable_tiling()
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            str(root / "scheduler"),
+            local_files_only=True,
+        )
+        loading(3, "ready")
+        self.stage_seconds = {}
+
+    def encode(self, prompt, guided):
+        prompts = [prompt, ""] if guided else [prompt]
+        formatted = [
+            self.tokenizer.apply_chat_template(
+                [{"role": "user", "content": text}],
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=True,
+            )
+            for text in prompts
+        ]
+        inputs = self.tokenizer(
+            formatted,
+            padding="max_length",
+            max_length=512,
+            truncation=True,
+            return_tensors="pt",
+        ).to(self.device)
+        self.text_encoder.to(self.device)
+        try:
+            mask = inputs.attention_mask.bool()
+            hidden = self.text_encoder(
+                input_ids=inputs.input_ids,
+                attention_mask=mask,
+                output_hidden_states=True,
+            ).hidden_states[-2]
+            return [row[row_mask] for row, row_mask in zip(hidden, mask)]
+        finally:
+            self.text_encoder.to("cpu")
+
+    @torch.inference_mode()
+    def __call__(self, request: ImageRequest) -> Image.Image:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+
+        recipe = RECIPES[self.config.checkpoint]
+        self.stage_seconds = {}
+        report("encoding")
+        started = time.perf_counter()
+        embeddings = self.encode(request.prompt, recipe["guidance_scale"] > 0)
+        self.stage_seconds["encoding"] = time.perf_counter() - started
+        generator = torch.Generator(self.device).manual_seed(request.seed)
+        latents = torch.randn(
+            (
+                1,
+                self.transformer.config.in_channels,
+                request.height // 8,
+                request.width // 8,
+            ),
+            generator=generator,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        seq_len = (latents.shape[2] // 2) * (latents.shape[3] // 2)
+        scheduler = self.scheduler
+        sc = scheduler.config
+        slope = (sc.get("max_shift", 1.15) - sc.get("base_shift", 0.5)) / (
+            sc.get("max_image_seq_len", 4096) - sc.get("base_image_seq_len", 256)
+        )
+        shift = sc.get("base_shift", 0.5) + slope * (
+            seq_len - sc.get("base_image_seq_len", 256)
+        )
+        steps = recipe["steps"]
+        # Explicit nonzero sample points: eight updates for Turbo, not nine
+        # sigma points advertised as nine denoise steps. Terminal sigma is zero.
+        scheduler.set_timesteps(
+            sigmas=torch.linspace(1, 1 / steps, steps).tolist(),
+            device=self.device,
+            mu=shift,
+        )
+        times = scheduler.timesteps
+        normalized = ((1000 - times.detach().cpu()) / 1000).tolist()
+        report("denoising", completed=0, total=len(times))
+        started = time.perf_counter()
+        with sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]):
+            for index, timestep in enumerate(times):
+                guided = (
+                    recipe["guidance_scale"] > 0
+                    and normalized[index] <= recipe["cfg_truncation"]
+                )
+                typed = latents.to(torch.float16)
+                model_input = typed.repeat(2, 1, 1, 1) if guided else typed
+                t = ((1000 - timestep) / 1000).expand(model_input.shape[0])
+                prediction = self.transformer(
+                    list(model_input.unsqueeze(2).unbind(0)),
+                    t,
+                    embeddings if guided else embeddings[:1],
+                    return_dict=False,
+                )[0]
+                if guided:
+                    positive, negative = prediction[0].float(), prediction[1].float()
+                    noise = (
+                        positive + recipe["guidance_scale"] * (positive - negative)
+                    )[None]
+                else:
+                    noise = torch.stack([x.float() for x in prediction])
+                latents = scheduler.step(
+                    -noise.squeeze(2), timestep, latents, return_dict=False
+                )[0]
+                report("denoising", completed=index + 1, total=len(times))
+        self.stage_seconds["denoising"] = time.perf_counter() - started
+        report("decoding")
+        started = time.perf_counter()
+        self.vae.to(self.device)
+        try:
+            shift_factor = self.vae.config.shift_factor or 0.0
+            image = self.vae.decode(
+                latents.float() / self.vae.config.scaling_factor + shift_factor,
+                return_dict=False,
+            )[0]
+            if not torch.isfinite(image).all():
+                raise RuntimeError(
+                    "Z-Image produced non-finite pixels; output was not saved"
+                )
+            pixels = (image[0].float() / 2 + 0.5).clamp(0, 1)
+            pixels = (
+                (pixels.permute(1, 2, 0).cpu().numpy() * 255).round().astype("uint8")
+            )
+            self.stage_seconds["decoding"] = time.perf_counter() - started
+            return Image.fromarray(pixels)
+        finally:
+            self.vae.to("cpu")

--- a/vllm/model_executor/models/z_image/precision.py
+++ b/vllm/model_executor/models/z_image/precision.py
@@ -46,11 +46,41 @@ class FP32FeedForward(nn.Module):
         return self.w2(F.silu(self.w1(value)) * self.w3(value))
 
 
-def preserve_projection_range(transformer: nn.Module):
+def preserve_projection_range(transformer: nn.Module, *, attention_fp32=False):
     for block in transformer.modules():
         attention = getattr(block, "attention", None)
         if attention is not None and isinstance(attention.to_out[0], nn.Linear):
             attention.to_out[0] = FP32OutputLinear(attention.to_out[0])
+            # Base checkpoint keys can exceed half range before QK RMSNorm.
+            # Its learned FP16 norm weights return normalized half features,
+            # so attention still uses the efficient FP16 implementation.
+            for projection, norm in (("to_q", "norm_q"), ("to_k", "norm_k")):
+                if getattr(attention, norm, None) is not None:
+                    linear = getattr(attention, projection)
+                    if isinstance(linear, nn.Linear):
+                        setattr(attention, projection, FP32OutputLinear(linear))
+            if attention_fp32:
+                # Base also has outliers in V, which has no following norm.
+                # Keep Q/K norms and SDPA in FP32 to match the value dtype;
+                # projection operands and the rest of the model remain FP16.
+                attention.to_v = FP32OutputLinear(attention.to_v)
+                attention.norm_q.float()
+                attention.norm_k.float()
+                # Keep AdaLN scaling and residual additions in FP32 as well:
+                # Base's large modulation can overflow before Q/K/V even run.
+                for name in (
+                    "attention_norm1",
+                    "attention_norm2",
+                    "ffn_norm1",
+                    "ffn_norm2",
+                ):
+                    getattr(block, name).float()
         feed_forward = getattr(block, "feed_forward", None)
         if feed_forward is not None and isinstance(feed_forward.w2, nn.Linear):
             block.feed_forward = FP32FeedForward(feed_forward)
+        if (
+            attention_fp32
+            and hasattr(block, "norm_final")
+            and isinstance(block.linear, nn.Linear)
+        ):
+            block.linear = FP32OutputLinear(block.linear)

--- a/vllm/model_executor/models/z_image/precision.py
+++ b/vllm/model_executor/models/z_image/precision.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Keep outlier projection outputs finite before the following RMSNorm."""
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class FP32OutputLinear(nn.Module):
+    def __init__(self, linear: nn.Linear):
+        super().__init__()
+        self.weight = linear.weight
+        self.bias = linear.bias
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        # The first noise-refiner attention projection can exceed FP16's 65504
+        # range on official Turbo weights. Clamping loses the following norm's
+        # scale. Keep FP16 operands/tensor cores, but retain the FP32 accumulator.
+        with torch.amp.autocast(value.device.type, enabled=False):
+            if value.is_cuda and value.dtype == self.weight.dtype == torch.float16:
+                output = torch.mm(
+                    value.reshape(-1, value.shape[-1]),
+                    self.weight.t(),
+                    out_dtype=torch.float32,
+                ).reshape(*value.shape[:-1], self.weight.shape[0])
+                return output if self.bias is None else output + self.bias.float()
+            return F.linear(
+                value.float(),
+                self.weight.float(),
+                None if self.bias is None else self.bias.float(),
+            )
+
+
+class FP32FeedForward(nn.Module):
+    def __init__(self, original: nn.Module):
+        super().__init__()
+        self.w1 = FP32OutputLinear(original.w1)
+        self.w2 = FP32OutputLinear(original.w2)
+        self.w3 = FP32OutputLinear(original.w3)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        # Gated activations also exceed half range in the first joint block.
+        # Do not clamp them: retain FP32 through gating and the down projection,
+        # then the checkpoint's existing RMSNorm safely returns FP16 features.
+        return self.w2(F.silu(self.w1(value)) * self.w3(value))
+
+
+def preserve_projection_range(transformer: nn.Module):
+    for block in transformer.modules():
+        attention = getattr(block, "attention", None)
+        if attention is not None and isinstance(attention.to_out[0], nn.Linear):
+            attention.to_out[0] = FP32OutputLinear(attention.to_out[0])
+        feed_forward = getattr(block, "feed_forward", None)
+        if feed_forward is not None and isinstance(feed_forward.w2, nn.Linear):
+            block.feed_forward = FP32FeedForward(feed_forward)

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -16,6 +16,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import cast
 
+from vllm.media.progress import ProgressCallback, reporting
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 
 from .gpu import acquire_gpu_group, worker_device_mask
@@ -67,9 +68,15 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
                 command = connection.recv()
                 if command is None:
                     break
-                request, output_dir = command
+                request, output_dir, track_progress = command
                 torch.accelerator.reset_peak_memory_stats()
-                video, audio = pipeline(request)
+                callback = (
+                    (lambda event: connection.send({"event": "progress", **event}))
+                    if rank == 0 and track_progress
+                    else None
+                )
+                with reporting(callback):
+                    video, audio = pipeline(request)
                 result = {
                     "rank": rank,
                     "stage_seconds": pipeline.stage_durations,
@@ -81,6 +88,8 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
                 if rank == 0:
                     from .media import export_video
 
+                    if callback:
+                        callback({"stage": "packaging"})
                     started = time.perf_counter()
                     result.update(
                         export_video(
@@ -156,7 +165,7 @@ class H3Engine:
             self.close()
             raise
 
-    def _receive_all(self, *, timeout):
+    def _receive_all(self, *, timeout, on_progress: ProgressCallback | None = None):
         from multiprocessing.connection import wait
 
         pending = set(self.connections)
@@ -170,6 +179,10 @@ class H3Engine:
                 message = connection.recv()
                 if "error" in message:
                     raise RuntimeError(message["error"])
+                if message.get("event") == "progress":
+                    if on_progress is not None:
+                        on_progress({k: v for k, v in message.items() if k != "event"})
+                    continue
                 results.append(message)
                 pending.remove(connection)
             for worker, connection in zip(self.workers, self.connections):
@@ -179,7 +192,13 @@ class H3Engine:
                     )
         return sorted(results, key=lambda result: result["rank"])
 
-    def generate(self, request: H3Request, output_dir: str | Path):
+    def generate(
+        self,
+        request: H3Request,
+        output_dir: str | Path,
+        *,
+        on_progress: ProgressCallback | None = None,
+    ):
         import json
 
         from vllm.model_executor.models.minimax_h3.validation import validate_request
@@ -196,9 +215,11 @@ class H3Engine:
             started = time.perf_counter()
             try:
                 for connection in self.connections:
-                    connection.send((request, str(output_dir)))
+                    connection.send((request, str(output_dir), on_progress is not None))
                 with NVMLMonitor(self.gpu_ids, output_dir / "nvml.jsonl"):
-                    ranks = self._receive_all(timeout=24 * 3600)
+                    ranks = self._receive_all(
+                        timeout=24 * 3600, on_progress=on_progress
+                    )
             except BaseException:
                 # A failing rank invalidates the whole communicator. Release
                 # only owned workers instead of reusing a partially alive group.

--- a/vllm/video/engine.py
+++ b/vllm/video/engine.py
@@ -16,7 +16,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import cast
 
-from vllm.media.progress import ProgressCallback, reporting
+from vllm.media.progress import DeviceProgress, ProgressCallback, reporting
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 
 from .gpu import acquire_gpu_group, worker_device_mask
@@ -75,7 +75,10 @@ def _worker(rank, config, gpu_ids, endpoint, connection):
                     if rank == 0 and track_progress
                     else None
                 )
-                with reporting(callback):
+                with (
+                    DeviceProgress(callback, device=rank) as observer,
+                    reporting(observer),
+                ):
                     video, audio = pipeline(request)
                 result = {
                     "rank": rank,

--- a/vllm/video/server.py
+++ b/vllm/video/server.py
@@ -94,7 +94,9 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                         state["engine"].generate,
                         request,
                         directory,
-                        on_progress=on_progress,
+                        on_progress=on_progress
+                        if metadata.get("progress_reporting", True)
+                        else None,
                     )
                     outputs.append(
                         {
@@ -210,6 +212,10 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                     "updated_at": time.time(),
                     "stage_progress": None,
                     "denoise_progress": None,
+                    "progress_reporting": request.headers.get(
+                        "X-1Cat-Progress", "true"
+                    ).lower()
+                    != "false",
                     "created_at": int(time.time()),
                     "partition": config.partition,
                     "size": f"{generation.sampling.width}x{generation.sampling.height}",

--- a/vllm/video/server.py
+++ b/vllm/video/server.py
@@ -19,6 +19,7 @@ from fastapi.responses import FileResponse, PlainTextResponse
 from pydantic import ValidationError
 from starlette.background import BackgroundTask
 
+from vllm.media.progress import update_metadata
 from vllm.model_executor.models.minimax_h3.config import H3Config, H3Request
 
 from .protocol import VideoRequest as VideoRequest
@@ -61,11 +62,20 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
         while True:
             identity = await queue.get()
             job = jobs.get(identity)
-            if job is None:
+            if job is None or job.metadata["status"] == "cancelled":
                 queue.task_done()
                 continue
             metadata = job.metadata
             metadata.update(status="in_progress", started_at=time.time())
+            loop = asyncio.get_running_loop()
+
+            def apply_progress(event, metadata=metadata):
+                if metadata["status"] == "in_progress":
+                    update_metadata(metadata, event, time.time())
+
+            def on_progress(event, loop=loop, apply_progress=apply_progress):
+                loop.call_soon_threadsafe(apply_progress, event)
+
             try:
                 outputs = []
                 for index in range(job.output_count):
@@ -81,7 +91,10 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                         else job.output_dir / f"output_{index}"
                     )
                     result = await asyncio.to_thread(
-                        state["engine"].generate, request, directory
+                        state["engine"].generate,
+                        request,
+                        directory,
+                        on_progress=on_progress,
                     )
                     outputs.append(
                         {
@@ -94,6 +107,7 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                         }
                     )
                     metadata["progress"] = round(100 * (index + 1) / job.output_count)
+                update_metadata(metadata, {"stage": "completed"}, time.time())
                 metadata.update(
                     status="completed",
                     completed_at=time.time(),
@@ -103,6 +117,7 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                 )
                 state["completed"] += 1
             except Exception as exc:
+                update_metadata(metadata, {"stage": "failed"}, time.time())
                 metadata.update(
                     status="failed",
                     error={"code": "generation_failed", "message": str(exc)},
@@ -190,6 +205,11 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
                     "model": config.model,
                     "status": "queued",
                     "progress": 0,
+                    "stage": "queued",
+                    "stage_started_at": time.time(),
+                    "updated_at": time.time(),
+                    "stage_progress": None,
+                    "denoise_progress": None,
                     "created_at": int(time.time()),
                     "partition": config.partition,
                     "size": f"{generation.sampling.width}x{generation.sampling.height}",
@@ -313,6 +333,20 @@ def create_app(config: H3Config, output_dir: str | Path, *, engine_factory=None)
             media_type="video/mp4",
             filename=f"{identity}_{output_index}.mp4",
         )
+
+    @app.post("/v1/videos/{identity}/cancel")
+    async def cancel_video(identity: str):
+        job = find_job(identity)
+        if job.metadata["status"] == "in_progress":
+            raise HTTPException(
+                409, "Running generation cannot be interrupted; output will be retained"
+            )
+        if job.metadata["status"] == "queued":
+            update_metadata(job.metadata, {"stage": "cancelled"}, time.time())
+            job.metadata.update(status="cancelled", completed_at=time.time())
+            job.done.set()
+        # A late cancellation never deletes a completed result.
+        return job.metadata
 
     @app.delete("/v1/videos/{identity}")
     async def delete_video(identity: str):


### PR DESCRIPTION
## Purpose

Add native Z-Image Turbo/Base image jobs and actual H3 lifecycle/denoise progress for a prompt-first creation flow. The image API supports persistent asynchronous jobs and synchronous compatibility; H3 progress uses ordered rank-zero events over the existing worker pipe, with no additional per-step device barrier or collective.

Z-Image uses local, versioned components. Measured V100 FP16 projection and AdaLN overflows are handled by retaining the required FP32 range; Base attention/residuals use FP32 with FP16 stored weights. No outlier clamping, BF16 requirement, CUDA/C++ change, GPU-policy change or Hub download fallback is introduced.

This differs from #578: that PR addresses work/efficiency metrics, while this change adds the image runtime, persistent job protocol and user-visible stage/iteration progress.

## Test Plan and Result

- 53 CPU media tests passed: async/sync APIs, true counts, cancellation, restart idempotency, outlier precision, corrupt records and disk-write failure without a stalled queue.
- Native pre-commit and CI passed. Existing ABI-matching SM70 extensions from b6d91d61ff were reused with PyTorch 2.10 / CUDA 12.8.
- Actual Studio frontend runs on V100 32 GB generated Turbo/Base 1024-square images and H3 text, keyframe and reference-image videos at 1344x768, 107 frames, 24 fps, with stereo audio. Playback/download/reload and media reuse passed.
- Fixed-input progress parity: Turbo/Base PNGs are byte-identical; warm H3 MP4s and raw audio are byte-identical. A first/warm audio difference up to 5.44e-7 also occurs with reporting enabled in both runs.

`docs/design/native_media/CREATIVE_JOBS.md` records the tested recipes and limits. Base's original 50-update recipe takes roughly ten minutes on one V100; Turbo remains the interactive default. These results do not claim exhaustive validation of every allowed output shape/duration.

AI assistance was used for implementation, debugging, tests and review. Contributions are signed off.
