### PR TITLE
[Perf] Recover DFlash2 capacity-tail graph execution

### DIFF
--- a/benchmarks/sm70_dflash2_tail_audit.py
+++ b/benchmarks/sm70_dflash2_tail_audit.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A/B instrumentation only; candidate dispatch and operators are runtime code."""
+
+from collections import Counter
+
+import torch
+
+from benchmarks.sm70_dflash2_prefill_route_audit import (
+    PrefillRouteAuditExtension as Base,
+)
+from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
+from vllm.v1.attention.ops import sm70_e4m3_long as grouped
+from vllm.v1.attention.ops import sm70_e4m3_scalar as scalar
+from vllm.v1.worker.gpu import cudagraph_utils as cg
+
+MODE = "candidate"
+COUNTS = Counter()
+MANAGERS = []
+original_init = cg.ModelCudaGraphManager.__init__
+original_dispatch = cg.CudaGraphManager.dispatch
+original_select = cg.ModelCudaGraphManager.select_attention_graph
+original_scalar = FlashAttnV100Impl._call_flash_attn_decode_paged
+original_scalar_load = scalar.load_scalar_tail_attention
+original_grouped_load = grouped.load_long_attention
+
+
+def init(self, *args, **kwargs):
+    original_init(self, *args, **kwargs)
+    if self._sm70_dflash2_tail_graphs:
+        MANAGERS.append(self)
+
+
+def dispatch(self, num_reqs, num_tokens, uniform_token_count):
+    tail = (
+        self in MANAGERS
+        and num_reqs == 1
+        and num_tokens == uniform_token_count
+        and 1 <= num_tokens < 8
+    )
+    if tail and MODE == "control" and self._graphs_captured:
+        COUNTS[f"control_q{num_tokens}_NONE"] += 1
+        return cg.BatchExecutionDescriptor(
+            cg_mode=cg.CUDAGraphMode.NONE, num_tokens=num_tokens, num_reqs=num_reqs
+        )
+    desc = original_dispatch(self, num_reqs, num_tokens, uniform_token_count)
+    if tail and self._graphs_captured:
+        COUNTS[f"{MODE}_q{num_tokens}_{desc.cg_mode.name}"] += 1
+    return desc
+
+
+def scalar_call(self, *args, **kwargs):
+    saved = self._sm70_scalar_tail_attention
+    if MODE == "control":
+        self._sm70_scalar_tail_attention = None
+    try:
+        return original_scalar(self, *args, **kwargs)
+    finally:
+        self._sm70_scalar_tail_attention = saved
+
+
+def select(self, desc, upper):
+    selected = original_select(self, desc, upper)
+    if self._graphs_captured and desc.num_reqs == 1 and 1 <= desc.num_tokens < 8:
+        COUNTS[
+            f"{MODE}_q{desc.num_tokens}_bucket_{selected.attention_context_bucket}"
+        ] += 1
+    return selected
+
+
+def scalar_load(*args, **kwargs):
+    op = original_scalar_load(*args, **kwargs)
+
+    def run(*a, **kw):
+        hit = op(*a, **kw)
+        if hit:
+            COUNTS["scalar_native_bindings"] += 1
+        return hit
+
+    return run
+
+
+def grouped_load(*args, **kwargs):
+    op, manifest = original_grouped_load(*args, **kwargs)
+
+    def run(*a, **kw):
+        COUNTS[f"grouped_q{a[0].shape[0]}_bindings"] += 1
+        return op(*a, **kw)
+
+    return run, manifest
+
+
+cg.ModelCudaGraphManager.__init__ = init
+cg.CudaGraphManager.dispatch = dispatch
+cg.ModelCudaGraphManager.select_attention_graph = select
+FlashAttnV100Impl._call_flash_attn_decode_paged = scalar_call
+scalar.load_scalar_tail_attention = scalar_load
+grouped.load_long_attention = grouped_load
+
+
+class TailAuditExtension(Base):
+    def tail_switch(self, mode):
+        global MODE
+        assert mode in ("control", "candidate")
+        torch.accelerator.synchronize()
+        MODE = mode
+        return self.tail_snapshot()
+
+    def long_attention_switch(self, mode):
+        assert mode == "candidate"
+        return self.tail_snapshot()
+
+    def tail_snapshot(self):
+        return dict(
+            rank=torch.distributed.get_rank(),
+            mode=MODE,
+            counts=dict(COUNTS),
+            graphs=[str(d) for m in MANAGERS for d in m.graphs],
+            contract=grouped.long_attention_graph_contract(),
+        )

--- a/docs/design/sm70_dflash2_tail_graphs_20260911.md
+++ b/docs/design/sm70_dflash2_tail_graphs_20260911.md
@@ -1,0 +1,199 @@
+# DFlash2 capacity-tail graph recovery
+
+## Problem and contract
+
+The TP4 QUASAR DFlash2 request at 261888 input tokens and 256 output tokens
+reaches the 262144-token capacity. Its normal q8 path remains approximately
+linear in context length, but the final partial-verifier and non-speculative
+q1 steps lose both full CUDA graphs and optimized attention dispatch.
+
+The inherited tail flag was nested inside adaptive lookup initialization.
+Ordinary seven-draft DFlash2 therefore never registered its q1/q6 graphs.
+The original long-attention loader also admitted only q8 through 132096.
+
+The workload is QUASAR Qwen3.8-27B NVFP4 revision
+`d8e6fbfa3e3a78899b440222b827430045a05b44`, DFlash2 revision
+`dedf8df68adfb1afeaf7b7480c0a0243108177b4`, four V100-SXM2-32GB GPUs, TP4,
+FP16 activations, E4M3 target KV, FP32 state/logits, CUDA 12.8 and
+Torch 2.10.0+cu128. Sequential requests use T=1, top-k=20, top-p=0.95,
+seven probabilistic drafts, Flash-V100 and CUDA graphs. The server retains
+max-num-seqs=4, max-num-batched-tokens=4096, memory utilization 0.8,
+prefix caching and aligned Mamba caching. This is a bounded speed window,
+not natural-EOS dataset scoring. Physical devices and local manifests are
+recorded in the retained handoff.
+
+Integration base: `fe67339ddf862df0441a4e844fc664d9cafdffd0`.
+Inherited PR596 head: `9930ebe8e6bff1fb031740d5787f86f6193d2cd9`.
+
+## Implementation
+
+`VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS=1` registers target-only B1 q1 through q7
+alongside q8. It does not depend on lookup augmentation and does not add
+tail shapes to the drafter, other speculative methods or multi-request
+uniform batches. Sequence-parallel configurations retain the previous path.
+The flag remains disabled by default.
+
+The grouped manifest can explicitly declare `max_context` and `query_rows`.
+Without those fields the contract remains 132096 and q8. A selected
+256K manifest uses `max_context: 262144` and `query_rows: [2,3,4,5,6,7,8]`.
+The CPU bound controls graph selection; device row lengths remain
+authoritative. Oversized or device-only bounds use the ordinary graph.
+No attention truncation, capacity increase or arithmetic change is made.
+
+`VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST` optionally loads the existing
+compact E4M3 q1 library. The loader checks the DSO hash and the compact
+six-head/lookup/256K contract. Its persistent FP32 numerator, maximum and
+sum buffers are allocated before profiling and capture, outside the graph
+pool. The operator requires the explicit 256K graph descriptor and the
+admitted B1/H6/D256/page3296 E4M3 layout. Short q1 contexts below 128K,
+windows, anchors and partition overrides retain the original operator.
+
+GDN runtime code is unchanged. Capture intentionally uses PAD_SLOT_ID to
+avoid mutating live state; tests verify that runtime preparation updates the
+same captured storage for all q1-q8 widths under both `none` and `align`
+Mamba cache modes. A comparison of capture placeholder values with live
+values alone would incorrectly diagnose this protection as a state bug.
+
+## Native prerequisites
+
+The grouped candidate retains 80 logical splits, K16 compensated QK,
+N32 online updates, compensated P/residual products and the complete FP32
+workspace. The scalar candidate retains its 256 partitions of 1024 tokens
+and complete FP32 partition buffers. No native source is changed here.
+
+| Native candidate | Source SHA256 | Measured DSO SHA256 |
+| --- | --- | --- |
+| P layout, early store, E4M3 lookup | `eb7a85511f581fcd22cf13619c85ed2f42a8cbc8b216bb3e632bf448f6b820e1` | `9db33737adb880cd4198266ac4f29785ce3e709936aa47dcc79011a9bce4b811` |
+| Compact scalar, lookup, 4 KiB shared reservation | `5e68578c0252c7525496abab98aef5ed5f774528ac1dab6c5e1c587912cfa632` | `6d2b2b1ec5e0501de9abf49a81670cca2fb2ee700be66365f98db118a62fee21` |
+
+The existing builders are `build_sm70_grouped_attention_swizzle.py` and
+`build_sm70_scalar_attention_candidate.py`. Keep their frozen source inputs
+and manifests; new compilations have their own DSO hashes. The former uses
+the admitted exact-LUT parent with `--probabilities --early-store`; the
+latter uses `--share-kv-six-heads --e4m3-lut --compact-page-map
+--dynamic-shared-bytes 4096`. Retained full workspace, tail and sanitizer
+evidence is documented in the
+[attention worklog](sm70_dflash2_attention_resources_20260910.md) and
+[long verification worklog](sm70_dflash2_long_verify_curve_20260909.md).
+
+Enable the measured runtime with explicit startup configuration:
+
+```bash
+export VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS=1
+export VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST=/path/to/grouped-tail-manifest.json
+export VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST=/path/to/compact-scalar/manifest.json
+```
+
+This change does not enable the separately frozen QPN2/context performance
+harness by default. Both A/B arms retain that same harness, FA2 sidecar,
+original FlashQLA prefill and q8 P-layout candidate. Legacy experimental
+hooks which overwrite MAX_CONTEXT with 262152 are not part of this runtime.
+
+## Verification
+
+First final-code startup: one warmup per arm, then three alternating measured
+requests per arm, at each of the four workload points below. All 16 request
+pairs preserve token IDs, finish reason and acceptance records. Each table
+entry is a median of request-average complete-round measurements.
+
+| Input | Seed | Control ms | Tail graphs ms | Saved ms |
+| ---: | ---: | ---: | ---: | ---: |
+| 1024 | 0 | 15.808 | 15.804 | 0.004 |
+| 131072 | 0 | 22.573 | 22.577 | -0.004 |
+| 261888 | 0 | 35.464 | 31.390 | 4.073 |
+| 261888 | 2 | 37.884 | 31.335 | 6.549 |
+
+Seed 0 reaches q1 tails. Seed 2 also reaches q6 and q7; all four ranks
+record actual FULL dispatch for these shapes. The first final-code startup
+records 36 q1, 12 q6 and 12 q7 dispatches over the three measured seed-2
+candidate requests across four ranks. Short-context runs have no tail
+dispatches. Native binding counters describe capture/warmup; graph selection
+and replay are separately observed.
+
+An earlier final-runtime integration smoke uses three seeds and twelve
+requests, all exact. Its warmed seed-2 result is 37.453 to 31.275 ms and
+154.739 to 185.307 pure decode tokens/s. Its scalar admission was subsequently
+restricted to the explicit long-context descriptor; the table above tests
+that final restriction. These startups are not interchangeable controls.
+
+Focused CPU checks cover actual graph initialization/dispatch, default-off,
+non-DFlash, non-SM70, draft manager and sequence-parallel fallbacks, manifest
+bounds, scalar layout/scale admission, and capture-to-runtime GDN buffer
+refresh. All applicable pre-commit hooks pass. Expanded final startup
+results and aggregate distributions are appended below when complete.
+
+## Rejected paths and limits
+
+The first private integration screen attempted to allocate the q6 workspace
+on its first eligible call, which occurred inside capture. The assertion
+failed before inference. The retained failure led to preallocating scalar
+buffers and keeping grouped workspaces in the existing graph-safe loader.
+
+Do not skip the drafter simply because the current q1 has no proposals:
+the observed scheduler can return from q1 to q8 after rejection correction.
+This change preserves scheduler accounting and all tail cost in the
+complete-round denominator. It does not alter capacity guards or sampling.
+
+The original 6.3-ms residual was not a pure non-attention stage: scalar
+attention had been classified as miscellaneous work, and q1 consumes time
+without incrementing the speculative-round counter. The q6 trace also shows
+rank arrival skew inside collectives. Unprofiled endpoint latency, traced
+kernel service and host time must remain separate.
+
+The 7-ms full-attention and 22-ms complete-round goals remain unmet.
+This scope recovers the boundary regression. It is not a complete numerical
+audit across every model, quantization, topology or natural-output corpus.
+
+## Three-startup result
+
+Three independent final-runtime startups complete 96 requests and 48 exact
+control/candidate pairs. Each startup and workload warms both arms before
+three alternating measurements. The runtime file hashes are identical.
+The third startup uses the packaged `benchmarks.sm70_dflash2_tail_audit`
+extension and additionally counts selected context buckets. Every measured
+q1/q6/q7 candidate tail selects the 262144 descriptor on all four ranks.
+
+| Input | Seed | Control round ms | Candidate round ms | Saved ms | Control/candidate pure decode tokens/s |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1024 | 0 | 15.823 | 15.824 | -0.001 | 298.432 / 298.419 |
+| 131072 | 0 | 22.573 | 22.577 | -0.004 | 191.441 / 191.374 |
+| 261888 | 0 | 35.464 | 31.396 | 4.067 | 143.809 / 162.337 |
+| 261888 | 2 | 37.403 | 31.335 | 6.068 | 154.899 / 184.953 |
+
+Round values are medians of the three startup medians; throughput values
+are medians across measured requests. Seed 2 preserves 4.727273 accepted
+drafts and 5.818182 emitted tokens per speculative round. Its latency drops
+16.22%. Seed 0 preserves 4.02 accepted drafts and 5.12 emitted tokens per
+speculative round; its latency drops 11.47%. Tail counts differ by generation
+trajectory, so the two seeds must remain separate comparisons.
+
+At 261888/seed2, warmed control/candidate prefill medians are 1200.716 and
+1201.185 ms; TTFT medians are 1439.936 and 1440.823 ms. These prefix-cached
+prefill values are separate from decode and are not cold-prefill throughput.
+Candidate request-average round mean/p50/p90/p99 are
+31.304/31.335/31.353/31.362 ms. Complete distributions, per-request tokens,
+acceptance and per-rank counters are retained in `final-summary-3starts.json`
+and `tail-final-{1,2,3}.json` under the local artifact root.
+
+After this repeated measurement, a narrow guard was added in
+`GPUModelRunner.execute_model`: q1-q7 prompts or prefill chunks do not use
+the decode-only tail graphs. Six actual-runner dispatch tests prove the
+prefill/decode distinction for q1/q6/q7. This guard does not affect the
+measured workload's 4096-token prefill chunks or decode. A final service
+check covers one-, six- and seven-token prompts plus the 261888/seed2 tail.
+The result of that check is recorded below.
+
+The final guard check completes 16 requests and eight exact pairs, including
+one-, six- and seven-token prompts. Its 261888/seed2 trajectory has 43
+speculative rounds and 4.837209 accepted drafts per round, differing from
+the prior startup sequence; retain this as a separate matched comparison.
+The warmed final-code pair improves 38.338 to 32.228 ms, saving 6.110 ms.
+It exercises q1/q6 FULL graphs and the 262144 context descriptors;
+q7 coverage comes from the preceding three-startup campaign.
+No short prefill is dispatched as a tail graph. Raw report:
+`tail-prefill-guard-1.json`.
+
+Final focused CPU suites pass 111 tests, with two GPU-only metadata tests
+skipped. The service validations above provide the actual V100 graph,
+operator-route and paired-output evidence. All relevant pre-commit checks
+pass. Every task-owned service is stopped and the rear-GPU leases released.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -2,6 +2,24 @@
 
 Date: 2026-05-30
 
+## DFlash2 TP4 capacity tails, 2026-09-11
+
+[The capacity-tail worklog](sm70_dflash2_tail_graphs_20260911.md) tracks PR596.
+Ordinary q8 DFlash2 did not enter the inherited lookup-only tail capture
+branch. Explicit target B1 q1-q7 graphs and manifest-bounded grouped/scalar
+attention now recover that path while retaining default-off behavior.
+Three independent starts, 96 requests and 48 exact pairs give 37.403 to
+31.335 ms at 261888/256 seed2, including q1/q6/q7 tail cost. Pure decode
+improves 154.899 to 184.953 tokens/s; 1K and 128K differences are under
+0.01 ms. A late short-prefill guard and its separate service check are
+tracked in the worklog; original repeated measurements remain identified.
+
+Do not repeat a capture-placeholder/live-state comparison as a GDN bug:
+PAD_SLOT_ID is intentional and runtime preparation refreshes the captured
+storage. Do not skip draft solely on proposals=0 or discard q1 time from
+the endpoint metric. No arithmetic, capacity guard or scheduler change is
+included. The complete-round 22-ms and attention 7-ms goals remain open.
+
 ## DFlash2 TP2 accepted endpoint, 2026-09-10
 
 The user closed TP2 optimization at **31.884546/29.279787 ms** complete rounds

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -1058,6 +1058,62 @@ def test_full_cuda_graph_capture_single_token_decode_is_not_spec(local_gdn_model
     assert meta.num_spec_decodes == 0
 
 
+@pytest.mark.parametrize("query_len", range(1, 9))
+@pytest.mark.parametrize("cache_mode", ["none", "align"])
+def test_dflash_tail_capture_matches_runtime_metadata(
+    local_gdn_model, query_len, cache_mode
+):
+    builders = [
+        _create_gdn_builder(
+            local_gdn_model,
+            num_speculative_tokens=7,
+            use_full_cuda_graph=True,
+            mamba_cache_mode=cache_mode,
+            max_cudagraph_capture_size=8,
+        )
+        for _ in range(2)
+    ]
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[262143], query_lens=[query_len]), BLOCK_SIZE, DEVICE
+    ).replace(
+        block_table_tensor=torch.arange(
+            10, 10 + 262144 // BLOCK_SIZE + 8, dtype=torch.int32
+        ).reshape(1, -1)
+    )
+    drafts = torch.tensor([-1 if query_len == 1 else query_len - 1])
+    runtime_kwargs = dict(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor([query_len], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=drafts,
+        common_gdn_metadata=compute_common_gdn_attn_metadata(
+            num_decode_draft_tokens_cpu=drafts,
+            query_start_loc=common.query_start_loc,
+            query_start_loc_cpu=common.query_start_loc_cpu,
+            num_spec_state_tokens=7,
+            legacy_mixed_decode_routing=False,
+        ),
+    )
+    runtime = builders[0].build(**runtime_kwargs)
+    captured = builders[1].build_for_cudagraph_capture(common)
+    # Capture deliberately poisons state indices. Runtime preparation must
+    # refresh the same storage referenced by the captured graph.
+    tensor = (
+        captured.non_spec_state_indices_tensor
+        if query_len == 1
+        else captured.spec_state_indices_tensor
+    )
+    pointer = tensor.data_ptr()
+    refreshed = builders[1].build(**runtime_kwargs)
+    refreshed_tensor = (
+        refreshed.non_spec_state_indices_tensor
+        if query_len == 1
+        else refreshed.spec_state_indices_tensor
+    )
+    assert refreshed_tensor.data_ptr() == pointer
+    _assert_gdn_metadata_equal(captured, runtime)
+
+
 def test_full_cuda_graph_capture_keeps_spec_state_selector(local_gdn_model):
     builder = _create_gdn_builder(
         local_gdn_model,

--- a/tests/v1/attention/test_sm70_e4m3_scalar_tail.py
+++ b/tests/v1/attention/test_sm70_e4m3_scalar_tail.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU admission checks for the explicitly loaded scalar tail operator."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.attention.ops import sm70_e4m3_scalar as scalar
+
+
+@pytest.fixture
+def scalar_call(monkeypatch):
+    calls = []
+    manifest = {
+        "share_kv_six_heads": True,
+        "compact_page_map": True,
+        "e4m3_lut": True,
+        "max_context": 262144,
+        "module_name": "test_scalar",
+        "library_sha256": "test_digest",
+    }
+    monkeypatch.setattr(
+        scalar,
+        "load_attention_library",
+        lambda _: (SimpleNamespace(run=lambda *args: calls.append(args)), manifest),
+    )
+    scalar.load_scalar_tail_attention.cache_clear()
+    monkeypatch.setattr(scalar, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        scalar,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            batch_descriptor=SimpleNamespace(attention_context_bucket=262144)
+        ),
+    )
+    run = scalar.load_scalar_tail_attention("test-manifest", torch.device("cpu"))
+    q = torch.zeros((1, 6, 256), dtype=torch.float16)
+    kv = torch.zeros((1, 3296, 1, 256), dtype=torch.uint8)
+    args = (
+        q,
+        kv,
+        kv,
+        torch.zeros((1, 80), dtype=torch.int32),
+        torch.tensor([262144], dtype=torch.int32),
+    )
+    kwargs = dict(
+        out=torch.empty_like(q),
+        softmax_scale=0.0625,
+        k_scale=1.0,
+        v_scale=1.0,
+        kv_cache_dtype="fp8_e4m3",
+        window_size=(-1, -1),
+        max_seq_len_hint=262144,
+        partition_size_hint=None,
+        anchor_lens=None,
+        anchored_window=0,
+    )
+    yield run, args, kwargs, calls
+    scalar.load_scalar_tail_attention.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"max_seq_len_hint": 262145},
+        {"max_seq_len_hint": None},
+        {"max_seq_len_hint": torch.tensor(262144)},
+        {"window_size": (2048, 0)},
+        {"kv_cache_dtype": "fp8_e5m2"},
+        {"partition_size_hint": 512},
+        {"anchor_lens": torch.tensor([10]), "anchored_window": 2048},
+    ],
+)
+def test_scalar_tail_preserves_unsupported_route(scalar_call, override):
+    run, args, kwargs, calls = scalar_call
+    assert not run(*args, **(kwargs | override))
+    assert not calls
+
+
+def test_scalar_tail_keeps_workspace_and_forwards_scale(scalar_call):
+    run, args, kwargs, calls = scalar_call
+    kwargs.update(k_scale=0.5, v_scale=2.0)
+    assert run(*args, **kwargs)
+    pointers = [t.data_ptr() for t in calls[0][6:10]]
+    assert run(*args, **kwargs)
+    assert [t.data_ptr() for t in calls[1][6:10]] == pointers
+    assert all(t.dtype == torch.float32 for t in calls[0][6:9])
+    assert calls[0][9].item() == 256
+    assert calls[0][-3:] == (0.0625, 0.5, 2.0)
+
+
+def test_ordinary_graph_preserves_original_scalar(scalar_call, monkeypatch):
+    run, args, kwargs, calls = scalar_call
+    monkeypatch.setattr(
+        scalar, "get_forward_context", lambda: SimpleNamespace(batch_descriptor=None)
+    )
+    assert not run(*args, **kwargs)
+    assert not calls

--- a/tests/v1/worker/test_sm70_long_attention_graphs.py
+++ b/tests/v1/worker/test_sm70_long_attention_graphs.py
@@ -8,8 +8,9 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm.config.compilation import CUDAGraphMode
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode
 from vllm.v1.attention.ops.sm70_e4m3_long import MAX_CONTEXT
+from vllm.v1.worker.gpu import cudagraph_utils as cg
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
@@ -49,6 +50,22 @@ def test_device_hint_never_copied_to_host(graph_pair):
     assert manager.select_attention_graph(ordinary, device_hint) == ordinary
 
 
+def test_scalar_graph_retains_short_and_oversized_fallback():
+    manager = ModelCudaGraphManager.__new__(ModelCudaGraphManager)
+    ordinary = BatchExecutionDescriptor(CUDAGraphMode.FULL, 1, 1, 1)
+    bounded = replace(ordinary, attention_context_bucket=262144)
+    manager._long_attention_graphs = {ordinary: bounded}
+    manager.graphs = {ordinary: object(), bounded: object()}
+    for upper in (1, 1024, 131071, 262145):
+        assert (
+            manager.select_attention_graph(ordinary, torch.tensor([upper])) == ordinary
+        )
+    for upper in (131072, 261888, 262144):
+        assert (
+            manager.select_attention_graph(ordinary, torch.tensor([upper])) == bounded
+        )
+
+
 def test_other_batch_shapes_and_missing_capture_fall_back(graph_pair):
     manager, ordinary, bounded = graph_pair
     other = replace(ordinary, num_tokens=16, num_reqs=2)
@@ -69,17 +86,121 @@ def test_disabled_operator_preserves_original_binding(monkeypatch):
     assert wrap_long_attention(original) is original
 
 
-@pytest.mark.parametrize("query_len", [1, 6, 8])
-def test_tail_shapes_use_bounded_graph(query_len):
-    manager = ModelCudaGraphManager.__new__(ModelCudaGraphManager)
-    ordinary = BatchExecutionDescriptor(CUDAGraphMode.FULL, query_len, 1, query_len)
-    bounded = replace(ordinary, attention_context_bucket=MAX_CONTEXT)
-    manager._long_attention_graphs = {ordinary: bounded}
-    manager.graphs = {ordinary: object(), bounded: object()}
-    assert (
-        manager.select_attention_graph(ordinary, torch.tensor([MAX_CONTEXT])) == bounded
+@pytest.mark.parametrize(
+    "enabled,method,sm70,target,sequence_parallel,expect_tail",
+    [
+        (True, "dflash", True, True, False, True),
+        (False, "dflash", True, True, False, False),
+        (True, "mtp", True, True, False, False),
+        (True, "dflash", False, True, False, False),
+        (True, "dflash", True, False, False, False),
+        (True, "dflash", True, True, True, False),
+    ],
+)
+def test_tail_capture_and_dispatch_from_real_initialization(
+    monkeypatch, enabled, method, sm70, target, sequence_parallel, expect_tail
+):
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS", str(int(enabled)))
+    monkeypatch.setenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "0")
+    monkeypatch.delenv("VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST", raising=False)
+    monkeypatch.setattr(cg.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(cg.current_platform, "is_device_capability", lambda cap: sm70)
+    monkeypatch.setattr(cg.current_platform, "get_global_graph_pool", lambda: None)
+    monkeypatch.setattr(
+        cg,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
     )
-    assert (
-        manager.select_attention_graph(ordinary, torch.tensor([MAX_CONTEXT + 1]))
-        == ordinary
+    compilation = CompilationConfig(
+        cudagraph_capture_sizes=[8, 16, 24, 32], max_cudagraph_capture_size=32
     )
+    compilation.pass_config.enable_sp = sequence_parallel
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+        compilation_config=compilation,
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1, tensor_parallel_size=4, pipeline_parallel_size=1
+        ),
+        speculative_config=SimpleNamespace(
+            method=method, num_speculative_tokens=7, ngram_assist=False
+        ),
+    )
+    cls = ModelCudaGraphManager if target else cg.CudaGraphManager
+    manager = cls(config, torch.device("cpu"), CUDAGraphMode.FULL_DECODE_ONLY, 8)
+    manager._graphs_captured = True
+    for q in range(1, 8):
+        desc = manager.dispatch(1, q, q)
+        assert desc.cg_mode == (
+            CUDAGraphMode.FULL if expect_tail else CUDAGraphMode.NONE
+        )
+        if expect_tail:
+            assert desc in manager._capture_descs[CUDAGraphMode.FULL]
+            assert desc.num_tokens == desc.uniform_token_count == q
+        # Admission is B1 only.
+        assert manager.dispatch(2, 2 * q, q).cg_mode == CUDAGraphMode.NONE
+    assert manager.dispatch(1, 8, 8).cg_mode == CUDAGraphMode.FULL
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {"max_context": 262145},
+        {"max_context": 0},
+        {"query_rows": [1, 8]},
+        {"query_rows": [9]},
+        {"query_rows": []},
+    ],
+)
+def test_reject_unadmitted_attention_manifest(manifest):
+    from vllm.v1.attention.ops.sm70_e4m3_long import long_attention_contract
+
+    with pytest.raises(ValueError):
+        long_attention_contract(manifest)
+
+
+def test_explicit_attention_manifest_preserves_default_and_extends_tail_domain():
+    from vllm.v1.attention.ops.sm70_e4m3_long import long_attention_contract
+
+    assert long_attention_contract({}) == (132096, (8,))
+    assert long_attention_contract(
+        {"max_context": 262144, "query_rows": list(range(2, 9))}
+    ) == (262144, tuple(range(2, 9)))
+
+
+@pytest.mark.parametrize("query_len", [1, 6, 7])
+@pytest.mark.parametrize("prefilling", [True, False])
+def test_runner_does_not_dispatch_short_prefill_as_tail(
+    monkeypatch, query_len, prefilling
+):
+    from vllm.v1.worker.gpu import model_runner as mrv2
+
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    runner.update_pp_decode_requests = lambda: None
+    for method in ("finish_requests", "free_states", "add_requests", "update_requests"):
+        setattr(runner, method, lambda _: None)
+    runner.block_tables = SimpleNamespace(apply_staged_writes=lambda: None)
+    runner.cudagraph_manager = SimpleNamespace(_sm70_dflash2_tail_graphs=True)
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={"r": 0},
+        num_computed_prefill_tokens=[0 if prefilling else 16],
+        prefill_len=SimpleNamespace(np=[16]),
+    )
+    runner.is_encoder_decoder = False
+    runner.dp_size = 1
+    runner.dp_rank = 0
+    scheduler = SimpleNamespace(
+        new_block_ids_to_zero=[],
+        total_num_scheduled_tokens=query_len,
+        num_scheduled_tokens={"r": query_len},
+    )
+
+    class DispatchObserved(Exception):
+        pass
+
+    def dispatch(manager, num_reqs, num_tokens, uniform, *args, **kwargs):
+        assert uniform == (None if prefilling else query_len)
+        raise DispatchObserved
+
+    monkeypatch.setattr(mrv2, "dispatch_cg_and_sync_dp", dispatch)
+    with pytest.raises(DispatchObserved):
+        runner.execute_model(scheduler)

--- a/tests/v1/worker/test_sm70_long_attention_graphs.py
+++ b/tests/v1/worker/test_sm70_long_attention_graphs.py
@@ -67,3 +67,19 @@ def test_disabled_operator_preserves_original_binding(monkeypatch):
         raise AssertionError("Binding inspection must not launch an operator")
 
     assert wrap_long_attention(original) is original
+
+
+@pytest.mark.parametrize("query_len", [1, 6, 8])
+def test_tail_shapes_use_bounded_graph(query_len):
+    manager = ModelCudaGraphManager.__new__(ModelCudaGraphManager)
+    ordinary = BatchExecutionDescriptor(CUDAGraphMode.FULL, query_len, 1, query_len)
+    bounded = replace(ordinary, attention_context_bucket=MAX_CONTEXT)
+    manager._long_attention_graphs = {ordinary: bounded}
+    manager.graphs = {ordinary: object(), bounded: object()}
+    assert (
+        manager.select_attention_graph(ordinary, torch.tensor([MAX_CONTEXT])) == bounded
+    )
+    assert (
+        manager.select_attention_graph(ordinary, torch.tensor([MAX_CONTEXT + 1]))
+        == ordinary
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -189,6 +189,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FA2_D256_LIBRARY: str | None = None
     VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST: str | None = None
     VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS: bool = False
+    VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST: str | None = None
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
     VLLM_SM70_NVFP4_QPN2_M16_NATIVE: bool = True
@@ -1882,10 +1883,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST": lambda: os.getenv(
         "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST", None
     ),
-    # Capture exact B1 q1/q6 verifier tails for SM70 DFlash2. Default-off keeps
+    # Capture exact B1 q1..q7 verifier tails for SM70 DFlash2. Default-off keeps
     # the existing eager fallback and its memory footprint unchanged.
     "VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS", "0"))
+    ),
+    "VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST": lambda: os.getenv(
+        "VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST", None
     ),
     "VLLM_SM70_FP8_PREFILL_CUTLASS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_CUTLASS", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -188,6 +188,7 @@ if TYPE_CHECKING:
     VLLM_SM70_SAMPLER_LIBRARY: str | None = None
     VLLM_SM70_FA2_D256_LIBRARY: str | None = None
     VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST: str | None = None
+    VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS: bool = False
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
     VLLM_SM70_NVFP4_QPN2_M16_NATIVE: bool = True
@@ -1880,6 +1881,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Experimental q8 long attention; unset preserves the full-context route.
     "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST": lambda: os.getenv(
         "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST", None
+    ),
+    # Capture exact B1 q1/q6 verifier tails for SM70 DFlash2. Default-off keeps
+    # the existing eager fallback and its memory footprint unchanged.
+    "VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS", "0"))
     ),
     "VLLM_SM70_FP8_PREFILL_CUTLASS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_CUTLASS", "1"))

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -4453,6 +4453,21 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         self.flash_attn_grouped_e4m3_fp32_paged = (
             load_grouped_e4m3_fp32() if use_e4m3_fp32 else None
         )
+        self._sm70_scalar_tail_attention = None
+        if (
+            use_e4m3_fp32
+            and envs.VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS
+            and envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST
+            and not os.environ.get("VLLM_FLASH_V100_DECODE_PARTITION_SIZE")
+        ):
+            from vllm.v1.attention.ops.sm70_e4m3_scalar import (
+                load_scalar_tail_attention,
+            )
+
+            self._sm70_scalar_tail_attention = load_scalar_tail_attention(
+                envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST,
+                torch.device("cuda", torch.accelerator.current_device_index()),
+            )
         if use_e4m3_fp32 and self.flash_attn_grouped_e4m3_fp32_paged is None:
             logger.warning_once(
                 "E4M3 grouped FP32 requires Flash-V100 precision revision 4; "
@@ -5307,6 +5322,26 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         anchor_lens: torch.Tensor | None = None,
         anchored_window: int = 0,
     ) -> None:
+        scalar_tail = getattr(self, "_sm70_scalar_tail_attention", None)
+        if scalar_tail is not None and scalar_tail(
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            seq_lens,
+            out=out,
+            softmax_scale=softmax_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            kv_cache_dtype=kv_cache_dtype,
+            window_size=window_size,
+            max_seq_len_hint=max_seq_len_hint,
+            partition_size_hint=partition_size_hint,
+            anchor_lens=anchor_lens,
+            anchored_window=anchored_window,
+        ):
+            _record_route("decode_e4m3_compact_scalar_tail")
+            return
         kwargs: dict[str, object] = {
             "softmax_scale": softmax_scale,
             "out": out,

--- a/vllm/v1/attention/ops/sm70_e4m3_long.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_long.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Opt-in compensated q8 scheduling with an explicit native build manifest."""
+"""Opt-in compensated attention with explicit native build manifests."""
 
 import hashlib
 import importlib.util
@@ -27,14 +27,10 @@ def long_attention_enabled() -> bool:
     return bool(os.environ.get(MANIFEST_ENV))
 
 
-@lru_cache(maxsize=1)
-def load_long_attention(manifest_name: str):
+@lru_cache(maxsize=4)
+def load_attention_library(manifest_name: str):
     manifest_path = Path(manifest_name).resolve()
     manifest = json.loads(manifest_path.read_text())
-    # Different split counts change arithmetic and workspace geometry. They
-    # must complete their own admission before extending this serving route.
-    if manifest.get("splits", 80) != 80 or manifest["head_groups"] != 1:
-        raise ValueError("The long-attention serving route requires 80 six-head splits")
     library = Path(manifest["library"])
     if not library.is_absolute():
         library = manifest_path.parent / library
@@ -56,15 +52,44 @@ def load_long_attention(manifest_name: str):
     loaded_file = module.__file__
     if loaded_file is None or Path(loaded_file).resolve() != library:
         raise RuntimeError("Long-attention native extension module alias")
+    return module, manifest
+
+
+@lru_cache(maxsize=1)
+def load_long_attention(manifest_name: str):
+    module, manifest = load_attention_library(manifest_name)
+    # Split counts change both arithmetic and workspace geometry.
+    if manifest.get("splits", 80) != 80 or manifest["head_groups"] != 1:
+        raise ValueError("The long-attention serving route requires 80 six-head splits")
+    context_limit, query_rows = long_attention_contract(manifest)
     logger.info_once(
         "Loaded experimental SM70 E4M3 q8 attention: module=%s SHA256=%s "
-        "max_context=%d; 80 splits, compensated FP32 state.",
-        name,
+        "max_context=%d query_rows=%s; 80 splits, compensated FP32 state.",
+        manifest["module_name"],
         manifest["library_sha256"],
-        MAX_CONTEXT,
+        context_limit,
+        query_rows,
         scope="process",
     )
     return module.run, manifest
+
+
+def long_attention_contract(manifest):
+    context_limit = manifest.get("max_context", MAX_CONTEXT)
+    query_rows = tuple(manifest.get("query_rows", [8]))
+    if (
+        type(context_limit) is not int
+        or not 0 < context_limit <= 262144
+        or not query_rows
+        or any(type(q) is not int or not 2 <= q <= 8 for q in query_rows)
+    ):
+        raise ValueError("Unsupported long-attention context or query-row contract")
+    return context_limit, query_rows
+
+
+def long_attention_graph_contract():
+    _, manifest = load_long_attention(os.environ[MANIFEST_ENV])
+    return long_attention_contract(manifest)
 
 
 def wrap_long_attention(fallback):
@@ -72,6 +97,7 @@ def wrap_long_attention(fallback):
     if not manifest_name:
         return fallback
     operator, manifest = load_long_attention(manifest_name)
+    context_limit, query_rows = long_attention_contract(manifest)
 
     def run(
         q, k, v, table, row_lengths, *, out, softmax_scale, k_scale=1.0, v_scale=1.0
@@ -83,8 +109,10 @@ def wrap_long_attention(fallback):
         )
         if not (
             descriptor is not None
-            and descriptor.attention_context_bucket == MAX_CONTEXT
-            and q.shape == (8, 6, 256)
+            and descriptor.attention_context_bucket == context_limit
+            and q.ndim == 3
+            and q.shape[0] in query_rows
+            and q.shape[1:] == (6, 256)
             and k.ndim == 4
             and k.shape[1] in (1648, 3296)
             and k.shape[2:] == (1, 256)
@@ -105,7 +133,7 @@ def wrap_long_attention(fallback):
         # replay never allocates. Layers reuse it in stream order; different
         # streams and versions never share the legacy 80-split buffers.
         stream = torch.cuda.current_stream(q.device).cuda_stream
-        key = (manifest["source_sha256"], MAX_CONTEXT, 80, q.device, stream)
+        key = (manifest["source_sha256"], context_limit, 80, q.device, stream)
         if key not in _WORKSPACES:
             _WORKSPACES[key] = (
                 torch.empty((80, 8, 6, 256), dtype=torch.float32, device=q.device),

--- a/vllm/v1/attention/ops/sm70_e4m3_scalar.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_scalar.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Explicit compact E4M3 scalar attention for SM70 target tail graphs."""
+
+from functools import lru_cache
+
+import torch
+
+from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import init_logger
+from vllm.v1.attention.ops.sm70_e4m3_long import load_attention_library
+
+logger = init_logger(__name__)
+
+
+@lru_cache(maxsize=4)
+def load_scalar_tail_attention(manifest_name: str, device: torch.device):
+    module, manifest = load_attention_library(manifest_name)
+    if not (
+        manifest.get("share_kv_six_heads")
+        and manifest.get("compact_page_map")
+        and manifest.get("e4m3_lut")
+        and manifest.get("max_context") == 262144
+    ):
+        raise ValueError("Scalar tails require the compact E4M3 256K manifest")
+    # Allocate before memory profiling and graph capture. Model layers execute
+    # serially on the worker stream; all target graphs retain this same storage.
+    buffers = (
+        torch.empty((1, 6, 256, 256), dtype=torch.float32, device=device),
+        torch.empty((1, 6, 256), dtype=torch.float32, device=device),
+        torch.empty((1, 6, 256), dtype=torch.float32, device=device),
+        torch.full((1,), 256, dtype=torch.int32, device=device),
+    )
+    logger.info_once(
+        "Loaded SM70 compact scalar tail attention: module=%s SHA256=%s; "
+        "256 partitions, FP32 numerator/max/sum.",
+        manifest["module_name"],
+        manifest["library_sha256"],
+        scope="process",
+    )
+
+    def run(
+        q,
+        k,
+        v,
+        table,
+        lengths,
+        *,
+        out,
+        softmax_scale,
+        k_scale,
+        v_scale,
+        kv_cache_dtype,
+        window_size,
+        max_seq_len_hint,
+        partition_size_hint,
+        anchor_lens,
+        anchored_window,
+    ) -> bool:
+        descriptor = (
+            get_forward_context().batch_descriptor
+            if is_forward_context_available()
+            else None
+        )
+        if not (
+            descriptor is not None
+            and descriptor.attention_context_bucket == 262144
+            and q.shape == (1, 6, 256)
+            and q.dtype == torch.float16
+            and q.device == device
+            and q.is_contiguous()
+            and k.ndim == 4
+            and k.shape[1:] == (3296, 1, 256)
+            and k.dtype == v.dtype == torch.uint8
+            and v.shape == k.shape
+            and kv_cache_dtype == "fp8_e4m3"
+            and window_size == (-1, -1)
+            and anchor_lens is None
+            and anchored_window == 0
+            and partition_size_hint in (None, 1024)
+            and type(max_seq_len_hint) is int
+            and 0 < max_seq_len_hint <= 262144
+        ):
+            return False
+        module.run(
+            q,
+            k,
+            v,
+            out,
+            table,
+            lengths,
+            *buffers,
+            float(softmax_scale),
+            float(k_scale),
+            float(v_scale),
+        )
+        return True
+
+    return run

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -165,6 +165,22 @@ class CudaGraphManager:
                     "query lengths %s.",
                     self.decode_query_lens,
                 )
+            if (
+                envs.VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS
+                and current_platform.is_cuda()
+                and current_platform.is_device_capability((7, 0))
+            ):
+                # The final verifier iterations can contain six or one token
+                # after draft acceptance. Capture those exact uniform B1
+                # shapes so they replay the target graph instead of entering
+                # the eager fallback.
+                self.decode_query_lens = tuple(
+                    dict.fromkeys((*self.decode_query_lens, 6, 1))
+                )
+                logger.info_once(
+                    "Capturing SM70 DFlash2 tail query lengths %s.",
+                    self.decode_query_lens,
+                )
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -203,10 +219,10 @@ class CudaGraphManager:
             # B1 short verification can still replay a graph when
             # max_num_seqs=1.
             if len(self.decode_query_lens) > 1:
-                short_query_len = min(self.decode_query_lens)
-                if short_query_len not in self._capture_sizes:
-                    self._capture_sizes.append(short_query_len)
-                    self._capture_sizes.sort()
+                for query_len in self.decode_query_lens:
+                    if query_len not in self._capture_sizes:
+                        self._capture_sizes.append(query_len)
+                self._capture_sizes.sort()
         self._init_candidates()
 
     def _init_candidates(self) -> None:
@@ -423,10 +439,10 @@ class ModelCudaGraphManager(CudaGraphManager):
         ):
             descs = self._capture_descs.get(CUDAGraphMode.FULL, [])
             for desc in list(descs):
-                if (desc.num_tokens, desc.num_reqs, desc.uniform_token_count) == (
-                    8,
-                    1,
-                    8,
+                if (
+                    desc.num_reqs == 1
+                    and desc.uniform_token_count in (1, 6, 8)
+                    and desc.num_tokens == desc.uniform_token_count
                 ):
                     variant = replace(desc, attention_context_bucket=MAX_CONTEXT)
                     self._long_attention_graphs[desc] = variant

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -165,22 +165,27 @@ class CudaGraphManager:
                     "query lengths %s.",
                     self.decode_query_lens,
                 )
-            if (
-                envs.VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS
-                and current_platform.is_cuda()
-                and current_platform.is_device_capability((7, 0))
-            ):
-                # The final verifier iterations can contain six or one token
-                # after draft acceptance. Capture those exact uniform B1
-                # shapes so they replay the target graph instead of entering
-                # the eager fallback.
-                self.decode_query_lens = tuple(
-                    dict.fromkeys((*self.decode_query_lens, 6, 1))
-                )
-                logger.info_once(
-                    "Capturing SM70 DFlash2 tail query lengths %s.",
-                    self.decode_query_lens,
-                )
+        self._sm70_dflash2_tail_graphs = bool(
+            envs.VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS
+            and isinstance(self, ModelCudaGraphManager)
+            and speculative_config is not None
+            and speculative_config.method == "dflash"
+            and decode_query_len == 8
+            and current_platform.is_cuda()
+            and current_platform.is_device_capability((7, 0))
+            and not self.compilation_config.pass_config.enable_sp
+        )
+        if self._sm70_dflash2_tail_graphs:
+            # Target verifier tails are independent of adaptive lookup. The
+            # drafter always produces its trained block width and must not
+            # capture these target-only shapes.
+            self.decode_query_lens = tuple(
+                dict.fromkeys((*self.decode_query_lens, *range(7, 0, -1)))
+            )
+            logger.info_once(
+                "Capturing SM70 DFlash2 target tail query lengths %s.",
+                self.decode_query_lens,
+            )
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -248,6 +253,14 @@ class CudaGraphManager:
                         query_len <= num_tokens <= self.max_num_reqs * query_len
                         and num_tokens % query_len == 0
                     ):
+                        if (
+                            self._sm70_dflash2_tail_graphs
+                            and query_len < self.decode_query_len
+                            and num_tokens != query_len
+                        ):
+                            # Only single-request tails are admitted. Avoid
+                            # changing batching routes or multiplying captures.
+                            continue
                         desc = BatchExecutionDescriptor(
                             cg_mode=decode_mode,
                             num_tokens=num_tokens,
@@ -426,8 +439,8 @@ class ModelCudaGraphManager(CudaGraphManager):
             BatchExecutionDescriptor, BatchExecutionDescriptor
         ] = {}
         from vllm.v1.attention.ops.sm70_e4m3_long import (
-            MAX_CONTEXT,
             long_attention_enabled,
+            long_attention_graph_contract,
         )
 
         if (
@@ -437,14 +450,21 @@ class ModelCudaGraphManager(CudaGraphManager):
             and self.dp_size == 1
             and vllm_config.parallel_config.pipeline_parallel_size == 1
         ):
+            context_limit, query_rows = long_attention_graph_contract()
+            if (
+                self._sm70_dflash2_tail_graphs
+                and envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST
+                and context_limit == 262144
+            ):
+                query_rows = (1, *query_rows)
             descs = self._capture_descs.get(CUDAGraphMode.FULL, [])
             for desc in list(descs):
                 if (
                     desc.num_reqs == 1
-                    and desc.uniform_token_count in (1, 6, 8)
+                    and desc.uniform_token_count in query_rows
                     and desc.num_tokens == desc.uniform_token_count
                 ):
-                    variant = replace(desc, attention_context_bucket=MAX_CONTEXT)
+                    variant = replace(desc, attention_context_bucket=context_limit)
                     self._long_attention_graphs[desc] = variant
                     descs.append(variant)
 
@@ -459,6 +479,10 @@ class ModelCudaGraphManager(CudaGraphManager):
         if cpu_upper_bounds.device.type != "cpu" or cpu_upper_bounds.numel() != 1:
             return desc
         upper = int(cpu_upper_bounds[0])
+        if desc.uniform_token_count == 1 and upper < 131072:
+            # The compact scalar route is admitted for long-context tails.
+            # Short q1 uses the ordinary graph and its original attention.
+            return desc
         limit = variant.attention_context_bucket
         if limit is not None and 0 < upper <= limit:
             return variant

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1459,6 +1459,21 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
         uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+        if (
+            not dummy_run
+            and getattr(self.cudagraph_manager, "_sm70_dflash2_tail_graphs", False)
+            and num_reqs == 1
+            and 1 <= num_toks < 8
+        ):
+            req_id = next(iter(scheduler_output.num_scheduled_tokens))
+            req_index = self.req_states.req_id_to_index[req_id]
+            if (
+                self.req_states.num_computed_prefill_tokens[req_index]
+                < self.req_states.prefill_len.np[req_index]
+            ):
+                # A short prompt/chunk must initialize GDN state rather than
+                # replay a graph captured for an already initialized decode.
+                uniform_tok_count = None
 
         skip_compiled = False
         if self.is_encoder_decoder and scheduler_output.scheduled_encoder_inputs:


### PR DESCRIPTION
## Purpose

At the 262144-token capacity, DFlash2 partial-verifier and q1 steps fell out of the normal q8 graph and optimized attention routes. The inherited tail flag only registered shapes under adaptive lookup, so ordinary seven-draft DFlash2 never reached it.

Register target-only B1 q1-q7 graphs independently of lookup, add explicit manifest bounds for the already validated grouped and compact scalar operators, and keep short prefill/chunks off decode-only graphs. Preserve the capacity guards, scheduler, sampling and FP32 numerical contract. The feature remains opt-in. This continues the existing PR596 scope; no duplicate PR is introduced.

Integration base: `fe67339ddf862df0441a4e844fc664d9cafdffd0`. Current head: `f3d5e7fe2614da8bfa43c06308422f879ee4ef6d`.

## Test Plan

- Test actual graph initialization/dispatch and fallback behavior, manifest/scalar admission, and GDN capture-storage refresh for q1-q8 in none/align cache modes.
- Run matched, unprofiled control/candidate requests on four V100-SXM2-32GB GPUs, CUDA 12.8, Torch 2.10.0+cu128, QUASAR Qwen3.8-27B NVFP4 + seven-draft DFlash2, E4M3 target KV, FP32 state/logits, Flash-V100 and CUDA graphs. T=1, top-k=20, top-p=0.95; 261888 input + 256 output budget, total capacity 262144.
- Keep QPN2/context schedules, native prefill and q8 P-layout fixed in both arms. Verify actual q1/q6/q7 FULL dispatch, selected 262144 descriptors, token IDs, finish and acceptance. Include 1K and 128K regressions and explicit short-prefill cases.

## Test Result

Three independent startups, 96 requests, **48 exact pairs**. Each workload warms both arms then measures three alternating pairs. Round values are medians of startup medians; all tail time remains included.

| Input | Seed | Control round ms | Candidate round ms | Saved ms | Pure decode tokens/s, control to candidate |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1024 | 0 | 15.823 | 15.824 | -0.001 | 298.432 to 298.419 |
| 131072 | 0 | 22.573 | 22.577 | -0.004 | 191.441 to 191.374 |
| 261888 | 0 | 35.464 | 31.396 | 4.067 | 143.809 to 162.337 |
| 261888 | 2 | 37.403 | 31.335 | 6.068 | 154.899 to 184.953 |

Seed2 exercises q1/q6/q7 on all four ranks. Its complete-round latency drops 16.22%, with accepted drafts/round 4.727273 and emitted tokens/round 5.818182 unchanged. Warm prefill remains 1200.716/1201.185 ms and TTFT 1439.936/1440.823 ms. Candidate request-average round mean/p50/p90/p99: 31.304/31.335/31.353/31.362 ms.

A final short-prefill guard was added after those repeated measurements. **Eight further exact pairs** validate 1/6/7-token prompts and the 261888/256 boundary. The latter startup has a different generation trajectory (43 speculative rounds); its paired final-source result is 38.338 to 32.228 ms, saving 6.110 ms. It exercises q1/q6 with the 262144 descriptors. Do not compare its trajectory across startups as an optimization delta.

Focused CPU command:

```text
CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest --confcutdir=tests/v1 tests/v1/worker/test_sm70_long_attention_graphs.py tests/v1/cudagraph/test_sm70_mtp_split_cudagraphs.py tests/v1/attention/test_gdn_metadata_builder.py tests/v1/attention/test_sm70_e4m3_scalar_tail.py -q
```

Result: **111 passed, 2 GPU-only metadata tests skipped**. All scoped pre-commit and signed-commit hooks pass. GPU service tests provide the runtime graph/route and output validation. All task-owned services stopped and GPU leases released.

The native implementations are unchanged: their retained full-workspace/canary/sanitizer evidence and source/DSO hashes are linked from `docs/design/sm70_dflash2_tail_graphs_20260911.md`. New runtime manifests select those explicit operators; neither native binaries nor local cache paths are committed. The migration control document records the recovered boundary path and rejected diagnoses.

## Limits

Keep Draft and opt-in. This recovers the capacity-tail regression; the 22-ms complete-round and 7-ms attention goals remain unmet. Bounded token/acceptance parity is not full natural-output corpus scoring. The separately frozen QPN2/context harness is not enabled by this PR. Multi-request tails, other topologies and sequence-parallel admission are not performance claims here.

The first private q6 integration failed before inference because its workspace was first requested during capture; preallocation resolved it. An apparent GDN capture/live mismatch was intentional PAD_SLOT_ID protection, not a runtime bug; GDN runtime code remains unchanged and tests cover the refresh. Do not remove q1 time from metrics or skip drafting based only on current proposals=0.

AI assistance: Codex implemented and validated this change under the user's development handoff. Human review is still required before promotion/merge.
