### PR TITLE
[SM70] FP8-resident MTP experts for AWQ and NVFP4 targets

### DIFF
--- a/docs/design/sm70_awq_fp8_mtp_experts.md
+++ b/docs/design/sm70_awq_fp8_mtp_experts.md
@@ -1,0 +1,71 @@
+# SM70 FP8-resident MTP experts with an AWQ target
+
+This opt-in mode compresses only the unquantized routed experts of a Qwen4Exp MTP draft. It uses the MTP weights already present in the AWQ checkpoint; a separate FP8 checkpoint is not required. The target model, draft attention/router, embeddings, output head and KV precision retain their existing configuration.
+
+## Configuration
+
+Add `"mtp_expert_quantization": "fp8"` to an existing MTP speculative configuration, for example:
+
+```json
+{"method": "mtp", "num_speculative_tokens": 3, "mtp_expert_quantization": "fp8"}
+```
+
+The supported configuration is SM70, FP16 execution, an AWQ checkpoint with unquantized MTP experts, the `Qwen4ExpMTP` draft architecture and the standard rejection sampler. Synthetic acceptance is rejected. NVFP4 target checkpoints and prequantized FP8 MTP checkpoint loading are outside this change.
+
+## Storage and kernel adaptation
+
+The ordinary loader first loads and shards FP16 expert matrices. Each shard is quantized per output row to E4M3, with scales rounded to the FP16 precision consumed by the existing SM70 weight-only FP8 kernel. Packing removes the unpacked weights; execution retains packed FP8 bytes and FP16 scales.
+
+For the tested TP4 model, the expert intermediate width is 160. Both gate/up halves and the down-projection input are zero-padded to 256 before quantization. Unpadded K=160 produced incorrect native GEMM results; merely accepting the layout in the packer is insufficient. The padding is therefore a correctness requirement, with a storage cost.
+
+The loader temporarily needs FP16 weights and conversion buffers. This is a steady-state memory optimization, not a claim of FP8-only loading or reduced loading peak.
+
+## Answer-quality contract
+
+The reference is the same AWQ target, not an unquantized target. Only draft probabilities change. With standard rejection sampling, a proposal drawn from the actual draft distribution q is accepted with probability min(1, p/q); rejection uses the normalized positive part of p-q. This preserves the target distribution p in exact arithmetic regardless of draft quality. Greedy verification uses the target argmax. This change does not modify either verification algorithm or the proposal-probability handoff.
+
+Reduced draft acceptance is allowed. A different random sample with the same seed does not imply a different output distribution. Conversely, finite logprobs or a few correct answers alone do not establish distribution preservation. Finite-precision kernels and batching can also change greedy text, so literal equality is reported separately from answer correctness.
+
+## Validation
+
+Tests use the native SM70 runtime from commit `752f86495f`, with the changed Python modules overlaid from this branch based on `fe67339ddf`. This is not a clean rebuild of all native extensions from the branch. The reused FP8 MoE implementation matches the branch base. The separate output-head-sharing fix is absent from both comparison arms.
+
+- CPU: `tests/models/qwen4_exp/test_mtp_fp8_experts.py`: 12 passed. Covers TP4 shapes, scale rounding, finite/zero rows, input preservation, scoped dispatch, padding equivalence and unsupported configuration guards.
+- V100: `tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py`: 4 passed, M=1/2/8/64, E=16, H=2560, unpadded I=160, top-4 routing. Compares the actual method against explicit reconstruction of its quantized experts and verifies identical CUDA Graph replay. The final committed test and quantizer were rerun successfully (4 passed).
+- Additional V100 probe: padded W13 [512,2560] and W2 [2560,256], GEMM M=1/2/4/8/16/64 and CUDA Graph passed.
+- Existing rejection-sampler test functions executed against the native runtime: adversarial stochastic draft distributions at speculative lengths 1 and 3, 200,000 trials each; corresponding greedy verification and calibrated nucleus checks passed. These isolate sampler behavior and are not an end-to-end benchmark.
+
+Full-model results from matched testing are recorded below. No throughput improvement or broad benchmark-quality guarantee is inferred from the smoke suite.
+
+### Runtime weight inspection
+
+All four TP ranks reported the same values after packing. The original FP16 `w13_weight` and `w2_weight` attributes were absent; a validation-only observer asserted this without changing the quantizer.
+
+| Per-rank expert payload | MiB |
+| --- | ---: |
+| Original FP16 W13 + W2 | 1200 |
+| Packed FP8 W13 + W2 | 960 |
+| FP16 scales for the packed weights | 15 |
+| Packed weights plus scales | 975 |
+| Weight-and-scale saving versus original FP16 | 225 |
+
+Pointer tables, layout metadata and execution buffers are excluded from this payload table. Full GPU usage is measured separately and must not be equated with weight compression alone.
+
+### Full-model paired run
+
+The same Qwen3.8 Flash-Next Uncensored AWQ-g32 checkpoint was run on four V100 32-GiB GPUs, TP4, FP16 activations/KV, MTP3, concurrency 2, CUDA Graphs and configured context length 262144. KV capacity was fixed to 5 GiB per rank, so freed memory could not be consumed by automatic KV sizing. The actual longest test prompt was approximately 7700 tokens; this is not a full-256K-context validation.
+
+| Measurement | FP16 draft experts | FP8 draft experts |
+| --- | ---: | ---: |
+| Idle whole-GPU usage after greedy requests, every rank (MiB) | 30992 | 29962 |
+| Idle whole-GPU usage after stochastic requests, every rank (MiB) | 30992 | 29962 |
+| Complete greedy responses matching the baseline | reference | 16/16 |
+| Stochastic/top-p requests with finite token logprobs | 16/16 | 16/16 |
+
+The observed whole-GPU reduction is 1030 MiB per rank. Only 225 MiB is the weight-and-scale payload reduction above; the rest has not been individually attributed across backend workspaces, allocator reservation and other runtime overhead. These are post-request idle snapshots, not loading peaks, and are specific to this configuration.
+
+Greedy prompts covered arithmetic, probability, Python/JavaScript/SQL, JSON, Chinese/English, translation, summarization and long-key retrieval. Two initially truncated responses were rerun in both arms with a 1024-token limit until natural stop. The final comparison includes the full response choices and token usage, not just matching prefixes. An earlier FP8 run differed from the baseline in two explanatory passages; rerunning those two prompts on the FP16 baseline reproduced the FP8 passages exactly. This establishes an existing reproducibility caveat rather than universal bitwise invariance.
+
+Stochastic requests used temperature 0.8, top-p 0.9, seeds 0 through 15, concurrency 2 and output caps 1/7/64/256. They exercised rejection and subsequent requests with changing lengths without request errors, non-finite returned logprobs or a stuck engine. Different same-seed text is expected when the proposal distribution changes; this smoke suite alone is not a statistical proof of the full-model output distribution. The preservation argument additionally depends on the unchanged target, actual proposal probabilities and standard rejection algorithm described above.
+
+Acceptance counters for the greedy campaign were 1106/1449 (76.33%) for FP16 and 1109/1446 (76.69%) for FP8. This small workload does not establish an acceptance-rate or throughput advantage.

--- a/docs/design/sm70_awq_fp8_mtp_experts.md
+++ b/docs/design/sm70_awq_fp8_mtp_experts.md
@@ -4,7 +4,7 @@ Qwen4Exp MTP experts can retain FP8 storage independently of the AWQ or NVFP4 ta
 
 The checkpoint route backports [vLLM #55513](https://github.com/vllm-project/vllm/pull/55513): ModelOpt `FP8_PB_WO` / `FP8_BLOCK_SCALES` dispatch and AMD/NVIDIA MTP quantization-metadata remapping. This PR adds SM70 storage and TP alignment to that upstream loading support. It does not use the resident-FP16 fallback from [1Cat #553](https://github.com/1CatAI/1Cat-vLLM/pull/553).
 
-**Validation status:** the online AWQ results below are complete. Checkpoint-native CPU loading and real-weight V100 kernel checks have passed; complete-model checkpoint-native AWQ and NVFP4 comparison runs are still in progress. The online results do not establish NVFP4 or native-checkpoint end-to-end acceptance.
+**Validation status:** online and checkpoint-native routes have completed full-model generation tests with both AWQ and NVFP4 targets. CPU loading and real-weight V100 kernel checks have passed. Same-source FP16 controls establish checkpoint-native memory savings for both target formats; the NVFP4 online arm is an additional integration test using that target checkpoint's own unquantized MTP.
 
 ## Configuration
 
@@ -30,7 +30,7 @@ For the tested TP4 model, the expert intermediate width is 160. Both gate/up hal
 
 The online route temporarily needs FP16 weights and conversion buffers. The checkpoint-native route allocates FP8 expert parameters directly and retains the original quantized bytes. At TP4, logical slices begin at offsets 0/32/64/96 within their original 128-wide blocks. Leading zero padding preserves these coordinates in both gate/up rows and down columns, keeping the original scales correctly associated without requantization. Each rank uses a physical width of 256; ordinary vLLM TP loading handles the expanded checkpoint tensors.
 
-The reused SM70 kernel stores scales as FP16. Source scales that become infinite or underflow to zero are rejected. The original BF16 scales in the real-weight probe are exactly representable in FP16; FP32 source scales may round to kernel precision. No reduction in loading peak or increase in speed is claimed.
+The reused SM70 kernel stores scales as FP16. Source scales that become infinite or underflow to zero are rejected. All 1536 original expert scale tensors in the tested NVIDIA draft are exactly representable in FP16; FP32 source scales may round to kernel precision. No reduction in loading peak or increase in speed is claimed.
 
 ## Answer-quality contract
 
@@ -49,14 +49,21 @@ Tests use the native SM70 runtime from commit `752f86495f`, with the changed Pyt
 
 Full-model results from matched testing are recorded below. No throughput improvement or broad benchmark-quality guarantee is inferred from the smoke suite.
 
-### Checkpoint-native validation in progress
+### Checkpoint-native validation
 
-- CPU: 47 tests passed across the online and checkpoint suites. The checkpoint suite covers original byte/scale preservation at TP1/2/4/8, invalid scales, both ModelOpt block-FP8 names, excluded layers, metadata remapping in both backends, complete weight/scale streams and normal TP loading under AWQ/ModelOpt NVFP4/mixed config names.
+- CPU: 48 tests passed across the online and checkpoint suites. The checkpoint suite covers original byte/scale preservation at TP1/2/4/8, invalid scales, both ModelOpt block-FP8 names, excluded layers, metadata remapping in both backends, complete weight/scale streams and normal TP loading under AWQ/ModelOpt NVFP4/mixed config names. Online conversion also covers unquantized ModelOpt experts omitted from mixed quantization metadata.
 - V100: the expanded GPU suite passed 20 tests: four online cases and sixteen checkpoint cases covering TP4 offsets at M=1/2/8/64. All compare reconstructed reference weights and exact CUDA Graph replay.
 - Two original experts from `nvidia/Qwen3.8-Flash-Next-NVFP4` revision `fc694b54fb0174e0913e6adf86691ef85a4ead47` passed the real loader/packer/kernel in four separate V100 processes at M=1/2/8/64. Maximum absolute error versus FP16 reconstruction was 0.0008544921875, relative L2 below 0.00082; graph replay was exact. The original BF16 scales were exactly representable in the kernel's FP16 scale format.
-- A compact draft containing unchanged source MTP, embedding and head tensors loaded alongside the AWQ target and completed 16 greedy plus 16 stochastic requests. The same-source FP16 expert control and NVFP4 target comparisons are pending. Whole-GPU memory for this first native AWQ run is recorded separately; no paired native-checkpoint saving is established yet.
+- A compact draft containing unchanged source MTP, embedding and head tensors loaded alongside the AWQ target. Its control reconstructs only the same source experts into FP16 using their original block scales. Each arm completed 16 greedy and 16 stochastic requests. Idle whole-GPU memory decreased from 30992 to 29982 MiB on every rank, both after greedy and after stochastic requests: **1010 MiB per rank saved**. Complete response choices matched in 14/16 cases and usage in 15/16. The differences were explanatory wording in the probability and list-versus-tuple answers; both retained the answer essentials. Serial retests on the unchanged FP16 control also changed the list-versus-tuple wording, but did not reproduce the FP8 text. The original paired results are retained rather than replaced with selected retests.
+- The same native draft and same-source FP16 control were paired with the full NVFP4 target. All 16 complete greedy response choices and token usage matched exactly; each arm also completed 16 stochastic/top-p requests with finite token logprobs. Idle whole-GPU usage was **31960 MiB with FP16 versus 31068 MiB with FP8**, on every rank after both campaigns: **892 MiB per rank saved**. Runtime inspection confirmed 975 MiB of packed MTP expert weights/scales per rank and absence of the original expert parameters. These measurements use the same fixed 5-GiB KV/rank, TP4/MTP3/C2 and graph settings as the AWQ comparisons. The NVFP4 target is `RadixArk/Qwen3.8-Flash-Next-NVFP4`, revision `7b719225242aacd3dbd3f9407468c2ee9a9d2594`.
 
-The native full-model run preceded two additional input guards (excluded ModelOpt layers and out-of-range kernel scales), while the 20 GPU tests use the current code. Neither guard changes numerical execution for the validated checkpoint. No native-checkpoint throughput or loading-peak claim is made.
+The first native AWQ FP8 run preceded two additional input guards (excluded ModelOpt layers and out-of-range kernel scales), while the 20 GPU tests and both NVFP4 arms include them. Neither guard changes numerical execution for the validated checkpoint. No native-checkpoint throughput or loading-peak claim is made.
+
+### NVFP4 online-conversion integration
+
+The NVFP4 checkpoint's own unquantized MTP also loaded with `mtp_expert_quantization=fp8`. All four ranks selected the online method, retained 975 MiB of packed expert weights/scales and removed the original FP16 expert parameters. The server completed 16 full greedy answers and 16 stochastic requests with finite logprobs. Idle whole-GPU usage was 31048 MiB on every rank after both campaigns.
+
+All 16 complete greedy choices and token usage matched the NVFP4 control above. This comparison keeps the same target and serving settings, but uses a different MTP source: the control expands NVIDIA's FP8 experts, while this online arm quantizes the NVFP4 checkpoint's own original experts. It is an integration and unchanged-target output check, not a same-source quantization comparison. The 892-MiB saving established by the native paired run remains the controlled NVFP4 memory result.
 
 ### Runtime weight inspection
 

--- a/docs/design/sm70_awq_fp8_mtp_experts.md
+++ b/docs/design/sm70_awq_fp8_mtp_experts.md
@@ -1,6 +1,10 @@
-# SM70 FP8-resident MTP experts with an AWQ target
+# SM70 FP8-resident MTP experts with AWQ or NVFP4 targets
 
-This opt-in mode compresses only the unquantized routed experts of a Qwen4Exp MTP draft. It uses the MTP weights already present in the AWQ checkpoint; a separate FP8 checkpoint is not required. The target model, draft attention/router, embeddings, output head and KV precision retain their existing configuration.
+Qwen4Exp MTP experts can retain FP8 storage independently of the AWQ or NVFP4 target. The implementation accepts both unquantized MTP experts for opt-in conversion and serialized block-FP8 experts with their original scales. The target model, draft attention/router, embeddings, output head and KV precision retain their existing configuration.
+
+The checkpoint route backports [vLLM #55513](https://github.com/vllm-project/vllm/pull/55513): ModelOpt `FP8_PB_WO` / `FP8_BLOCK_SCALES` dispatch and AMD/NVIDIA MTP quantization-metadata remapping. This PR adds SM70 storage and TP alignment to that upstream loading support. It does not use the resident-FP16 fallback from [1Cat #553](https://github.com/1CatAI/1Cat-vLLM/pull/553).
+
+**Validation status:** the online AWQ results below are complete. Checkpoint-native CPU loading and real-weight V100 kernel checks have passed; complete-model checkpoint-native AWQ and NVFP4 comparison runs are still in progress. The online results do not establish NVFP4 or native-checkpoint end-to-end acceptance.
 
 ## Configuration
 
@@ -10,7 +14,13 @@ Add `"mtp_expert_quantization": "fp8"` to an existing MTP speculative configurat
 {"method": "mtp", "num_speculative_tokens": 3, "mtp_expert_quantization": "fp8"}
 ```
 
-The supported configuration is SM70, FP16 execution, an AWQ checkpoint with unquantized MTP experts, the `Qwen4ExpMTP` draft architecture and the standard rejection sampler. Synthetic acceptance is rejected. NVFP4 target checkpoints and prequantized FP8 MTP checkpoint loading are outside this change.
+This flag is for unquantized MTP experts in AWQ or ModelOpt checkpoints. Serialized FP8 experts use the checkpoint-native route automatically on SM70. An independent FP8 MTP checkpoint can be selected using the existing speculative `model` and `quantization` fields:
+
+```json
+{"method": "mtp", "num_speculative_tokens": 3, "model": "/path/to/fp8-mtp-checkpoint", "quantization": "modelopt_mixed"}
+```
+
+The SM70 adaptation requires FP16 execution, the `Qwen4ExpMTP` draft architecture, ordinary tensor parallelism, pipeline-parallel size 1 and standard rejection sampling. Expert parallelism and synthetic acceptance are rejected. Checkpoint-native weights must use E4M3 with 128x128 block scales and separate per-expert gate/up/down tensors. Excluded unquantized experts retain their original method unless online conversion is explicitly requested. Other GPU architectures retain upstream dispatch.
 
 ## Storage and kernel adaptation
 
@@ -18,11 +28,13 @@ The ordinary loader first loads and shards FP16 expert matrices. Each shard is q
 
 For the tested TP4 model, the expert intermediate width is 160. Both gate/up halves and the down-projection input are zero-padded to 256 before quantization. Unpadded K=160 produced incorrect native GEMM results; merely accepting the layout in the packer is insufficient. The padding is therefore a correctness requirement, with a storage cost.
 
-The loader temporarily needs FP16 weights and conversion buffers. This is a steady-state memory optimization, not a claim of FP8-only loading or reduced loading peak.
+The online route temporarily needs FP16 weights and conversion buffers. The checkpoint-native route allocates FP8 expert parameters directly and retains the original quantized bytes. At TP4, logical slices begin at offsets 0/32/64/96 within their original 128-wide blocks. Leading zero padding preserves these coordinates in both gate/up rows and down columns, keeping the original scales correctly associated without requantization. Each rank uses a physical width of 256; ordinary vLLM TP loading handles the expanded checkpoint tensors.
+
+The reused SM70 kernel stores scales as FP16. Source scales that become infinite or underflow to zero are rejected. The original BF16 scales in the real-weight probe are exactly representable in FP16; FP32 source scales may round to kernel precision. No reduction in loading peak or increase in speed is claimed.
 
 ## Answer-quality contract
 
-The reference is the same AWQ target, not an unquantized target. Only draft probabilities change. With standard rejection sampling, a proposal drawn from the actual draft distribution q is accepted with probability min(1, p/q); rejection uses the normalized positive part of p-q. This preserves the target distribution p in exact arithmetic regardless of draft quality. Greedy verification uses the target argmax. This change does not modify either verification algorithm or the proposal-probability handoff.
+The reference is the same AWQ or NVFP4 target, not an unquantized target. Only draft probabilities change. With standard rejection sampling, a proposal drawn from the actual draft distribution q is accepted with probability min(1, p/q); rejection uses the normalized positive part of p-q. This preserves the target distribution p in exact arithmetic regardless of draft quality. Greedy verification uses the target argmax. This change does not modify either verification algorithm or the proposal-probability handoff.
 
 Reduced draft acceptance is allowed. A different random sample with the same seed does not imply a different output distribution. Conversely, finite logprobs or a few correct answers alone do not establish distribution preservation. Finite-precision kernels and batching can also change greedy text, so literal equality is reported separately from answer correctness.
 
@@ -36,6 +48,15 @@ Tests use the native SM70 runtime from commit `752f86495f`, with the changed Pyt
 - Existing rejection-sampler test functions executed against the native runtime: adversarial stochastic draft distributions at speculative lengths 1 and 3, 200,000 trials each; corresponding greedy verification and calibrated nucleus checks passed. These isolate sampler behavior and are not an end-to-end benchmark.
 
 Full-model results from matched testing are recorded below. No throughput improvement or broad benchmark-quality guarantee is inferred from the smoke suite.
+
+### Checkpoint-native validation in progress
+
+- CPU: 47 tests passed across the online and checkpoint suites. The checkpoint suite covers original byte/scale preservation at TP1/2/4/8, invalid scales, both ModelOpt block-FP8 names, excluded layers, metadata remapping in both backends, complete weight/scale streams and normal TP loading under AWQ/ModelOpt NVFP4/mixed config names.
+- V100: the expanded GPU suite passed 20 tests: four online cases and sixteen checkpoint cases covering TP4 offsets at M=1/2/8/64. All compare reconstructed reference weights and exact CUDA Graph replay.
+- Two original experts from `nvidia/Qwen3.8-Flash-Next-NVFP4` revision `fc694b54fb0174e0913e6adf86691ef85a4ead47` passed the real loader/packer/kernel in four separate V100 processes at M=1/2/8/64. Maximum absolute error versus FP16 reconstruction was 0.0008544921875, relative L2 below 0.00082; graph replay was exact. The original BF16 scales were exactly representable in the kernel's FP16 scale format.
+- A compact draft containing unchanged source MTP, embedding and head tensors loaded alongside the AWQ target and completed 16 greedy plus 16 stochastic requests. The same-source FP16 expert control and NVFP4 target comparisons are pending. Whole-GPU memory for this first native AWQ run is recorded separately; no paired native-checkpoint saving is established yet.
+
+The native full-model run preceded two additional input guards (excluded ModelOpt layers and out-of-range kernel scales), while the 20 GPU tests use the current code. Neither guard changes numerical execution for the validated checkpoint. No native-checkpoint throughput or loading-peak claim is made.
 
 ### Runtime weight inspection
 

--- a/tests/models/qwen4_exp/test_mtp_fp8_checkpoint.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_checkpoint.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia.mtp_fp8_checkpoint import (
+    pad_mtp_fp8_checkpoint_matrix,
+    padded_mtp_fp8_width,
+)
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    return False
+
+
+def reconstruct(weight, scale):
+    scales = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    return weight.float() * scales[: weight.shape[0], : weight.shape[1]]
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("down", [False, True])
+def test_checkpoint_shards_preserve_fp8_bytes_and_original_block_scales(tp_size, down):
+    torch.manual_seed(37)
+    shape = (256, 640) if down else (640, 256)
+    weight = torch.randint(-16, 16, shape).to(torch.float8_e4m3fn)
+    scale_shape = tuple(dim // 128 for dim in shape)
+    # Distinct blocks make incorrect TP offsets visible in the reconstruction.
+    scale = torch.arange(1, 11, dtype=torch.float32).reshape(scale_shape) / 16
+    original = weight.view(torch.uint8).clone()
+    original_scale = scale.clone()
+    padded_weight, padded_scale = pad_mtp_fp8_checkpoint_matrix(
+        weight, scale, down_projection=down, tp_size=tp_size
+    )
+    axis = 1 if down else 0
+    width = padded_mtp_fp8_width(640 // tp_size, tp_size)
+    reference = reconstruct(weight, scale)
+    for rank in range(tp_size):
+        start = rank * (640 // tp_size)
+        offset = start % 128
+        local_w = padded_weight.narrow(axis, rank * width, width)
+        local_s = padded_scale.narrow(axis, rank * width // 128, width // 128)
+        actual = reconstruct(local_w, local_s)
+        valid = actual.narrow(axis, offset, 640 // tp_size)
+        torch.testing.assert_close(
+            valid, reference.narrow(axis, start, 640 // tp_size), rtol=0, atol=0
+        )
+        mask = actual.clone()
+        mask.narrow(axis, offset, 640 // tp_size).zero_()
+        assert torch.count_nonzero(mask) == 0
+    assert torch.equal(weight.view(torch.uint8), original)
+    assert torch.equal(scale, original_scale)
+
+
+def test_tp4_width_retains_block_offsets_without_extra_quantization():
+    assert padded_mtp_fp8_width(160, 4) == 256
+    assert [(rank * 160) % 128 for rank in range(4)] == [0, 32, 64, 96]
+
+
+@pytest.mark.parametrize("bad_scale", [float("nan"), float("inf"), -1.0])
+def test_bad_checkpoint_scales_are_rejected(bad_scale):
+    weight = torch.zeros((640, 256), dtype=torch.float8_e4m3fn)
+    scale = torch.ones((5, 2))
+    scale[1, 0] = bad_scale
+    with pytest.raises(ValueError, match="scales must be finite and nonnegative"):
+        pad_mtp_fp8_checkpoint_matrix(weight, scale, down_projection=False, tp_size=4)
+
+
+@pytest.mark.parametrize("bad_scale", [1e10, 1e-15])
+def test_scales_that_overflow_or_underflow_in_the_sm70_kernel_are_rejected(bad_scale):
+    weight = torch.ones((640, 256), dtype=torch.float32).to(torch.float8_e4m3fn)
+    scale = torch.full((5, 2), bad_scale)
+    with pytest.raises(ValueError, match="outside the SM70 FP16 scale range"):
+        pad_mtp_fp8_checkpoint_matrix(weight, scale, down_projection=False, tp_size=4)
+
+
+@pytest.mark.parametrize("algo", ["FP8_PB_WO", "FP8_BLOCK_SCALES"])
+def test_upstream_modelopt_dispatch_and_sm70_checkpoint_selection(algo):
+    from unittest.mock import MagicMock, patch
+
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptMixedPrecisionConfig,
+    )
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import checkpoint_fp8_prefixes
+
+    prefix = "mtp.layers.48.mlp.experts"
+    config = ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quantization": {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {prefix: {"quant_algo": algo, "group_size": 128}},
+            }
+        }
+    )
+    layer = MagicMock(spec=RoutedExperts)
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.Fp8MoEMethod"
+    ) as method:
+        assert config.get_quant_method(layer, prefix) is method.return_value
+        assert method.call_args.args[0] is config.fp8_block_config
+    assert config.fp8_block_config.weight_block_size == [128, 128]
+    assert config.has_blocked_weights()
+    assert checkpoint_fp8_prefixes(config, {prefix}) == {prefix}
+    config.exclude_modules = [prefix]
+    assert config.get_quant_method(layer, prefix) is None
+    assert checkpoint_fp8_prefixes(config, {prefix}) == set()
+
+
+@pytest.mark.parametrize("backend", ["amd", "nvidia"])
+def test_upstream_mtp_metadata_remapping_preserves_main_layers(backend):
+    # Both backends register the same custom-op names. Import them in separate
+    # interpreters, as in the upstream test, without importing API-server helpers.
+    script = textwrap.dedent("""
+        import sys
+        from importlib import import_module
+        module = import_module(f"vllm.models.qwen4_exp.{sys.argv[1]}.mtp")
+        main = {"quant_algo": "NVFP4"}
+        draft = {"quant_algo": "FP8_BLOCK_SCALES", "group_size": 128}
+        source = {"model.layers.0.mlp.experts": main,
+                  "mtp.layers.0.mlp.experts": draft}
+        actual = module._remap_quantized_layers(source, 48)
+        assert actual == {"model.layers.0.mlp.experts": main,
+                          "mtp.layers.48.mlp.experts": draft}
+        assert "mtp.layers.0.mlp.experts" in source
+    """)
+    subprocess.run([sys.executable, "-c", script, backend], check=True)
+
+
+def checkpoint_pairs():
+    prefix = "model.layers.0.mlp.experts"
+    rows = []
+    for expert in range(2):
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            shape = (256, 640) if projection == "down_proj" else (640, 256)
+            weight = torch.ones(shape, dtype=torch.float32).to(torch.float8_e4m3fn)
+            scale = torch.full(tuple(dim // 128 for dim in shape), expert + 0.5)
+            base = f"{prefix}.{expert}.{projection}"
+            rows.extend(
+                [(base + ".weight", weight), (base + ".weight_scale_inv", scale)]
+            )
+    return prefix, rows
+
+
+def test_checkpoint_stream_orders_preserve_pairs_and_unrelated_tensors():
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_checkpoint import (
+        prepare_mtp_fp8_checkpoint,
+    )
+
+    prefix, rows = checkpoint_pairs()
+    head = torch.ones(2, 2)
+    for weights in (rows, list(reversed(rows))):
+        actual = dict(
+            prepare_mtp_fp8_checkpoint(
+                [("lm_head.weight", head), *weights], {prefix}, tp_size=4, num_experts=2
+            )
+        )
+        assert actual["lm_head.weight"] is head
+        assert len(actual) == 13
+        assert actual[prefix + ".0.gate_proj.weight"].dtype == torch.float8_e4m3fn
+        assert actual[prefix + ".0.gate_proj.weight"].shape == (1024, 256)
+
+
+@pytest.mark.parametrize("failure", ["missing_pair", "duplicate", "extra_expert"])
+def test_checkpoint_stream_rejects_incomplete_or_duplicate_experts(failure):
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_checkpoint import (
+        prepare_mtp_fp8_checkpoint,
+    )
+
+    prefix, rows = checkpoint_pairs()
+    if failure == "missing_pair":
+        rows = rows[2:]
+    elif failure == "duplicate":
+        rows += rows[:2]
+    else:
+        rows += [(prefix + ".2.gate_proj.weight", rows[0][1])]
+    with pytest.raises(ValueError):
+        list(prepare_mtp_fp8_checkpoint(rows, {prefix}, tp_size=4, num_experts=2))
+
+
+def test_checkpoint_selection_respects_unquantized_expert_exclusions():
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import checkpoint_fp8_prefixes
+
+    prefix = "mtp.layers.48.mlp.experts"
+    config = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[128, 128],
+        ignored_layers=[prefix],
+    )
+    assert checkpoint_fp8_prefixes(config, {prefix}) == set()
+    assert checkpoint_fp8_prefixes(config, {prefix, "mtp.layers.49.mlp.experts"}) == {
+        "mtp.layers.49.mlp.experts"
+    }
+
+
+@pytest.mark.parametrize("quant_name", ["awq", "modelopt_fp4", "modelopt_mixed"])
+@pytest.mark.parametrize("rank", range(4))
+def test_native_checkpoint_uses_normal_tp_loader_with_each_target_format(
+    quant_name, rank
+):
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import (
+        MTPCheckpointFp8SM70MoEMethod,
+    )
+
+    # Exercise the real parameter allocator and weight_loader without a GPU
+    # process group or a runner. The target's quantization name must not cause
+    # the MTP FP8 weight/scale tensors to take a ModelOpt FP4 loading branch.
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    parallel = SimpleNamespace(tp_size=4, tp_rank=rank)
+    layer.moe_parallel_config = parallel
+    layer.moe_config = SimpleNamespace(
+        moe_parallel_config=parallel, has_bias=False, is_act_and_mul=True
+    )
+    layer.quant_config = SimpleNamespace(get_name=lambda: quant_name)
+    layer.expert_map_manager = SimpleNamespace(
+        map_global_to_local=lambda expert: expert
+    )
+    method = MTPCheckpointFp8SM70MoEMethod(layer)
+    layer.quant_method = method
+    h, i = method.maybe_roundup_sizes(256, 160, torch.float16, parallel)
+    method.create_weights(layer, 2, h, i, torch.float16)
+    assert layer.w13_weight.dtype == layer.w2_weight.dtype == torch.float8_e4m3fn
+    prefix, rows = checkpoint_pairs()
+    raw = dict(rows)
+    for name, tensor in rows:
+        if not name.endswith(".weight"):
+            continue
+        base = name.removesuffix(".weight")
+        expert = int(base.split(".")[-2])
+        projection = base.split(".")[-1]
+        down = projection == "down_proj"
+        shard = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}[projection]
+        weight, scale = pad_mtp_fp8_checkpoint_matrix(
+            tensor, raw[base + ".weight_scale_inv"], down_projection=down, tp_size=4
+        )
+        stem = "w2" if down else "w13"
+        for suffix, value in [("weight", weight), ("weight_scale_inv", scale)]:
+            param_name = stem + "_" + suffix
+            assert layer.weight_loader(
+                getattr(layer, param_name), value, param_name, shard, expert, True
+            )
+        actual = reconstruct(
+            getattr(layer, stem + "_weight")[expert],
+            getattr(layer, stem + "_weight_scale_inv")[expert],
+        )
+        if not down:
+            actual = actual[:i] if shard == "w1" else actual[i:]
+        axis = 1 if down else 0
+        start = rank * 160
+        actual = actual.narrow(axis, start % 128, 160)
+        expected = reconstruct(tensor, raw[base + ".weight_scale_inv"]).narrow(
+            axis, start, 160
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/models/qwen4_exp/test_mtp_fp8_checkpoint.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_checkpoint.py
@@ -201,6 +201,42 @@ def test_checkpoint_selection_respects_unquantized_expert_exclusions():
     }
 
 
+def test_online_mixed_mtp_can_be_unquantized_by_absence_from_metadata():
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptMixedPrecisionConfig,
+    )
+    from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import (
+        MTPExpertFp8Config,
+        MTPFp8SM70MoEMethod,
+    )
+
+    fallback = ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quantization": {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.layers.0.mlp.experts": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    }
+                },
+            }
+        }
+    )
+    layer = MagicMock(spec=RoutedExperts)
+    layer.moe_config = SimpleNamespace(has_bias=False)
+    assert isinstance(
+        MTPExpertFp8Config(fallback).get_quant_method(
+            layer, "mtp.layers.48.mlp.experts"
+        ),
+        MTPFp8SM70MoEMethod,
+    )
+
+
 @pytest.mark.parametrize("quant_name", ["awq", "modelopt_fp4", "modelopt_mixed"])
 @pytest.mark.parametrize("rank", range(4))
 def test_native_checkpoint_uses_normal_tp_loader_with_each_target_format(

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts.py
@@ -27,8 +27,12 @@ def should_do_global_cleanup_after_test():
     ],
 )
 def test_fp8_feature_requires_supported_draft_and_real_verification(
-    method, architecture, sampler, valid
+    monkeypatch, method, architecture, sampler, valid
 ):
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform",
+        SimpleNamespace(is_cuda=lambda: True, is_device_capability=lambda cap: True),
+    )
     config = SimpleNamespace(
         mtp_expert_quantization="fp8",
         method=method,
@@ -42,6 +46,50 @@ def test_fp8_feature_requires_supported_draft_and_real_verification(
     else:
         with pytest.raises(ValueError):
             SpeculativeConfig._verify_mtp_expert_quantization(config)
+
+
+@pytest.mark.parametrize(
+    "platform,capability", [("rocm", 90), ("cpu", 0), ("cuda", 80)]
+)
+def test_fp8_feature_rejects_unsupported_platform(monkeypatch, platform, capability):
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: platform == "cuda",
+            is_device_capability=lambda cap: capability == cap[0] * 10 + cap[1],
+        ),
+    )
+    config = SimpleNamespace(
+        mtp_expert_quantization="fp8",
+        method="mtp",
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["Qwen4ExpMTP"])
+        ),
+        rejection_sample_method="standard",
+    )
+    with pytest.raises(ValueError, match="requires CUDA SM70"):
+        SpeculativeConfig._verify_mtp_expert_quantization(config)
+    # Existing configurations without the opt-in stay available on all platforms.
+    config.mtp_expert_quantization = None
+    SpeculativeConfig._verify_mtp_expert_quantization(config)
+
+
+def test_online_fp8_has_a_distinct_compilation_hash():
+    config = SimpleNamespace(
+        method="mtp",
+        mtp_expert_quantization=None,
+        draft_model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+        use_dflash_family=lambda: False,
+        use_dspark=lambda: False,
+        use_dflash_ddtree=lambda: False,
+    )
+    original = SpeculativeConfig.compute_hash(config)
+    config.mtp_expert_quantization = "fp8"
+    fp8 = SpeculativeConfig.compute_hash(config)
+    assert fp8 != original
+    assert SpeculativeConfig.compute_hash(config) == fp8
+    config.mtp_expert_quantization = None
+    assert SpeculativeConfig.compute_hash(config) == original
 
 
 @pytest.mark.parametrize("shape", [(320, 2560), (2560, 160), (16, 16)])

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia import mtp_fp8_experts as impl
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    # These tests only create CPU tensors and never initialize a process group.
+    return False
+
+
+@pytest.mark.parametrize("shape", [(320, 2560), (2560, 160), (16, 16)])
+def test_online_rows_keep_shape_and_bound_rounding(shape):
+    generator = torch.Generator().manual_seed(7)
+    weight = torch.randn(shape, generator=generator, dtype=torch.float16)
+    weight[0].zero_()
+    original = weight.clone()
+    quantized, scale = impl.quantize_expert_rows(weight)
+    recovered = quantized.float() * scale
+    assert quantized.dtype == torch.float8_e4m3fn
+    assert quantized.shape == weight.shape
+    assert scale.shape == (shape[0], 1)
+    assert torch.equal(weight, original)
+    assert torch.isfinite(recovered).all()
+    assert torch.equal(recovered[0], weight[0].float())
+    # E4M3's largest adjacent spacing is 32, so rounding contributes at
+    # most half a step at the row scale (plus scale-rounding saturation).
+    assert ((recovered - weight.float()).abs() <= 17 * scale).all()
+    assert quantized.numel() + scale.numel() * scale.element_size() < weight.numel() * 2
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_nonfinite_checkpoint_rejected(value):
+    weight = torch.zeros(8, 8, dtype=torch.float16)
+    weight[0, 0] = value
+    with pytest.raises(ValueError, match="non-finite"):
+        impl.quantize_expert_rows(weight)
+
+
+def test_only_unquantized_draft_experts_are_overridden(monkeypatch):
+    unquantized = Mock(spec=impl.UnquantizedFusedMoEMethod)
+    fallback = SimpleNamespace(
+        packed_modules_mapping={}, get_quant_method=lambda layer, prefix: unquantized
+    )
+    wrapped = impl.MTPExpertFp8Config(fallback)
+    expert = Mock(spec=impl.RoutedExperts)
+    fp8 = object()
+    monkeypatch.setattr(impl, "MTPFp8SM70MoEMethod", lambda layer: fp8)
+    assert wrapped.get_quant_method(expert, "mtp.layers.48.mlp.experts") is fp8
+    assert wrapped.get_quant_method(expert, "model.layers.0.mlp.experts") is unquantized
+    for prefix in ("mtp.layers.48.mlp.gate", "lm_head", "model.embed_tokens"):
+        assert wrapped.get_quant_method(torch.nn.Linear(4, 4), prefix) is unquantized
+    assert fallback.get_quant_method(expert, "mtp.layers.48.mlp.experts") is unquantized
+    fallback.get_quant_method = lambda layer, prefix: object()
+    with pytest.raises(ValueError, match="unquantized checkpoint"):
+        wrapped.get_quant_method(expert, "mtp.layers.48.mlp.experts")

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+from vllm.config.speculative import SpeculativeConfig
 from vllm.models.qwen4_exp.nvidia import mtp_fp8_experts as impl
 
 
@@ -14,6 +15,33 @@ from vllm.models.qwen4_exp.nvidia import mtp_fp8_experts as impl
 def should_do_global_cleanup_after_test():
     # These tests only create CPU tensors and never initialize a process group.
     return False
+
+
+@pytest.mark.parametrize(
+    "method,architecture,sampler,valid",
+    [
+        ("mtp", "Qwen4ExpMTP", "standard", True),
+        ("mtp", "Qwen4ExpMTP", "synthetic", False),
+        ("mtp", "Qwen3_5MTP", "standard", False),
+        ("eagle3", "Qwen4ExpMTP", "standard", False),
+    ],
+)
+def test_fp8_feature_requires_supported_draft_and_real_verification(
+    method, architecture, sampler, valid
+):
+    config = SimpleNamespace(
+        mtp_expert_quantization="fp8",
+        method=method,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[architecture])
+        ),
+        rejection_sample_method=sampler,
+    )
+    if valid:
+        SpeculativeConfig._verify_mtp_expert_quantization(config)
+    else:
+        with pytest.raises(ValueError):
+            SpeculativeConfig._verify_mtp_expert_quantization(config)
 
 
 @pytest.mark.parametrize("shape", [(320, 2560), (2560, 160), (16, 16)])

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts.py
@@ -9,6 +9,7 @@ import torch
 
 from vllm.config.speculative import SpeculativeConfig
 from vllm.models.qwen4_exp.nvidia import mtp_fp8_experts as impl
+from vllm.utils.hashing import safe_hash
 
 
 @pytest.fixture
@@ -84,9 +85,13 @@ def test_online_fp8_has_a_distinct_compilation_hash():
         use_dflash_ddtree=lambda: False,
     )
     original = SpeculativeConfig.compute_hash(config)
+    # Before this fix, both modes used this key. Neither may reuse its artifacts.
+    legacy = safe_hash(str([False, False]).encode(), usedforsecurity=False).hexdigest()
+    assert original != legacy
     config.mtp_expert_quantization = "fp8"
     fp8 = SpeculativeConfig.compute_hash(config)
     assert fp8 != original
+    assert fp8 != legacy
     assert SpeculativeConfig.compute_hash(config) == fp8
     config.mtp_expert_quantization = None
     assert SpeculativeConfig.compute_hash(config) == original

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts.py
@@ -44,6 +44,26 @@ def test_nonfinite_checkpoint_rejected(value):
         impl.quantize_expert_rows(weight)
 
 
+def test_padding_preserves_gated_expert_and_still_reduces_storage():
+    generator = torch.Generator().manual_seed(9)
+    gate_up = torch.randn(320, 64, generator=generator)
+    down = torch.randn(64, 160, generator=generator)
+    x = torch.randn(3, 64, generator=generator)
+    padded_gate_up = impl.pad_expert_matrix(gate_up, True)
+    padded_down = impl.pad_expert_matrix(down, False)
+    assert padded_gate_up.shape == (512, 64)
+    assert padded_down.shape == (64, 256)
+    gate, up = (x @ gate_up.T).chunk(2, dim=-1)
+    padded_gate, padded_up = (x @ padded_gate_up.T).chunk(2, dim=-1)
+    expected = (torch.nn.functional.silu(gate) * up) @ down.T
+    actual = (torch.nn.functional.silu(padded_gate) * padded_up) @ padded_down.T
+    torch.testing.assert_close(actual, expected)
+    # Payload savings survive the required padding: 160/256 * FP16/FP8.
+    assert padded_gate_up.numel() + padded_down.numel() < 2 * (
+        gate_up.numel() + down.numel()
+    )
+
+
 def test_only_unquantized_draft_experts_are_overridden(monkeypatch):
     unquantized = Mock(spec=impl.UnquantizedFusedMoEMethod)
     fallback = SimpleNamespace(

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py
@@ -6,7 +6,11 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.models.qwen4_exp.nvidia.mtp_fp8_checkpoint import (
+    pad_mtp_fp8_checkpoint_matrix,
+)
 from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import (
+    MTPCheckpointFp8SM70MoEMethod,
     MTPFp8SM70MoEMethod,
     quantize_expert_rows,
 )
@@ -68,3 +72,77 @@ def test_padded_mtp_fp8_moe_matches_reconstructed_weights_and_graph(num_tokens):
             graph.replay()
             torch.accelerator.synchronize()
             torch.testing.assert_close(captured, actual, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("rank", range(4))
+@pytest.mark.parametrize("num_tokens", [1, 2, 8, 64])
+def test_checkpoint_block_scales_preserve_tp_offsets_and_graph(rank, num_tokens):
+    with torch.device("cuda"):
+        torch.manual_seed(41)
+        e, h, logical, topk = 4, 2560, 160, 2
+        layer = torch.nn.Module()
+        layer.moe_config = SimpleNamespace(
+            has_bias=False, is_act_and_mul=True, experts_per_token=topk
+        )
+        layer.local_num_experts = layer.global_num_experts = e
+        layer.expert_map = None
+        layer.apply_router_weight_on_input = False
+        method = MTPCheckpointFp8SM70MoEMethod(layer)
+        _, padded = method.maybe_roundup_sizes(
+            h, logical, torch.float16, SimpleNamespace(tp_size=4)
+        )
+        method.create_weights(layer, e, h, padded, torch.float16)
+        raw_refs: list[list[torch.Tensor]] = [[], [], []]
+        for expert in range(e):
+            for index in range(3):
+                down = index == 2
+                shape = (h, 640) if down else (640, h)
+                q = torch.randint(-16, 17, shape).to(torch.float8_e4m3fn)
+                scale = (
+                    (torch.rand(tuple(dim // 128 for dim in shape)) * 0.002 + 0.001)
+                    .to(torch.bfloat16)
+                    .float()
+                )
+                axis = 1 if down else 0
+                ref = (
+                    q.float()
+                    * scale.repeat_interleave(128, 0).repeat_interleave(128, 1)
+                ).half()
+                raw_refs[index].append(ref.narrow(axis, rank * logical, logical))
+                weight, scales = pad_mtp_fp8_checkpoint_matrix(
+                    q, scale, down_projection=down, tp_size=4
+                )
+                local_w = weight.narrow(axis, rank * padded, padded)
+                local_s = scales.narrow(axis, rank * padded // 128, padded // 128)
+                if down:
+                    layer.w2_weight.data[expert].copy_(local_w)
+                    layer.w2_weight_scale_inv.data[expert].copy_(local_s)
+                else:
+                    layer.w13_weight.data[
+                        expert, index * padded : (index + 1) * padded
+                    ].copy_(local_w)
+                    layer.w13_weight_scale_inv.data[
+                        expert, index * padded // 128 : (index + 1) * padded // 128
+                    ].copy_(local_s)
+        refs = [torch.stack(weights) for weights in raw_refs]
+        method.process_weights_after_loading(layer)
+        assert not hasattr(layer, "w13_weight") and not hasattr(layer, "w2_weight")
+        x = torch.randn(num_tokens, h, dtype=torch.float16)
+        ids = torch.stack([torch.randperm(e)[:topk] for _ in range(num_tokens)]).int()
+        weights = torch.softmax(torch.randn(num_tokens, topk), dim=-1)
+        reference = torch.zeros_like(x)
+        for slot in range(topk):
+            chosen = ids[:, slot].long()
+            gate = torch.bmm(refs[0][chosen], x.unsqueeze(-1)).squeeze(-1)
+            up = torch.bmm(refs[1][chosen], x.unsqueeze(-1)).squeeze(-1)
+            hidden = torch.nn.functional.silu(gate) * up
+            out = torch.bmm(refs[2][chosen], hidden.unsqueeze(-1)).squeeze(-1)
+            reference += (out.float() * weights[:, slot, None]).half()
+        actual = method.apply(layer, x, weights, ids, None, None).clone()
+        torch.testing.assert_close(actual, reference, atol=0.003, rtol=0.03)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = method.apply(layer, x, weights, ids, None, None)
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(captured, actual, atol=0, rtol=0)

--- a/tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py
+++ b/tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia.mtp_fp8_experts import (
+    MTPFp8SM70MoEMethod,
+    quantize_expert_rows,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="Requires SM70 native operators",
+)
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    return False
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 8, 64])
+def test_padded_mtp_fp8_moe_matches_reconstructed_weights_and_graph(num_tokens):
+    with torch.device("cuda"):
+        torch.manual_seed(11)
+        e, h, i, topk = 16, 2560, 160, 4
+        layer = torch.nn.Module()
+        layer.moe_config = SimpleNamespace(
+            has_bias=False, is_act_and_mul=True, experts_per_token=topk
+        )
+        layer.local_num_experts = e
+        layer.global_num_experts = e
+        layer.expert_map = None
+        layer.apply_router_weight_on_input = False
+        method = MTPFp8SM70MoEMethod(layer)
+        method.create_weights(layer, e, h, i, torch.float16)
+        layer.w13_weight.data.normal_(std=0.02)
+        layer.w2_weight.data.normal_(std=0.02)
+        refs = []
+        for weights in [layer.w13_weight, layer.w2_weight]:
+            ref = []
+            for weight in weights:
+                q, s = quantize_expert_rows(weight)
+                ref.append((q.float() * s).half())
+            refs.append(torch.stack(ref))
+        method.process_weights_after_loading(layer)
+        assert not hasattr(layer, "w13_weight") and not hasattr(layer, "w2_weight")
+        for m in [num_tokens]:
+            x = torch.randn(m, h, dtype=torch.float16)
+            ids = torch.stack([torch.randperm(e)[:topk] for _ in range(m)]).int()
+            weights = torch.softmax(torch.randn(m, topk), dim=-1)
+            ref = torch.zeros_like(x)
+            for slot in range(topk):
+                w13 = refs[0][ids[:, slot].long()]
+                w2 = refs[1][ids[:, slot].long()]
+                gate, up = torch.bmm(w13, x.unsqueeze(-1)).squeeze(-1).chunk(2, dim=-1)
+                act = torch.nn.functional.silu(gate) * up
+                out = torch.bmm(w2, act.unsqueeze(-1)).squeeze(-1)
+                ref += (out.float() * weights[:, slot, None]).half()
+            actual = method.apply(layer, x, weights, ids, None, None).clone()
+            torch.testing.assert_close(actual, ref, atol=0.003, rtol=0.03)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured = method.apply(layer, x, weights, ids, None, None)
+            graph.replay()
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(captured, actual, atol=0, rtol=0)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -392,6 +392,10 @@ class SpeculativeConfig:
         )
         factors.append(uses_aux_hidden_states)
 
+        # Online FP8 changes the draft expert kernels and padded weight layout.
+        if self.mtp_expert_quantization is not None:
+            factors.append(("mtp_expert_quantization", self.mtp_expert_quantization))
+
         # The specific layers used also affect the computation graph
         if uses_aux_hidden_states and self.draft_model_config is not None:
             layer_ids = getattr(
@@ -1427,6 +1431,12 @@ class SpeculativeConfig:
     def _verify_mtp_expert_quantization(self):
         if self.mtp_expert_quantization is None:
             return
+        from vllm.platforms import current_platform
+
+        if not current_platform.is_cuda() or not current_platform.is_device_capability(
+            (7, 0)
+        ):
+            raise ValueError("mtp_expert_quantization currently requires CUDA SM70")
         hf_config = getattr(self.draft_model_config, "hf_config", None)
         if self.method != "mtp" or getattr(hf_config, "architectures", []) != [
             "Qwen4ExpMTP"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -393,7 +393,9 @@ class SpeculativeConfig:
         factors.append(uses_aux_hidden_states)
 
         # Online FP8 changes the draft expert kernels and padded weight layout.
-        if self.mtp_expert_quantization is not None:
+        # Include None too: old MTP artifacts may have been compiled with FP8
+        # under the same key as FP16, before this field was hashed.
+        if self.method == "mtp":
             factors.append(("mtp_expert_quantization", self.mtp_expert_quantization))
 
         # The specific layers used also affect the computation graph

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -153,8 +153,10 @@ class SpeculativeConfig:
 
     # Draft model configuration
     mtp_expert_quantization: Literal["fp8"] | None = None
-    """Opt in to FP8-resident Qwen4Exp MTP experts on SM70 with an AWQ
-    checkpoint whose MTP experts are unquantized. Target weights are unchanged.
+    """Opt in to FP8-resident Qwen4Exp MTP experts on SM70 with an AWQ or
+    ModelOpt checkpoint whose MTP experts are unquantized. Serialized block-FP8
+    MTP experts use their checkpoint scales without this online-conversion flag.
+    Target weights are unchanged.
     """
     quantization: me_quant.QuantizationMethods | str | None = None
     """Quantization method that was used to quantize the draft model weights.

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1396,6 +1396,7 @@ class SpeculativeConfig:
                     "dflash_ddtree tree verification is enabled."
                 )
 
+        self._verify_mtp_expert_quantization()
         if self.rejection_sample_method == "synthetic":
             # Consolidate to per-position rates
             self.synthetic_acceptance_rates = self._resolve_synthetic_acceptance_rates(
@@ -1420,6 +1421,17 @@ class SpeculativeConfig:
 
         self.verify_equal_vocab_size_if_draft_model()
         return self
+
+    def _verify_mtp_expert_quantization(self):
+        if self.mtp_expert_quantization is None:
+            return
+        hf_config = getattr(self.draft_model_config, "hf_config", None)
+        if self.method != "mtp" or getattr(hf_config, "architectures", []) != [
+            "Qwen4ExpMTP"
+        ]:
+            raise ValueError("mtp_expert_quantization currently requires Qwen4Exp MTP")
+        if self.rejection_sample_method != "standard":
+            raise ValueError("FP8 MTP requires standard rejection sampling")
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -152,6 +152,10 @@ class SpeculativeConfig:
     warn users when they mistakenly provide the wrong argument."""
 
     # Draft model configuration
+    mtp_expert_quantization: Literal["fp8"] | None = None
+    """Opt in to FP8-resident Qwen4Exp MTP experts on SM70 with an AWQ
+    checkpoint whose MTP experts are unquantized. Target weights are unchanged.
+    """
     quantization: me_quant.QuantizationMethods | str | None = None
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     swap_w13_to_w31,
@@ -97,6 +98,9 @@ if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
 
 logger = init_logger(__name__)
+
+# Backported from vllm-project/vllm#55513: canonical name and legacy alias.
+_BLOCK_FP8_MOE_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")
 
 QUANT_ALGOS = [
     # FP8 (per-tensor weight + optional static activation scale).
@@ -2366,6 +2370,29 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         self.nvfp4_config = nvfp4_config
         self.w4a16_nvfp4_config = w4a16_nvfp4_config
 
+        block_sizes = {
+            int(layer_info.get("group_size", 128))
+            for layer_info in quantized_layers.values()
+            if layer_info.get("quant_algo", "").upper() in _BLOCK_FP8_MOE_ALGOS
+        }
+        if len(block_sizes) > 1:
+            raise ValueError(
+                "MIXED_PRECISION currently requires all block-FP8 MoE layers "
+                f"to use one group_size, got {sorted(block_sizes)}."
+            )
+        block_size = next(iter(block_sizes), 128)
+        self.fp8_block_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[block_size, block_size],
+        )
+
+    def has_blocked_weights(self) -> bool:
+        return any(
+            info.get("quant_algo", "").upper() in _BLOCK_FP8_MOE_ALGOS
+            for info in self.quantized_layers.values()
+        )
+
     def get_name(self) -> QuantizationMethods:
         return "modelopt_mixed"
 
@@ -2564,6 +2591,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
             return UnquantizedLinearMethod()
 
         if isinstance(layer, RoutedExperts):
+            if quant_algo in _BLOCK_FP8_MOE_ALGOS:
+                return Fp8MoEMethod(self.fp8_block_config, layer)
             if quant_algo == "FP8":
                 return ModelOptFp8MoEMethod(
                     quant_config=self.fp8_config,

--- a/vllm/models/qwen4_exp/amd/mtp.py
+++ b/vllm/models/qwen4_exp/amd/mtp.py
@@ -73,6 +73,17 @@ def _remap_ignored_layers(
     return remapped
 
 
+def _remap_quantized_layers(
+    quantized_layers: dict[str, dict],
+    mtp_start_layer_idx: int,
+) -> dict[str, dict]:
+    """Map checkpoint MTP layer indices to standalone draft indices."""
+    return {
+        _remap_ignored_layers([name], mtp_start_layer_idx)[0]: layer_info
+        for name, layer_info in quantized_layers.items()
+    }
+
+
 def _remap_mtp_weight_name(name: str) -> str | None:
     """Map Qwen4Exp checkpoint paths into the standalone draft model."""
 
@@ -151,6 +162,13 @@ def _make_draft_vllm_config(
                 draft_quant_config,
                 "exclude_modules",
                 _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+        quantized_layers = getattr(draft_quant_config, "quantized_layers", None)
+        if quantized_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "quantized_layers",
+                _remap_quantized_layers(quantized_layers, mtp_start_layer_idx),
             )
 
     draft_vllm_config = replace(

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -173,6 +173,23 @@ def _make_draft_vllm_config(
     )
     # VllmConfig post-init derives the target quant config, so restore the
     # independently resolved draft quant config after replacement.
+    if getattr(speculative_config, "mtp_expert_quantization", None) == "fp8":
+        from vllm.model_executor.layers.quantization.sm70_turbomind import (
+            is_exact_sm70_cuda_platform,
+        )
+
+        from .mtp_fp8_experts import MTPExpertFp8Config
+
+        if (
+            not is_exact_sm70_cuda_platform()
+            or draft_vllm_config.model_config.dtype != torch.float16
+            or draft_quant_config is None
+            or draft_quant_config.get_name() != "awq"
+        ):
+            raise ValueError(
+                "MTP FP8 experts require SM70, FP16, and an AWQ checkpoint"
+            )
+        draft_quant_config = MTPExpertFp8Config(draft_quant_config)
     draft_vllm_config.quant_config = draft_quant_config
     return draft_vllm_config
 

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -86,6 +86,17 @@ def _remap_ignored_layers(
     return remapped
 
 
+def _remap_quantized_layers(
+    quantized_layers: dict[str, dict],
+    mtp_start_layer_idx: int,
+) -> dict[str, dict]:
+    """Map checkpoint MTP layer indices to standalone draft indices."""
+    return {
+        _remap_ignored_layers([name], mtp_start_layer_idx)[0]: layer_info
+        for name, layer_info in quantized_layers.items()
+    }
+
+
 def _remap_mtp_weight_name(name: str) -> str | None:
     """Map Qwen4Exp checkpoint paths into the standalone draft model."""
 
@@ -166,6 +177,13 @@ def _make_draft_vllm_config(
                 "exclude_modules",
                 _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
             )
+        quantized_layers = getattr(draft_quant_config, "quantized_layers", None)
+        if quantized_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "quantized_layers",
+                _remap_quantized_layers(quantized_layers, mtp_start_layer_idx),
+            )
 
     draft_vllm_config = replace(
         vllm_config,
@@ -173,23 +191,42 @@ def _make_draft_vllm_config(
     )
     # VllmConfig post-init derives the target quant config, so restore the
     # independently resolved draft quant config after replacement.
-    if getattr(speculative_config, "mtp_expert_quantization", None) == "fp8":
-        from vllm.model_executor.layers.quantization.sm70_turbomind import (
-            is_exact_sm70_cuda_platform,
-        )
+    from vllm.model_executor.layers.quantization.sm70_turbomind import (
+        is_exact_sm70_cuda_platform,
+    )
 
-        from .mtp_fp8_experts import MTPExpertFp8Config
+    from .mtp_fp8_experts import MTPExpertFp8Config, checkpoint_fp8_prefixes
 
+    online_fp8 = getattr(speculative_config, "mtp_expert_quantization", None) == "fp8"
+    checkpoint_prefixes = set()
+    if draft_quant_config is not None and is_exact_sm70_cuda_platform():
+        config = draft_vllm_config.model_config.hf_text_config
+        prefixes = {
+            f"mtp.layers.{mtp_start_layer_idx + index}.mlp.experts"
+            for index in range(getattr(config, "mtp_num_hidden_layers", 1))
+        }
+        checkpoint_prefixes = checkpoint_fp8_prefixes(draft_quant_config, prefixes)
+    if online_fp8 or checkpoint_prefixes:
         if (
             not is_exact_sm70_cuda_platform()
             or draft_vllm_config.model_config.dtype != torch.float16
             or draft_quant_config is None
-            or draft_quant_config.get_name() != "awq"
+            or draft_quant_config.get_name()
+            not in ("awq", "modelopt_fp4", "modelopt_mixed", "fp8")
+            or draft_vllm_config.parallel_config.pipeline_parallel_size != 1
+            or draft_vllm_config.parallel_config.enable_expert_parallel
+            or speculative_config.rejection_sample_method != "standard"
         ):
             raise ValueError(
-                "MTP FP8 experts require SM70, FP16, and an AWQ checkpoint"
+                "MTP FP8 experts require SM70, FP16, an AWQ/ModelOpt/FP8 draft "
+                "checkpoint, tensor parallelism without PP or EP, and standard "
+                "rejection sampling"
             )
-        draft_quant_config = MTPExpertFp8Config(draft_quant_config)
+        draft_quant_config = MTPExpertFp8Config(
+            draft_quant_config,
+            checkpoint_prefixes,
+            quantize_unquantized=online_fp8,
+        )
     draft_vllm_config.quant_config = draft_quant_config
     return draft_vllm_config
 
@@ -226,6 +263,14 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
             vllm_config,
             self.mtp_start_layer_idx,
         )
+        self.fp8_mtp_checkpoint_prefixes = {
+            f"model.layers.{int(name.split('.')[2]) - self.mtp_start_layer_idx}"
+            ".mlp.experts"
+            for name in getattr(
+                draft_vllm_config.quant_config, "checkpoint_prefixes", ()
+            )
+        }
+        self.fp8_mtp_tp_size = draft_vllm_config.parallel_config.tensor_parallel_size
         with set_current_vllm_config(draft_vllm_config, prefix=prefix):
             # residual_linear_shared fusion: fc_embedding projects the token
             # embedding, fc_hidden (shared across HC branches) projects the
@@ -510,7 +555,16 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
             skip_substrs=["hyper_connection_mixer.block_inject_weight"],
             ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
         )
-        loaded_weights = loader.load_weights(remap_weight_names())
+        from .mtp_fp8_checkpoint import prepare_mtp_fp8_checkpoint
+
+        loaded_weights = loader.load_weights(
+            prepare_mtp_fp8_checkpoint(
+                remap_weight_names(),
+                self.model.fp8_mtp_checkpoint_prefixes,
+                tp_size=self.model.fp8_mtp_tp_size,
+                num_experts=self.model.config.num_experts,
+            )
+        )
         _validate_mtp_expert_weights_loaded(self, loaded_weights)
         return loaded_weights
 

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_checkpoint.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_checkpoint.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Preserve checkpoint FP8 blocks across padded MTP tensor-parallel shards."""
+
+from collections.abc import Iterable, Iterator
+
+import torch
+
+
+def padded_mtp_fp8_width(intermediate: int, tp_size: int) -> int:
+    """Use one block-aligned physical width for all logical TP slices."""
+    if intermediate <= 0 or tp_size <= 0:
+        raise ValueError("MTP expert width and TP size must be positive")
+    max_offset = max((rank * intermediate) % 128 for rank in range(tp_size))
+    return (intermediate + max_offset + 127) // 128 * 128
+
+
+def pad_mtp_fp8_checkpoint_matrix(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    down_projection: bool,
+    tp_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Expand a global matrix for the ordinary block-aware TP loader.
+
+    Retain the original FP8 bytes and block scales. Each TP slice starts at
+    its original offset within a 128-wide block; zero padding masks elements
+    owned by neighboring ranks. Gate/up rows and down columns therefore use
+    the same physical intermediate coordinates, without requantization.
+    """
+    if weight.ndim != 2 or weight.dtype != torch.float8_e4m3fn:
+        raise ValueError("MTP checkpoint weights must be 2D FP8 E4M3 tensors")
+    expected = tuple((dim + 127) // 128 for dim in weight.shape)
+    if tuple(scale.shape) != expected or not scale.is_floating_point():
+        raise ValueError(f"MTP checkpoint scales must have block shape {expected}")
+    if not torch.isfinite(weight.float()).all():
+        raise ValueError("MTP checkpoint weights must be finite")
+    if not torch.isfinite(scale).all() or (scale < 0).any():
+        raise ValueError("MTP checkpoint scales must be finite and nonnegative")
+    kernel_scale = scale.to(torch.float16)
+    if (
+        not torch.isfinite(kernel_scale).all()
+        or ((scale > 0) & (kernel_scale == 0)).any()
+    ):
+        raise ValueError("MTP checkpoint scales are outside the SM70 FP16 scale range")
+    axis = 1 if down_projection else 0
+    if tp_size <= 0 or weight.shape[axis] % tp_size:
+        raise ValueError("MTP checkpoint intermediate width must divide TP size")
+    if weight.shape[1 - axis] % 128:
+        raise ValueError("MTP checkpoint hidden size must be divisible by 128")
+    logical = weight.shape[axis] // tp_size
+    padded = padded_mtp_fp8_width(logical, tp_size)
+    shape = list(weight.shape)
+    shape[axis] = padded * tp_size
+    result = weight.new_zeros(shape)
+    scale_shape = list(expected)
+    scale_shape[axis] = padded // 128 * tp_size
+    result_scale = scale.new_ones(scale_shape)
+    for rank in range(tp_size):
+        start = rank * logical
+        offset = start % 128
+        result.narrow(axis, rank * padded + offset, logical).copy_(
+            weight.narrow(axis, start, logical)
+        )
+        block_count = (offset + logical + 127) // 128
+        result_scale.narrow(axis, rank * (padded // 128), block_count).copy_(
+            scale.narrow(axis, start // 128, block_count)
+        )
+    return result, result_scale
+
+
+def prepare_mtp_fp8_checkpoint(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    expert_prefixes: set[str],
+    *,
+    tp_size: int,
+    num_experts: int,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Pair checkpoint weights/scales and retain their FP8 representation.
+
+    Other model tensors pass through unchanged. Check completeness per expert,
+    not just per fused runtime parameter, before accepting the checkpoint.
+    """
+    if not expert_prefixes:
+        yield from weights
+        return
+    pending: dict[str, dict[str, torch.Tensor]] = {}
+    seen: set[str] = set()
+    projections = {"gate_proj", "up_proj", "down_proj"}
+    expected = {
+        f"{prefix}.{expert}.{projection}.{suffix}"
+        for prefix in expert_prefixes
+        for expert in range(num_experts)
+        for projection in projections
+        for suffix in ("weight", "weight_scale_inv")
+    }
+    for name, tensor in weights:
+        if name not in expected:
+            if any(name.startswith(prefix + ".") for prefix in expert_prefixes):
+                raise ValueError(f"Unexpected MTP FP8 expert tensor: {name}")
+            yield name, tensor
+            continue
+        if name in seen:
+            raise ValueError(f"Duplicate MTP FP8 checkpoint tensor: {name}")
+        seen.add(name)
+        base, suffix = name.rsplit(".", 1)
+        pair = pending.setdefault(base, {})
+        pair[suffix] = tensor
+        if len(pair) == 2:
+            weight, scale = pad_mtp_fp8_checkpoint_matrix(
+                pair["weight"],
+                pair["weight_scale_inv"],
+                down_projection=base.endswith(".down_proj"),
+                tp_size=tp_size,
+            )
+            del pending[base]
+            yield base + ".weight", weight
+            yield base + ".weight_scale_inv", scale
+    missing = expected - seen
+    if missing:
+        raise ValueError(
+            "Missing MTP FP8 checkpoint tensors: " + ", ".join(sorted(missing)[:5])
+        )

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
@@ -81,12 +81,20 @@ class MTPFp8SM70MoEMethod(Fp8SM70MoEMethod):
         # Channelwise scales avoid crossing gate/up or TP shard boundaries.
         for name in ("w13", "w2"):
             source = getattr(layer, name + "_weight")
-            quantized = torch.empty_like(source, dtype=torch.float8_e4m3fn)
+            padded_shape = pad_expert_matrix(source[0], name == "w13").shape
+            quantized = torch.empty(
+                (source.shape[0], *padded_shape),
+                dtype=torch.float8_e4m3fn,
+                device=source.device,
+            )
             scales = torch.empty(
-                (*source.shape[:2], 1), dtype=torch.float32, device=source.device
+                (source.shape[0], padded_shape[0], 1),
+                dtype=torch.float32,
+                device=source.device,
             )
             for expert in range(source.shape[0]):
-                quantized[expert], scales[expert] = quantize_expert_rows(source[expert])
+                padded = pad_expert_matrix(source[expert], name == "w13")
+                quantized[expert], scales[expert] = quantize_expert_rows(padded)
             setattr(
                 layer, name + "_weight", nn.Parameter(quantized, requires_grad=False)
             )
@@ -96,6 +104,22 @@ class MTPFp8SM70MoEMethod(Fp8SM70MoEMethod):
         # The existing packer accepts channel scales and the existing method
         # discards the unpacked weights after preparing the runtime layout.
         super().process_weights_after_loading(layer)
+
+
+def pad_expert_matrix(weight: torch.Tensor, gate_up: bool) -> torch.Tensor:
+    """Keep gate/up halves aligned with the zero-padded down-projection input."""
+    intermediate = weight.shape[0] // 2 if gate_up else weight.shape[1]
+    padded = (intermediate + 127) // 128 * 128
+    if padded == intermediate:
+        return weight
+    if gate_up:
+        result = weight.new_zeros((2 * padded, weight.shape[1]))
+        result[:intermediate].copy_(weight[:intermediate])
+        result[padded : padded + intermediate].copy_(weight[intermediate:])
+    else:
+        result = weight.new_zeros((weight.shape[0], padded))
+        result[:, :intermediate].copy_(weight)
+    return result
 
 
 class MTPExpertFp8Config(QuantizationConfig):

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Online weight-only FP8 storage for the standalone SM70 MTP experts."""
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+    UnquantizedFusedMoEMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.fp8_sm70_moe import Fp8SM70MoEMethod
+from vllm.model_executor.utils import set_weight_attrs
+
+
+def quantize_expert_rows(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize one already-sharded matrix; zero rows retain a finite scale.
+
+    Channel scales are rounded to FP16 before quantizing because the SM70
+    weight-only kernel consumes FP16 scales. No target-model tensor is modified.
+    """
+    if weight.ndim != 2 or weight.dtype != torch.float16:
+        raise ValueError("MTP online FP8 requires a two-dimensional FP16 matrix")
+    if not torch.isfinite(weight).all():
+        raise ValueError("Cannot quantize non-finite MTP expert weights")
+    limit = torch.finfo(torch.float8_e4m3fn).max
+    scale = (
+        (weight.float().abs().amax(dim=1, keepdim=True) / limit)
+        .clamp_min(torch.finfo(torch.float16).tiny)
+        .half()
+        .float()
+    )
+    quantized = (weight.float() / scale).clamp(-limit, limit)
+    return quantized.to(torch.float8_e4m3fn), scale
+
+
+class MTPFp8SM70MoEMethod(Fp8SM70MoEMethod):
+    """Load ordinary TP shards, then retain only packed FP8 expert weights."""
+
+    def __init__(self, layer: RoutedExperts):
+        super().__init__(
+            SimpleNamespace(weight_block_size=[128, 128], activation_scheme="dynamic"),
+            layer,
+        )
+
+    def create_weights(
+        self,
+        layer,
+        num_experts,
+        hidden_size,
+        intermediate_size_per_partition,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        if params_dtype != torch.float16 or not self.moe.is_act_and_mul:
+            raise ValueError("SM70 MTP FP8 requires FP16 gated experts")
+        layer.num_experts = num_experts
+        layer.orig_dtype = params_dtype
+        # The checkpoint is unquantized. The normal loader must slice its
+        # weights in element units, including a TP4 intermediate width of 160.
+        layer.weight_block_size = None
+        for name, shape in (
+            (
+                "w13_weight",
+                (num_experts, 2 * intermediate_size_per_partition, hidden_size),
+            ),
+            ("w2_weight", (num_experts, hidden_size, intermediate_size_per_partition)),
+        ):
+            param = nn.Parameter(
+                torch.empty(shape, dtype=params_dtype), requires_grad=False
+            )
+            layer.register_parameter(name, param)
+            set_weight_attrs(param, extra_weight_attrs)
+        layer.w13_input_scale = layer.w2_input_scale = None
+
+    def process_weights_after_loading(self, layer):
+        # Work one expert at a time, rather than creating a full FP32 MoE copy.
+        # Channelwise scales avoid crossing gate/up or TP shard boundaries.
+        for name in ("w13", "w2"):
+            source = getattr(layer, name + "_weight")
+            quantized = torch.empty_like(source, dtype=torch.float8_e4m3fn)
+            scales = torch.empty(
+                (*source.shape[:2], 1), dtype=torch.float32, device=source.device
+            )
+            for expert in range(source.shape[0]):
+                quantized[expert], scales[expert] = quantize_expert_rows(source[expert])
+            setattr(
+                layer, name + "_weight", nn.Parameter(quantized, requires_grad=False)
+            )
+            layer.register_parameter(
+                name + "_weight_scale_inv", nn.Parameter(scales, requires_grad=False)
+            )
+        # The existing packer accepts channel scales and the existing method
+        # discards the unpacked weights after preparing the runtime layout.
+        super().process_weights_after_loading(layer)
+
+
+class MTPExpertFp8Config(QuantizationConfig):
+    """Override only excluded, unquantized MTP experts in a draft config."""
+
+    def __init__(self, fallback: QuantizationConfig):
+        super().__init__()
+        self.fallback = fallback
+        self.packed_modules_mapping = fallback.packed_modules_mapping
+
+    def get_name(self):
+        return self.fallback.get_name()
+
+    def get_supported_act_dtypes(self):
+        return [torch.float16]
+
+    @classmethod
+    def get_min_capability(cls):
+        return 70
+
+    @staticmethod
+    def get_config_filenames():
+        return []
+
+    @classmethod
+    def from_config(cls, config):
+        raise NotImplementedError("Construct from the resolved MTP draft config")
+
+    def get_cache_scale(self, name):
+        return self.fallback.get_cache_scale(name)
+
+    def get_quant_method(self, layer, prefix):
+        method = self.fallback.get_quant_method(layer, prefix)
+        if isinstance(layer, RoutedExperts) and prefix.startswith("mtp.layers."):
+            if not isinstance(method, UnquantizedFusedMoEMethod):
+                raise ValueError(
+                    "Online MTP FP8 requires unquantized checkpoint experts"
+                )
+            return MTPFp8SM70MoEMethod(layer)
+        return method

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
@@ -234,9 +234,19 @@ class MTPExpertFp8Config(QuantizationConfig):
             and isinstance(layer, RoutedExperts)
             and prefix.startswith("mtp.layers.")
         ):
+            from vllm.model_executor.layers.quantization.modelopt import (
+                ModelOptMixedPrecisionConfig,
+            )
+
             excluded = getattr(self.fallback, "is_layer_excluded", lambda _: False)
+            # Mixed checkpoints also leave layers unquantized by omitting them
+            # from quantized_layers; an explicit exclusion is not required.
+            absent_from_mixed = (
+                isinstance(self.fallback, ModelOptMixedPrecisionConfig)
+                and self.fallback._resolve_quant_algo(prefix) is None
+            )
             if not isinstance(method, UnquantizedFusedMoEMethod) and not (
-                method is None and excluded(prefix)
+                method is None and (excluded(prefix) or absent_from_mixed)
             ):
                 raise ValueError(
                     "Online MTP FP8 requires unquantized checkpoint experts"

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
@@ -57,6 +57,8 @@ class MTPFp8SM70MoEMethod(Fp8SM70MoEMethod):
     ):
         if params_dtype != torch.float16 or not self.moe.is_act_and_mul:
             raise ValueError("SM70 MTP FP8 requires FP16 gated experts")
+        if hidden_size % 128:
+            raise ValueError("SM70 MTP FP8 requires a hidden size divisible by 128")
         layer.num_experts = num_experts
         layer.orig_dtype = params_dtype
         # The checkpoint is unquantized. The normal loader must slice its

--- a/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp_fp8_experts.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Online weight-only FP8 storage for the standalone SM70 MTP experts."""
+"""Checkpoint and online weight-only FP8 for standalone SM70 MTP experts."""
 
 from types import SimpleNamespace
 
@@ -14,6 +14,71 @@ from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.quantization.fp8_sm70_moe import Fp8SM70MoEMethod
 from vllm.model_executor.utils import set_weight_attrs
+
+from .mtp_fp8_checkpoint import padded_mtp_fp8_width
+
+
+def checkpoint_fp8_prefixes(fallback, expert_prefixes: set[str]) -> set[str]:
+    """Resolve supported checkpoint formats independently of target quantization."""
+    if fallback.get_name() == "fp8" and fallback.is_checkpoint_fp8_serialized:
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            is_layer_skipped,
+        )
+
+        selected = {
+            prefix
+            for prefix in expert_prefixes
+            if not is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=fallback.ignored_layers,
+                fused_mapping=fallback.packed_modules_mapping,
+                match_mode=fallback.ignored_layers_match_mode,
+            )
+        }
+        if not selected:
+            return set()
+        if fallback.weight_block_size != [128, 128]:
+            raise ValueError("MTP checkpoint FP8 requires 128x128 block scales")
+        return selected
+    result = set()
+    if fallback.get_name() == "modelopt_mixed":
+        from vllm.model_executor.layers.quantization.modelopt import (
+            _BLOCK_FP8_MOE_ALGOS,
+        )
+
+        for prefix in expert_prefixes:
+            if fallback.is_layer_excluded(prefix):
+                continue
+            if fallback._resolve_quant_algo(prefix) in _BLOCK_FP8_MOE_ALGOS:
+                if fallback.fp8_block_config.weight_block_size != [128, 128]:
+                    raise ValueError("MTP checkpoint FP8 requires 128x128 block scales")
+                result.add(prefix)
+    return result
+
+
+class MTPCheckpointFp8SM70MoEMethod(Fp8SM70MoEMethod):
+    """Load padded checkpoint FP8 blocks without an FP16 expert allocation."""
+
+    def __init__(self, layer: RoutedExperts):
+        super().__init__(
+            SimpleNamespace(weight_block_size=[128, 128], activation_scheme="dynamic"),
+            layer,
+        )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size,
+        intermediate_size_per_partition,
+        act_dtype,
+        moe_parallel_config,
+    ):
+        if act_dtype != torch.float16 or hidden_size % 128:
+            raise ValueError(
+                "SM70 MTP FP8 requires FP16 and hidden size divisible by 128"
+            )
+        return hidden_size, padded_mtp_fp8_width(
+            intermediate_size_per_partition, moe_parallel_config.tp_size
+        )
 
 
 def quantize_expert_rows(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -127,10 +192,17 @@ def pad_expert_matrix(weight: torch.Tensor, gate_up: bool) -> torch.Tensor:
 class MTPExpertFp8Config(QuantizationConfig):
     """Override only excluded, unquantized MTP experts in a draft config."""
 
-    def __init__(self, fallback: QuantizationConfig):
+    def __init__(
+        self,
+        fallback: QuantizationConfig,
+        checkpoint_prefixes: set[str] | None = None,
+        quantize_unquantized: bool = True,
+    ):
         super().__init__()
         self.fallback = fallback
         self.packed_modules_mapping = fallback.packed_modules_mapping
+        self.checkpoint_prefixes = checkpoint_prefixes or set()
+        self.quantize_unquantized = quantize_unquantized
 
     def get_name(self):
         return self.fallback.get_name()
@@ -154,9 +226,18 @@ class MTPExpertFp8Config(QuantizationConfig):
         return self.fallback.get_cache_scale(name)
 
     def get_quant_method(self, layer, prefix):
+        if isinstance(layer, RoutedExperts) and prefix in self.checkpoint_prefixes:
+            return MTPCheckpointFp8SM70MoEMethod(layer)
         method = self.fallback.get_quant_method(layer, prefix)
-        if isinstance(layer, RoutedExperts) and prefix.startswith("mtp.layers."):
-            if not isinstance(method, UnquantizedFusedMoEMethod):
+        if (
+            self.quantize_unquantized
+            and isinstance(layer, RoutedExperts)
+            and prefix.startswith("mtp.layers.")
+        ):
+            excluded = getattr(self.fallback, "is_layer_excluded", lambda _: False)
+            if not isinstance(method, UnquantizedFusedMoEMethod) and not (
+                method is None and excluded(prefix)
+            ):
                 raise ValueError(
                     "Online MTP FP8 requires unquantized checkpoint experts"
                 )


### PR DESCRIPTION
## Problem and implementation

Qwen4Exp MTP experts can consume substantial memory even when the target is AWQ or NVFP4. Keep the draft experts resident in FP8 while preserving the target model and standard rejection verification. Reduced proposal acceptance is allowed; the unchanged target distribution must be preserved.

Support both input routes:

- Opt-in online conversion of unquantized MTP experts with `"mtp_expert_quantization": "fp8"`.
- Direct loading of serialized E4M3 MTP experts and their original 128x128 block scales, independently of the target's AWQ/NVFP4 quantization. Use the existing speculative `model` field for a separate draft checkpoint; ModelOpt mixed checkpoints and regular block-FP8 metadata are recognized.

This backports **vllm-project/vllm#55513**, merged as `60ad959b6f1a5c8f602edbd608c8decbc0788c50`: ModelOpt `FP8_PB_WO` / `FP8_BLOCK_SCALES` dispatch and AMD/NVIDIA MTP layer-metadata remapping. The new work is SM70 resident execution, TP padding that preserves original FP8 bytes and block-scale offsets, and the independent online expert option. It does not depend on 1CatAI/1Cat-vLLM#553, whose SM70 fallback retains FP16 expert weights. vllm-project/vllm#55498 overlaps the already-merged generic loading fix.

On the tested TP4 shape, logical width 160 needs physical width 256. Native checkpoint loading preserves offsets 0/32/64/96 inside original scale blocks, without dequantizing and requantizing. The SM70 kernel uses FP16 scales; overflowing/underflowing scales are rejected. Online conversion is restricted to unquantized draft experts. Explicit opt-in is rejected on non-SM70 platforms, including ROCm. FP16 and online FP8 MTP use distinct compilation keys, and neither reuses the legacy key that omitted this option. SM70/FP16, Qwen4ExpMTP, ordinary TP without PP/EP, and standard rejection sampling are required.

## Validation

**Both loading routes completed full-model tests with AWQ and NVFP4 targets.**

- CPU: `.venv/bin/python -m pytest tests/models/qwen4_exp/test_mtp_fp8_experts.py tests/models/qwen4_exp/test_mtp_fp8_checkpoint.py -q`: **52 passed**. Includes compilation-key separation (including rejection of legacy ambiguous keys), unsupported-platform rejection, both ModelOpt aliases, exclusions, metadata remapping, TP1/2/4/8 byte/scale preservation, incomplete checkpoints, the real allocator/TP loader with AWQ/NVFP4/mixed configuration names, and online conversion of unquantized experts omitted from mixed metadata.
- V100: `.venv/bin/python -m pytest tests/models/qwen4_exp/test_mtp_fp8_experts_gpu.py -q`: **20 passed**, covering online and checkpoint-native methods, four TP4 offsets, M=1/2/8/64, reference reconstruction and exact CUDA Graph replay.
- Original NVIDIA checkpoint experts with original BF16 scales: four V100 processes × M=1/2/8/64 passed. Maximum absolute error 0.0008544921875, relative L2 below 0.00082; graph replay exact. These scales retain their values exactly in the kernel's FP16 representation.
- Checkpoint-native AWQ: same-source FP16-control versus original FP8 experts, **30992 to 29982 MiB/rank (1010 MiB saved)**. Both arms completed 16 complete greedy and 16 stochastic requests. Full choices matched in 14/16 cases and usage in 15/16; probability and list-versus-tuple explanations differed in wording while retaining their conclusions. The unchanged FP16 control also varied on a serial wording retest; original pair results are retained.
- Checkpoint-native NVFP4: same-source FP16-control versus original FP8 experts, **31960 to 31068 MiB/rank (892 MiB saved)**. **16/16 complete greedy choices and token usage identical**, plus 16 successful finite-logprob stochastic requests per arm. Every rank retained 975 MiB of packed MTP expert weights/scales; original expert parameters were absent.
- NVFP4 online conversion: the target checkpoint's own unquantized MTP loaded and retained **975 MiB expert payload/rank**, with no original FP16 expert parameters. Whole-GPU usage was **31048 MiB/rank** after both campaigns. Completed 16 greedy and 16 finite-logprob stochastic requests; all greedy choices/usage matched the same NVFP4 target control. This uses a different MTP source from the native FP16 control, so it is an integration/output check rather than a same-source quantization comparison.
- Earlier online AWQ paired validation: fixed 5-GiB KV/rank, TP4/MTP3/C2, 16/16 final greedy responses identical to FP16 baseline, 16 stochastic requests per arm successful with finite logprobs. Actual packed expert weights/scales were 975 versus 1200 MiB/rank; whole-GPU usage was 29962 versus 30992 MiB/rank. The extra saving beyond 225 MiB of payload was not individually attributed.
- Existing rejection-sampler tests passed in the native runtime, including adversarial draft distributions at K1/K3 with 200,000 trials each, greedy verification and calibrated nucleus sampling.
- Applicable pre-commit hooks passed. These are local checks, not a claim of hosted CI success.

All paired full-model arms use TP4/MTP3/C2, FP16 execution/KV, CUDA Graphs and fixed 5-GiB KV/rank. Memory values are idle snapshots after both greedy and stochastic campaigns, identical across all four ranks. Whole-GPU reductions include runtime overhead and must not be attributed entirely to the 225-MiB expert-payload reduction. Actual test prompts reach approximately 7700 tokens; configured 262144 context is not a full-context validation.

The native runtime uses extensions built from `752f86495f`, with changed Python modules overlaid from this branch based on `fe67339ddf`; it is not a clean native rebuild. The first checkpoint-native AWQ run preceded two additional input guards; the 20 GPU tests and NVFP4 runs include them. Main target weights, shared-head handling and rejection sampling are not modified. Tests are bounded correctness/integration evidence, not a universal bitwise or benchmark-quality guarantee. Standard rejection sampling preserves the unchanged target distribution using actual proposal probabilities. No throughput or loading-peak improvement is claimed.

See [design and validation details](https://github.com/Leonccaa/1Cat-vLLM/blob/feat/sm70-fp8-mtp-experts/docs/design/sm70_awq_fp8_mtp_experts.md). This submits the implementation validated in Leonccaa/1Cat-vLLM#13 for upstream review. No production deployment is included.

AI assistance: Codex assisted with implementation, tests and documentation under the submitter's direction.

