### PR TITLE
[Bugfix][Platform] Resolve an unspecified device_id to the worker's own device

### DIFF
--- a/tests/platforms/test_capability_default_device.py
+++ b/tests/platforms/test_capability_default_device.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""An unspecified device index resolves to the worker's own device.
+
+``has_device_capability(80)`` and friends default to ``device_id=None``. On
+CUDA that means: once the process has selected its device, answer for that
+device; before that (engine core, API server), keep index 0 of the visibility
+list as before. Explicit indices are untouched.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.platforms.cuda import NonNvmlCudaPlatform, NvmlCudaPlatform
+from vllm.platforms.interface import DeviceCapability, Platform
+
+# A node that mixes card generations: Turing first, Volta second, Ampere last.
+NODE = {
+    0: DeviceCapability(major=7, minor=5),
+    1: DeviceCapability(major=7, minor=0),
+    2: DeviceCapability(major=8, minor=0),
+}
+
+
+@pytest.fixture
+def cuda(monkeypatch) -> SimpleNamespace:
+    """A fake CUDA runtime: whether a context exists, which ordinal is
+    current, and which lookups (torch after init, NVML before) were made."""
+    state = SimpleNamespace(initialized=False, current=0, torch=[], nvml=[])
+
+    def torch_lookup(device_id: int) -> DeviceCapability:
+        state.torch.append(device_id)
+        return NODE[device_id]
+
+    def nvml_lookup(device_id: int) -> DeviceCapability:
+        state.nvml.append(device_id)
+        return NODE[device_id]
+
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: state.initialized)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: state.current)
+    monkeypatch.setattr(NvmlCudaPlatform, "_torch_device_capability", torch_lookup)
+    monkeypatch.setattr(NvmlCudaPlatform, "_nvml_device_capability", nvml_lookup)
+    monkeypatch.setattr(NonNvmlCudaPlatform, "_device_capability", torch_lookup)
+    return state
+
+
+def test_without_a_cuda_context_the_default_stays_device_zero(cuda) -> None:
+    cuda.initialized = False
+    cuda.current = 2
+    assert NvmlCudaPlatform.resolve_device_id(None) == 0
+    assert NvmlCudaPlatform.get_device_capability() == NODE[0]
+    assert cuda.nvml == [0] and cuda.torch == []
+
+
+def test_with_a_cuda_context_the_default_is_the_current_device(cuda) -> None:
+    cuda.initialized = True
+    cuda.current = 1
+    assert NvmlCudaPlatform.resolve_device_id(None) == 1
+    assert NvmlCudaPlatform.get_device_capability() == NODE[1]
+
+
+def test_after_initialization_torch_answers_and_nvml_is_left_alone(cuda) -> None:
+    """NVML counts in PCI bus order, the CUDA runtime by default fastest
+    first; once the process has a context, the torch ordinal is the truth."""
+    cuda.initialized = True
+    cuda.current = 2
+    assert NvmlCudaPlatform.get_device_capability(1) == NODE[1]
+    assert cuda.torch == [1] and cuda.nvml == []
+
+
+def test_an_explicit_index_always_wins(cuda) -> None:
+    cuda.initialized = True
+    cuda.current = 1
+    assert NvmlCudaPlatform.resolve_device_id(2) == 2
+    assert NvmlCudaPlatform.get_device_capability(2) == NODE[2]
+    assert NvmlCudaPlatform.has_device_capability(80, device_id=2)
+    assert not NvmlCudaPlatform.has_device_capability(80, device_id=0)
+
+
+@pytest.mark.parametrize(
+    ("current", "has_80", "is_70", "family_70"),
+    [(0, False, False, True), (1, False, True, True), (2, True, False, False)],
+)
+def test_every_query_follows_the_current_device(
+    cuda, current: int, has_80: bool, is_70: bool, family_70: bool
+) -> None:
+    cuda.initialized = True
+    cuda.current = current
+    assert NvmlCudaPlatform.has_device_capability(80) is has_80
+    assert NvmlCudaPlatform.is_device_capability(70) is is_70
+    assert NvmlCudaPlatform.is_device_capability_family(70) is family_70
+
+
+def test_the_cache_is_addressed_by_the_resolved_index(cuda) -> None:
+    """The lookup behind the cache must see the concrete index, never None,
+    so an unspecified device cannot freeze one process-wide answer."""
+    cuda.initialized = True
+    cuda.current = 1
+    NvmlCudaPlatform.get_device_capability()
+    cuda.current = 2
+    NvmlCudaPlatform.get_device_capability()
+    assert cuda.torch == [1, 2]
+
+
+def test_non_nvml_platform_resolves_the_same_way(cuda) -> None:
+    cuda.initialized = True
+    cuda.current = 2
+    assert NonNvmlCudaPlatform.get_device_capability() == NODE[2]
+    assert NonNvmlCudaPlatform.has_device_capability(80)
+
+
+def test_an_unusable_index_answers_none_after_initialization(monkeypatch) -> None:
+    """The NVML path answers None for an index it cannot resolve; the torch
+    path must keep that contract instead of raising torch's AssertionError."""
+
+    def invalid(device_id: int) -> tuple[int, int]:
+        raise AssertionError("Invalid device id")
+
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", invalid)
+    NvmlCudaPlatform._torch_device_capability.cache_clear()
+    try:
+        assert NvmlCudaPlatform.get_device_capability(7) is None
+        assert not NvmlCudaPlatform.has_device_capability(80, device_id=7)
+    finally:
+        NvmlCudaPlatform._torch_device_capability.cache_clear()
+
+
+def test_the_base_platform_keeps_device_zero() -> None:
+    assert Platform.resolve_device_id(None) == 0
+    assert Platform.resolve_device_id(3) == 3
+    assert not Platform.has_device_capability(70)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -218,7 +218,22 @@ class CudaPlatformBase(Platform):
         torch.cuda.manual_seed_all(seed)
 
     @classmethod
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+    def resolve_device_id(cls, device_id: int | None) -> int:
+        if device_id is not None:
+            return device_id
+        # A worker that has already selected its device (torch.cuda.set_device
+        # in init_device) answers for that device. A process without a CUDA
+        # context -- the engine core, the API server, a worker before device
+        # selection -- keeps index 0 of the visibility list, as before.
+        # is_initialized() only reports; it never creates a context.
+        if torch.cuda.is_initialized():
+            return torch.cuda.current_device()
+        return 0
+
+    @classmethod
+    def get_device_capability(
+        cls, device_id: int | None = None
+    ) -> DeviceCapability | None:
         raise NotImplementedError
 
     @classmethod
@@ -650,9 +665,37 @@ class NvmlCudaPlatform(CudaPlatformBase):
         return super().device_id_to_physical_device_id(device_id)
 
     @classmethod
+    def get_device_capability(
+        cls, device_id: int | None = None
+    ) -> DeviceCapability | None:
+        # Resolve before the caches: they are keyed by the concrete index, so
+        # an unspecified device never freezes one process-wide answer.
+        device_id = cls.resolve_device_id(device_id)
+        # Once this process holds a CUDA context, torch is authoritative for
+        # the ordinal. NVML enumerates in PCI bus order while the CUDA runtime
+        # defaults to FASTEST_FIRST; on a node that mixes card generations the
+        # two orders differ unless CUDA_DEVICE_ORDER=PCI_BUS_ID is set. Reading
+        # torch after initialization cannot trigger the initialization that
+        # NvmlCudaPlatform exists to avoid, so NVML stays the pre-init path.
+        if torch.cuda.is_initialized():
+            return cls._torch_device_capability(device_id)
+        return cls._nvml_device_capability(device_id)
+
+    @classmethod
+    @cache
+    def _torch_device_capability(cls, device_id: int) -> DeviceCapability | None:
+        # Same contract as the NVML path: an unusable index answers None.
+        # torch raises AssertionError for an out-of-range ordinal.
+        try:
+            major, minor = torch.cuda.get_device_capability(device_id)
+        except (RuntimeError, AssertionError):
+            return None
+        return DeviceCapability(major=major, minor=minor)
+
+    @classmethod
     @cache
     @with_nvml_context
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+    def _nvml_device_capability(cls, device_id: int) -> DeviceCapability | None:
         try:
             physical_device_id = cls.device_id_to_physical_device_id(device_id)
             handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
@@ -666,7 +709,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
     def has_device_capability(
         cls,
         capability: tuple[int, int] | int,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> bool:
         try:
             return super().has_device_capability(capability, device_id)
@@ -887,8 +930,12 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
 class NonNvmlCudaPlatform(CudaPlatformBase):
     @classmethod
+    def get_device_capability(cls, device_id: int | None = None) -> DeviceCapability:
+        return cls._device_capability(cls.resolve_device_id(device_id))
+
+    @classmethod
     @cache
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
+    def _device_capability(cls, device_id: int) -> DeviceCapability:
         major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -296,18 +296,35 @@ class Platform:
         return AttentionBackendEnum.TORCH_SDPA
 
     @classmethod
+    def resolve_device_id(cls, device_id: int | None) -> int:
+        """Turn an unspecified device index into a concrete one.
+
+        ``None`` means "the device this process runs on". The base platform
+        cannot know that device and keeps the historical answer, index 0 of
+        the visibility list. Accelerator platforms override this so that a
+        worker which has already selected its device answers for that device
+        rather than for whichever card happens to be listed first.
+        """
+        return 0 if device_id is None else device_id
+
+    @classmethod
     def get_device_capability(
         cls,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> DeviceCapability | None:
-        """Stateless version of [torch.cuda.get_device_capability][]."""
+        """Stateless version of [torch.cuda.get_device_capability][].
+
+        ``device_id=None`` answers for the current device of this process
+        where the platform can tell (see
+        [`resolve_device_id`][vllm.platforms.interface.Platform.resolve_device_id]).
+        """
         return None
 
     @classmethod
     def has_device_capability(
         cls,
         capability: tuple[int, int] | int,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> bool:
         """
         Test whether this platform is compatible with a device capability.
@@ -318,7 +335,9 @@ class Platform:
         - An integer `<major><minor>`. (See
         [`DeviceCapability.to_int`][vllm.platforms.interface.DeviceCapability.to_int])
         """
-        current_capability = cls.get_device_capability(device_id=device_id)
+        current_capability = cls.get_device_capability(
+            device_id=cls.resolve_device_id(device_id)
+        )
         if current_capability is None:
             return False
 
@@ -331,7 +350,7 @@ class Platform:
     def is_device_capability(
         cls,
         capability: tuple[int, int] | int,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> bool:
         """
         Test whether this platform has exactly the specified device capability.
@@ -342,7 +361,9 @@ class Platform:
         - An integer `<major><minor>`. (See
         [`DeviceCapability.to_int`][vllm.platforms.interface.DeviceCapability.to_int])
         """
-        current_capability = cls.get_device_capability(device_id=device_id)
+        current_capability = cls.get_device_capability(
+            device_id=cls.resolve_device_id(device_id)
+        )
         if current_capability is None:
             return False
 
@@ -355,13 +376,15 @@ class Platform:
     def is_device_capability_family(
         cls,
         capability: int,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> bool:
         """
         Returns True if the device capability is any <major>.x.
         Mirrors CUDA 13 'family' architecture semantics (e.g. 10.x, 11.x, 12.x).
         """
-        current_capability = cls.get_device_capability(device_id=device_id)
+        current_capability = cls.get_device_capability(
+            device_id=cls.resolve_device_id(device_id)
+        )
         if current_capability is None:
             return False
         return (current_capability.to_int() // 10) == (capability // 10)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -653,8 +653,14 @@ class RocmPlatform(Platform):
         torch.cuda.manual_seed_all(seed)
 
     @classmethod
+    def get_device_capability(
+        cls, device_id: int | None = None
+    ) -> DeviceCapability | None:
+        return cls._device_capability(cls.resolve_device_id(device_id))
+
+    @classmethod
     @lru_cache(maxsize=8)
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+    def _device_capability(cls, device_id: int) -> DeviceCapability | None:
         cap = _capability_from_gcn_arch(_GCN_ARCH)
         if cap is not None:
             return DeviceCapability(major=cap[0], minor=cap[1])

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -138,7 +138,7 @@ class XPUPlatform(Platform):
     @classmethod
     def get_device_capability(
         cls,
-        device_id: int = 0,
+        device_id: int | None = None,
     ) -> DeviceCapability | None:
         # capacity format differs from cuda's and will cause unexpected
         # failure, so use None directly


### PR DESCRIPTION

## Purpose

Generalizes #412. That issue named three device-0 capability gates; they
were fixed one by one (#514, #403, #576) and the issue closed with the
second item left as is. This change fixes the class instead of the
instances.

Every capability query on `current_platform` — `get_device_capability`,
`has_device_capability`, `is_device_capability`,
`is_device_capability_family` — defaults to `device_id=0`, which
`NvmlCudaPlatform` maps to index 0 of `CUDA_VISIBLE_DEVICES`. On a node that
mixes card generations, every worker except the one on the first listed card
therefore gates its kernels on somebody else's capability. #514 and #576 fixed
two instances by passing the worker's device explicitly; a count on today's
`main` finds 263 call sites that still query without a device index, two of
them inside `_flashinfer_topk` and `_use_sm70_bf16_emulation` (fixed in the
sibling PR), the rest spread over quantization, MoE, GDN, attention and the
model runners. Patching them one by one is not a plan.

This change moves the decision to the one place all four queries share:

- `device_id` now defaults to `None`, meaning "the device this process runs
  on". `Platform.resolve_device_id()` turns it into a concrete index. The base
  platform keeps the historical answer (0). The CUDA platform answers with
  `torch.cuda.current_device()` once the process holds a CUDA context and 0
  before that, so the engine core, the API server and a worker before
  `set_device` behave exactly as today; a worker after `init_device` answers
  for its own card. `torch.cuda.is_initialized()` only reports and never
  creates a context.
- Explicit indices are untouched: `has_device_capability(80, device_id=i)`
  still asks device `i`.
- Once CUDA is initialized, `NvmlCudaPlatform` reads the capability from
  `torch.cuda.get_device_capability(ordinal)` instead of NVML. NVML counts in
  PCI bus order, the CUDA runtime defaults to `FASTEST_FIRST`; on a mixed node
  the two orders differ unless `CUDA_DEVICE_ORDER=PCI_BUS_ID` is set, which is
  exactly the situation `log_warnings` warns about. torch is authoritative for
  the ordinal, and reading it after initialization cannot trigger the
  initialization the NVML path exists to avoid. NVML remains the pre-init
  path. (Same approach as vllm-project/vllm#53834, which did not land.)
- The caches are keyed by the resolved index (`_torch_device_capability`,
  `_nvml_device_capability`, ROCm `_device_capability`), never by `None`, so an
  unspecified device cannot freeze one process-wide answer.

Signatures of the ROCm and XPU overrides are widened to match (`int | None`),
their behaviour is unchanged (base resolution, index 0). The torch path keeps
the NVML contract for an unusable index: it answers `None` (torch raises
`AssertionError` there), so `has_device_capability(80, device_id=7)` on a
five-card node is `False`, not an exception.

Cost: resolving the current device adds about half a microsecond per query
(Tesla V100, after `set_device`, 20,000 calls: `is_device_capability(70)`
0.36 → 0.84 µs, `has_device_capability(80)` 2.84 → 3.41 µs). The queries
that sit in forward paths run on the order of a hundred times per decode
step, i.e. well under 0.1 % of a 30 ms step.

Not covered, on purpose: `get_device_name`, `get_device_uuid`,
`get_device_total_memory`, `is_integrated_gpu` and `num_compute_units` keep
their `device_id=0` default; only the capability queries select kernels.
Module-level constants evaluated at import time in a worker before
`set_device` still see index 0; they need a different fix (lazy evaluation)
and are out of scope here.

## Test Plan

1. `pre-commit run --files vllm/platforms/{interface,cuda,rocm,xpu}.py tests/platforms/test_capability_default_device.py`
   and the same with `mypy-3.10 --hook-stage manual`, plus mypy over
   `vllm/platforms/*.py` (override compatibility).
2. New CPU-only `tests/platforms/test_capability_default_device.py`: a mocked
   node (Turing at 0, Volta at 1, Ampere at 2); resolution with and without a
   CUDA context, explicit index wins, all three predicate queries follow the
   current device, torch answers after init and NVML is left alone, the
   caches see the resolved index, an unusable index answers `None`, the base
   platform keeps index 0.
3. Existing gate tests that go through the real interface:
   `tests/config/test_sm70_gates_any_visible_device.py` (#514) and
   `tests/cuda/`.
4. Hardware probe on the mixed node (2x Quadro RTX 8000 + 3x Tesla V100):
   `CUDA_VISIBLE_DEVICES=0,1` (RTX first), one process does
   `torch.cuda.set_device(1)` like a worker with local rank 1 and then asks
   `get_device_capability()` without an index — on `main` and with this
   change, once with `CUDA_DEVICE_ORDER=PCI_BUS_ID` and once without.

## Test Result

1. All applicable hooks passed; mypy-3.10 passed on the five files and on
   `vllm/platforms/*.py`.
2. 11 passed.
3. 48 passed, 6 failed — the six fail identically without this change:
   three parametrizations of `test_sm70_baseline_defaults_follow_any_visible_device`
   need `facebook/opt-125m` from the Hub (run offline), three
   `TestSetCudaContext` cases need a visible GPU (run with none).
4. Probe on the mixed node, `CUDA_VISIBLE_DEVICES=0,1` (Quadro RTX 8000
   first, Tesla V100 second), one process, `torch.cuda.set_device(1)`:

   | | before `set_device` | after `set_device(1)`, a V100 |
   |---|---|---|
   | `main` (fe67339d + #572) | `(7, 5)` | `(7, 5)`, `has(75)=True`, `is(70)=False` |
   | this change | `(7, 5)` | `(7, 0)`, `has(75)=False`, `is(70)=True` |

   Identical with `CUDA_DEVICE_ORDER=PCI_BUS_ID` and with the default
   ordering. `main` keeps answering for the first listed card no matter which
   device the process selected; with this change the process answers for its
   own card, and before device selection nothing changes.
5. Per-call cost, Tesla V100 after `set_device`, 20,000 calls each:
   `is_device_capability(70)` 0.36 → 0.84 µs, `has_device_capability(80)`
   2.84 → 3.41 µs.

## Not a duplicate

Checked on 2026-09-11 against `1CatAI/1Cat-vLLM` (`gh issue view 412
--comments`; `gh pr list --state open --search "412 in:body"` → #572 and
#594, neither touches the platform queries; `gh pr list --state open
--search` for "device_id default", "current device capability",
"resolve_device_id", "device 0 capability", "worker device capability";
issues for "device 0 capability"; `gh pr diff --name-only` over every open
PR for `vllm/platforms/{interface,cuda}.py`). Open PRs touching `cuda.py` are
#431 (custom all-reduce on Volta) and #435 (build fixes); both add a new
`has_device_capability(70)` call and neither changes the query itself. #514
(merged) and #576 (open) are the per-site fixes this change generalizes;
their explicit `device_id` arguments keep working unchanged. Upstream:
vllm-project/vllm#53834 (closed, not merged) covers the torch-after-init part
only.

AI assistance (Claude) was used to trace the failure class, count the call
sites and prepare the change; I reviewed every line and ran the tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
