### PR TITLE
[Bugfix][Spec Decode] Share MTP heads through multimodal targets

### DIFF
--- a/tests/v1/spec_decode/test_eagle_weight_sharing.py
+++ b/tests/v1/spec_decode/test_eagle_weight_sharing.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.v1.worker.gpu.spec_decode.eagle import utils
+
+
+class ConditionalTarget(nn.Module):
+    def __init__(self, language_model):
+        super().__init__()
+        self.language_model = language_model
+
+    def get_language_model(self):
+        return self.language_model
+
+
+def make_model():
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.embed_tokens = nn.Embedding(8, 4)
+    model.lm_head = nn.Linear(4, 8, bias=False)
+    return model
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("own_head", ["absent", "identical", "different"])
+def test_loader_shares_target_head_without_replacing_distinct_draft(
+    monkeypatch, wrapped, own_head
+):
+    language_model = make_model()
+    target = ConditionalTarget(language_model) if wrapped else language_model
+    draft = make_model()
+    if own_head == "absent":
+        del draft.lm_head
+    else:
+        draft.has_own_lm_head = True
+        with torch.no_grad():
+            draft.lm_head.weight.copy_(language_model.lm_head.weight)
+            if own_head == "different":
+                draft.lm_head.weight.add_(1)
+    original_head = getattr(draft, "lm_head", None)
+    # Models using a per-layer shared head must receive the same alias too.
+    layer = nn.Module()
+    layer.shared_head = nn.Module()
+    layer.shared_head.head = original_head
+    draft.model.layers = nn.ModuleList([layer])
+    monkeypatch.setattr(utils, "get_model", lambda **_kwargs: draft)
+    monkeypatch.setattr(utils, "get_pp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(
+        "vllm.compilation.backends.set_model_tag", lambda _tag: nullcontext()
+    )
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=object())
+    )
+
+    result = utils.load_eagle_model(target, config)
+
+    expected = original_head if own_head == "different" else language_model.lm_head
+    assert result is draft
+    assert result.model.embed_tokens is language_model.model.embed_tokens
+    assert result.lm_head is expected
+    assert layer.shared_head.head is expected
+    assert result.lm_head.weight.data_ptr() == expected.weight.data_ptr()
+
+
+def test_target_head_resolution_prefers_language_model_and_keeps_fallback():
+    language_model = make_model()
+    wrapper = ConditionalTarget(language_model)
+    wrapper.lm_head = nn.Linear(4, 8, bias=False)
+    assert utils.get_target_lm_head(wrapper, language_model) is language_model.lm_head
+    del language_model.lm_head
+    assert utils.get_target_lm_head(wrapper, language_model) is wrapper.lm_head
+    del wrapper.lm_head
+    assert utils.get_target_lm_head(wrapper, language_model) is None

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -63,7 +63,7 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
                 del draft_inner.embed_tokens
             draft_inner.embed_tokens = target_embed
 
-    target_lm_head = getattr(target_model, "lm_head", None)
+    target_lm_head = get_target_lm_head(target_model, target_language_model)
     draft_lm_head = getattr(eagle_model, "lm_head", None)
     if target_lm_head is not None and _should_share(
         eagle_model, "has_own_lm_head", draft_lm_head, target_lm_head


### PR DESCRIPTION
## Purpose

For a multimodal target with `lm_head` inside `language_model`, `load_eagle_model` only looks at the outer wrapper. It consequently skips sharing the target head with MTP/EAGLE, even when the draft head contains identical weights.

Use the existing `get_target_lm_head(target_model, target_language_model)` helper in the loader. The existing equality guard and per-layer head rebinding remain in place, so a draft's distinct head is preserved.

This follows the upstream vLLM fix in https://github.com/vllm-project/vllm/pull/47914 (related issue: https://github.com/vllm-project/vllm/issues/48700). 1Cat already has the helper, but this call site still uses the outer-only lookup. No open 1Cat PR addressing this missed call site was found in the duplicate-work checks.

## Test Plan

- `.venv/bin/python -m pytest tests/v1/spec_decode/test_eagle_weight_sharing.py -q` using the existing project virtual environment: actual loader with tiny PyTorch modules; plain/wrapped targets; absent, identical and distinct draft heads; embedding and per-layer head aliases; helper fallback.
- `pre-commit run --files vllm/v1/worker/gpu/spec_decode/eagle/utils.py tests/v1/spec_decode/test_eagle_weight_sharing.py`.
- Real Qwen3.8 Flash-Next AWQ-g32 model, 4 x V100 32 GB, TP4, FP16 head, MTP with 3 draft tokens, CUDA Graph enabled. Compare baseline and patched loader using identical settings and a fixed 5 GiB KV cache per GPU. Inspect head identity, storage pointers and weight equality on every rank, then run four deterministic chat requests at concurrency 2.

## Test Result

CPU: baseline **2 failed, 5 passed** (both wrapped-target sharing cases fail); patched **7 passed**. Scoped pre-commit hooks passed.

GPU: all four ranks passed the following checks:

| Check | Baseline | Patched |
| --- | --- | --- |
| Target/draft head is the same object and storage | No | Yes |
| Target/draft head weights are equal | Yes | Yes |
| Embedding shared | Yes | Yes |
| Idle GPU memory after the same requests (MiB/card, `nvidia-smi`) | 30,712 | 30,412 |

Each redundant head shard is FP16 `[62080, 2560]`, or **303.125 MiB**. Observed steady-state device-memory reduction was **300 MiB/card** with fixed KV capacity. The immediate post-loader `memory_allocated()` reading was unchanged; it precedes the runtime's later garbage collection, so it is not evidence of an immediate release or reduced loading peak.

Both runs completed CUDA Graph capture and four requests (concurrency 2, temperature 0, seed 0), with identical choices and token usage. Responses: `READY`, `42`, `苹果`, and the same Python addition function. Each run drafted 24 speculative tokens and accepted 21. These are smoke tests, not a quality or throughput benchmark.

GPU validation uses the existing native runtime built at `752f86495f`; its loader file is identical to the PR base (`fe67339ddf`) before this one-line change. This is a loader integration test, not a full rebuild of the latest main branch. NVFP4 full-model inference was not tested.

AI assistance: Codex assisted with implementation, regression tests and validation under the submitter's direction.
