### PR TITLE
[Perf] Ship the SM70 grouped long-context route on by default

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -113,6 +113,23 @@ if(VLLM_FLASH_ATTN_SM70 AND TARGET _vllm_fa2_C)
     "${SM70_V37_DIR}/register.cpp")
 endif()
 
+# The grouped E4M3 FP32 long-context route ships inside the same extension, so
+# the accelerated path is available without an externally built DSO.
+if(VLLM_FLASH_ATTN_SM70 AND TARGET _vllm_fa2_C)
+  set(SM70_GROUPED_LONG_DIR
+      "${CMAKE_CURRENT_LIST_DIR}/../../csrc/attention/sm70_grouped_long")
+  set(SM70_GROUPED_LONG_SRC
+      "${SM70_GROUPED_LONG_DIR}/kernel/grouped-attention.cu")
+  # Flags mirror the manifest the operator was qualified with. As with v37, the
+  # properties must be set in the target scope or SM70 silently loses them.
+  set_source_files_properties(${SM70_GROUPED_LONG_SRC}
+    TARGET_DIRECTORY _vllm_fa2_C
+    PROPERTIES COMPILE_OPTIONS
+      "-gencode=arch=compute_70,code=sm_70;-O3;-std=c++17;--use_fast_math;--expt-relaxed-constexpr;--expt-extended-lambda;-U__CUDA_NO_HALF_OPERATORS__;-U__CUDA_NO_HALF_CONVERSIONS__;-U__CUDA_NO_HALF2_OPERATORS__")
+  target_include_directories(_vllm_fa2_C PRIVATE "${SM70_GROUPED_LONG_DIR}/include")
+  target_sources(_vllm_fa2_C PRIVATE ${SM70_GROUPED_LONG_SRC})
+endif()
+
 # Restore the install prefix after FA's install rules
 install(CODE "set(CMAKE_INSTALL_PREFIX \"\${OLD_CMAKE_INSTALL_PREFIX}\")" ALL_COMPONENTS)
 install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)

--- a/csrc/attention/sm70_grouped_long/LICENSE
+++ b/csrc/attention/sm70_grouped_long/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, D.Skryabin
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT INCLUDING
+NEGLIGENCE OR OTHERWISE ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/csrc/attention/sm70_grouped_long/include/fused_mha.h
+++ b/csrc/attention/sm70_grouped_long/include/fused_mha.h
@@ -1,0 +1,173 @@
+#ifndef FUSED_MHA_H
+#define FUSED_MHA_H
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+#include <torch/extension.h>
+#include <ATen/ATen.h>
+
+std::vector<at::Tensor> flash_attention_forward(
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_);
+
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal);
+
+at::Tensor flash_attention_decode_paged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window);
+
+at::Tensor flash_attention_decode_paged_xqa(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right, const int batch_context_max_seq_len);
+
+at::Tensor flash_attention_decode_paged_xqa_staged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, at::Tensor& online_rescales,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const int partition_size, const int launch_num_partitions,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const int window_size_left, const int window_size_right);
+
+at::Tensor flash_attention_grouped_verify_paged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& partial_out,
+    at::Tensor& partial_lse, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool one_pass);
+
+int64_t flash_attention_grouped_verify_max_query_tokens();
+
+int64_t flash_attention_grouped_verify_request_major_abi_version();
+
+at::Tensor flash_attention_grouped_e4m3_fp32_paged(
+    const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    at::Tensor& out, const at::Tensor& block_table,
+    const at::Tensor& row_lengths, at::Tensor& partial, at::Tensor& lse,
+    float scale, float k_scale, float v_scale);
+
+int64_t flash_attention_grouped_e4m3_fp32_precision_version();
+
+int64_t flash_attention_grouped_sparse_page4_abi_version();
+
+at::Tensor flash_attention_grouped_sparse_page4(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& token_masks, const at::Tensor& seq_lens, at::Tensor& lse,
+    const float softmax_scale, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale);
+
+at::Tensor flash_attention_grouped_sparse_page4_plan(
+    const at::Tensor& logical_indices, const at::Tensor& block_table,
+    const at::Tensor& token_to_req, const at::Tensor& query_positions,
+    const at::Tensor& sequence_lengths, at::Tensor& output_blocks,
+    at::Tensor& output_masks, at::Tensor& output_seq_lens, const int page_size,
+    const int physical_page_stride, const int num_cache_blocks);
+
+at::Tensor flash_attention_decode_paged_wmma(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale,
+    const float v_scale);
+
+at::Tensor flash_attention_decode_qk_scores(
+    const at::Tensor& q, const at::Tensor& k_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale, const int partition_size,
+    const std::string& kv_cache_dtype, const float k_scale);
+
+at::Tensor flash_attention_turboquant_decode_paged(
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction);
+
+at::Tensor flash_attention_prefill_paged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window);
+
+std::vector<at::Tensor>
+flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale);
+
+std::vector<at::Tensor>
+flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    at::Tensor& split_tmp_out, at::Tensor& split_tmp_row_max,
+    at::Tensor& split_tmp_row_sum, const at::Tensor& block_table,
+    const int64_t actual_n, const float softmax_scale);
+
+at::Tensor flash_attention_prefill_paged_bfla(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const at::Tensor& bfla_block_mask,
+    const int bfla_mask_block_n, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right);
+
+at::Tensor flash_attention_prefill_paged_splitkv(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const int split_kv_tokens,
+    const int max_seq_len_hint);
+
+void flash_attention_fp8_e5m2_paged_kv_to_fp16(
+    const at::Tensor& key_cache, const at::Tensor& value_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& key_out, at::Tensor& value_out, const float key_scale,
+    const float value_scale);
+
+void flash_attention_fp8_e4m3_paged_kv_to_fp16(
+    const at::Tensor& key_cache, const at::Tensor& value_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& key_out, at::Tensor& value_out, const float key_scale,
+    const float value_scale);
+
+std::vector<at::Tensor> flash_attention_backward(
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state);
+
+#endif

--- a/csrc/attention/sm70_grouped_long/include/fused_mma.h
+++ b/csrc/attention/sm70_grouped_long/include/fused_mma.h
@@ -1,0 +1,441 @@
+#ifndef FUSED_MMA_H
+#define FUSED_MMA_H
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ != 700)
+  #error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
+#endif
+
+#include <cuda_fp16.h>
+
+namespace volta {
+
+struct row_major {};
+struct col_major {};
+struct matrix_a {};
+struct matrix_b {};
+struct accumulator {};
+
+enum layout_t { mem_row_major, mem_col_major };
+
+template <typename Use, int M, int N, int K, typename T, typename Layout = void>
+struct fragment;
+
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+
+template <>
+struct fragment<accumulator, 16, 16, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 32, 8, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 8, 32, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+
+__device__ __forceinline__ unsigned get_lane_id() {
+  unsigned lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+}
+
+template <int M, int N, int K>
+__device__ __forceinline__ void fill_fragment(
+    fragment<accumulator, M, N, K, float>& frag, float value) {
+#pragma unroll
+  for (int i = 0; i < 8; ++i) frag.x[i] = value;
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 16, 16, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  }
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 32, 8, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  }
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 8, 32, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
+        : "l"(smem_ptr), "r"(ldm)
+        : "memory");
+  }
+}
+
+__device__ __forceinline__ void store_matrix_sync(
+    float* smem_ptr, const fragment<accumulator, 16, 16, 16, float>& frag,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
+}
+
+__device__ __forceinline__ void store_matrix_sync(
+    float* smem_ptr, const fragment<accumulator, 32, 8, 16, float>& frag,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
+}
+
+__device__ __forceinline__ void store_matrix_sync(
+    float* smem_ptr, const fragment<accumulator, 8, 32, 16, float>& frag,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
+}
+
+#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY)                            \
+  __device__ __forceinline__ void mma_sync(                                \
+      fragment<accumulator, M, N, K, float>& d,                            \
+      const fragment<matrix_a, M, N, K, half, ALAY##_major>& a,            \
+      const fragment<matrix_b, M, N, K, half, BLAY##_major>& b,            \
+      const fragment<accumulator, M, N, K, float>& c) {                    \
+    asm volatile(                                                          \
+        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K     \
+        ".f32.f32 "                                                        \
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, "                                      \
+        "{%8,%9,%10,%11,%12,%13,%14,%15}, "                                \
+        "{%16,%17,%18,%19,%20,%21,%22,%23}, "                              \
+        "{%24,%25,%26,%27,%28,%29,%30,%31};"                               \
+        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]),          \
+          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7])           \
+        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(a.x[4]), \
+          "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), "r"(b.x[0]), "r"(b.x[1]), \
+          "r"(b.x[2]), "r"(b.x[3]), "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), \
+          "r"(b.x[7]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
+          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]));             \
+  }
+
+VOLTA_WMMA_MMA_F32(16, 16, 16, row, col)
+VOLTA_WMMA_MMA_F32(16, 16, 16, row, row)
+VOLTA_WMMA_MMA_F32(16, 16, 16, col, col)
+VOLTA_WMMA_MMA_F32(16, 16, 16, col, row)
+
+VOLTA_WMMA_MMA_F32(32, 8, 16, row, col)
+VOLTA_WMMA_MMA_F32(32, 8, 16, row, row)
+VOLTA_WMMA_MMA_F32(32, 8, 16, col, col)
+VOLTA_WMMA_MMA_F32(32, 8, 16, col, row)
+
+VOLTA_WMMA_MMA_F32(8, 32, 16, row, col)
+VOLTA_WMMA_MMA_F32(8, 32, 16, row, row)
+VOLTA_WMMA_MMA_F32(8, 32, 16, col, col)
+VOLTA_WMMA_MMA_F32(8, 32, 16, col, row)
+
+#undef VOLTA_WMMA_MMA_F32
+
+}  // namespace volta
+
+#endif

--- a/csrc/attention/sm70_grouped_long/kernel/flash_v100_traits.cuh
+++ b/csrc/attention/sm70_grouped_long/kernel/flash_v100_traits.cuh
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+template <int D>
+struct FlashV100Traits {
+  static constexpr int BLOCK_M_16 = 16;
+  static constexpr int BLOCK_N_16 = 512;
+  static constexpr int BLOCK_M_32 = 32;
+  static constexpr int BLOCK_N_32 = 256;
+  static constexpr int BLOCK_M_64 = 64;
+  static constexpr int BLOCK_N_64 = 128;
+  static constexpr int BLOCK_M_128 = 32;
+  static constexpr int BLOCK_N_128 = 176;
+  static constexpr int BLOCK_M_256 = 32;
+  static constexpr int BLOCK_N_256 = 64;
+  static constexpr int WARPS_PER_BLOCK = 16;
+  static constexpr int THREADS_PER_WARP = 32;
+
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+
+  static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+
+  static constexpr int kBlockM = BLOCK_M;
+  static constexpr int kBlockN = BLOCK_N;
+  static constexpr int kHeadDim = D;
+
+  static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
+  static constexpr int kGmemRowsPerThread = 1;
+  static constexpr int kGmemElemsPerLoad = 8;
+
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+};
+
+template <typename Traits>
+__device__ __forceinline__ int64_t resolve_thread_kv_page_slice_offset(
+    const int tidx, const int n_block, const int page_block_size,
+    const int* __restrict__ block_table, const int page_stride,
+    const int row_stride, const int partial_block_size = -1) {
+  constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
+  constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
+  constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
+  constexpr int kBlockN = Traits::kBlockN;
+
+  const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
+  int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
+
+  if (partial_block_size > 0) {
+    const int final_row_offset = max(partial_block_size - 1, 0);
+    const int final_thread_row_offset =
+        ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) *
+        kGmemRowsPerThread;
+    block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
+  }
+
+  const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
+
+  const int64_t page_offset = global_row_offset % page_block_size;
+  const int64_t virtual_page_idx = global_row_offset / page_block_size;
+
+  const int64_t physical_offset =
+      ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride) +
+      page_offset * ((int64_t)row_stride) + col_offset;
+
+  return physical_offset;
+}
+
+template <typename Traits>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int n_block,
+    const int page_block_size, const int page_stride, const int row_stride,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads, const int partial_block_size = -1) {
+  constexpr int PER_UINT4 = Traits::PER_UINT4;
+  constexpr int d_stride_uint4 = Traits::d_stride_uint4;
+  constexpr int kBlockN = Traits::kBlockN;
+
+  const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
+
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
+
+      const int64_t physical_offset_halves =
+          resolve_thread_kv_page_slice_offset<Traits>(
+              tid, n_block, page_block_size, block_table, page_stride,
+              row_stride, partial_block_size);
+
+      const int64_t physical_offset_uint4 = physical_offset_halves / PER_UINT4;
+
+      kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
+    }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
+}

--- a/csrc/attention/sm70_grouped_long/kernel/fp8_kv_utils.cuh
+++ b/csrc/attention/sm70_grouped_long/kernel/fp8_kv_utils.cuh
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+namespace flash_v100 {
+
+constexpr int KV_CACHE_DTYPE_FP16 = 0;
+constexpr int KV_CACHE_DTYPE_FP8_E4M3 = 1;
+constexpr int KV_CACHE_DTYPE_FP8_E5M2 = 2;
+
+__device__ __forceinline__ float quiet_nan_f() {
+  return __int_as_float(0x7fffffff);
+}
+
+__device__ __forceinline__ float inf_f() { return __int_as_float(0x7f800000); }
+
+__device__ __forceinline__ float exp2_int(const int exponent) {
+  return __uint_as_float(static_cast<uint32_t>(exponent + 127) << 23);
+}
+
+__device__ __forceinline__ float fp8_e4m3fn_to_float(uint8_t raw) {
+  const int sign = raw >> 7;
+  const int exp = (raw >> 3) & 0x0f;
+  const int mant = raw & 0x07;
+
+  if ((raw & 0x7f) == 0) {
+    return sign ? -0.0f : 0.0f;
+  }
+
+  float value;
+  if (exp == 0) {
+    value = static_cast<float>(mant) * 0.001953125f;  // 2^-9
+  } else {
+    if (exp == 0x0f && mant == 0x07) {
+      return quiet_nan_f();
+    }
+    value = (1.0f + static_cast<float>(mant) * 0.125f) * exp2_int(exp - 7);
+  }
+  return sign ? -value : value;
+}
+
+__device__ __forceinline__ __half fp8_e5m2_to_half(uint8_t raw) {
+  // E5M2 and IEEE fp16 use the same sign bit, exponent width, and exponent
+  // bias. Expanding the two mantissa bits into the high fp16 mantissa bits is
+  // exact for normals, subnormals, zero, inf, and NaN.
+  return __ushort_as_half(static_cast<unsigned short>(raw) << 8);
+}
+
+__device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
+  const uint32_t half2_bits = (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+                              (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+  union {
+    uint32_t u;
+    __half2 h2;
+  } converter;
+  converter.u = half2_bits;
+  return converter.h2;
+}
+
+__device__ __forceinline__ __half2 load_fp8_e5m2_half2_unscaled(
+    const void* __restrict__ cache, const int64_t byte_index) {
+  const uint16_t* cache_u16 = reinterpret_cast<const uint16_t*>(cache);
+  return fp8_e5m2_pair_to_half2(cache_u16[byte_index >> 1]);
+}
+
+__device__ __forceinline__ float fp8_e5m2_to_float(uint8_t raw) {
+  return __half2float(fp8_e5m2_to_half(raw));
+}
+
+template <int KV_DTYPE>
+__device__ __forceinline__ float load_kv_cache_float_unscaled(
+    const void* __restrict__ cache, const int64_t index) {
+  if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP16) {
+    const __half* cache_h = reinterpret_cast<const __half*>(cache);
+    return __half2float(cache_h[index]);
+  } else {
+    const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
+    const uint8_t raw = cache_u8[index];
+    const float value = KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3
+                            ? fp8_e4m3fn_to_float(raw)
+                            : fp8_e5m2_to_float(raw);
+    return value;
+  }
+}
+
+template <int KV_DTYPE>
+__device__ __forceinline__ float load_kv_cache_float(
+    const void* __restrict__ cache, const int64_t index, const float scale) {
+  return load_kv_cache_float_unscaled<KV_DTYPE>(cache, index) * scale;
+}
+
+template <int KV_DTYPE>
+__device__ __forceinline__ __half load_kv_cache_half(
+    const void* __restrict__ cache, const int64_t index, const float scale) {
+  if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP8_E5M2) {
+    const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
+    return __float2half_rn(__half2float(fp8_e5m2_to_half(cache_u8[index])) *
+                           scale);
+  }
+  return __float2half_rn(load_kv_cache_float<KV_DTYPE>(cache, index, scale));
+}
+
+}  // namespace flash_v100

--- a/csrc/attention/sm70_grouped_long/kernel/grouped-attention.cu
+++ b/csrc/attention/sm70_grouped_long/kernel/grouped-attention.cu
@@ -1,0 +1,4342 @@
+#include <cuda.h>
+#include <torch/library.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <mma.h>
+#include <algorithm>
+#include <atomic>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <type_traits>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <cub/block/block_radix_sort.cuh>
+
+#include "fp8_kv_utils.cuh"
+#include "fused_mma.h"
+
+namespace {
+
+int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
+  if (kv_cache_dtype == "auto" || kv_cache_dtype == "float16" ||
+      kv_cache_dtype == "bfloat16") {
+    return flash_v100::KV_CACHE_DTYPE_FP16;
+  }
+  if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
+  }
+  if (kv_cache_dtype == "fp8_e5m2") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
+  }
+  return -1;
+}
+
+constexpr int kWarpSize = 32;
+constexpr int kThreadsPerBlock = 256;
+constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
+constexpr int kXQATCBlockN = 128;
+constexpr int kXQATCStride = 128;
+// QSA exposes selected four-token microblocks as virtual paged KV. Keep enough
+// page slots for one full XQA tile at that minimum supported granularity.
+constexpr int kXQATCPageIdsCapacity = kXQATCBlockN / 4;
+constexpr int kXQATC256WideWarpCount = 8;
+constexpr int kXQATC256WideThreads = kXQATC256WideWarpCount * kWarpSize;
+constexpr int kXQATC256WideBlockM = 8;
+constexpr int kXQATC256WideThreadsPerRow = kWarpSize;
+constexpr int kXQATCG6DualCtaThreads = 6 * kWarpSize;
+constexpr int kXQATCG6Pipeline8WarpThreads = 8 * kWarpSize;
+constexpr int kXQARouteAllSeqLens = 0;
+constexpr int kXQARouteShortSeqLens = -1;
+constexpr int kXQARouteLongSeqLens = 1;
+constexpr int kXQARouteP1024Sawtooth = 4;
+constexpr int kXQARouteP256Sawtooth = 5;
+constexpr int kXQARouteP1024SawtoothMid = 6;
+constexpr int kXQARouteP1024SawtoothFinal = 7;
+constexpr int kXQARouteRangeSeqLens = 8;
+constexpr int kXQARouteWaveLongSeqLens = 9;
+// The dense 256/128-half strides alias Volta shared-memory banks in the
+// WMMA A/B fragment loads. Both padded strides remain 16-byte aligned.
+constexpr int kXQATC256WidePaddedQStride = 264;
+constexpr int kXQATC256WidePaddedKVStride = 136;
+constexpr int kXQATC256WideAlignedPaddedQStride = 272;
+constexpr int kXQATC256WideAlignedPaddedKVStride = 144;
+constexpr int kXQATCQKPipelinePanelDim = 64;
+constexpr int kXQATCQKPipelineKVStride = 72;
+constexpr float kXQANegInf = -1.0e30f;
+
+template <bool PADDED_SMEM, bool ALIGNED_PADDED_SMEM = false>
+struct alignas(256) XQATCSmem256WideLayout {
+  static_assert(!ALIGNED_PADDED_SMEM || PADDED_SMEM,
+                "Aligned padding requires padded shared memory");
+  static constexpr int kQStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedQStride
+                                         : kXQATC256WidePaddedQStride)
+                  : 256;
+  static constexpr int kKVStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedKVStride
+                                         : kXQATC256WidePaddedKVStride)
+                  : kXQATCStride;
+  static constexpr int kQKStride = kKVStride;
+  alignas(16) __half q[kXQATC256WideBlockM * kQStride];
+  union {
+    alignas(16) __half k[kXQATCBlockN * kKVStride];
+    alignas(16) __half v[kXQATCBlockN * kKVStride];
+  } reuse_kv;
+  struct {
+    alignas(16) float s[kXQATC256WideBlockM * kXQATCBlockN];
+    alignas(16) __half p[kXQATC256WideBlockM * kXQATCBlockN];
+  } reuse_sp;
+  alignas(16) float row_max[kXQATC256WideBlockM];
+  alignas(16) float row_sum[kXQATC256WideBlockM];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+
+  __device__ __forceinline__ __half* k_buffer(int) { return reuse_kv.k; }
+  __device__ __forceinline__ __half* v_buffer() { return reuse_kv.v; }
+};
+
+template <bool PADDED_SMEM, bool ALIGNED_PADDED_SMEM = false>
+struct alignas(256) XQATCQKPipelineSmem256WideLayout {
+  static_assert(!ALIGNED_PADDED_SMEM || PADDED_SMEM,
+                "Aligned padding requires padded shared memory");
+  static constexpr int kQStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedQStride
+                                         : kXQATC256WidePaddedQStride)
+                  : 256;
+  static constexpr int kKVStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedKVStride
+                                         : kXQATC256WidePaddedKVStride)
+                  : kXQATCStride;
+  static constexpr int kQKStride = kXQATCQKPipelineKVStride;
+  struct QKBuffers {
+    alignas(16) __half panel[2][kXQATCBlockN * kQKStride];
+  };
+
+  alignas(16) __half q[kXQATC256WideBlockM * kQStride];
+  union {
+    QKBuffers qk;
+    alignas(16) __half v[kXQATCBlockN * kKVStride];
+  } reuse_kv;
+  struct {
+    alignas(16) float s[kXQATC256WideBlockM * kXQATCBlockN];
+    alignas(16) __half p[kXQATC256WideBlockM * kXQATCBlockN];
+  } reuse_sp;
+  alignas(16) float row_max[kXQATC256WideBlockM];
+  alignas(16) float row_sum[kXQATC256WideBlockM];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+
+  __device__ __forceinline__ __half* k_buffer(int index) {
+    return reuse_kv.qk.panel[index];
+  }
+  __device__ __forceinline__ __half* v_buffer() { return reuse_kv.v; }
+};
+
+constexpr int kXQATCStagedPVTileRows = 64;
+
+template <bool PADDED_SMEM>
+struct alignas(256) XQATCStagedPVSmem256Wide {
+  static constexpr int kKVStride =
+      PADDED_SMEM ? kXQATC256WidePaddedKVStride : kXQATCStride;
+  alignas(16) __half v[kXQATCStagedPVTileRows * kKVStride];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+};
+
+bool xqa_padded_smem_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_PADDED_SMEM");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_g6_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_DUAL_CTA");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_batch_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_batch_optimized_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_page800_fastpath_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_PAGE800_FASTPATH");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_page800_fastpath_trace_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_E4M3_PAGE800_FASTPATH_TRACE");
+  return value != nullptr && value[0] == '1';
+}
+
+void trace_xqa_e4m3_page800_fastpath(const int batch_size,
+                                     const int partition_size,
+                                     const bool active) {
+  if (!active || !xqa_e4m3_page800_fastpath_trace_enabled()) {
+    return;
+  }
+  static std::atomic<bool> traced{false};
+  if (!traced.exchange(true, std::memory_order_relaxed)) {
+    TORCH_WARN("Flash-V100 E4M3 page800 fast path active: batch=", batch_size,
+               ", partition_size=", partition_size,
+               ", standard interleaved Hkv=1, PV=half2");
+  }
+}
+
+bool xqa_e5m2_g6_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_g6_split_reduce_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_partition_page_ids_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_pair_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_batch_wide_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
+bool dflash2_grouped_fixed_interleaved_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DFLASH2_FIXED_INTERLEAVED");
+  return value == nullptr || value[0] != '0';
+}
+
+bool dflash2_grouped_stage_page_ids_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DFLASH2_STAGE_PAGE_IDS");
+  return value == nullptr || value[0] != '0';
+}
+
+int xqa_e5m2_p1024_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN");
+  return value == nullptr ? 61633 : std::max(1, std::atoi(value));
+}
+
+int xqa_e5m2_scalar_xqa_seq_len() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN");
+  return value == nullptr ? 16384 : std::max(1, std::atoi(value));
+}
+
+bool xqa_e5m2_g6_dual_cta_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_mtp5_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_MTP5_DUAL_CTA");
+  return value == nullptr || value[0] == '1';
+}
+
+bool xqa_g6_dual_cta_dense_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_DUAL_CTA_DENSE");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_g6_p1024_auto_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_AUTO");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_g6_p1024_auto_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_AUTO_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_g6_p1024_sawtooth_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_g6_p64_p256_auto_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P64_P256_AUTO");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_g6_p64_p256_auto_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P64_P256_AUTO_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_e4m3_g6_p256_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P256_BEGIN");
+  return value == nullptr ? 12288 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_dual_cta_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_DUAL_CTA_BEGIN");
+  return value == nullptr ? 32768 : std::max(1, std::atoi(value));
+}
+
+bool xqa_e4m3_g6_wave_partitions_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_WAVE_PARTITIONS");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_g6_merged_wave_launch_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_MERGED_WAVE_LAUNCH");
+  return value != nullptr && value[0] == '1';
+}
+
+int xqa_e4m3_g6_p512_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P512_BEGIN");
+  return value == nullptr ? 49152 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_p896_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P896_BEGIN");
+  return value == nullptr ? 98304 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_p1664_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P1664_BEGIN");
+  return value == nullptr ? 196608 : std::max(1, std::atoi(value));
+}
+
+bool decode_partition_size_overridden() {
+  return std::getenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE") != nullptr;
+}
+
+bool xqa_g6_qk_pipeline_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE");
+  return value == nullptr || value[0] != '0';
+}
+
+int xqa_g6_qk_pipeline_warps() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS");
+  return value != nullptr && std::atoi(value) == 6 ? 6 : 8;
+}
+
+bool xqa_g6_qk_pipeline_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_g6_p1024_sawtooth_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_g6_p1024_sawtooth_p1024_mid_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_MID_SEQ_LEN");
+  return value == nullptr ? 111104 : std::max(1, std::atoi(value));
+}
+
+int xqa_g6_p1024_sawtooth_p256_long_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P256_LONG_SEQ_LEN");
+  return value == nullptr ? 147841 : std::max(1, std::atoi(value));
+}
+
+int xqa_g6_p1024_sawtooth_p1024_final_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_FINAL_SEQ_LEN");
+  return value == nullptr ? 258176 : std::max(1, std::atoi(value));
+}
+
+bool xqa_split_reduce_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_SPLIT_REDUCE");
+  return value != nullptr && value[0] == '1';
+}
+
+enum class XQABatchContextRoute : int {
+  kDisabled = -1,
+  kBaseline = 0,
+  kDualCta = 1,
+  kDualCtaSplit = 2,
+};
+
+bool xqa_batch_context_routing_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_batch_context_routing_trace_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING_TRACE");
+  return value != nullptr && value[0] == '1';
+}
+
+XQABatchContextRoute select_xqa_batch_context_route(const int batch_size,
+                                                    const int max_seq_len,
+                                                    const int partition_size) {
+  if (!xqa_batch_context_routing_enabled() || batch_size < 4 ||
+      max_seq_len <= 0) {
+    return XQABatchContextRoute::kDisabled;
+  }
+  if (batch_size <= 4) {
+    if (max_seq_len <= 8191) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    if (max_seq_len <= 12287) {
+      return XQABatchContextRoute::kDualCta;
+    }
+    return partition_size == 1024 ? XQABatchContextRoute::kBaseline
+                                  : XQABatchContextRoute::kDualCtaSplit;
+  }
+  if (batch_size <= 8) {
+    if (max_seq_len <= 4095) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    return max_seq_len <= 12287 ? XQABatchContextRoute::kDualCta
+                                : XQABatchContextRoute::kDualCtaSplit;
+  }
+  if (batch_size <= 12) {
+    if (max_seq_len <= 2047) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    return max_seq_len <= 16000 ? XQABatchContextRoute::kDualCta
+                                : XQABatchContextRoute::kDualCtaSplit;
+  }
+  return max_seq_len <= 12287 ? XQABatchContextRoute::kBaseline
+                              : XQABatchContextRoute::kDualCta;
+}
+
+const char* xqa_batch_context_route_name(const XQABatchContextRoute route) {
+  switch (route) {
+    case XQABatchContextRoute::kBaseline:
+      return "baseline";
+    case XQABatchContextRoute::kDualCta:
+      return "dual_cta";
+    case XQABatchContextRoute::kDualCtaSplit:
+      return "dual_cta_split";
+    default:
+      return "disabled";
+  }
+}
+
+void trace_xqa_batch_context_route(const int batch_size, const int max_seq_len,
+                                   const int partition_size,
+                                   const int block_size,
+                                   const XQABatchContextRoute route) {
+  if (!xqa_batch_context_routing_trace_enabled() ||
+      route == XQABatchContextRoute::kDisabled) {
+    return;
+  }
+  const int batch_class = batch_size <= 4    ? 0
+                          : batch_size <= 8  ? 1
+                          : batch_size <= 12 ? 2
+                                             : 3;
+  const int context_class = max_seq_len <= 4095    ? 0
+                            : max_seq_len <= 8191  ? 1
+                            : max_seq_len <= 12287 ? 2
+                            : max_seq_len <= 16000 ? 3
+                                                   : 4;
+  const unsigned long long bit =
+      1ULL << (batch_class * 15 + context_class * 3 + static_cast<int>(route));
+  static std::atomic<unsigned long long> traced_routes{0};
+  const unsigned long long previous =
+      traced_routes.fetch_or(bit, std::memory_order_relaxed);
+  if ((previous & bit) == 0) {
+    TORCH_WARN("Flash-V100 XQA batch/context route active: batch=", batch_size,
+               ", max_seq_len=", max_seq_len,
+               ", partition_size=", partition_size, ", block_size=", block_size,
+               ", route=", xqa_batch_context_route_name(route));
+  }
+}
+
+int xqa_block16_layout_mode() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT");
+  if (value == nullptr) {
+    return 0;
+  }
+  const int mode = std::atoi(value);
+  return mode == 1 || mode == 2 ? mode : 0;
+}
+
+bool xqa_block16_layout_required() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT_REQUIRE");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_block16_layout_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_block784_index_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK784_INDEX");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_block784_index_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK784_INDEX_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_aligned_padded_smem_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_ALIGNED_PADDED_SMEM");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_aligned_padded_smem_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_ALIGNED_PADDED_SMEM_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_split_reduce_dim_tile() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_SPLIT_REDUCE_D_TILE");
+  if (value == nullptr) {
+    return 8;
+  }
+  const int dim_tile = std::atoi(value);
+  return dim_tile == 8 || dim_tile == 16 || dim_tile == 32 ? dim_tile : 8;
+}
+
+template <int SEQ_LEN_ROUTE>
+__device__ __forceinline__ bool xqa_seq_len_route_active(
+    const int seq_len, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final) {
+  if constexpr (SEQ_LEN_ROUTE == kXQARouteShortSeqLens) {
+    return seq_len < route_seq_len_begin;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteLongSeqLens) {
+    return seq_len >= route_seq_len_begin;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024Sawtooth) {
+    return (seq_len >= route_seq_len_begin && seq_len < route_seq_len_end) ||
+           seq_len >= route_seq_len_final;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP256Sawtooth) {
+    return seq_len < route_seq_len_begin ||
+           (seq_len >= route_seq_len_end && seq_len < route_seq_len_final);
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothMid) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothFinal) {
+    return seq_len >= route_seq_len_final;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteRangeSeqLens) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteWaveLongSeqLens) {
+    return seq_len >= route_seq_len_begin;
+  }
+  return true;
+}
+
+__device__ __forceinline__ int xqa_sawtooth_partition_size(
+    const int seq_len, const int p1024_mid_seq_len, const int p256_long_seq_len,
+    const int p1024_final_seq_len) {
+  const bool use_p1024 =
+      (seq_len >= p1024_mid_seq_len && seq_len < p256_long_seq_len) ||
+      seq_len >= p1024_final_seq_len;
+  return use_p1024 ? 1024 : 256;
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+    val += __shfl_down_sync(0xffffffff, val, offset);
+  }
+  return val;
+}
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+    val = fmaxf(val, __shfl_down_sync(0xffffffff, val, offset));
+  }
+  return val;
+}
+
+template <int NUM_WARPS>
+__device__ __forceinline__ float block_reduce_sum(float val) {
+  __shared__ float shared[NUM_WARPS];
+  __shared__ float result;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  val = warp_reduce_sum(val);
+  if (lane == 0) {
+    shared[warp] = val;
+  }
+  __syncthreads();
+
+  val = threadIdx.x < NUM_WARPS ? shared[lane] : 0.f;
+  if (warp == 0) {
+    val = warp_reduce_sum(val);
+    if (lane == 0) {
+      result = val;
+    }
+  }
+  __syncthreads();
+  return result;
+}
+
+template <int NUM_WARPS>
+__device__ __forceinline__ float block_reduce_max(float val) {
+  __shared__ float shared[NUM_WARPS];
+  __shared__ float result;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  val = warp_reduce_max(val);
+  if (lane == 0) {
+    shared[warp] = val;
+  }
+  __syncthreads();
+
+  val = threadIdx.x < NUM_WARPS ? shared[lane] : -1.0e20f;
+  if (warp == 0) {
+    val = warp_reduce_max(val);
+    if (lane == 0) {
+      result = val;
+    }
+  }
+  __syncthreads();
+  return result;
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e5m2_pair_to_half2_bits(const uint16_t raw_pair) {
+  return (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+         (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+}
+
+__device__ __forceinline__ uint4 fp8_e5m2_vector_to_half8(const uint64_t raw) {
+  return make_uint4(
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(const uint8_t raw) {
+  const uint16_t sign = static_cast<uint16_t>(raw & 0x80u) << 8;
+  const uint8_t magnitude = raw & 0x7fu;
+  const uint8_t exponent = magnitude >> 3;
+  const uint8_t mantissa = magnitude & 0x07u;
+  if (magnitude == 0) {
+    return sign;
+  }
+  if (exponent == 0) {
+    // E4M3 subnormals are exact fp16 normals: mantissa * 2^-9.
+    const uint16_t magnitude_bits =
+        mantissa < 2
+            ? 0x1800u
+            : (mantissa < 4
+                   ? static_cast<uint16_t>(0x1c00u | ((mantissa - 2) << 9))
+                   : static_cast<uint16_t>(0x2000u | ((mantissa - 4) << 8)));
+    return sign | magnitude_bits;
+  }
+  if (magnitude == 0x7fu) {
+    return sign | 0x7e00u;
+  }
+  return sign | static_cast<uint16_t>((exponent + 8) << 10) |
+         static_cast<uint16_t>(mantissa << 7);
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits(const uint16_t raw_pair) {
+  return static_cast<uint32_t>(
+             fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair))) |
+         (static_cast<uint32_t>(
+              fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair >> 8)))
+          << 16);
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits_fast(const uint16_t raw_pair) {
+  const uint8_t raw0 = static_cast<uint8_t>(raw_pair);
+  const uint8_t raw1 = static_cast<uint8_t>(raw_pair >> 8);
+  if ((raw0 & 0x7fu) == 0x7fu || (raw1 & 0x7fu) == 0x7fu) {
+    return fp8_e4m3fn_pair_to_half2_bits(raw_pair);
+  }
+
+  // Moving a finite E4M3 encoding into the corresponding fp16 sign,
+  // exponent, and mantissa fields represents exactly value / 256. A packed
+  // half2 multiply restores both values without per-byte exponent branches.
+  const uint32_t expanded = (static_cast<uint32_t>(raw_pair & 0x0080u) << 8) |
+                            (static_cast<uint32_t>(raw_pair & 0x007fu) << 7) |
+                            (static_cast<uint32_t>(raw_pair & 0x8000u) << 16) |
+                            (static_cast<uint32_t>(raw_pair & 0x7f00u) << 15);
+  union {
+    uint32_t u;
+    __half2 h2;
+  } converter;
+  converter.u = expanded;
+  converter.h2 = __hmul2(converter.h2, __float2half2_rn(256.0f));
+  return converter.u;
+}
+
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8(const uint64_t raw) {
+  return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8_fast(const uint64_t raw) {
+  return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint4 fp8_e4m3fn_vector_to_half8_lut(
+    const uint64_t raw, const uint16_t* __restrict__ lut) {
+  return make_uint4(
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 8)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 16)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 24)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 32)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 40)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 48)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 56)]) << 16));
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
+    const void* __restrict__ kv_cache, const int* __restrict__ page_ids,
+    const int copy_idx, const int panel_d_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  const int row = copy_idx / panel_d_stride_uint4;
+  const int vec_col = copy_idx % panel_d_stride_uint4;
+  const int token_offset = tile_page_offset + kv_tile_start + row;
+  static_assert(BLOCK_SIZE == 0 || BLOCK_SIZE == 4 || BLOCK_SIZE == 16 ||
+                    BLOCK_SIZE == 784 || BLOCK_SIZE == 800 ||
+                    BLOCK_SIZE == 1568 || BLOCK_SIZE == 1648 ||
+                    BLOCK_SIZE == 3296,
+                "Unsupported paged-KV block-size specialization");
+  static_assert(!CONTIGUOUS_HKV1_LAYOUT || BLOCK_SIZE == 16 ||
+                    BLOCK_SIZE == 800 || BLOCK_SIZE == 1568 ||
+                    BLOCK_SIZE == 1648 || BLOCK_SIZE == 3296,
+                "The fixed-stride Hkv=1 layout requires a specialized page");
+  int logical_block;
+  int block_offset;
+  if constexpr (BLOCK_SIZE == 4) {
+    logical_block = token_offset >> 2;
+    block_offset = token_offset & 3;
+  } else if constexpr (BLOCK_SIZE == 16) {
+    logical_block = token_offset >> 4;
+    block_offset = token_offset & 15;
+  } else if constexpr (BLOCK_SIZE == 784) {
+    logical_block = token_offset / 784;
+    block_offset = token_offset - logical_block * 784;
+  } else if constexpr (BLOCK_SIZE == 800) {
+    logical_block = token_offset >= 800;
+    block_offset = token_offset - logical_block * 800;
+  } else if constexpr (BLOCK_SIZE == 1568) {
+    logical_block = token_offset / 1568;
+    block_offset = token_offset - logical_block * 1568;
+  } else if constexpr (BLOCK_SIZE == 1648) {
+    logical_block = token_offset / 1648;
+    block_offset = token_offset - logical_block * 1648;
+  } else if constexpr (BLOCK_SIZE == 3296) {
+    logical_block = token_offset / 3296;
+    block_offset = token_offset - logical_block * 3296;
+  } else {
+    logical_block = token_offset / block_size;
+    block_offset = token_offset % block_size;
+  }
+  const int physical_block = page_ids[logical_block];
+  int64_t physical_offset;
+  if constexpr (CONTIGUOUS_HKV1_LAYOUT) {
+    constexpr int64_t kHeadDim = 256;
+    constexpr int64_t kBlockStride =
+        BLOCK_SIZE == 16 ? 16 * kHeadDim : 2 * BLOCK_SIZE * kHeadDim;
+    physical_offset = static_cast<int64_t>(physical_block) * kBlockStride +
+                      static_cast<int64_t>(block_offset) * kHeadDim +
+                      panel_offset;
+  } else {
+    physical_offset = static_cast<int64_t>(physical_block) * block_stride +
+                      static_cast<int64_t>(block_offset) * token_stride +
+                      static_cast<int64_t>(kv_head_idx) * head_stride +
+                      panel_offset;
+  }
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const uint4* cache_vec = reinterpret_cast<const uint4*>(kv_cache);
+    return __ldg(&cache_vec[physical_offset / 8 + vec_col]);
+  } else {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "XQA only supports fp16, FP8 E4M3, and FP8 E5M2 KV");
+    const uint64_t* cache_vec = reinterpret_cast<const uint64_t*>(kv_cache);
+    const uint64_t raw = __ldg(&cache_vec[physical_offset / 8 + vec_col]);
+    if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+      if constexpr (E4M3_SHARED_LUT) {
+        return fp8_e4m3fn_vector_to_half8_lut(raw, e4m3_lut);
+      } else {
+        return fp8_e4m3fn_vector_to_half8(raw);
+      }
+    } else {
+      static_assert(!E4M3_SHARED_LUT,
+                    "The E4M3 conversion LUT requires E4M3 KV");
+      return fp8_e5m2_vector_to_half8(raw);
+    }
+  }
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool FP8_PAIR_LOAD = false, bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ void load_xqa_tc_kv_panel(
+    __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
+    const int* __restrict__ page_ids, const int valid_kv_tile_rows,
+    const int panel_d_stride_uint4, const int kv_smem_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const int copy_thread_idx = threadIdx.x,
+    const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
+  if constexpr (FP8_PAIR_LOAD) {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "Paired XQA loads require FP8 KV");
+    static_assert(!E4M3_SHARED_LUT,
+                  "Paired E4M3 conversion does not use the shared LUT");
+    const int pair_stride = panel_d_stride_uint4 / 2;
+    const int pair_count = valid_kv_tile_rows * pair_stride;
+    for (int pair_idx = copy_thread_idx; pair_idx < pair_count;
+         pair_idx += NUM_THREADS) {
+      const int row = pair_idx / pair_stride;
+      const int vec_pair = pair_idx % pair_stride;
+      const int token_offset = tile_page_offset + kv_tile_start + row;
+      int logical_block;
+      int block_offset;
+      if constexpr (BLOCK_SIZE == 4) {
+        logical_block = token_offset >> 2;
+        block_offset = token_offset & 3;
+      } else if constexpr (BLOCK_SIZE == 16) {
+        logical_block = token_offset >> 4;
+        block_offset = token_offset & 15;
+      } else if constexpr (BLOCK_SIZE == 784) {
+        logical_block = token_offset / 784;
+        block_offset = token_offset - logical_block * 784;
+      } else if constexpr (BLOCK_SIZE == 800) {
+        logical_block = token_offset >= 800;
+        block_offset = token_offset - logical_block * 800;
+      } else if constexpr (BLOCK_SIZE == 1568) {
+        logical_block = token_offset / 1568;
+        block_offset = token_offset - logical_block * 1568;
+      } else if constexpr (BLOCK_SIZE == 1648) {
+        logical_block = token_offset / 1648;
+        block_offset = token_offset - logical_block * 1648;
+      } else if constexpr (BLOCK_SIZE == 3296) {
+        logical_block = token_offset / 3296;
+        block_offset = token_offset - logical_block * 3296;
+      } else {
+        logical_block = token_offset / block_size;
+        block_offset = token_offset % block_size;
+      }
+      const int physical_block = page_ids[logical_block];
+      int64_t physical_offset;
+      if constexpr (CONTIGUOUS_HKV1_LAYOUT) {
+        constexpr int64_t kHeadDim = 256;
+        constexpr int64_t kPhysicalBlockStride =
+            BLOCK_SIZE == 16 ? 16 * kHeadDim : 2 * BLOCK_SIZE * kHeadDim;
+        physical_offset =
+            static_cast<int64_t>(physical_block) * kPhysicalBlockStride +
+            static_cast<int64_t>(block_offset) * kHeadDim + panel_offset;
+      } else {
+        physical_offset = static_cast<int64_t>(physical_block) * block_stride +
+                          static_cast<int64_t>(block_offset) * token_stride +
+                          static_cast<int64_t>(kv_head_idx) * head_stride +
+                          panel_offset;
+      }
+      const uint4 raw = __ldg(reinterpret_cast<const uint4*>(kv_cache) +
+                              physical_offset / 16 + vec_pair);
+      const int shared_offset = row * kv_smem_stride_uint4 + vec_pair * 2;
+      const uint64_t raw_lo =
+          static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
+      shared_vec[shared_offset] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_lo)
+              : fp8_e5m2_vector_to_half8(raw_lo);
+      const uint64_t raw_hi =
+          static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
+      shared_vec[shared_offset + 1] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_hi)
+              : fp8_e5m2_vector_to_half8(raw_hi);
+    }
+  } else {
+    const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
+    for (int copy_idx = copy_thread_idx; copy_idx < copy_count;
+         copy_idx += NUM_THREADS) {
+      const int row = copy_idx / panel_d_stride_uint4;
+      const int vec_col = copy_idx % panel_d_stride_uint4;
+      shared_vec[row * kv_smem_stride_uint4 + vec_col] =
+          load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE,
+                                E4M3_SHARED_LUT>(
+              kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
+              tile_page_offset, kv_tile_start, block_size, kv_head_idx,
+              block_stride, token_stride, head_stride, panel_offset, e4m3_lut);
+    }
+  }
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ void load_xqa_tc_kv_panel_and_zero(
+    __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
+    const int* __restrict__ page_ids, const int valid_kv_tile_rows,
+    const int panel_d_stride_uint4, const int kv_smem_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const int copy_thread_idx,
+    const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
+  uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
+  constexpr int kLoadStages = 4;
+  for (int copy_base = copy_thread_idx; copy_base < copy_count;
+       copy_base += NUM_THREADS * kLoadStages) {
+    uint4 staged[kLoadStages];
+#pragma unroll
+    for (int stage = 0; stage < kLoadStages; ++stage) {
+      const int copy_idx = copy_base + stage * NUM_THREADS;
+      if (copy_idx < copy_count) {
+        staged[stage] =
+            load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE,
+                                  E4M3_SHARED_LUT>(
+                kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
+                tile_page_offset, kv_tile_start, block_size, kv_head_idx,
+                block_stride, token_stride, head_stride, panel_offset,
+                e4m3_lut);
+      }
+    }
+#pragma unroll
+    for (int stage = 0; stage < kLoadStages; ++stage) {
+      const int copy_idx = copy_base + stage * NUM_THREADS;
+      if (copy_idx < copy_count) {
+        const int row = copy_idx / panel_d_stride_uint4;
+        const int vec_col = copy_idx % panel_d_stride_uint4;
+        shared_vec[row * kv_smem_stride_uint4 + vec_col] = staged[stage];
+      }
+    }
+  }
+  for (int copy_idx = copy_thread_idx + copy_count;
+       copy_idx < kXQATCBlockN * panel_d_stride_uint4;
+       copy_idx += NUM_THREADS) {
+    const int row = copy_idx / panel_d_stride_uint4;
+    const int vec_col = copy_idx % panel_d_stride_uint4;
+    shared_vec[row * kv_smem_stride_uint4 + vec_col] = make_uint4(0, 0, 0, 0);
+  }
+}
+
+template <int D>
+__device__ __forceinline__ float dot_qk_half2(const __half* __restrict__ q_ptr,
+                                              const __half* __restrict__ k_ptr,
+                                              const int lane) {
+  static_assert(D % 2 == 0, "Head dim must be even for half2 dot");
+  const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_ptr);
+  const __half2* k_ptr2 = reinterpret_cast<const __half2*>(k_ptr);
+
+  float acc = 0.f;
+#pragma unroll
+  for (int i = lane; i < D / 2; i += kWarpSize) {
+    const float2 qv = __half22float2(q_ptr2[i]);
+    const float2 kv = __half22float2(k_ptr2[i]);
+    acc = fmaf(qv.x, kv.x, acc);
+    acc = fmaf(qv.y, kv.y, acc);
+  }
+  return warp_reduce_sum(acc);
+}
+
+template <int D, int KV_DTYPE>
+__device__ __forceinline__ float dot_qk_cache(const __half* __restrict__ q_ptr,
+                                              const void* __restrict__ k_cache,
+                                              const int64_t k_index_base,
+                                              const int lane) {
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const __half* k_ptr =
+        reinterpret_cast<const __half*>(k_cache) + k_index_base;
+    return dot_qk_half2<D>(q_ptr, k_ptr, lane);
+  } else if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2) {
+    static_assert(D % 2 == 0, "Head dim must be even for e5m2 half2 dot");
+    const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_ptr);
+    float acc = 0.f;
+#pragma unroll
+    for (int i = lane; i < D / 2; i += kWarpSize) {
+      const float2 qv = __half22float2(q_ptr2[i]);
+      const __half2 k_h2 = flash_v100::load_fp8_e5m2_half2_unscaled(
+          k_cache, k_index_base + static_cast<int64_t>(i) * 2);
+      const float2 kv = __half22float2(k_h2);
+      acc = fmaf(qv.x, kv.x, acc);
+      acc = fmaf(qv.y, kv.y, acc);
+    }
+    return warp_reduce_sum(acc);
+  } else {
+    float acc = 0.f;
+#pragma unroll
+    for (int d = lane; d < D; d += kWarpSize) {
+      const float qv = __half2float(q_ptr[d]);
+      const float kv = flash_v100::load_kv_cache_float_unscaled<KV_DTYPE>(
+          k_cache, k_index_base + d);
+      acc = fmaf(qv, kv, acc);
+    }
+    return warp_reduce_sum(acc);
+  }
+}
+
+template <int D, int PARTITION_SIZE, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool ANCHORED_SWA = false,
+          typename PARTIAL_T = __half>
+__global__ void flash_attention_decode_partition_kernel(
+    const __half* __restrict__ q, const void* __restrict__ k_cache,
+    const void* __restrict__ v_cache, PARTIAL_T* __restrict__ tmp_out,
+    float* __restrict__ max_logits, float* __restrict__ exp_sums,
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    const int* __restrict__ active_num_partitions, const int batch_size,
+    const int max_num_blocks, const int max_num_partitions,
+    const int num_heads_q, const int num_heads_kv, const int block_size,
+    const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t k_block_stride,
+    const int64_t k_token_stride, const int64_t k_head_stride,
+    const int64_t v_block_stride, const int64_t v_token_stride,
+    const int64_t v_head_stride, const float softmax_scale, const float k_scale,
+    const float v_scale, const int window_size_left,
+    const int window_size_right, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final,
+    const int* __restrict__ anchor_lens, const int anchored_window) {
+  // The anchored decode-window mask variant is only generated for the fp16-KV
+  // configuration; every other instantiation keeps its original code path.
+  static_assert(!ANCHORED_SWA || KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                "ANCHORED_SWA requires an fp16 KV cache");
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+
+  if (batch_idx >= batch_size || head_idx >= num_heads_q ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+  const int runtime_num_partitions = active_num_partitions[0];
+  const int seq_num_partitions =
+      (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE;
+  const int effective_num_partitions =
+      min(max_num_partitions, max(runtime_num_partitions, seq_num_partitions));
+  if (partition_idx >= effective_num_partitions) {
+    return;
+  }
+
+  const int query_pos = seq_len - 1;
+  const int min_token_idx =
+      window_size_left >= 0 ? max(0, query_pos - window_size_left) : 0;
+  const int max_token_idx =
+      window_size_right >= 0 ? min(seq_len - 1, query_pos + window_size_right)
+                             : seq_len - 1;
+  const int part_start = max(start_token_idx, min_token_idx);
+  const int part_end = min(start_token_idx + PARTITION_SIZE, max_token_idx + 1);
+
+  // Anchored decode window: keys below the per-request prompt length stay
+  // globally visible; later (generated) keys must fall inside the sliding
+  // window over generated positions. Keys inside [gap_lo, gap_hi) are masked.
+  int gap_lo = seq_len;
+  int gap_hi = seq_len;
+  if constexpr (ANCHORED_SWA) {
+    const int anchor_len = anchor_lens[batch_idx];
+    gap_lo = anchor_len;
+    gap_hi = max(anchor_len, query_pos - anchored_window + 1);
+  }
+  const int q_per_kv = num_heads_q / num_heads_kv;
+  const int kv_head_idx = head_idx / q_per_kv;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp_idx = threadIdx.x / kWarpSize;
+  const float score_scale = KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+                                ? softmax_scale
+                                : softmax_scale * k_scale;
+
+  const int64_t tmp_out_base =
+      static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1 +
+      static_cast<int64_t>(partition_idx) * tmp_out_stride2;
+  if (part_start >= part_end) {
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      tmp_out[tmp_out_base + d] = __float2half(0.f);
+    }
+    if (threadIdx.x == 0) {
+      const int64_t stats_index =
+          static_cast<int64_t>(batch_idx) * stats_stride0 +
+          static_cast<int64_t>(head_idx) * stats_stride1 + partition_idx;
+      max_logits[stats_index] = -1.0e20f;
+      exp_sums[stats_index] = 0.f;
+    }
+    return;
+  }
+
+  const int part_tokens = part_end - part_start;
+
+  __shared__ __half q_shared[D];
+  __shared__ float scores_shared[PARTITION_SIZE];
+  __shared__ int block_idx_shared[PARTITION_SIZE];
+  __shared__ int block_offset_shared[PARTITION_SIZE];
+
+  const __half* q_ptr = q + static_cast<int64_t>(batch_idx) * q_stride0 +
+                        static_cast<int64_t>(head_idx) * q_stride1;
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    q_shared[d] = q_ptr[d];
+  }
+  for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    const int token_idx = part_start + i;
+    const int logical_block = token_idx / block_size;
+    block_idx_shared[i] =
+        block_table[batch_idx * max_num_blocks + logical_block];
+    block_offset_shared[i] = token_idx - logical_block * block_size;
+  }
+  __syncthreads();
+
+  float local_max = -1.0e20f;
+  for (int token_local = warp_idx; token_local < part_tokens;
+       token_local += kWarpsPerBlock) {
+    const int physical_block = block_idx_shared[token_local];
+    const int block_offset = block_offset_shared[token_local];
+    const int64_t k_index =
+        static_cast<int64_t>(physical_block) * k_block_stride +
+        static_cast<int64_t>(block_offset) * k_token_stride +
+        static_cast<int64_t>(kv_head_idx) * k_head_stride;
+
+    float score = dot_qk_cache<D, KV_DTYPE>(q_shared, k_cache, k_index, lane);
+    if (lane == 0) {
+      if constexpr (ANCHORED_SWA) {
+        const int token_idx = part_start + token_local;
+        if (token_idx >= gap_lo && token_idx < gap_hi) {
+          // Masked gap key: never contributes (nulled gap blocks included).
+          scores_shared[token_local] = -1.0e30f;
+        } else {
+          score *= score_scale;
+          scores_shared[token_local] = score;
+          local_max = fmaxf(local_max, score);
+        }
+      } else {
+        score *= score_scale;
+        scores_shared[token_local] = score;
+        local_max = fmaxf(local_max, score);
+      }
+    }
+  }
+
+  const float part_max = block_reduce_max<kWarpsPerBlock>(local_max);
+
+  float local_sum = 0.f;
+  for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    if constexpr (ANCHORED_SWA) {
+      const int token_idx = part_start + i;
+      if (token_idx >= gap_lo && token_idx < gap_hi) {
+        // Exact zero weight for masked keys (no reliance on expf underflow).
+        scores_shared[i] = 0.f;
+        continue;
+      }
+    }
+    const float p = __expf(scores_shared[i] - part_max);
+    scores_shared[i] = p;
+    local_sum += p;
+  }
+  const float part_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+  const float inv_part_sum = part_sum > 0.f ? 1.f / part_sum : 0.f;
+  __syncthreads();
+
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    float acc = 0.f;
+    for (int i = 0; i < part_tokens; ++i) {
+      const int physical_block = block_idx_shared[i];
+      const int block_offset = block_offset_shared[i];
+      const int64_t v_index =
+          static_cast<int64_t>(physical_block) * v_block_stride +
+          static_cast<int64_t>(block_offset) * v_token_stride +
+          static_cast<int64_t>(kv_head_idx) * v_head_stride + d;
+      const float vv =
+          flash_v100::load_kv_cache_float_unscaled<KV_DTYPE>(v_cache, v_index);
+      acc = fmaf(scores_shared[i], vv, acc);
+    }
+    const float out_scale = KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+                                ? inv_part_sum
+                                : inv_part_sum * v_scale;
+    if constexpr (std::is_same_v<PARTIAL_T, float>) {
+      tmp_out[tmp_out_base + d] = acc * out_scale;
+    } else {
+      tmp_out[tmp_out_base + d] = __float2half(acc * out_scale);
+    }
+  }
+
+  if (threadIdx.x == 0) {
+    const int64_t stats_index =
+        static_cast<int64_t>(batch_idx) * stats_stride0 +
+        static_cast<int64_t>(head_idx) * stats_stride1 + partition_idx;
+    max_logits[stats_index] = part_max;
+    exp_sums[stats_index] = part_sum;
+  }
+}
+
+template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM, int NUM_THREADS,
+          int MIN_BLOCKS_PER_SM, int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
+          bool ALIGNED_PADDED_SMEM, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
+          bool PARTITION_PAGE_IDS = false, bool FP8_PAIR_LOAD = false,
+          bool E4M3_SHARED_LUT = false>
+__global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
+    flash_attention_decode_xqa_tc_partition_kernel_256_wide(
+        const __half* __restrict__ q, const void* __restrict__ k_cache,
+        const void* __restrict__ v_cache, __half* __restrict__ tmp_out,
+        float* __restrict__ max_logits, float* __restrict__ exp_sums,
+        const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+        const int* __restrict__ active_num_partitions, const int batch_size,
+        const int max_num_blocks, const int max_num_partitions,
+        const int num_heads_q, const int num_heads_kv, const int block_size,
+        const int64_t q_stride0, const int64_t q_stride1,
+        const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+        const int64_t tmp_out_stride2, const int64_t stats_stride0,
+        const int64_t stats_stride1, const int64_t k_block_stride,
+        const int64_t k_token_stride, const int64_t k_head_stride,
+        const int64_t v_block_stride, const int64_t v_token_stride,
+        const int64_t v_head_stride, const float softmax_scale,
+        const float k_scale, const float v_scale, const int route_seq_len_begin,
+        const int route_seq_len_end, const int route_seq_len_final) {
+  constexpr int D = 256;
+  constexpr int WMMA_M = 8;
+  constexpr int WMMA_N = 32;
+  constexpr int WMMA_K = 16;
+  constexpr int kPVPanelDim = kXQATCStride;
+  constexpr int kNumPVPanels = D / kPVPanelDim;
+  constexpr int kQKPanelDim =
+      QK_SW_PIPELINE ? kXQATCQKPipelinePanelDim : kXQATCStride;
+  constexpr int kNumQKPanels = D / kQKPanelDim;
+  using SmemLayout = std::conditional_t<
+      QK_SW_PIPELINE,
+      XQATCQKPipelineSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>,
+      XQATCSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>>;
+  // Keep softmax P in fp32 through PV for fp16 KV, avoiding a half round-trip.
+  // Preserve the half-P path for fp8_e5m2 so quantized-cache behavior remains
+  // bit-exact. This branch is resolved entirely at compile time.
+  constexpr bool kKeepPfp32 = (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16);
+  constexpr int q_global_stride_uint4 = D / 8;
+  constexpr int q_smem_stride_uint4 = SmemLayout::kQStride / 8;
+  constexpr int kv_smem_stride_uint4 = SmemLayout::kKVStride / 8;
+  constexpr int pv_panel_d_stride_uint4 = kPVPanelDim / 8;
+  constexpr int qk_smem_stride_uint4 =
+      QK_SW_PIPELINE ? SmemLayout::kQKStride / 8 : kv_smem_stride_uint4;
+  constexpr int qk_panel_d_stride_uint4 = kQKPanelDim / 8;
+  constexpr int kAccumsPerThread = D / kWarpSize;
+  constexpr bool kPVHalf2 = CONTIGUOUS_HKV1_LAYOUT &&
+                            (BLOCK_SIZE == 800 || BLOCK_SIZE == 1568) &&
+                            KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
+  static_assert(GROUP_SIZE == 4 || GROUP_SIZE == 6 || GROUP_SIZE == 8,
+                "Wide D=256 TC XQA kernel supports q_per_kv in {4, 6, 8}");
+  static_assert(NUM_THREADS >= GROUP_SIZE * kWarpSize,
+                "Each XQA query head requires one full softmax/PV warp");
+  static_assert(
+      !QK_SW_PIPELINE || (GROUP_SIZE == 6 && (NUM_THREADS == 6 * kWarpSize ||
+                                              NUM_THREADS == 8 * kWarpSize)),
+      "The QK software pipeline requires a six- or eight-warp G6 "
+      "kernel");
+  static_assert(
+      !E4M3_SHARED_LUT || KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+      "The shared conversion LUT is only valid for E4M3 KV");
+  const int batch_idx = blockIdx.x;
+  const int kv_head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+
+  if (batch_idx >= batch_size || kv_head_idx >= num_heads_kv ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  int partition_size;
+  if constexpr (PARTITION_SIZE == -1) {
+    static_assert(SEQ_LEN_ROUTE == kXQARouteWaveLongSeqLens,
+                  "Runtime wave partitions require the wave-long route");
+    partition_size = seq_len < route_seq_len_end
+                         ? 512
+                         : (seq_len < route_seq_len_final ? 896 : 1664);
+  } else if constexpr (PARTITION_SIZE == 0) {
+    const int partition_size_begin =
+        route_seq_len_end > 0 ? route_seq_len_end : route_seq_len_begin;
+    partition_size = seq_len < partition_size_begin ? 64 : 256;
+  } else {
+    partition_size = PARTITION_SIZE;
+  }
+  const int start_token_idx = partition_idx * partition_size;
+  if (seq_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+  const int runtime_num_partitions = active_num_partitions[0];
+  const int seq_num_partitions =
+      (seq_len + partition_size - 1) / partition_size;
+  const int effective_num_partitions =
+      min(max_num_partitions, max(runtime_num_partitions, seq_num_partitions));
+  if (partition_idx >= effective_num_partitions) {
+    return;
+  }
+
+  const int q_head_base = kv_head_idx * GROUP_SIZE;
+  if (q_head_base + GROUP_SIZE > num_heads_q) {
+    return;
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+  const int part_tokens = min(partition_size, seq_len - start_token_idx);
+  const int num_k_tiles = (part_tokens + kXQATCBlockN - 1) / kXQATCBlockN;
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  extern __shared__ char smem_raw[];
+  auto& smem = *reinterpret_cast<SmemLayout*>(smem_raw);
+  uint16_t* e4m3_lut = nullptr;
+  if constexpr (E4M3_SHARED_LUT) {
+    e4m3_lut = reinterpret_cast<uint16_t*>(smem_raw + sizeof(SmemLayout));
+    for (int raw = tid; raw < 256; raw += NUM_THREADS) {
+      e4m3_lut[raw] = fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw));
+    }
+  }
+  __half* sQ = smem.q;
+  __half* sK = smem.k_buffer(0);
+  __half* sV = smem.v_buffer();
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float row_max_reg = kXQANegInf;
+  float row_sum_reg = 0.f;
+  float out_acc[kAccumsPerThread];
+#pragma unroll
+  for (int i = 0; i < kAccumsPerThread; ++i) {
+    out_acc[i] = 0.f;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+  for (int idx = tid; idx < GROUP_SIZE * q_global_stride_uint4;
+       idx += NUM_THREADS) {
+    const int row = idx / q_global_stride_uint4;
+    const int vec_col = idx % q_global_stride_uint4;
+    const int64_t q_offset =
+        static_cast<int64_t>(batch_idx) * q_stride0 +
+        static_cast<int64_t>(q_head_base + row) * q_stride1;
+    sQ_vec[row * q_smem_stride_uint4 + vec_col] =
+        __ldg(&q_vec[q_offset / 8 + vec_col]);
+  }
+  for (int idx = tid;
+       idx < (kXQATC256WideBlockM - GROUP_SIZE) * q_global_stride_uint4;
+       idx += NUM_THREADS) {
+    const int row = GROUP_SIZE + idx / q_global_stride_uint4;
+    const int vec_col = idx % q_global_stride_uint4;
+    sQ_vec[row * q_smem_stride_uint4 + vec_col] = make_uint4(0, 0, 0, 0);
+  }
+  __syncthreads();
+
+  int partition_start_page = 0;
+  int partition_page_offset = 0;
+  if constexpr (PARTITION_PAGE_IDS) {
+    int partition_page_count;
+    if constexpr (BLOCK_SIZE == 800) {
+      partition_start_page = start_token_idx / 800;
+      partition_page_offset = start_token_idx - partition_start_page * 800;
+      partition_page_count = 1 + (partition_page_offset + part_tokens > 800);
+    } else {
+      partition_start_page = start_token_idx / block_size;
+      partition_page_offset =
+          start_token_idx - partition_start_page * block_size;
+      partition_page_count =
+          (partition_page_offset + part_tokens + block_size - 1) / block_size;
+    }
+    for (int idx = tid; idx < partition_page_count; idx += NUM_THREADS) {
+      smem.page_ids[idx] = __ldg(&block_table_seq[partition_start_page + idx]);
+    }
+    __syncthreads();
+  }
+
+  for (int block_n = 0; block_n < num_k_tiles; ++block_n) {
+    const int tile_token_start = start_token_idx + block_n * kXQATCBlockN;
+    const int valid_k_rows =
+        min(kXQATCBlockN, part_tokens - block_n * kXQATCBlockN);
+    int start_page = partition_start_page;
+    int tile_page_offset;
+    int page_count = 0;
+    if constexpr (PARTITION_PAGE_IDS) {
+      tile_page_offset = partition_page_offset + block_n * kXQATCBlockN;
+    } else if constexpr (BLOCK_SIZE == 16) {
+      start_page = tile_token_start >> 4;
+      tile_page_offset = tile_token_start & 15;
+      page_count = (tile_page_offset + valid_k_rows + 15) >> 4;
+    } else if constexpr (BLOCK_SIZE == 784) {
+      start_page = tile_token_start / 784;
+      tile_page_offset = tile_token_start - start_page * 784;
+      page_count = (tile_page_offset + valid_k_rows + 783) / 784;
+    } else if constexpr (BLOCK_SIZE == 800) {
+      start_page = tile_token_start / 800;
+      tile_page_offset = tile_token_start - start_page * 800;
+      page_count = 1 + (tile_page_offset + valid_k_rows > 800);
+    } else if constexpr (BLOCK_SIZE == 1568) {
+      start_page = tile_token_start / 1568;
+      tile_page_offset = tile_token_start - start_page * 1568;
+      page_count = (tile_page_offset + valid_k_rows + 1567) / 1568;
+    } else {
+      start_page = tile_token_start / block_size;
+      tile_page_offset = tile_token_start - start_page * block_size;
+      page_count =
+          (tile_page_offset + valid_k_rows + block_size - 1) / block_size;
+    }
+
+    if constexpr (!PARTITION_PAGE_IDS) {
+      for (int idx = tid; idx < page_count; idx += NUM_THREADS) {
+        smem.page_ids[idx] = __ldg(&block_table_seq[start_page + idx]);
+      }
+      __syncthreads();
+    }
+
+    for (int kv_tile_start = 0; kv_tile_start < valid_k_rows;
+         kv_tile_start += kXQATCBlockN) {
+      const int valid_kv_tile_rows =
+          min(kXQATCBlockN, valid_k_rows - kv_tile_start);
+      // The QK fragments die before softmax/PV. This permits the compiler to
+      // reuse their registers for the memory-latency-sensitive PV phase.
+      volta::fragment<volta::matrix_a, WMMA_M, WMMA_N, WMMA_K, half,
+                      volta::row_major>
+          qk_a_frag;
+      volta::fragment<volta::matrix_b, WMMA_M, WMMA_N, WMMA_K, half,
+                      volta::col_major>
+          qk_b_frag;
+      volta::fragment<volta::accumulator, WMMA_M, WMMA_N, WMMA_K, float>
+          qk_acc_frag;
+      if (warp_id < (kXQATCBlockN / WMMA_N)) {
+        volta::fill_fragment(qk_acc_frag, 0.0f);
+      }
+
+      if constexpr (QK_SW_PIPELINE) {
+        constexpr int kConsumerWarps = kXQATCBlockN / WMMA_N;
+        constexpr int kProducerThreads =
+            NUM_THREADS - kConsumerWarps * kWarpSize;
+        const int producer_tid = tid - kConsumerWarps * kWarpSize;
+        if (producer_tid >= 0) {
+          load_xqa_tc_kv_panel_and_zero<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                                        kProducerThreads, KV_DTYPE,
+                                        E4M3_SHARED_LUT>(
+              smem.k_buffer(0), k_cache, smem.page_ids, valid_kv_tile_rows,
+              qk_panel_d_stride_uint4, qk_smem_stride_uint4, tile_page_offset,
+              kv_tile_start, block_size, kv_head_idx, k_block_stride,
+              k_token_stride, k_head_stride, 0, producer_tid, e4m3_lut);
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int panel_idx = 0; panel_idx < kNumQKPanels; ++panel_idx) {
+          const int panel_offset = panel_idx * kQKPanelDim;
+          if (producer_tid >= 0 && panel_idx + 1 < kNumQKPanels) {
+            load_xqa_tc_kv_panel_and_zero<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                                          kProducerThreads, KV_DTYPE,
+                                          E4M3_SHARED_LUT>(
+                smem.k_buffer((panel_idx + 1) & 1), k_cache, smem.page_ids,
+                valid_kv_tile_rows, qk_panel_d_stride_uint4,
+                qk_smem_stride_uint4, tile_page_offset, kv_tile_start,
+                block_size, kv_head_idx, k_block_stride, k_token_stride,
+                k_head_stride, panel_offset + kQKPanelDim, producer_tid,
+                e4m3_lut);
+          }
+          if (warp_id < kConsumerWarps) {
+            const int tile_n = warp_id * WMMA_N;
+            const __half* sK_panel = smem.k_buffer(panel_idx & 1);
+#pragma unroll
+            for (int k_tile = 0; k_tile < (kQKPanelDim / WMMA_K); ++k_tile) {
+              const int k_offset = k_tile * WMMA_K;
+              volta::load_matrix_sync(qk_a_frag, sQ + panel_offset + k_offset,
+                                      SmemLayout::kQStride);
+              volta::load_matrix_sync(
+                  qk_b_frag,
+                  sK_panel + tile_n * SmemLayout::kQKStride + k_offset,
+                  SmemLayout::kQKStride);
+              volta::mma_sync(qk_acc_frag, qk_a_frag, qk_b_frag, qk_acc_frag);
+            }
+          }
+          __syncthreads();
+        }
+      } else {
+#pragma unroll
+        for (int panel_idx = 0; panel_idx < kNumQKPanels; ++panel_idx) {
+          const int panel_offset = panel_idx * kQKPanelDim;
+          load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
+                               KV_DTYPE, FP8_PAIR_LOAD, E4M3_SHARED_LUT>(
+              sK, k_cache, smem.page_ids, valid_kv_tile_rows,
+              qk_panel_d_stride_uint4, qk_smem_stride_uint4, tile_page_offset,
+              kv_tile_start, block_size, kv_head_idx, k_block_stride,
+              k_token_stride, k_head_stride, panel_offset, threadIdx.x,
+              e4m3_lut);
+          for (int idx = tid + valid_kv_tile_rows * qk_panel_d_stride_uint4;
+               idx < kXQATCBlockN * qk_panel_d_stride_uint4;
+               idx += NUM_THREADS) {
+            const int row = idx / qk_panel_d_stride_uint4;
+            const int vec_col = idx % qk_panel_d_stride_uint4;
+            reinterpret_cast<uint4*>(sK)[row * qk_smem_stride_uint4 + vec_col] =
+                make_uint4(0, 0, 0, 0);
+          }
+          __syncthreads();
+
+          if (warp_id < (kXQATCBlockN / WMMA_N)) {
+            const int tile_n = warp_id * WMMA_N;
+#pragma unroll
+            for (int k_tile = 0; k_tile < (kQKPanelDim / WMMA_K); ++k_tile) {
+              const int k_offset = k_tile * WMMA_K;
+              volta::load_matrix_sync(qk_a_frag, sQ + panel_offset + k_offset,
+                                      SmemLayout::kQStride);
+              volta::load_matrix_sync(
+                  qk_b_frag, sK + tile_n * SmemLayout::kQKStride + k_offset,
+                  SmemLayout::kQKStride);
+              volta::mma_sync(qk_acc_frag, qk_a_frag, qk_b_frag, qk_acc_frag);
+            }
+          }
+          __syncthreads();
+        }
+      }
+
+      if (warp_id < (kXQATCBlockN / WMMA_N)) {
+#pragma unroll
+        for (int i = 0; i < qk_acc_frag.num_elements; ++i) {
+          qk_acc_frag.x[i] *= KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+                                  ? softmax_scale
+                                  : softmax_scale * k_scale;
+        }
+        volta::store_matrix_sync(sS + kv_tile_start + warp_id * WMMA_N,
+                                 qk_acc_frag, kXQATCBlockN,
+                                 volta::mem_row_major);
+      }
+      __syncthreads();
+    }
+
+    if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+      const int row = tid / kXQATC256WideThreadsPerRow;
+      const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+      const unsigned mask = 0xffffffffu;
+      float* sS_row_f = sS + row * kXQATCBlockN;
+      __half* sP_row_h = sP + row * kXQATCBlockN;
+      float* sP_row_f = sS + row * kXQATCBlockN;
+      const int vec_cols = valid_k_rows >> 2;
+      const int tail_start = vec_cols << 2;
+      const int vec_col = thread_in_row;
+
+      float thread_max = kXQANegInf;
+      __half2 packed_exp0 = __float22half2_rn(make_float2(0.f, 0.f));
+      __half2 packed_exp1 = __float22half2_rn(make_float2(0.f, 0.f));
+      if (vec_col < vec_cols) {
+        const float4 v4 = reinterpret_cast<float4*>(sS_row_f)[vec_col];
+        thread_max =
+            fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+      }
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += kXQATC256WideThreadsPerRow) {
+        thread_max = fmaxf(thread_max, sS_row_f[c]);
+      }
+#pragma unroll
+      for (int o = kXQATC256WideThreadsPerRow / 2; o > 0; o >>= 1) {
+        thread_max =
+            fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o, kWarpSize));
+      }
+
+      const float row_max = __shfl_sync(mask, thread_max, 0, kWarpSize);
+      const float old_max = __shfl_sync(mask, row_max_reg, 0, kWarpSize);
+      const float new_max = fmaxf(old_max, row_max);
+      const float exp_diff = __expf(old_max - new_max);
+
+      float thread_sum = 0.f;
+      if (vec_col < vec_cols) {
+        const float4 v4 = reinterpret_cast<float4*>(sS_row_f)[vec_col];
+        const float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+        const float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+        const float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+        const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+        thread_sum += (e0 + e1) + (e2 + e3);
+        if constexpr (kKeepPfp32) {
+          reinterpret_cast<float4*>(sP_row_f)[vec_col] =
+              make_float4(e0, e1, e2, e3);
+        } else {
+          packed_exp0 = __float22half2_rn(make_float2(e0, e1));
+          packed_exp1 = __float22half2_rn(make_float2(e2, e3));
+        }
+      }
+
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < kXQATCBlockN;
+           c += kXQATC256WideThreadsPerRow) {
+        const float v = (c < valid_k_rows) ? sS_row_f[c] : kXQANegInf;
+        const float e = __expf(fmaxf(v - new_max, -80.0f));
+        thread_sum += (c < valid_k_rows) ? e : 0.0f;
+        if constexpr (kKeepPfp32) {
+          sP_row_f[c] = (c < valid_k_rows) ? e : 0.0f;
+        } else {
+          sP_row_h[c] =
+              (c < valid_k_rows) ? __float2half_rn(e) : __float2half(0.f);
+        }
+      }
+
+#pragma unroll
+      for (int o = kXQATC256WideThreadsPerRow / 2; o > 0; o >>= 1) {
+        thread_sum += __shfl_down_sync(mask, thread_sum, o, kWarpSize);
+      }
+
+      const float row_sum = __shfl_sync(mask, thread_sum, 0, kWarpSize);
+      const float old_sum = __shfl_sync(mask, row_sum_reg, 0, kWarpSize);
+
+      if (thread_in_row == 0) {
+        row_sum_reg = exp_diff * old_sum + row_sum;
+        row_max_reg = new_max;
+      }
+      if constexpr (!kKeepPfp32) {
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+        if (vec_col < vec_cols) {
+          const int base_offset = vec_col * 2;
+          sP_half2[base_offset] = packed_exp0;
+          sP_half2[base_offset + 1] = packed_exp1;
+        }
+      }
+
+      if (block_n > 0) {
+#pragma unroll
+        for (int i = 0; i < kAccumsPerThread; ++i) {
+          out_acc[i] *= exp_diff;
+        }
+      }
+    }
+    __syncthreads();
+
+    for (int panel_idx = 0; panel_idx < kNumPVPanels; ++panel_idx) {
+      const int panel_offset = panel_idx * kPVPanelDim;
+      for (int kv_tile_start = 0; kv_tile_start < valid_k_rows;
+           kv_tile_start += kXQATCBlockN) {
+        const int valid_kv_tile_rows =
+            min(kXQATCBlockN, valid_k_rows - kv_tile_start);
+        load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
+                             KV_DTYPE, FP8_PAIR_LOAD, E4M3_SHARED_LUT>(
+            sV, v_cache, smem.page_ids, valid_kv_tile_rows,
+            pv_panel_d_stride_uint4, kv_smem_stride_uint4, tile_page_offset,
+            kv_tile_start, block_size, kv_head_idx, v_block_stride,
+            v_token_stride, v_head_stride, panel_offset, threadIdx.x, e4m3_lut);
+        for (int idx = tid + valid_kv_tile_rows * pv_panel_d_stride_uint4;
+             idx < kXQATCBlockN * pv_panel_d_stride_uint4; idx += NUM_THREADS) {
+          const int row = idx / pv_panel_d_stride_uint4;
+          const int vec_col = idx % pv_panel_d_stride_uint4;
+          reinterpret_cast<uint4*>(sV)[row * kv_smem_stride_uint4 + vec_col] =
+              make_uint4(0, 0, 0, 0);
+        }
+        __syncthreads();
+
+        if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+          const int row = tid / kXQATC256WideThreadsPerRow;
+          const __half* sP_row = sP + row * kXQATCBlockN + kv_tile_start;
+          const float* sP_row_f = sS + row * kXQATCBlockN + kv_tile_start;
+#pragma unroll
+          for (int token = 0; token < kXQATCBlockN; ++token) {
+            if (token >= valid_kv_tile_rows) {
+              break;
+            }
+            float prob;
+            if constexpr (kKeepPfp32) {
+              prob = sP_row_f[token];
+            } else {
+              prob = __half2float(sP_row[token]);
+            }
+            const __half* sV_row = sV + token * SmemLayout::kKVStride;
+            if constexpr (kPVHalf2) {
+#pragma unroll
+              for (int d_iter = 0; d_iter < (kPVPanelDim / (2 * kWarpSize));
+                   ++d_iter) {
+                const int local_d2 = lane_id + d_iter * kWarpSize;
+                const float2 value = __half22float2(
+                    reinterpret_cast<const __half2*>(sV_row)[local_d2]);
+                const int acc_idx =
+                    panel_idx * (kPVPanelDim / kWarpSize) + d_iter * 2;
+                out_acc[acc_idx] = fmaf(prob, value.x, out_acc[acc_idx]);
+                out_acc[acc_idx + 1] =
+                    fmaf(prob, value.y, out_acc[acc_idx + 1]);
+              }
+            } else {
+#pragma unroll
+              for (int d_iter = 0; d_iter < (kPVPanelDim / kWarpSize);
+                   ++d_iter) {
+                const int local_d = lane_id + d_iter * kWarpSize;
+                const int acc_idx =
+                    panel_idx * (kPVPanelDim / kWarpSize) + d_iter;
+                out_acc[acc_idx] =
+                    fmaf(prob, __half2float(sV_row[local_d]), out_acc[acc_idx]);
+              }
+            }
+          }
+        }
+        __syncthreads();
+      }
+    }
+  }
+
+  if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+    const int row = tid / kXQATC256WideThreadsPerRow;
+    const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+    if (thread_in_row == 0) {
+      smem.row_max[row] = row_max_reg;
+      smem.row_sum[row] = row_sum_reg;
+    }
+  }
+  __syncthreads();
+
+  if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+    const int row = tid / kXQATC256WideThreadsPerRow;
+    const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+    const int head_idx = q_head_base + row;
+    const float row_sum = smem.row_sum[row];
+    const float inv_row_sum = row_sum > 0.f ? 1.f / row_sum : 0.f;
+    __half* tmp_out_ptr = tmp_out +
+                          static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+                          static_cast<int64_t>(head_idx) * tmp_out_stride1 +
+                          static_cast<int64_t>(partition_idx) * tmp_out_stride2;
+    const float output_scale = KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+                                   ? inv_row_sum
+                                   : inv_row_sum * v_scale;
+    if constexpr (kPVHalf2) {
+#pragma unroll
+      for (int acc_idx = 0; acc_idx < kAccumsPerThread; ++acc_idx) {
+        constexpr int kAccumsPerPanel = kPVPanelDim / kWarpSize;
+        const int panel_idx = acc_idx / kAccumsPerPanel;
+        const int panel_acc_idx = acc_idx % kAccumsPerPanel;
+        const int d_iter = panel_acc_idx / 2;
+        const int component = panel_acc_idx & 1;
+        const int d = panel_idx * kPVPanelDim + d_iter * (2 * kWarpSize) +
+                      thread_in_row * 2 + component;
+        tmp_out_ptr[d] = __float2half(out_acc[acc_idx] * output_scale);
+      }
+    } else {
+      for (int d = thread_in_row; d < D; d += kXQATC256WideThreadsPerRow) {
+        tmp_out_ptr[d] = __float2half(out_acc[d / kWarpSize] * output_scale);
+      }
+    }
+    if (thread_in_row == 0) {
+      const int64_t stats_index =
+          static_cast<int64_t>(batch_idx) * stats_stride0 +
+          static_cast<int64_t>(head_idx) * stats_stride1 + partition_idx;
+      max_logits[stats_index] = smem.row_max[row];
+      exp_sums[stats_index] = row_sum;
+    }
+  }
+}
+
+// Exact grouped selector-verifier kernel for the admitted TP4 tensor contract.
+//
+// Independent-row decode scans the same paged KV prefix once for every
+// verifier token. This kernel instead assigns one packed GQA group to each of
+// eighty context splits. Every CTA handles all six query heads for all eight
+// verifier tokens, so K/V is shared across the 48 rows before the exact
+// split-softmax states are merged.
+//
+// The diagnostic two-pass variant intentionally uses:
+//   1. QK computes the exact FP32 max/sum for each query row.
+//   2. QK is recomputed, then half P x half V is accumulated with Volta WMMA.
+// It remains a numerical oracle for the production one-pass register-rescale
+// variant, which loads K once and preserves the same online-softmax/PV result.
+//
+// The verifier shape has one KV head and six query heads. Keep each CTA at 48
+// rows for both supported widths: q8 packs six heads in one CTA, while q16
+// packs three heads in each of two CTAs. The q16 route halves the number of
+// context splits, preserving eighty CTAs and the q8 workspace byte count.
+constexpr int kGroupedVerifyQ8MaxQ = 8;
+constexpr int kGroupedVerifyQ16MaxQ = 16;
+constexpr int kGroupedVerifyMaxSupportedQ = kGroupedVerifyQ16MaxQ;
+constexpr int kGroupedVerifyHeads = 6;
+constexpr int kGroupedVerifyHeadDim = 256;
+constexpr int kGroupedVerifyRows = 48;
+constexpr int kGroupedVerifyBlockN = 32;
+constexpr int kGroupedVerifyQStride = 264;
+constexpr int kGroupedVerifyKVStride = 264;
+constexpr int kGroupedVerifyScoreStride = 32;
+constexpr int kGroupedVerifyProbStride = 40;
+constexpr int kGroupedVerifyPageIdsCapacity = 16;
+// One packed head group times eighty context splits maps one 512-thread CTA to
+// each of V100's eighty SMs. Short sequences still reduce active_splits using
+// kGroupedVerifyMinTokensPerSplit inside the captured graph.
+constexpr int kGroupedVerifyQ8Splits = 80;
+constexpr int kGroupedVerifyWorkspaceRows =
+    kGroupedVerifyQ8MaxQ * kGroupedVerifyQ8Splits;
+// A packed CTA replaces two 256-thread head-group CTAs and can occupy only one
+// SM. Use 64-token chunks to expose enough short-context parallelism without
+// paying one split reduction per N32 tile; longer contexts saturate at the
+// unchanged eighty splits. The single-query utility variant keeps the old
+// 128-token split contract for its stricter FP32-reference error envelope.
+constexpr int kGroupedVerifyMinTokensPerSplit = 64;
+constexpr int kGroupedVerifySingleQueryMinTokensPerSplit = 128;
+constexpr int kGroupedVerifyShortContextMaxTokens = 128;
+constexpr int kGroupedVerifyThreads = 512;
+constexpr int kGroupedVerifyWarps = kGroupedVerifyThreads / kWarpSize;
+constexpr int kGroupedVerifyQKWarps =
+    (kGroupedVerifyRows / 16) * (kGroupedVerifyBlockN / 16);
+constexpr int kGroupedVerifyOutputTiles =
+    (kGroupedVerifyRows / 16) * (kGroupedVerifyHeadDim / 16);
+constexpr int kGroupedVerifyOutputTilesPerWarp =
+    kGroupedVerifyOutputTiles / kGroupedVerifyWarps;
+
+template <int MAX_QUERY_TOKENS>
+struct GroupedVerifyTraits {
+  static_assert(MAX_QUERY_TOKENS == kGroupedVerifyQ8MaxQ ||
+                    MAX_QUERY_TOKENS == kGroupedVerifyQ16MaxQ,
+                "grouped verifier supports q8 and q16 workspaces only");
+  static constexpr int kHeadsPerCta = kGroupedVerifyRows / MAX_QUERY_TOKENS;
+  static constexpr int kHeadGroups = kGroupedVerifyHeads / kHeadsPerCta;
+  static constexpr int kSplits = kGroupedVerifyWorkspaceRows / MAX_QUERY_TOKENS;
+  static_assert(MAX_QUERY_TOKENS * kHeadsPerCta == kGroupedVerifyRows,
+                "grouped verifier CTA must retain 48 rows");
+  static_assert(kGroupedVerifyHeads % kHeadsPerCta == 0,
+                "query heads must divide evenly across grouped CTAs");
+  static_assert(kSplits * MAX_QUERY_TOKENS == kGroupedVerifyWorkspaceRows,
+                "q8 and q16 workspaces must have equal element counts");
+};
+
+struct alignas(256) GroupedVerifySmem {
+  union {
+    struct {
+      alignas(16) __half q[kGroupedVerifyRows * kGroupedVerifyQStride];
+      alignas(16) __half kv[kGroupedVerifyBlockN * kGroupedVerifyKVStride];
+      alignas(16) float scores[kGroupedVerifyRows * kGroupedVerifyScoreStride];
+      alignas(16) __half probs[kGroupedVerifyRows * kGroupedVerifyProbStride];
+    } compute;
+    alignas(16) float output[kGroupedVerifyRows * kGroupedVerifyHeadDim];
+  } storage;
+  alignas(16) float row_max[kGroupedVerifyRows];
+  alignas(16) float row_sum[kGroupedVerifyRows];
+  alignas(16) float row_scale[kGroupedVerifyRows];
+  alignas(16) int page_ids[kGroupedVerifyPageIdsCapacity];
+  alignas(16) uint32_t sparse_token_masks[kGroupedVerifyBlockN / 4];
+};
+
+static_assert(sizeof(GroupedVerifySmem) <= 64 * 1024,
+              "packed grouped verifier must fit Volta's 64 KiB opt-in budget");
+static_assert(kGroupedVerifyOutputTiles % kGroupedVerifyWarps == 0,
+              "output tiles must divide evenly across warps");
+
+template <int MAX_QUERY_TOKENS, bool SINGLE_QUERY>
+__device__ __forceinline__ int grouped_verify_active_splits(
+    const int total_kv) {
+  using Traits = GroupedVerifyTraits<MAX_QUERY_TOKENS>;
+  constexpr int kMinTokensPerSplit =
+      SINGLE_QUERY ? kGroupedVerifySingleQueryMinTokensPerSplit
+                   : kGroupedVerifyMinTokensPerSplit;
+  const int active_splits =
+      min(Traits::kSplits,
+          max(1, (total_kv + kMinTokensPerSplit - 1) / kMinTokensPerSplit));
+  if constexpr (SINGLE_QUERY) {
+    return active_splits;
+  }
+  return total_kv <= kGroupedVerifyShortContextMaxTokens ? 1 : active_splits;
+}
+
+template <bool COMPENSATE = false>
+__device__ __forceinline__ void grouped_verify_qk(
+    const __half* __restrict__ shared_q, const __half* __restrict__ shared_k,
+    float* __restrict__ shared_scores, const float qk_scale,
+    const int active_m_tiles) {
+  const int warp_id = threadIdx.x / kWarpSize;
+  if (warp_id >= kGroupedVerifyQKWarps) {
+    return;
+  }
+
+  const int m_tile = warp_id / (kGroupedVerifyBlockN / 16);
+  if ((active_m_tiles & (1 << m_tile)) == 0) {
+    return;
+  }
+  const int n_tile = warp_id % (kGroupedVerifyBlockN / 16);
+  volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>
+      q_fragment;
+  volta::fragment<volta::matrix_b, 16, 16, 16, half, volta::col_major>
+      k_fragment;
+  volta::fragment<volta::accumulator, 16, 16, 16, float> score_fragment;
+  volta::fill_fragment(score_fragment, 0.0f);
+  float correction[8] = {};
+
+#pragma unroll 2
+  for (int k_offset = 0; k_offset < kGroupedVerifyHeadDim; k_offset += 16) {
+    volta::load_matrix_sync(
+        q_fragment, shared_q + m_tile * 16 * kGroupedVerifyQStride + k_offset,
+        kGroupedVerifyQStride);
+    // K is row-major [N, D].  The same bytes represent K^T as a col-major
+    // [D, N] matrix, which is the B operand needed by Q @ K^T.
+    volta::load_matrix_sync(
+        k_fragment, shared_k + n_tile * 16 * kGroupedVerifyKVStride + k_offset,
+        kGroupedVerifyKVStride);
+    if constexpr (COMPENSATE) {
+      // E4M3 x FP16 products fit comfortably in FP32, but a D256 Tensor
+      // Core accumulation can still lose low bits. Sum short K16 products
+      // with compensated FP32 additions; explicit RN operations preserve
+      // the correction under the standard fast-math build.
+      volta::fragment<volta::accumulator, 16, 16, 16, float> tile_fragment;
+      volta::fill_fragment(tile_fragment, 0.0f);
+      volta::mma_sync(tile_fragment, q_fragment, k_fragment, tile_fragment);
+#pragma unroll
+      for (int i = 0; i < score_fragment.num_elements; ++i) {
+        const float y = __fsub_rn(tile_fragment.x[i], correction[i]);
+        const float sum = __fadd_rn(score_fragment.x[i], y);
+        correction[i] = __fsub_rn(__fsub_rn(sum, score_fragment.x[i]), y);
+        score_fragment.x[i] = sum;
+      }
+    } else {
+      volta::mma_sync(score_fragment, q_fragment, k_fragment, score_fragment);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < score_fragment.num_elements; ++i) {
+    score_fragment.x[i] *= qk_scale;
+  }
+  volta::store_matrix_sync(
+      shared_scores + m_tile * 16 * kGroupedVerifyScoreStride + n_tile * 16,
+      score_fragment, kGroupedVerifyScoreStride, volta::mem_row_major);
+}
+
+__device__ __forceinline__ void grouped_verify_scale_output_fragment(
+    volta::fragment<volta::accumulator, 16, 16, 16, float>& fragment,
+    const float* __restrict__ row_scale, const int tile_row_start) {
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
+  const float first_scale = row_scale[tile_row_start + row];
+  const float second_scale = row_scale[tile_row_start + row + 2];
+  fragment.x[0] *= first_scale;
+  fragment.x[1] *= first_scale;
+  fragment.x[2] *= second_scale;
+  fragment.x[3] *= second_scale;
+  fragment.x[4] *= first_scale;
+  fragment.x[5] *= first_scale;
+  fragment.x[6] *= second_scale;
+  fragment.x[7] *= second_scale;
+}
+
+__device__ __forceinline__ void grouped_verify_add_output_tile(
+    volta::fragment<volta::accumulator, 16, 16, 16, float>& output,
+    const volta::fragment<volta::accumulator, 16, 16, 16, float>& tile,
+    const float* row_scale, const int tile_row_start) {
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
+  const float first_scale = row_scale[tile_row_start + row];
+  const float second_scale = row_scale[tile_row_start + row + 2];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const float scale = (i & 2) ? second_scale : first_scale;
+    output.x[i] = fmaf(output.x[i], scale, tile.x[i]);
+  }
+}
+
+template <bool SPARSE_PAGE4, bool ROW_SEQLENS = false>
+__device__ __forceinline__ bool grouped_verify_key_visible(
+    const uint32_t* __restrict__ sparse_tile_masks, const int token_idx,
+    const int query_len, const int head_idx, const int kv_idx,
+    const int valid_k_rows, const int lane_or_col, const int prefix_kv_len,
+    const int* row_lengths = nullptr) {
+  const bool row_valid = token_idx < query_len &&
+                         head_idx < kGroupedVerifyHeads &&
+                         lane_or_col < valid_k_rows;
+  if (!row_valid) {
+    return false;
+  }
+  if constexpr (SPARSE_PAGE4) {
+    const uint32_t token_mask =
+        sparse_tile_masks[(kv_idx & (kGroupedVerifyBlockN - 1)) >> 2];
+    const int mask_bit = token_idx * 4 + (kv_idx & 3);
+    return (token_mask & (1u << mask_bit)) != 0;
+  }
+  if constexpr (ROW_SEQLENS) {
+    return kv_idx < row_lengths[token_idx];
+  }
+  return kv_idx <= prefix_kv_len + token_idx;
+}
+
+template <int MAX_QUERY_TOKENS, bool TWO_PASS, int PAGE_BLOCK_SIZE = 0,
+          bool SINGLE_QUERY = false, bool CONTIGUOUS_HKV1_LAYOUT = false,
+          bool STAGE_PARTITION_PAGE_IDS = false,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+          bool SPARSE_PAGE4 = false, typename PARTIAL_T = __half,
+          bool ROW_SEQLENS = false, bool COMPENSATE_P = false, bool PAIR_E4M3 = false>
+__global__
+__launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_e5m2_partial_kernel(
+    const __half* __restrict__ q, const void* __restrict__ k_cache,
+    const void* __restrict__ v_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, PARTIAL_T* __restrict__ partial_out,
+    float* __restrict__ partial_lse, const int query_len,
+    const int max_num_blocks, const int page_block_size,
+    const int64_t k_block_stride, const int64_t k_token_stride,
+    const int64_t k_head_stride, const int64_t v_block_stride,
+    const int64_t v_token_stride, const int64_t v_head_stride,
+    const float qk_scale, const float v_scale,
+    const uint32_t* __restrict__ sparse_token_masks = nullptr,
+    const int num_groups = 1, const int* row_lengths = nullptr) {
+  static_assert(!ROW_SEQLENS || !SPARSE_PAGE4,
+                "explicit row lengths apply to dense causal groups only");
+  static_assert(
+      !COMPENSATE_P || (!TWO_PASS && ROW_SEQLENS &&
+                        KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                        std::is_same_v<PARTIAL_T, float>),
+      "probability compensation is isolated to E4M3 FP32 groups");
+  using Traits = GroupedVerifyTraits<MAX_QUERY_TOKENS>;
+  const int head_group = blockIdx.x;
+  const int split_id = blockIdx.y;
+  const int group_idx = blockIdx.z;
+  if (head_group >= Traits::kHeadGroups || split_id >= Traits::kSplits ||
+      group_idx >= num_groups || query_len <= 0 ||
+      query_len > MAX_QUERY_TOKENS) {
+    return;
+  }
+
+  if constexpr (!SPARSE_PAGE4) {
+    partial_out += static_cast<int64_t>(group_idx) * Traits::kSplits *
+                   MAX_QUERY_TOKENS * kGroupedVerifyHeads *
+                   kGroupedVerifyHeadDim;
+    partial_lse += static_cast<int64_t>(group_idx) * Traits::kSplits *
+                   MAX_QUERY_TOKENS * kGroupedVerifyHeads;
+  }
+
+  int total_kv = seq_lens[group_idx];
+  if constexpr (ROW_SEQLENS) {
+    total_kv = 0;
+    for (int i = 0; i < query_len; ++i)
+      total_kv = max(total_kv, row_lengths[i]);
+  }
+  if (total_kv <= 0) {
+    if constexpr (SPARSE_PAGE4) {
+      constexpr int kGroupOutputElements =
+          kGroupedVerifyQ8MaxQ * kGroupedVerifyHeads * kGroupedVerifyHeadDim;
+      const int64_t group_output_offset =
+          static_cast<int64_t>(group_idx) * kGroupOutputElements;
+      for (int idx = threadIdx.x; idx < kGroupOutputElements;
+           idx += kGroupedVerifyThreads) {
+        partial_out[group_output_offset + idx] = __float2half_rn(0.0f);
+      }
+      constexpr int kGroupLseElements =
+          kGroupedVerifyQ8MaxQ * kGroupedVerifyHeads;
+      if (threadIdx.x < kGroupLseElements) {
+        partial_lse[static_cast<int64_t>(group_idx) * kGroupLseElements +
+                    threadIdx.x] = kXQANegInf;
+      }
+    }
+    return;
+  }
+  const int active_splits =
+      SPARSE_PAGE4
+          ? 1
+          : grouped_verify_active_splits<MAX_QUERY_TOKENS, SINGLE_QUERY>(
+                total_kv);
+  if (split_id >= active_splits) {
+    return;
+  }
+  const int total_tiles =
+      (total_kv + kGroupedVerifyBlockN - 1) / kGroupedVerifyBlockN;
+  const int base_tiles = total_tiles / active_splits;
+  const int extra_tiles = total_tiles - base_tiles * active_splits;
+  const int split_tile_start =
+      split_id * base_tiles + min(split_id, extra_tiles);
+  const int split_tiles = base_tiles + (split_id < extra_tiles ? 1 : 0);
+  const int split_start = split_tile_start * kGroupedVerifyBlockN;
+  const int split_end =
+      min(total_kv, split_start + split_tiles * kGroupedVerifyBlockN);
+  const int prefix_kv_len = max(0, total_kv - query_len);
+  const int head_start = head_group * Traits::kHeadsPerCta;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+
+  extern __shared__ char grouped_verify_smem_raw[];
+  GroupedVerifySmem& smem =
+      *reinterpret_cast<GroupedVerifySmem*>(grouped_verify_smem_raw);
+  __half* shared_q = smem.storage.compute.q;
+  __half* shared_kv = smem.storage.compute.kv;
+  float* shared_scores = smem.storage.compute.scores;
+  __half* shared_probs = smem.storage.compute.probs;
+  // The compensated entry reserves one padded probability panel after the
+  // legacy layout. Match P's shared-memory stride without aliasing live QK
+  // rows. Legacy entries retain their existing shared-memory footprint.
+  __half* shared_prob_residual = reinterpret_cast<__half*>(
+      grouped_verify_smem_raw + sizeof(GroupedVerifySmem));
+  constexpr int kResidualStride = kGroupedVerifyProbStride;
+  __half* shared_values = shared_prob_residual + kGroupedVerifyRows * kResidualStride;
+  const int* page_ids =
+      block_table + static_cast<int64_t>(group_idx) * max_num_blocks;
+  int split_page_offset = 0;
+  bool use_staged_page_ids = false;
+  if constexpr (STAGE_PARTITION_PAGE_IDS) {
+    static_assert(PAGE_BLOCK_SIZE > 0,
+                  "partition page staging requires a specialized page size");
+    const int split_start_page = split_start / PAGE_BLOCK_SIZE;
+    split_page_offset = split_start - split_start_page * PAGE_BLOCK_SIZE;
+    const int split_page_count =
+        (split_page_offset + split_end - split_start + PAGE_BLOCK_SIZE - 1) /
+        PAGE_BLOCK_SIZE;
+    use_staged_page_ids = split_page_count <= kGroupedVerifyPageIdsCapacity;
+    if (use_staged_page_ids) {
+      for (int idx = tid; idx < split_page_count;
+           idx += kGroupedVerifyThreads) {
+        smem.page_ids[idx] = __ldg(&page_ids[split_start_page + idx]);
+      }
+    }
+    if (use_staged_page_ids) {
+      page_ids = smem.page_ids;
+    }
+  }
+
+  constexpr int kVecsPerRow = kGroupedVerifyHeadDim / 8;
+  constexpr int kSharedQVecsPerRow = kGroupedVerifyQStride / 8;
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q);
+  uint4* shared_q_vec = reinterpret_cast<uint4*>(shared_q);
+  for (int idx = tid; idx < kGroupedVerifyRows * kVecsPerRow;
+       idx += kGroupedVerifyThreads) {
+    const int row = idx / kVecsPerRow;
+    const int vec_col = idx % kVecsPerRow;
+    const int token_idx = row / Traits::kHeadsPerCta;
+    const int local_head = row % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const int64_t query_row =
+          static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+      shared_q_vec[row * kSharedQVecsPerRow + vec_col] = __ldg(
+          q_vec + (query_row * kGroupedVerifyHeads + head_idx) * kVecsPerRow +
+          vec_col);
+    } else {
+      shared_q_vec[row * kSharedQVecsPerRow + vec_col] = make_uint4(0, 0, 0, 0);
+    }
+  }
+  if (tid < kGroupedVerifyRows) {
+    smem.row_max[tid] = kXQANegInf;
+    smem.row_sum[tid] = 0.0f;
+    smem.row_scale[tid] = 1.0f;
+  }
+  // This barrier publishes both Q and the optional split-local page IDs.
+  __syncthreads();
+
+  constexpr int kPanelStrideVec = kGroupedVerifyHeadDim / 8;
+  constexpr int kSharedStrideVec = kGroupedVerifyKVStride / 8;
+
+  volta::fragment<volta::accumulator, 16, 16, 16, float>
+      output_fragments[kGroupedVerifyOutputTilesPerWarp];
+#pragma unroll
+  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+       ++fragment_idx) {
+    volta::fill_fragment(output_fragments[fragment_idx], 0.0f);
+  }
+
+  // The conservative baseline computes exact per-split FP32 max/sum in a
+  // separate pass. The candidate below fuses this state update with P x V.
+  if constexpr (TWO_PASS) {
+    for (int tile_start = split_start; tile_start < split_end;
+         tile_start += kGroupedVerifyBlockN) {
+      const int valid_k_rows =
+          min(kGroupedVerifyBlockN, split_end - tile_start);
+      if constexpr (SPARSE_PAGE4) {
+        const int valid_sparse_pages = (valid_k_rows + 3) / 4;
+        if (tid < kGroupedVerifyBlockN / 4) {
+          smem.sparse_token_masks[tid] =
+              tid < valid_sparse_pages
+                  ? __ldg(sparse_token_masks +
+                          static_cast<int64_t>(group_idx) * max_num_blocks +
+                          (tile_start >> 2) + tid)
+                  : 0;
+        }
+      }
+      const int tile_page_offset =
+          use_staged_page_ids ? split_page_offset + tile_start - split_start
+                              : tile_start;
+      load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                           kGroupedVerifyThreads, KV_DTYPE,
+                           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                               (KV_DTYPE ==
+                                    flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                                !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+          shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
+          kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+          k_block_stride, k_token_stride, k_head_stride, 0);
+      for (int idx = tid + valid_k_rows * kSharedStrideVec;
+           idx < kGroupedVerifyBlockN * kSharedStrideVec;
+           idx += kGroupedVerifyThreads) {
+        reinterpret_cast<uint4*>(shared_kv)[idx] = make_uint4(0, 0, 0, 0);
+      }
+      __syncthreads();
+
+      int active_m_tiles = 0x7;
+      if constexpr (SPARSE_PAGE4) {
+        uint32_t active_query_nibbles = 0;
+#pragma unroll
+        for (int page = 0; page < kGroupedVerifyBlockN / 4; ++page) {
+          active_query_nibbles |= smem.sparse_token_masks[page];
+        }
+        active_m_tiles = 0;
+#pragma unroll
+        for (int token = 0; token < kGroupedVerifyQ8MaxQ; ++token) {
+          if ((active_query_nibbles & (0xFu << (token * 4))) != 0) {
+            const int first_row = token * kGroupedVerifyHeads;
+            const int last_row = first_row + kGroupedVerifyHeads - 1;
+            active_m_tiles |= 1 << (first_row / 16);
+            active_m_tiles |= 1 << (last_row / 16);
+          }
+        }
+      }
+      grouped_verify_qk(shared_q, shared_kv, shared_scores, qk_scale,
+                        active_m_tiles);
+      __syncthreads();
+
+#pragma unroll
+      for (int row = warp_id; row < kGroupedVerifyRows;
+           row += kGroupedVerifyWarps) {
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + lane_id;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, lane_id, prefix_kv_len, row_lengths);
+        const float score =
+            visible ? shared_scores[row * kGroupedVerifyScoreStride + lane_id]
+                    : kXQANegInf;
+        const float tile_max_lane = warp_reduce_max(score);
+        const float tile_max = __shfl_sync(0xffffffffu, tile_max_lane, 0);
+        const float probability =
+            visible ? __expf(fmaxf(score - tile_max, -80.0f)) : 0.0f;
+        const float tile_sum_lane = warp_reduce_sum(probability);
+        const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
+        if (lane_id == 0 && tile_sum > 0.0f) {
+          const float old_max = smem.row_max[row];
+          const float old_sum = smem.row_sum[row];
+          const float new_max = fmaxf(old_max, tile_max);
+          smem.row_sum[row] =
+              old_sum * __expf(fmaxf(old_max - new_max, -80.0f)) +
+              tile_sum * __expf(fmaxf(tile_max - new_max, -80.0f));
+          smem.row_max[row] = new_max;
+        }
+      }
+      __syncthreads();
+    }
+  }
+
+  // Recompute QK for the conservative path, or consume it once while updating
+  // the online state for the fused path. Both form half P and use identical
+  // Volta WMMA P @ V arithmetic.
+  for (int tile_start = split_start; tile_start < split_end;
+       tile_start += kGroupedVerifyBlockN) {
+    const int valid_k_rows = min(kGroupedVerifyBlockN, split_end - tile_start);
+    if constexpr (SPARSE_PAGE4) {
+      const int valid_sparse_pages = (valid_k_rows + 3) / 4;
+      if (tid < kGroupedVerifyBlockN / 4) {
+        smem.sparse_token_masks[tid] =
+            tid < valid_sparse_pages
+                ? __ldg(sparse_token_masks +
+                        static_cast<int64_t>(group_idx) * max_num_blocks +
+                        (tile_start >> 2) + tid)
+                : 0;
+      }
+    }
+    const int tile_page_offset =
+        use_staged_page_ids ? split_page_offset + tile_start - split_start
+                            : tile_start;
+    load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                         kGroupedVerifyThreads, KV_DTYPE,
+                         KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                             (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+        shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
+        kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+        k_block_stride, k_token_stride, k_head_stride, 0);
+    for (int idx = tid + valid_k_rows * kSharedStrideVec;
+         idx < kGroupedVerifyBlockN * kSharedStrideVec;
+         idx += kGroupedVerifyThreads) {
+      reinterpret_cast<uint4*>(shared_kv)[idx] = make_uint4(0, 0, 0, 0);
+    }
+    __syncthreads();
+
+    int active_m_tiles = 0x7;
+    if constexpr (COMPENSATE_P) {
+      // Native MTP4 supplies five rows: only 30 of the 48 packed rows are
+      // live. Avoid QK/PV for wholly padded M tiles to pay for the residual
+      // product without changing arithmetic in any live row.
+      active_m_tiles =
+          (1 << ((query_len * Traits::kHeadsPerCta + 15) / 16)) - 1;
+    }
+    if constexpr (SPARSE_PAGE4) {
+      uint32_t active_query_nibbles = 0;
+#pragma unroll
+      for (int page = 0; page < kGroupedVerifyBlockN / 4; ++page) {
+        active_query_nibbles |= smem.sparse_token_masks[page];
+      }
+      active_m_tiles = 0;
+#pragma unroll
+      for (int token = 0; token < kGroupedVerifyQ8MaxQ; ++token) {
+        if ((active_query_nibbles & (0xFu << (token * 4))) != 0) {
+          const int first_row = token * kGroupedVerifyHeads;
+          const int last_row = first_row + kGroupedVerifyHeads - 1;
+          active_m_tiles |= 1 << (first_row / 16);
+          active_m_tiles |= 1 << (last_row / 16);
+        }
+      }
+    }
+    grouped_verify_qk<COMPENSATE_P>(shared_q, shared_kv, shared_scores,
+                                    qk_scale, active_m_tiles);
+    if (warp_id >= kGroupedVerifyQKWarps) {
+      constexpr int kValueLoadThreads = kGroupedVerifyThreads - kGroupedVerifyQKWarps * kWarpSize;
+      const int value_load_tid = tid - kGroupedVerifyQKWarps * kWarpSize;
+    load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                         kValueLoadThreads, KV_DTYPE,
+                         KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                             (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+        shared_values, v_cache, page_ids, valid_k_rows, kPanelStrideVec,
+        kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+        v_block_stride, v_token_stride, v_head_stride, 0, value_load_tid);
+    for (int idx = value_load_tid + valid_k_rows * kSharedStrideVec;
+         idx < kGroupedVerifyBlockN * kSharedStrideVec;
+         idx += kValueLoadThreads) {
+      reinterpret_cast<uint4*>(shared_values)[idx] = make_uint4(0, 0, 0, 0);
+    }
+    }
+
+    __syncthreads();
+
+    if constexpr (TWO_PASS) {
+      for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyBlockN;
+           idx += kGroupedVerifyThreads) {
+        const int row = idx / kGroupedVerifyBlockN;
+        const int col = idx % kGroupedVerifyBlockN;
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + col;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, col, prefix_kv_len, row_lengths) &&
+            smem.row_sum[row] > 0.0f;
+        const float probability =
+            visible ? __expf(fmaxf(
+                          shared_scores[row * kGroupedVerifyScoreStride + col] -
+                              smem.row_max[row],
+                          -80.0f))
+                    : 0.0f;
+        shared_probs[row * kGroupedVerifyProbStride + col] =
+            __float2half_rn(probability);
+      }
+      __syncthreads();
+    } else {
+#pragma unroll
+      for (int row = warp_id; row < kGroupedVerifyRows;
+           row += kGroupedVerifyWarps) {
+        if constexpr (COMPENSATE_P) {
+          if ((active_m_tiles & (1 << (row / 16))) == 0) {
+            continue;
+          }
+        }
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + lane_id;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, lane_id, prefix_kv_len, row_lengths);
+        const float score =
+            visible ? shared_scores[row * kGroupedVerifyScoreStride + lane_id]
+                    : kXQANegInf;
+        const float tile_max_lane = warp_reduce_max(score);
+        const float tile_max = __shfl_sync(0xffffffffu, tile_max_lane, 0);
+        const float old_max = smem.row_max[row];
+        const float new_max = fmaxf(old_max, tile_max);
+        const float probability =
+            visible ? __expf(fmaxf(score - new_max, -80.0f)) : 0.0f;
+        const float tile_sum_lane = warp_reduce_sum(probability);
+        const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
+        const float exp_diff =
+            tile_sum > 0.0f ? __expf(fmaxf(old_max - new_max, -80.0f)) : 1.0f;
+        shared_probs[row * kGroupedVerifyProbStride + lane_id] =
+            __float2half_rn(probability);
+        if constexpr (COMPENSATE_P) {
+          const float rounded = __half2float(__float2half_rn(probability));
+          shared_prob_residual[row * kResidualStride + lane_id] =
+              __float2half_rn((probability - rounded) * 2048.0f);
+        }
+        // Finish every lane's shared-state reads before lane 0 overwrites the
+        // online maximum. Shuffle synchronization does not order memory.
+        __syncwarp();
+        if (lane_id == 0) {
+          if (tile_sum > 0.0f) {
+            smem.row_sum[row] = smem.row_sum[row] * exp_diff + tile_sum;
+            smem.row_max[row] = new_max;
+          }
+          smem.row_scale[row] = exp_diff;
+        }
+      }
+      __syncthreads();
+      if constexpr (!COMPENSATE_P) {
+#pragma unroll
+        for (int fragment_idx = 0;
+             fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+          const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
+          const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
+          grouped_verify_scale_output_fragment(output_fragments[fragment_idx],
+                                               smem.row_scale, m_tile * 16);
+        }
+      }
+    }
+
+
+
+#pragma unroll
+    for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+         ++fragment_idx) {
+      const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
+      const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
+      const int d_tile = output_tile % (kGroupedVerifyHeadDim / 16);
+      if constexpr (SPARSE_PAGE4 || COMPENSATE_P) {
+        if ((active_m_tiles & (1 << m_tile)) == 0) {
+          continue;
+        }
+      }
+      volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>
+          probability_fragment;
+      volta::fragment<volta::matrix_b, 16, 16, 16, half, volta::row_major>
+          value_fragment;
+      volta::fragment<volta::accumulator, 16, 16, 16, float> tile_fragment;
+      if constexpr (COMPENSATE_P) {
+        // Keep Tensor Core accumulation local to N32. Carrying a large C
+        // through every KV tile loses small PV corrections at long contexts.
+        // The online state remains FP32 and is updated once per tile below.
+        volta::fill_fragment(tile_fragment, 0.0f);
+      }
+      auto& pv_fragment =
+          COMPENSATE_P ? tile_fragment : output_fragments[fragment_idx];
+#pragma unroll
+      for (int k_offset = 0; k_offset < kGroupedVerifyBlockN; k_offset += 16) {
+        volta::load_matrix_sync(
+            probability_fragment,
+            shared_probs + m_tile * 16 * kGroupedVerifyProbStride + k_offset,
+            kGroupedVerifyProbStride);
+        volta::load_matrix_sync(
+            value_fragment,
+            shared_values + k_offset * kGroupedVerifyKVStride + d_tile * 16,
+            kGroupedVerifyKVStride);
+        volta::mma_sync(pv_fragment, probability_fragment, value_fragment,
+                        pv_fragment);
+        if constexpr (COMPENSATE_P) {
+          // Scale the residual up before its FP16 conversion so small
+          // corrections do not underflow. Every finite E4M3 value divided
+          // by 2048 is still exactly representable in FP16, so applying
+          // the inverse power of two to V introduces no operand rounding.
+          volta::load_matrix_sync(
+              probability_fragment,
+              shared_prob_residual + m_tile * 16 * kResidualStride + k_offset,
+              kResidualStride);
+#pragma unroll
+          for (int i = 0; i < value_fragment.num_elements / 2; ++i) {
+            union {
+              uint32_t bits;
+              __half2 pair;
+            } packed_value;
+            packed_value.bits = value_fragment.x[i];
+            packed_value.pair =
+                __hmul2(packed_value.pair, __float2half2_rn(1.0f / 2048.0f));
+            value_fragment.x[i] = packed_value.bits;
+          }
+          volta::mma_sync(pv_fragment, probability_fragment, value_fragment,
+                          pv_fragment);
+        }
+      }
+      if constexpr (COMPENSATE_P) {
+        grouped_verify_add_output_tile(output_fragments[fragment_idx],
+                                       tile_fragment, smem.row_scale,
+                                       m_tile * 16);
+      }
+    }
+    __syncthreads();
+  }
+
+  // The compute buffers are dead. Reuse their storage for the dense FP32
+  // partial output, then normalize and write only real query/head rows.
+  __syncthreads();
+  float* shared_output = smem.storage.output;
+#pragma unroll
+  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+       ++fragment_idx) {
+    const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
+    const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
+    const int d_tile = output_tile % (kGroupedVerifyHeadDim / 16);
+    volta::store_matrix_sync(
+        shared_output + m_tile * 16 * kGroupedVerifyHeadDim + d_tile * 16,
+        output_fragments[fragment_idx], kGroupedVerifyHeadDim,
+        volta::mem_row_major);
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyHeadDim;
+       idx += kGroupedVerifyThreads) {
+    const int row = idx / kGroupedVerifyHeadDim;
+    const int d = idx % kGroupedVerifyHeadDim;
+    const int token_idx = row / Traits::kHeadsPerCta;
+    const int local_head = row % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const float sum = smem.row_sum[row];
+      // Explicit-row FP32 groups retain the numerator until the final merge.
+      // Normalizing each partition and encoding its weight as m+log(sum)
+      // introduces avoidable rounding, including at FP16 output midpoints.
+      const float scale =
+          sum > 0.0f ? (ROW_SEQLENS ? v_scale : v_scale / sum) : 0.0f;
+      int64_t output_idx;
+      if constexpr (SPARSE_PAGE4) {
+        const int64_t global_token_idx =
+            static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+        output_idx = (global_token_idx * kGroupedVerifyHeads + head_idx) *
+                         kGroupedVerifyHeadDim +
+                     d;
+      } else {
+        output_idx =
+            (((static_cast<int64_t>(split_id) * MAX_QUERY_TOKENS + token_idx) *
+                  kGroupedVerifyHeads +
+              head_idx) *
+                 kGroupedVerifyHeadDim +
+             d);
+      }
+      if constexpr (std::is_same_v<PARTIAL_T, float>) {
+        partial_out[output_idx] = shared_output[idx] * scale;
+      } else {
+        partial_out[output_idx] = __float2half_rn(shared_output[idx] * scale);
+      }
+    }
+  }
+  if (tid < kGroupedVerifyRows) {
+    const int token_idx = tid / Traits::kHeadsPerCta;
+    const int local_head = tid % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const float sum = smem.row_sum[tid];
+      int64_t lse_idx;
+      if constexpr (SPARSE_PAGE4) {
+        const int64_t global_token_idx =
+            static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+        lse_idx = global_token_idx * kGroupedVerifyHeads + head_idx;
+      } else {
+        lse_idx =
+            (static_cast<int64_t>(split_id) * MAX_QUERY_TOKENS + token_idx) *
+                kGroupedVerifyHeads +
+            head_idx;
+      }
+      if constexpr (ROW_SEQLENS) {
+        partial_lse[2 * lse_idx] = sum > 0.0f ? smem.row_max[tid] : kXQANegInf;
+        partial_lse[2 * lse_idx + 1] = sum;
+      } else {
+        partial_lse[lse_idx] =
+            sum > 0.0f ? smem.row_max[tid] + logf(sum) : kXQANegInf;
+      }
+    }
+  }
+}
+
+template <int MAX_QUERY_TOKENS, bool SINGLE_QUERY, typename PARTIAL_T = __half,
+          bool ROW_SEQLENS = false>
+__global__
+__launch_bounds__(kGroupedVerifyThreads) void flash_attention_grouped_verify_e5m2_combine_kernel(
+    const PARTIAL_T* __restrict__ partial_out,
+    const float* __restrict__ partial_lse, const int* __restrict__ seq_lens,
+    __half* __restrict__ out, const int query_len,
+    const int* row_lengths = nullptr) {
+  using Traits = GroupedVerifyTraits<MAX_QUERY_TOKENS>;
+  const int token_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  const int request_idx = blockIdx.z;
+  if (token_idx >= query_len || head_idx >= kGroupedVerifyHeads) {
+    return;
+  }
+  partial_out += static_cast<int64_t>(request_idx) * Traits::kSplits *
+                 MAX_QUERY_TOKENS * kGroupedVerifyHeads * kGroupedVerifyHeadDim;
+  partial_lse += static_cast<int64_t>(request_idx) * Traits::kSplits *
+                 MAX_QUERY_TOKENS * kGroupedVerifyHeads;
+  seq_lens += request_idx;
+  out += static_cast<int64_t>(request_idx) * query_len * kGroupedVerifyHeads *
+         kGroupedVerifyHeadDim;
+
+  int total_kv = seq_lens[0];
+  if constexpr (ROW_SEQLENS) {
+    total_kv = 0;
+    for (int i = 0; i < query_len; ++i)
+      total_kv = max(total_kv, row_lengths[i]);
+    // Padding may leave every partial unwritten. Never read stale workspace.
+    if (row_lengths[token_idx] <= 0) {
+      for (int d = threadIdx.x; d < kGroupedVerifyHeadDim; d += blockDim.x)
+        out[(token_idx * kGroupedVerifyHeads + head_idx) *
+                kGroupedVerifyHeadDim +
+            d] = __float2half_rn(0.0f);
+      return;
+    }
+  }
+  const int active_splits =
+      grouped_verify_active_splits<MAX_QUERY_TOKENS, SINGLE_QUERY>(total_kv);
+  __shared__ float split_lse[Traits::kSplits];
+  __shared__ float split_sum[ROW_SEQLENS ? Traits::kSplits : 1];
+  __shared__ float final_max;
+  __shared__ float final_inv_sum;
+
+  if (threadIdx.x < Traits::kSplits) {
+    const int64_t lse_idx =
+        (static_cast<int64_t>(threadIdx.x) * MAX_QUERY_TOKENS + token_idx) *
+            kGroupedVerifyHeads +
+        head_idx;
+    if constexpr (ROW_SEQLENS) {
+      split_lse[threadIdx.x] =
+          threadIdx.x < active_splits ? partial_lse[2 * lse_idx] : kXQANegInf;
+      split_sum[threadIdx.x] =
+          threadIdx.x < active_splits ? partial_lse[2 * lse_idx + 1] : 0.0f;
+    } else {
+      split_lse[threadIdx.x] =
+          threadIdx.x < active_splits ? partial_lse[lse_idx] : kXQANegInf;
+    }
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    float max_lse = kXQANegInf;
+    for (int split = 0; split < active_splits; ++split) {
+      max_lse = fmaxf(max_lse, split_lse[split]);
+    }
+    float sum = 0.0f;
+    for (int split = 0; split < active_splits; ++split) {
+      if (split_lse[split] > -1.0e20f) {
+        const float weight = __expf(fmaxf(split_lse[split] - max_lse, -80.0f));
+        if constexpr (ROW_SEQLENS) {
+          sum = fmaf(weight, split_sum[split], sum);
+        } else {
+          sum += weight;
+        }
+      }
+    }
+    final_max = max_lse;
+    final_inv_sum = sum > 0.0f ? 1.0f / sum : 0.0f;
+  }
+  __syncthreads();
+
+  for (int d = threadIdx.x; d < kGroupedVerifyHeadDim;
+       d += kGroupedVerifyThreads) {
+    float accumulator = 0.0f;
+    for (int split = 0; split < active_splits; ++split) {
+      if (split_lse[split] > -1.0e20f) {
+        const float weight =
+            __expf(fmaxf(split_lse[split] - final_max, -80.0f)) * final_inv_sum;
+        const int64_t partial_idx =
+            (((static_cast<int64_t>(split) * MAX_QUERY_TOKENS + token_idx) *
+                  kGroupedVerifyHeads +
+              head_idx) *
+                 kGroupedVerifyHeadDim +
+             d);
+        if constexpr (std::is_same_v<PARTIAL_T, float>) {
+          accumulator = fmaf(weight, partial_out[partial_idx], accumulator);
+        } else {
+          accumulator =
+              fmaf(weight, __half2float(partial_out[partial_idx]), accumulator);
+        }
+      }
+    }
+    out[(token_idx * kGroupedVerifyHeads + head_idx) * kGroupedVerifyHeadDim +
+        d] = __float2half_rn(accumulator);
+  }
+}
+
+template <int D, int PARTITION_SIZE, int SEQ_LEN_ROUTE = kXQARouteAllSeqLens,
+          typename PARTIAL_T = __half>
+__global__ void flash_attention_decode_reduce_kernel(
+    const PARTIAL_T* __restrict__ tmp_out, const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums, const int* __restrict__ seq_lens,
+    const int* __restrict__ active_num_partitions, __half* __restrict__ out,
+    const int batch_size, const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
+    const int64_t out_stride1, const int route_partition_size_begin,
+    const int route_seq_len_begin, const int route_seq_len_end,
+    const int route_seq_len_final) {
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+
+  if (batch_idx >= batch_size || head_idx >= num_heads_q) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  int partition_size;
+  if constexpr (PARTITION_SIZE == -1) {
+    static_assert(SEQ_LEN_ROUTE == kXQARouteWaveLongSeqLens,
+                  "Runtime wave partitions require the wave-long route");
+    partition_size = seq_len < route_seq_len_end
+                         ? 512
+                         : (seq_len < route_seq_len_final ? 896 : 1664);
+  } else if constexpr (PARTITION_SIZE == 0) {
+    partition_size = seq_len < route_partition_size_begin ? 64 : 256;
+  } else {
+    partition_size = PARTITION_SIZE;
+  }
+  const int num_partitions =
+      min(max_num_partitions, (seq_len + partition_size - 1) / partition_size);
+  (void)active_num_partitions;
+
+  if (seq_len <= 0 || num_partitions <= 0) {
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      out[static_cast<int64_t>(batch_idx) * out_stride0 +
+          static_cast<int64_t>(head_idx) * out_stride1 + d] = __float2half(0.f);
+    }
+    return;
+  }
+
+  extern __shared__ float shared_mem[];
+  float* max_shared = shared_mem;
+  float* weight_shared = shared_mem + max_num_partitions;
+
+  float local_max = -1.0e20f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const int64_t stats_index =
+        static_cast<int64_t>(batch_idx) * stats_stride0 +
+        static_cast<int64_t>(head_idx) * stats_stride1 + i;
+    const float m = max_logits[stats_index];
+    max_shared[i] = m;
+    local_max = fmaxf(local_max, m);
+  }
+  const float global_max = block_reduce_max<kWarpsPerBlock>(local_max);
+
+  float local_sum = 0.f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const int64_t stats_index =
+        static_cast<int64_t>(batch_idx) * stats_stride0 +
+        static_cast<int64_t>(head_idx) * stats_stride1 + i;
+    const float weight =
+        exp_sums[stats_index] * __expf(max_shared[i] - global_max);
+    weight_shared[i] = weight;
+    local_sum += weight;
+  }
+  const float global_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+  const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
+  __syncthreads();
+
+  const int64_t out_base = static_cast<int64_t>(batch_idx) * out_stride0 +
+                           static_cast<int64_t>(head_idx) * out_stride1;
+  const int64_t tmp_out_base =
+      static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1;
+
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    float acc = 0.f;
+    for (int i = 0; i < num_partitions; ++i) {
+      acc = fmaf(weight_shared[i],
+                 static_cast<float>(
+                     tmp_out[tmp_out_base +
+                             static_cast<int64_t>(i) * tmp_out_stride2 + d]),
+                 acc);
+    }
+    out[out_base + d] = __float2half(acc * inv_global_sum);
+  }
+}
+
+// This separates only the cross-partition reducer. The stats kernel preserves
+// the original block-wide max/sum tree, and each output dimension retains its
+// original ascending-partition FMA order.
+template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM, int NUM_THREADS,
+          int MIN_BLOCKS_PER_SM>
+__global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
+    flash_attention_decode_xqa_tc_qk_softmax_staged_kernel_256_wide(
+        const __half* __restrict__ q, const __half* __restrict__ k_cache,
+        __half* __restrict__ probabilities, float* __restrict__ max_logits,
+        float* __restrict__ exp_sums, float* __restrict__ online_rescales,
+        const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+        const int* __restrict__ active_num_partitions, const int batch_size,
+        const int max_num_blocks, const int max_num_partitions,
+        const int num_heads_q, const int num_heads_kv, const int block_size,
+        const int64_t q_stride0, const int64_t q_stride1,
+        const int64_t probability_stride0, const int64_t probability_stride1,
+        const int64_t probability_stride2, const int64_t stats_stride0,
+        const int64_t stats_stride1, const int64_t online_rescale_stride0,
+        const int64_t online_rescale_stride1, const int64_t k_block_stride,
+        const int64_t k_token_stride, const int64_t k_head_stride,
+        const float softmax_scale) {
+  constexpr int D = 256;
+  constexpr int WMMA_M = 8;
+  constexpr int WMMA_N = 32;
+  constexpr int WMMA_K = 16;
+  constexpr int kPanelDim = kXQATCStride;
+  constexpr int kNumPanels = D / kPanelDim;
+  using SmemLayout = XQATCSmem256WideLayout<PADDED_SMEM>;
+  constexpr int q_global_stride_uint4 = D / 8;
+  constexpr int q_smem_stride_uint4 = SmemLayout::kQStride / 8;
+  constexpr int kv_smem_stride_uint4 = SmemLayout::kKVStride / 8;
+  constexpr int panel_d_stride_uint4 = kPanelDim / 8;
+  static_assert(GROUP_SIZE == 6,
+                "Staged D=256 TC XQA is specialized for q_per_kv=6");
+  static_assert(NUM_THREADS >= GROUP_SIZE * kWarpSize,
+                "Each XQA query head requires one softmax warp");
+
+  const int batch_idx = blockIdx.x;
+  const int kv_head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+  if (batch_idx >= batch_size || kv_head_idx >= num_heads_kv ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+  const int runtime_num_partitions = active_num_partitions[0];
+  const int seq_num_partitions =
+      (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE;
+  const int effective_num_partitions =
+      min(max_num_partitions, max(runtime_num_partitions, seq_num_partitions));
+  if (partition_idx >= effective_num_partitions) {
+    return;
+  }
+
+  const int q_head_base = kv_head_idx * GROUP_SIZE;
+  if (q_head_base + GROUP_SIZE > num_heads_q) {
+    return;
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+  const int part_tokens = min(PARTITION_SIZE, seq_len - start_token_idx);
+  const int num_k_tiles = (part_tokens + kXQATCBlockN - 1) / kXQATCBlockN;
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  extern __shared__ char smem_raw[];
+  auto& smem = *reinterpret_cast<SmemLayout*>(smem_raw);
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float row_max_reg = kXQANegInf;
+  float row_sum_reg = 0.f;
+  float row_rescale_reg = 1.f;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+  for (int idx = tid; idx < GROUP_SIZE * q_global_stride_uint4;
+       idx += NUM_THREADS) {
+    const int row = idx / q_global_stride_uint4;
+    const int vec_col = idx % q_global_stride_uint4;
+    const int64_t q_offset =
+        static_cast<int64_t>(batch_idx) * q_stride0 +
+        static_cast<int64_t>(q_head_base + row) * q_stride1;
+    sQ_vec[row * q_smem_stride_uint4 + vec_col] =
+        __ldg(&q_vec[q_offset / 8 + vec_col]);
+  }
+  for (int idx = tid;
+       idx < (kXQATC256WideBlockM - GROUP_SIZE) * q_global_stride_uint4;
+       idx += NUM_THREADS) {
+    const int row = GROUP_SIZE + idx / q_global_stride_uint4;
+    const int vec_col = idx % q_global_stride_uint4;
+    sQ_vec[row * q_smem_stride_uint4 + vec_col] = make_uint4(0, 0, 0, 0);
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_k_tiles; ++block_n) {
+    const int tile_token_start = start_token_idx + block_n * kXQATCBlockN;
+    const int valid_k_rows =
+        min(kXQATCBlockN, part_tokens - block_n * kXQATCBlockN);
+    const int start_page = tile_token_start / block_size;
+    const int tile_page_offset = tile_token_start - start_page * block_size;
+    const int page_count =
+        (tile_page_offset + valid_k_rows + block_size - 1) / block_size;
+
+    for (int idx = tid; idx < page_count; idx += NUM_THREADS) {
+      smem.page_ids[idx] = __ldg(&block_table_seq[start_page + idx]);
+    }
+    __syncthreads();
+
+    volta::fragment<volta::matrix_a, WMMA_M, WMMA_N, WMMA_K, half,
+                    volta::row_major>
+        qk_a_frag;
+    volta::fragment<volta::matrix_b, WMMA_M, WMMA_N, WMMA_K, half,
+                    volta::col_major>
+        qk_b_frag;
+    volta::fragment<volta::accumulator, WMMA_M, WMMA_N, WMMA_K, float>
+        qk_acc_frag;
+    if (warp_id < (kXQATCBlockN / WMMA_N)) {
+      volta::fill_fragment(qk_acc_frag, 0.0f);
+    }
+
+    for (int panel_idx = 0; panel_idx < kNumPanels; ++panel_idx) {
+      const int panel_offset = panel_idx * kPanelDim;
+      for (int idx = tid; idx < valid_k_rows * panel_d_stride_uint4;
+           idx += NUM_THREADS) {
+        const int row = idx / panel_d_stride_uint4;
+        const int vec_col = idx % panel_d_stride_uint4;
+        const int token_offset = tile_page_offset + row;
+        const int physical_block = smem.page_ids[token_offset / block_size];
+        const int block_offset = token_offset % block_size;
+        const int64_t physical_offset_half_elements =
+            static_cast<int64_t>(physical_block) * k_block_stride +
+            static_cast<int64_t>(block_offset) * k_token_stride +
+            static_cast<int64_t>(kv_head_idx) * k_head_stride + panel_offset;
+        const uint4* k_vec = reinterpret_cast<const uint4*>(k_cache);
+        reinterpret_cast<uint4*>(sK)[row * kv_smem_stride_uint4 + vec_col] =
+            __ldg(&k_vec[physical_offset_half_elements / 8 + vec_col]);
+      }
+      for (int idx = tid + valid_k_rows * panel_d_stride_uint4;
+           idx < kXQATCBlockN * panel_d_stride_uint4; idx += NUM_THREADS) {
+        reinterpret_cast<uint4*>(sK)[idx] = make_uint4(0, 0, 0, 0);
+      }
+      __syncthreads();
+
+      if (warp_id < (kXQATCBlockN / WMMA_N)) {
+        const int tile_n = warp_id * WMMA_N;
+#pragma unroll
+        for (int k_tile = 0; k_tile < (kPanelDim / WMMA_K); ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          volta::load_matrix_sync(qk_a_frag, sQ + panel_offset + k_offset,
+                                  SmemLayout::kQStride);
+          volta::load_matrix_sync(
+              qk_b_frag, sK + tile_n * SmemLayout::kKVStride + k_offset,
+              SmemLayout::kKVStride);
+          volta::mma_sync(qk_acc_frag, qk_a_frag, qk_b_frag, qk_acc_frag);
+        }
+      }
+      __syncthreads();
+    }
+
+    if (warp_id < (kXQATCBlockN / WMMA_N)) {
+#pragma unroll
+      for (int i = 0; i < qk_acc_frag.num_elements; ++i) {
+        qk_acc_frag.x[i] *= softmax_scale;
+      }
+      volta::store_matrix_sync(sS + warp_id * WMMA_N, qk_acc_frag, kXQATCBlockN,
+                               volta::mem_row_major);
+    }
+    __syncthreads();
+
+    if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+      const int row = tid / kXQATC256WideThreadsPerRow;
+      const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+      const unsigned mask = 0xffffffffu;
+      float* sS_row_f = sS + row * kXQATCBlockN;
+      __half* sP_row_h = sP + row * kXQATCBlockN;
+      const int vec_cols = valid_k_rows >> 2;
+      const int tail_start = vec_cols << 2;
+      const int vec_col = thread_in_row;
+
+      float thread_max = kXQANegInf;
+      __half2 packed_exp0 = __float22half2_rn(make_float2(0.f, 0.f));
+      __half2 packed_exp1 = __float22half2_rn(make_float2(0.f, 0.f));
+      if (vec_col < vec_cols) {
+        const float4 v4 = reinterpret_cast<float4*>(sS_row_f)[vec_col];
+        thread_max =
+            fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+      }
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += kXQATC256WideThreadsPerRow) {
+        thread_max = fmaxf(thread_max, sS_row_f[c]);
+      }
+#pragma unroll
+      for (int o = kXQATC256WideThreadsPerRow / 2; o > 0; o >>= 1) {
+        thread_max =
+            fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o, kWarpSize));
+      }
+
+      const float row_max = __shfl_sync(mask, thread_max, 0, kWarpSize);
+      const float old_max = __shfl_sync(mask, row_max_reg, 0, kWarpSize);
+      const float new_max = fmaxf(old_max, row_max);
+      const float exp_diff = __expf(old_max - new_max);
+
+      float thread_sum = 0.f;
+      if (vec_col < vec_cols) {
+        const float4 v4 = reinterpret_cast<float4*>(sS_row_f)[vec_col];
+        const float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+        const float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+        const float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+        const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+        thread_sum += (e0 + e1) + (e2 + e3);
+        packed_exp0 = __float22half2_rn(make_float2(e0, e1));
+        packed_exp1 = __float22half2_rn(make_float2(e2, e3));
+      }
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < kXQATCBlockN;
+           c += kXQATC256WideThreadsPerRow) {
+        const float v = (c < valid_k_rows) ? sS_row_f[c] : kXQANegInf;
+        const float e = __expf(fmaxf(v - new_max, -80.0f));
+        thread_sum += (c < valid_k_rows) ? e : 0.0f;
+        sP_row_h[c] =
+            (c < valid_k_rows) ? __float2half_rn(e) : __float2half(0.f);
+      }
+#pragma unroll
+      for (int o = kXQATC256WideThreadsPerRow / 2; o > 0; o >>= 1) {
+        thread_sum += __shfl_down_sync(mask, thread_sum, o, kWarpSize);
+      }
+
+      const float row_sum = __shfl_sync(mask, thread_sum, 0, kWarpSize);
+      const float old_sum = __shfl_sync(mask, row_sum_reg, 0, kWarpSize);
+      if (thread_in_row == 0) {
+        row_sum_reg = exp_diff * old_sum + row_sum;
+        row_max_reg = new_max;
+      }
+      if (block_n > 0) {
+        row_rescale_reg = exp_diff;
+      }
+
+      __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+      if (vec_col < vec_cols) {
+        const int base_offset = vec_col * 2;
+        sP_half2[base_offset] = packed_exp0;
+        sP_half2[base_offset + 1] = packed_exp1;
+      }
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < GROUP_SIZE * valid_k_rows; idx += NUM_THREADS) {
+      const int row = idx / valid_k_rows;
+      const int token = idx % valid_k_rows;
+      const int head_idx = q_head_base + row;
+      __half* probability_ptr =
+          probabilities +
+          static_cast<int64_t>(batch_idx) * probability_stride0 +
+          static_cast<int64_t>(head_idx) * probability_stride1 +
+          static_cast<int64_t>(partition_idx) * probability_stride2 +
+          block_n * kXQATCBlockN + token;
+      *probability_ptr = sP[row * kXQATCBlockN + token];
+    }
+    __syncthreads();
+  }
+
+  if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+    const int row = tid / kXQATC256WideThreadsPerRow;
+    const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+    if (thread_in_row == 0) {
+      const int head_idx = q_head_base + row;
+      const int64_t stats_index =
+          static_cast<int64_t>(batch_idx) * stats_stride0 +
+          static_cast<int64_t>(head_idx) * stats_stride1 + partition_idx;
+      max_logits[stats_index] = row_max_reg;
+      exp_sums[stats_index] = row_sum_reg;
+      online_rescales[static_cast<int64_t>(batch_idx) * online_rescale_stride0 +
+                      static_cast<int64_t>(head_idx) * online_rescale_stride1 +
+                      partition_idx] = row_rescale_reg;
+    }
+  }
+}
+
+template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM, int NUM_THREADS,
+          int MIN_BLOCKS_PER_SM>
+__global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
+    flash_attention_decode_xqa_tc_pv_staged_kernel_256_wide(
+        const __half* __restrict__ v_cache, const __half* probabilities,
+        __half* tmp_out, const float* __restrict__ exp_sums,
+        const float* __restrict__ online_rescales,
+        const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+        const int* __restrict__ active_num_partitions, const int batch_size,
+        const int max_num_blocks, const int max_num_partitions,
+        const int num_heads_q, const int num_heads_kv, const int block_size,
+        const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+        const int64_t tmp_out_stride2, const int64_t stats_stride0,
+        const int64_t stats_stride1, const int64_t online_rescale_stride0,
+        const int64_t online_rescale_stride1, const int64_t v_block_stride,
+        const int64_t v_token_stride, const int64_t v_head_stride) {
+  constexpr int D = 256;
+  constexpr int kPanelDim = kXQATCStride;
+  constexpr int kNumPanels = D / kPanelDim;
+  constexpr int kAccumsPerThread = D / kWarpSize;
+  using SmemLayout = XQATCStagedPVSmem256Wide<PADDED_SMEM>;
+  constexpr int kv_smem_stride_uint4 = SmemLayout::kKVStride / 8;
+  constexpr int panel_d_stride_uint4 = kPanelDim / 8;
+  static_assert(GROUP_SIZE == 6,
+                "Staged D=256 TC XQA is specialized for q_per_kv=6");
+  static_assert(NUM_THREADS >= GROUP_SIZE * kWarpSize,
+                "Each XQA query head requires one PV warp");
+
+  const int batch_idx = blockIdx.x;
+  const int kv_head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+  if (batch_idx >= batch_size || kv_head_idx >= num_heads_kv ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+  const int runtime_num_partitions = active_num_partitions[0];
+  const int seq_num_partitions =
+      (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE;
+  const int effective_num_partitions =
+      min(max_num_partitions, max(runtime_num_partitions, seq_num_partitions));
+  if (partition_idx >= effective_num_partitions) {
+    return;
+  }
+
+  const int q_head_base = kv_head_idx * GROUP_SIZE;
+  if (q_head_base + GROUP_SIZE > num_heads_q) {
+    return;
+  }
+
+  const int tid = threadIdx.x;
+  const int lane_id = tid % kWarpSize;
+  const int part_tokens = min(PARTITION_SIZE, seq_len - start_token_idx);
+  const int num_k_tiles = (part_tokens + kXQATCBlockN - 1) / kXQATCBlockN;
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+  extern __shared__ char smem_raw[];
+  auto& smem = *reinterpret_cast<SmemLayout*>(smem_raw);
+  __half* sV = smem.v;
+  float out_acc[kAccumsPerThread];
+#pragma unroll
+  for (int i = 0; i < kAccumsPerThread; ++i) {
+    out_acc[i] = 0.f;
+  }
+
+  for (int block_n = 0; block_n < num_k_tiles; ++block_n) {
+    const int tile_token_start = start_token_idx + block_n * kXQATCBlockN;
+    const int valid_k_rows =
+        min(kXQATCBlockN, part_tokens - block_n * kXQATCBlockN);
+    const int start_page = tile_token_start / block_size;
+    const int tile_page_offset = tile_token_start - start_page * block_size;
+    const int page_count =
+        (tile_page_offset + valid_k_rows + block_size - 1) / block_size;
+    for (int idx = tid; idx < page_count; idx += NUM_THREADS) {
+      smem.page_ids[idx] = __ldg(&block_table_seq[start_page + idx]);
+    }
+    __syncthreads();
+
+    if (block_n > 0 && tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+      const int row = tid / kXQATC256WideThreadsPerRow;
+      const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+      float rescale = 1.f;
+      if (thread_in_row == 0) {
+        const int head_idx = q_head_base + row;
+        rescale = online_rescales[static_cast<int64_t>(batch_idx) *
+                                      online_rescale_stride0 +
+                                  static_cast<int64_t>(head_idx) *
+                                      online_rescale_stride1 +
+                                  partition_idx];
+      }
+      rescale = __shfl_sync(0xffffffffu, rescale, 0, kWarpSize);
+#pragma unroll
+      for (int i = 0; i < kAccumsPerThread; ++i) {
+        out_acc[i] *= rescale;
+      }
+    }
+
+    for (int panel_idx = 0; panel_idx < kNumPanels; ++panel_idx) {
+      const int panel_offset = panel_idx * kPanelDim;
+      for (int v_tile_start = 0; v_tile_start < valid_k_rows;
+           v_tile_start += kXQATCStagedPVTileRows) {
+        const int valid_v_rows =
+            min(kXQATCStagedPVTileRows, valid_k_rows - v_tile_start);
+        for (int idx = tid; idx < valid_v_rows * panel_d_stride_uint4;
+             idx += NUM_THREADS) {
+          const int row = idx / panel_d_stride_uint4;
+          const int vec_col = idx % panel_d_stride_uint4;
+          const int token_offset = tile_page_offset + v_tile_start + row;
+          const int physical_block = smem.page_ids[token_offset / block_size];
+          const int block_offset = token_offset % block_size;
+          const int64_t physical_offset_half_elements =
+              static_cast<int64_t>(physical_block) * v_block_stride +
+              static_cast<int64_t>(block_offset) * v_token_stride +
+              static_cast<int64_t>(kv_head_idx) * v_head_stride + panel_offset;
+          const uint4* v_vec = reinterpret_cast<const uint4*>(v_cache);
+          reinterpret_cast<uint4*>(sV)[row * kv_smem_stride_uint4 + vec_col] =
+              __ldg(&v_vec[physical_offset_half_elements / 8 + vec_col]);
+        }
+        for (int idx = tid + valid_v_rows * panel_d_stride_uint4;
+             idx < kXQATCStagedPVTileRows * panel_d_stride_uint4;
+             idx += NUM_THREADS) {
+          reinterpret_cast<uint4*>(sV)[idx] = make_uint4(0, 0, 0, 0);
+        }
+        __syncthreads();
+
+        if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+          const int row = tid / kXQATC256WideThreadsPerRow;
+          const int head_idx = q_head_base + row;
+          const __half* probability_ptr =
+              probabilities +
+              static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+              static_cast<int64_t>(head_idx) * tmp_out_stride1 +
+              static_cast<int64_t>(partition_idx) * tmp_out_stride2 +
+              block_n * kXQATCBlockN + v_tile_start;
+#pragma unroll
+          for (int token = 0; token < kXQATCStagedPVTileRows; ++token) {
+            if (token >= valid_v_rows) {
+              break;
+            }
+            float prob = 0.f;
+            if (lane_id == 0) {
+              prob = __half2float(probability_ptr[token]);
+            }
+            prob = __shfl_sync(0xffffffffu, prob, 0, kWarpSize);
+            const __half* sV_row = sV + token * SmemLayout::kKVStride;
+#pragma unroll
+            for (int d_iter = 0; d_iter < (kPanelDim / kWarpSize); ++d_iter) {
+              const int local_d = lane_id + d_iter * kWarpSize;
+              const int acc_idx = panel_idx * (kPanelDim / kWarpSize) + d_iter;
+              out_acc[acc_idx] =
+                  fmaf(prob, __half2float(sV_row[local_d]), out_acc[acc_idx]);
+            }
+          }
+        }
+        __syncthreads();
+      }
+    }
+  }
+
+  if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
+    const int row = tid / kXQATC256WideThreadsPerRow;
+    const int thread_in_row = tid % kXQATC256WideThreadsPerRow;
+    const int head_idx = q_head_base + row;
+    const float row_sum =
+        exp_sums[static_cast<int64_t>(batch_idx) * stats_stride0 +
+                 static_cast<int64_t>(head_idx) * stats_stride1 +
+                 partition_idx];
+    const float inv_row_sum = row_sum > 0.f ? 1.f / row_sum : 0.f;
+    __half* tmp_out_ptr = tmp_out +
+                          static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+                          static_cast<int64_t>(head_idx) * tmp_out_stride1 +
+                          static_cast<int64_t>(partition_idx) * tmp_out_stride2;
+    for (int d = thread_in_row; d < D; d += kXQATC256WideThreadsPerRow) {
+      tmp_out_ptr[d] = __float2half(out_acc[d / kWarpSize] * inv_row_sum);
+    }
+  }
+}
+
+template <int PARTITION_SIZE, int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
+__global__ void flash_attention_decode_xqa_reduce_stats_kernel(
+    float* __restrict__ max_logits, float* __restrict__ exp_sums,
+    const int* __restrict__ seq_lens, const int batch_size,
+    const int max_num_partitions, const int num_heads_q,
+    const int64_t stats_stride0, const int64_t stats_stride1,
+    const int route_seq_len_begin, const int route_seq_len_end,
+    const int route_seq_len_final) {
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  if (batch_idx >= batch_size || head_idx >= num_heads_q) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  const int partition_size =
+      PARTITION_SIZE == 0
+          ? xqa_sawtooth_partition_size(seq_len, route_seq_len_begin,
+                                        route_seq_len_end, route_seq_len_final)
+          : PARTITION_SIZE;
+  const int num_partitions =
+      min(max_num_partitions, (seq_len + partition_size - 1) / partition_size);
+  if (seq_len <= 0 || num_partitions <= 0) {
+    return;
+  }
+
+  extern __shared__ float max_shared[];
+  const int64_t stats_base = static_cast<int64_t>(batch_idx) * stats_stride0 +
+                             static_cast<int64_t>(head_idx) * stats_stride1;
+
+  float local_max = -1.0e20f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const float m = max_logits[stats_base + i];
+    max_shared[i] = m;
+    local_max = fmaxf(local_max, m);
+  }
+  const float global_max = block_reduce_max<kWarpsPerBlock>(local_max);
+
+  float local_sum = 0.f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const float weight =
+        exp_sums[stats_base + i] * __expf(max_shared[i] - global_max);
+    max_logits[stats_base + i] = weight;
+    local_sum += weight;
+  }
+  const float global_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+  if (threadIdx.x == 0) {
+    // The partition sum is dead after weights have been materialized.
+    exp_sums[stats_base] = global_sum;
+  }
+}
+
+template <int D, int PARTITION_SIZE, int D_TILE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
+__global__ void flash_attention_decode_xqa_reduce_output_kernel(
+    const __half* __restrict__ tmp_out, const float* __restrict__ weights,
+    const float* __restrict__ global_sums, const int* __restrict__ seq_lens,
+    __half* __restrict__ out, const int batch_size,
+    const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
+    const int64_t out_stride1, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final) {
+  static_assert(D_TILE > 0 && D_TILE <= kWarpSize,
+                "Split-reduce dimension tile must fit in one warp");
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  const int d = blockIdx.z * D_TILE + threadIdx.x;
+  if (batch_idx >= batch_size || head_idx >= num_heads_q || d >= D) {
+    return;
+  }
+
+  const int64_t out_index = static_cast<int64_t>(batch_idx) * out_stride0 +
+                            static_cast<int64_t>(head_idx) * out_stride1 + d;
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  const int partition_size =
+      PARTITION_SIZE == 0
+          ? xqa_sawtooth_partition_size(seq_len, route_seq_len_begin,
+                                        route_seq_len_end, route_seq_len_final)
+          : PARTITION_SIZE;
+  const int num_partitions =
+      min(max_num_partitions, (seq_len + partition_size - 1) / partition_size);
+  if (seq_len <= 0 || num_partitions <= 0) {
+    out[out_index] = __float2half(0.f);
+    return;
+  }
+
+  const int64_t stats_base = static_cast<int64_t>(batch_idx) * stats_stride0 +
+                             static_cast<int64_t>(head_idx) * stats_stride1;
+  const int64_t tmp_out_base =
+      static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1;
+  const float global_sum = global_sums[stats_base];
+  const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
+
+  float acc = 0.f;
+  for (int i = 0; i < num_partitions; ++i) {
+    acc = fmaf(
+        weights[stats_base + i],
+        __half2float(tmp_out[tmp_out_base +
+                             static_cast<int64_t>(i) * tmp_out_stride2 + d]),
+        acc);
+  }
+  out[out_index] = __float2half(acc * inv_global_sum);
+}
+
+template <int D, int PARTITION_SIZE, int KV_DTYPE>
+__global__ void flash_attention_decode_qk_scores_kernel(
+    const __half* __restrict__ q, const void* __restrict__ k_cache,
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    float* __restrict__ scores, const int batch_size, const int max_num_blocks,
+    const int max_num_partitions, const int num_heads_q, const int num_heads_kv,
+    const int block_size, const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t scores_stride0, const int64_t scores_stride1,
+    const int64_t scores_stride2, const int64_t k_block_stride,
+    const int64_t k_token_stride, const int64_t k_head_stride,
+    const float softmax_scale, const float k_scale) {
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+
+  if (batch_idx >= batch_size || head_idx >= num_heads_q ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+
+  const int part_tokens = min(PARTITION_SIZE, seq_len - start_token_idx);
+  const int q_per_kv = num_heads_q / num_heads_kv;
+  const int kv_head_idx = head_idx / q_per_kv;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp_idx = threadIdx.x / kWarpSize;
+  const float score_scale = KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+                                ? softmax_scale
+                                : softmax_scale * k_scale;
+
+  __shared__ __half q_shared[D];
+  __shared__ int block_idx_shared[PARTITION_SIZE];
+  __shared__ int block_offset_shared[PARTITION_SIZE];
+
+  const __half* q_ptr = q + static_cast<int64_t>(batch_idx) * q_stride0 +
+                        static_cast<int64_t>(head_idx) * q_stride1;
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    q_shared[d] = q_ptr[d];
+  }
+  for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    const int token_idx = start_token_idx + i;
+    const int logical_block = token_idx / block_size;
+    block_idx_shared[i] =
+        block_table[batch_idx * max_num_blocks + logical_block];
+    block_offset_shared[i] = token_idx - logical_block * block_size;
+  }
+  __syncthreads();
+
+  const int64_t score_base =
+      static_cast<int64_t>(batch_idx) * scores_stride0 +
+      static_cast<int64_t>(head_idx) * scores_stride1 +
+      static_cast<int64_t>(partition_idx) * scores_stride2;
+  for (int token_local = warp_idx; token_local < part_tokens;
+       token_local += kWarpsPerBlock) {
+    const int physical_block = block_idx_shared[token_local];
+    const int block_offset = block_offset_shared[token_local];
+    const int64_t k_index =
+        static_cast<int64_t>(physical_block) * k_block_stride +
+        static_cast<int64_t>(block_offset) * k_token_stride +
+        static_cast<int64_t>(kv_head_idx) * k_head_stride;
+
+    float score = dot_qk_cache<D, KV_DTYPE>(q_shared, k_cache, k_index, lane);
+    if (lane == 0) {
+      scores[score_base + token_local] = score * score_scale;
+    }
+  }
+}
+
+template <int D, int PARTITION_SIZE, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, typename PARTIAL_T = __half>
+void launch_flash_attention_decode_paged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const int launch_num_partitions, const float k_scale, const float v_scale,
+    const int window_size_left, const int window_size_right,
+    cudaStream_t stream, const int route_seq_len_begin = 0,
+    const int route_seq_len_end = 0, const int route_seq_len_final = 0,
+    const bool launch_reduce = true, const int* anchor_lens = nullptr,
+    const int anchored_window = 0) {
+  const int batch_size = q.size(0);
+  const int num_heads_q = q.size(1);
+  const int num_heads_kv = k_cache.size(2);
+  const int block_size = k_cache.size(1);
+  const int max_num_blocks = block_table.size(1);
+  const int max_num_partitions = launch_num_partitions;
+
+  const dim3 partition_grid(batch_size, num_heads_q, max_num_partitions);
+  const dim3 reduce_grid(batch_size, num_heads_q, 1);
+  const dim3 block(kThreadsPerBlock);
+  const size_t reduce_shared_mem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+
+  const bool use_anchored = anchor_lens != nullptr && anchored_window > 0;
+  // Second kernel version: the anchored decode-window mask is a separate
+  // template instantiation, generated only for the fp16-KV configuration;
+  // the non-anchored instantiations stay untouched.
+  const auto launch_partition = [&](auto anchored_tag) {
+    constexpr bool kAnchored = decltype(anchored_tag)::value;
+    flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
+                                            SEQ_LEN_ROUTE, kAnchored, PARTIAL_T>
+        <<<partition_grid, block, 0, stream>>>(
+            reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+            k_cache.data_ptr(), v_cache.data_ptr(),
+            reinterpret_cast<PARTIAL_T*>(tmp_out.data_ptr()),
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+            block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+            active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
+            max_num_partitions, num_heads_q, num_heads_kv, block_size,
+            q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),
+            tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+            k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
+            v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, route_seq_len_begin, route_seq_len_end,
+            route_seq_len_final, anchor_lens, anchored_window);
+  };
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    if (use_anchored) {
+      launch_partition(std::true_type{});
+    } else {
+      launch_partition(std::false_type{});
+    }
+  } else {
+    TORCH_CHECK(!use_anchored,
+                "anchored decode window requires an fp16 KV cache");
+    launch_partition(std::false_type{});
+  }
+
+  if (!launch_reduce) {
+    return;
+  }
+
+  flash_attention_decode_reduce_kernel<D, PARTITION_SIZE, kXQARouteAllSeqLens,
+                                       PARTIAL_T>
+      <<<reduce_grid, block, reduce_shared_mem, stream>>>(
+          reinterpret_cast<const PARTIAL_T*>(tmp_out.data_ptr()),
+          max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+          seq_lens.data_ptr<int>(), active_num_partitions.data_ptr<int>(),
+          reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+          max_num_partitions, num_heads_q, tmp_out.stride(0), tmp_out.stride(1),
+          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+          out.stride(0), out.stride(1), 0, 0, 0, 0);
+}
+
+template <int PARTITION_SIZE, int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
+void launch_flash_attention_decode_xqa_split_reduce(
+    at::Tensor& out, const at::Tensor& seq_lens, const at::Tensor& tmp_out,
+    at::Tensor& max_logits, at::Tensor& exp_sums,
+    const int launch_num_partitions, const int dim_tile, cudaStream_t stream,
+    const int route_seq_len_begin = 0, const int route_seq_len_end = 0,
+    const int route_seq_len_final = 0) {
+  const int batch_size = out.size(0);
+  const int num_heads_q = out.size(1);
+  const dim3 stats_grid(batch_size, num_heads_q, 1);
+  const dim3 stats_block(kThreadsPerBlock);
+  const size_t stats_shared_mem =
+      static_cast<size_t>(launch_num_partitions) * sizeof(float);
+  flash_attention_decode_xqa_reduce_stats_kernel<PARTITION_SIZE, SEQ_LEN_ROUTE>
+      <<<stats_grid, stats_block, stats_shared_mem, stream>>>(
+          max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+          seq_lens.data_ptr<int>(), batch_size, launch_num_partitions,
+          num_heads_q, max_logits.stride(0), max_logits.stride(1),
+          route_seq_len_begin, route_seq_len_end, route_seq_len_final);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+#define LAUNCH_SPLIT_REDUCE_OUTPUT(D_TILE)                                   \
+  do {                                                                       \
+    const dim3 output_grid(batch_size, num_heads_q,                          \
+                           (256 + D_TILE - 1) / D_TILE);                     \
+    const dim3 output_block(D_TILE);                                         \
+    flash_attention_decode_xqa_reduce_output_kernel<256, PARTITION_SIZE,     \
+                                                    D_TILE, SEQ_LEN_ROUTE>   \
+        <<<output_grid, output_block, 0, stream>>>(                          \
+            reinterpret_cast<const __half*>(tmp_out.data_ptr<at::Half>()),   \
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),        \
+            seq_lens.data_ptr<int>(),                                        \
+            reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size, \
+            launch_num_partitions, num_heads_q, tmp_out.stride(0),           \
+            tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),      \
+            max_logits.stride(1), out.stride(0), out.stride(1),              \
+            route_seq_len_begin, route_seq_len_end, route_seq_len_final);    \
+  } while (0)
+
+  switch (dim_tile) {
+    case 16:
+      LAUNCH_SPLIT_REDUCE_OUTPUT(16);
+      break;
+    case 32:
+      LAUNCH_SPLIT_REDUCE_OUTPUT(32);
+      break;
+    default:
+      LAUNCH_SPLIT_REDUCE_OUTPUT(8);
+      break;
+  }
+#undef LAUNCH_SPLIT_REDUCE_OUTPUT
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM,
+          int NUM_THREADS = kXQATC256WideThreads, int MIN_BLOCKS_PER_SM = 1,
+          int BLOCK_SIZE = 0, bool CONTIGUOUS_HKV1_LAYOUT = false,
+          bool ALIGNED_PADDED_SMEM = false,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
+          bool PARTITION_PAGE_IDS = false, bool FP8_PAIR_LOAD = false,
+          int KV_DTYPE_OVERRIDE = -1, bool E4M3_SHARED_LUT = false>
+void launch_flash_attention_decode_paged_xqa_tc_256_wide(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const float k_scale, const float v_scale, const int launch_num_partitions,
+    const bool use_split_reduce, const int split_reduce_dim_tile,
+    cudaStream_t stream, const int route_seq_len_begin = 0,
+    const int route_seq_len_end = 0, const int route_seq_len_final = 0,
+    const bool launch_reduce = true) {
+  static_assert(!E4M3_SHARED_LUT ||
+                    KV_DTYPE_OVERRIDE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+                "The shared conversion LUT requires an E4M3 specialization");
+  const int batch_size = q.size(0);
+  const int num_heads_q = q.size(1);
+  const int num_heads_kv = k_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const dim3 partition_grid(batch_size, num_heads_kv, launch_num_partitions);
+  using SmemLayout = std::conditional_t<
+      QK_SW_PIPELINE,
+      XQATCQKPipelineSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>,
+      XQATCSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>>;
+  const size_t shared_mem =
+      sizeof(SmemLayout) + (E4M3_SHARED_LUT ? 256 * sizeof(uint16_t) : 0);
+#define LAUNCH_XQA_PARTITION(KV_DTYPE)                                         \
+  do {                                                                         \
+    auto partition_kernel =                                                    \
+        (void*)flash_attention_decode_xqa_tc_partition_kernel_256_wide<        \
+            PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,              \
+            MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,             \
+            ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,      \
+            PARTITION_PAGE_IDS, FP8_PAIR_LOAD, E4M3_SHARED_LUT>;               \
+    cudaFuncSetAttribute(partition_kernel,                                     \
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,          \
+                         shared_mem);                                          \
+    if constexpr (MIN_BLOCKS_PER_SM > 1) {                                     \
+      cudaFuncSetAttribute(partition_kernel,                                   \
+                           cudaFuncAttributePreferredSharedMemoryCarveout,     \
+                           100);                                               \
+    }                                                                          \
+    flash_attention_decode_xqa_tc_partition_kernel_256_wide<                   \
+        PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,                  \
+        MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,                 \
+        ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,          \
+        PARTITION_PAGE_IDS, FP8_PAIR_LOAD, E4M3_SHARED_LUT>                    \
+        <<<partition_grid, NUM_THREADS, shared_mem, stream>>>(                 \
+            reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),           \
+            k_cache.data_ptr(), v_cache.data_ptr(),                            \
+            reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),           \
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),          \
+            block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),             \
+            active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks, \
+            launch_num_partitions, num_heads_q, num_heads_kv, k_cache.size(1), \
+            q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),    \
+            tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),     \
+            k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),           \
+            v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),           \
+            softmax_scale, k_scale, v_scale, route_seq_len_begin,              \
+            route_seq_len_end, route_seq_len_final);                           \
+  } while (0)
+
+  if constexpr (KV_DTYPE_OVERRIDE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+    static_assert(!(FP8_PAIR_LOAD && E4M3_SHARED_LUT),
+                  "Paired E4M3 conversion and the shared LUT are exclusive");
+    TORCH_CHECK(k_cache.scalar_type() == at::kByte,
+                "E4M3 XQA requires uint8 KV cache");
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E4M3);
+  } else if constexpr (FP8_PAIR_LOAD) {
+    static_assert(!E4M3_SHARED_LUT, "The E4M3 conversion LUT requires E4M3 KV");
+    TORCH_CHECK(k_cache.scalar_type() == at::kByte,
+                "Paired XQA loads require uint8 FP8 KV cache");
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
+  } else if (k_cache.scalar_type() == at::kByte) {
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
+  } else {
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP16);
+  }
+#undef LAUNCH_XQA_PARTITION
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  if (!launch_reduce) {
+    return;
+  }
+
+  if constexpr (PARTITION_SIZE == -1) {
+    TORCH_CHECK(!use_split_reduce,
+                "Runtime wave partitions do not support split reduction");
+  }
+  if (use_split_reduce) {
+    if constexpr (PARTITION_SIZE != -1) {
+      launch_flash_attention_decode_xqa_split_reduce<PARTITION_SIZE>(
+          out, seq_lens, tmp_out, max_logits, exp_sums, launch_num_partitions,
+          split_reduce_dim_tile, stream);
+    }
+  } else {
+    const dim3 reduce_grid(batch_size, num_heads_q, 1);
+    const dim3 block(kThreadsPerBlock);
+    const size_t reduce_shared_mem =
+        static_cast<size_t>(2 * launch_num_partitions) * sizeof(float);
+    flash_attention_decode_reduce_kernel<256, PARTITION_SIZE, SEQ_LEN_ROUTE>
+        <<<reduce_grid, block, reduce_shared_mem, stream>>>(
+            reinterpret_cast<const __half*>(tmp_out.data_ptr<at::Half>()),
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+            seq_lens.data_ptr<int>(), active_num_partitions.data_ptr<int>(),
+            reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+            launch_num_partitions, num_heads_q, tmp_out.stride(0),
+            tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),
+            max_logits.stride(1), out.stride(0), out.stride(1),
+            route_seq_len_end > 0 ? route_seq_len_end : route_seq_len_begin,
+            route_seq_len_begin, route_seq_len_end, route_seq_len_final);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <int PARTITION_SIZE, int SEQ_LEN_ROUTE = kXQARouteAllSeqLens,
+          bool FIXED_INTERLEAVED_HKV1_LAYOUT = false>
+void launch_flash_attention_decode_paged_xqa_e4m3_g6_page1568(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const float k_scale, const float v_scale, const int launch_num_partitions,
+    cudaStream_t stream, const int route_seq_len_begin = 0,
+    const int route_seq_len_end = 0, const int route_seq_len_final = 0,
+    const bool launch_reduce = true) {
+  launch_flash_attention_decode_paged_xqa_tc_256_wide<
+      PARTITION_SIZE, 6, true, kXQATCG6DualCtaThreads, 2, 1568,
+      FIXED_INTERLEAVED_HKV1_LAYOUT, false, SEQ_LEN_ROUTE, false, true, false,
+      flash_v100::KV_CACHE_DTYPE_FP8_E4M3, true>(
+      q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+      exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+      launch_num_partitions, false, 8, stream, route_seq_len_begin,
+      route_seq_len_end, route_seq_len_final, launch_reduce);
+}
+
+void launch_flash_attention_decode_paged_xqa_tc_256_staged(
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    at::Tensor& online_rescales, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int launch_num_partitions,
+    const bool use_split_reduce, const int split_reduce_dim_tile,
+    cudaStream_t stream) {
+  constexpr int kGroupSize = 6;
+  constexpr int kQKThreads = kXQATCG6DualCtaThreads;
+  constexpr int kPVThreads = kXQATCG6DualCtaThreads;
+  constexpr int kQKMinBlocksPerSM = 2;
+  constexpr int kPVMinBlocksPerSM = 4;
+  using QKSmem = XQATCSmem256WideLayout<true>;
+  using PVSmem = XQATCStagedPVSmem256Wide<true>;
+
+  const int batch_size = q.size(0);
+  const int num_heads_q = q.size(1);
+  const int num_heads_kv = k_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const dim3 partition_grid(batch_size, num_heads_kv, launch_num_partitions);
+  const size_t qk_shared_mem = sizeof(QKSmem);
+  const size_t pv_shared_mem = sizeof(PVSmem);
+  auto qk_kernel =
+      (void*)flash_attention_decode_xqa_tc_qk_softmax_staged_kernel_256_wide<
+          256, kGroupSize, true, kQKThreads, kQKMinBlocksPerSM>;
+  auto pv_kernel =
+      (void*)flash_attention_decode_xqa_tc_pv_staged_kernel_256_wide<
+          256, kGroupSize, true, kPVThreads, kPVMinBlocksPerSM>;
+  const cudaError_t qk_smem_status = cudaFuncSetAttribute(
+      qk_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, qk_shared_mem);
+  TORCH_CHECK(qk_smem_status == cudaSuccess,
+              "Failed to set staged XQA QK shared memory: ",
+              cudaGetErrorString(qk_smem_status));
+  const cudaError_t qk_carveout_status = cudaFuncSetAttribute(
+      qk_kernel, cudaFuncAttributePreferredSharedMemoryCarveout, 100);
+  TORCH_CHECK(qk_carveout_status == cudaSuccess,
+              "Failed to set staged XQA QK shared-memory carveout: ",
+              cudaGetErrorString(qk_carveout_status));
+  const cudaError_t pv_smem_status = cudaFuncSetAttribute(
+      pv_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, pv_shared_mem);
+  TORCH_CHECK(pv_smem_status == cudaSuccess,
+              "Failed to set staged XQA PV shared memory: ",
+              cudaGetErrorString(pv_smem_status));
+  const cudaError_t pv_carveout_status = cudaFuncSetAttribute(
+      pv_kernel, cudaFuncAttributePreferredSharedMemoryCarveout, 100);
+  TORCH_CHECK(pv_carveout_status == cudaSuccess,
+              "Failed to set staged XQA PV shared-memory carveout: ",
+              cudaGetErrorString(pv_carveout_status));
+
+  flash_attention_decode_xqa_tc_qk_softmax_staged_kernel_256_wide<
+      256, kGroupSize, true, kQKThreads, kQKMinBlocksPerSM>
+      <<<partition_grid, kQKThreads, qk_shared_mem, stream>>>(
+          reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+          reinterpret_cast<const __half*>(k_cache.data_ptr<at::Half>()),
+          reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
+          max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+          online_rescales.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), active_num_partitions.data_ptr<int>(),
+          batch_size, max_num_blocks, launch_num_partitions, num_heads_q,
+          num_heads_kv, k_cache.size(1), q.stride(0), q.stride(1),
+          tmp_out.stride(0), tmp_out.stride(1), tmp_out.stride(2),
+          max_logits.stride(0), max_logits.stride(1), online_rescales.stride(0),
+          online_rescales.stride(1), k_cache.stride(0), k_cache.stride(1),
+          k_cache.stride(2), softmax_scale);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  flash_attention_decode_xqa_tc_pv_staged_kernel_256_wide<
+      256, kGroupSize, true, kPVThreads, kPVMinBlocksPerSM>
+      <<<partition_grid, kPVThreads, pv_shared_mem, stream>>>(
+          reinterpret_cast<const __half*>(v_cache.data_ptr<at::Half>()),
+          reinterpret_cast<const __half*>(tmp_out.data_ptr<at::Half>()),
+          reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
+          exp_sums.data_ptr<float>(), online_rescales.data_ptr<float>(),
+          block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+          active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
+          launch_num_partitions, num_heads_q, num_heads_kv, v_cache.size(1),
+          tmp_out.stride(0), tmp_out.stride(1), tmp_out.stride(2),
+          max_logits.stride(0), max_logits.stride(1), online_rescales.stride(0),
+          online_rescales.stride(1), v_cache.stride(0), v_cache.stride(1),
+          v_cache.stride(2));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  if (use_split_reduce) {
+    launch_flash_attention_decode_xqa_split_reduce<256>(
+        out, seq_lens, tmp_out, max_logits, exp_sums, launch_num_partitions,
+        split_reduce_dim_tile, stream);
+  } else {
+    const dim3 reduce_grid(batch_size, num_heads_q, 1);
+    const dim3 reduce_block(kThreadsPerBlock);
+    const size_t reduce_shared_mem =
+        static_cast<size_t>(2 * launch_num_partitions) * sizeof(float);
+    flash_attention_decode_reduce_kernel<256, 256>
+        <<<reduce_grid, reduce_block, reduce_shared_mem, stream>>>(
+            reinterpret_cast<const __half*>(tmp_out.data_ptr<at::Half>()),
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+            seq_lens.data_ptr<int>(), active_num_partitions.data_ptr<int>(),
+            reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+            launch_num_partitions, num_heads_q, tmp_out.stride(0),
+            tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),
+            max_logits.stride(1), out.stride(0), out.stride(1), 0, 0, 0, 0);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <int D, int PARTITION_SIZE, int KV_DTYPE>
+void launch_flash_attention_decode_qk_scores(
+    const at::Tensor& q, const at::Tensor& k_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& scores, const float softmax_scale, const float k_scale,
+    cudaStream_t stream) {
+  const int batch_size = q.size(0);
+  const int num_heads_q = q.size(1);
+  const int num_heads_kv = k_cache.size(2);
+  const int block_size = k_cache.size(1);
+  const int max_num_blocks = block_table.size(1);
+  const int max_num_partitions = scores.size(2);
+
+  const dim3 grid(batch_size, num_heads_q, max_num_partitions);
+  const dim3 block(kThreadsPerBlock);
+
+  flash_attention_decode_qk_scores_kernel<D, PARTITION_SIZE, KV_DTYPE>
+      <<<grid, block, 0, stream>>>(
+          reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+          k_cache.data_ptr(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), scores.data_ptr<float>(), batch_size,
+          max_num_blocks, max_num_partitions, num_heads_q, num_heads_kv,
+          block_size, q.stride(0), q.stride(1), scores.stride(0),
+          scores.stride(1), scores.stride(2), k_cache.stride(0),
+          k_cache.stride(1), k_cache.stride(2), softmax_scale, k_scale);
+}
+
+constexpr int kGroupedSparseQueries = 8;
+constexpr int kGroupedSparsePlannerThreads = 512;
+constexpr int kGroupedSparseHashCapacity = 8192;
+constexpr unsigned long long kGroupedSparseEmptyEntry = 0x00000000ffffffffULL;
+constexpr int kGroupedSparseItemsPerThread =
+    kGroupedSparseHashCapacity / kGroupedSparsePlannerThreads;
+using GroupedSparseSort =
+    cub::BlockRadixSort<unsigned long long, kGroupedSparsePlannerThreads,
+                        kGroupedSparseItemsPerThread, unsigned long long>;
+// Hash entries plus logical owners exactly fit Volta's 96 KiB opt-in limit.
+// After loading both into registers, reuse this storage for sorting and scans.
+constexpr size_t kGroupedSparsePlannerSharedMemory =
+    kGroupedSparseHashCapacity *
+    (sizeof(unsigned long long) + sizeof(uint32_t));
+static_assert(sizeof(GroupedSparseSort::TempStorage) <=
+              kGroupedSparsePlannerSharedMemory);
+
+__device__ __forceinline__ void grouped_sparse_hash_insert(
+    unsigned long long* __restrict__ hash_table,
+    uint32_t* __restrict__ logical_owners, const int physical_microblock,
+    const uint32_t token_mask, const int query, const int logical_token) {
+  if (physical_microblock < 0 || token_mask == 0) {
+    return;
+  }
+  int slot = (static_cast<uint32_t>(physical_microblock) * 2654435761u) &
+             (kGroupedSparseHashCapacity - 1);
+  const unsigned long long desired =
+      (static_cast<unsigned long long>(token_mask) << 32) |
+      static_cast<uint32_t>(physical_microblock);
+#pragma unroll 1
+  for (int probe = 0; probe < kGroupedSparseHashCapacity; ++probe) {
+    const unsigned long long old =
+        atomicCAS(hash_table + slot, kGroupedSparseEmptyEntry, desired);
+    if (old == kGroupedSparseEmptyEntry ||
+        static_cast<uint32_t>(old) ==
+            static_cast<uint32_t>(physical_microblock)) {
+      atomicOr(hash_table + slot, static_cast<unsigned long long>(token_mask)
+                                      << 32);
+      // Nonnegative int32 tokens use at most 29 bits after division by four.
+      // The first contributing query owns shared pages, independent of request
+      // slot IDs, physical allocation, insertion order, and hash collisions.
+      const uint32_t owner = (static_cast<uint32_t>(query) << 29) |
+                             (static_cast<uint32_t>(logical_token) >> 2);
+      atomicMin(logical_owners + slot, owner);
+      return;
+    }
+    slot = (slot + 1) & (kGroupedSparseHashCapacity - 1);
+  }
+}
+
+__device__ __forceinline__ int grouped_sparse_physical_microblock(
+    const int token, const int request_idx,
+    const int* __restrict__ request_block_table,
+    const int64_t request_block_table_stride, const int block_table_width,
+    const int page_size, const int physical_page_stride,
+    const int num_cache_blocks) {
+  if (token < 0) {
+    return -1;
+  }
+  const int logical_page = token / page_size;
+  if (logical_page < 0 || logical_page >= block_table_width) {
+    return -1;
+  }
+  const int page_offset = token - logical_page * page_size;
+  const int physical_page =
+      __ldg(request_block_table +
+            static_cast<int64_t>(request_idx) * request_block_table_stride +
+            logical_page);
+  if (physical_page < 0 || physical_page >= num_cache_blocks) {
+    return -1;
+  }
+  return physical_page * physical_page_stride + page_offset / 4;
+}
+
+__device__ __forceinline__ int grouped_sparse_active_m_tiles(
+    const uint32_t token_mask) {
+  int active_m_tiles = 0;
+#pragma unroll
+  for (int query = 0; query < kGroupedSparseQueries; ++query) {
+    if ((token_mask & (0xFu << (query * 4))) != 0) {
+      const int first_row = query * kGroupedVerifyHeads;
+      const int last_row = first_row + kGroupedVerifyHeads - 1;
+      active_m_tiles |= 1 << (first_row / 16);
+      active_m_tiles |= 1 << (last_row / 16);
+    }
+  }
+  return active_m_tiles;
+}
+
+__global__
+__launch_bounds__(kGroupedSparsePlannerThreads, 1) void grouped_sparse_page4_plan_kernel(
+    const int* __restrict__ logical_indices,
+    const int* __restrict__ request_block_table,
+    const int* __restrict__ token_to_req,
+    const int64_t* __restrict__ query_positions,
+    const int* __restrict__ sequence_lengths, int* __restrict__ output_blocks,
+    uint32_t* __restrict__ output_masks, int* __restrict__ output_seq_lens,
+    const int selection_width, const int64_t logical_indices_stride,
+    const int64_t request_block_table_stride, const int num_requests,
+    const int block_table_width, const int output_width, const int page_size,
+    const int physical_page_stride, const int num_cache_blocks) {
+  const int group_idx = blockIdx.x;
+  const int tid = threadIdx.x;
+  extern __shared__ unsigned long long hash_table[];
+  auto* logical_owners =
+      reinterpret_cast<uint32_t*>(hash_table + kGroupedSparseHashCapacity);
+  for (int slot = tid; slot < kGroupedSparseHashCapacity;
+       slot += kGroupedSparsePlannerThreads) {
+    hash_table[slot] = kGroupedSparseEmptyEntry;
+    logical_owners[slot] = UINT_MAX;
+  }
+  __syncthreads();
+
+  const int full_page4_count = selection_width / 4;
+  for (int selected_page = tid; selected_page < full_page4_count;
+       selected_page += kGroupedSparsePlannerThreads) {
+#pragma unroll
+    for (int query = 0; query < kGroupedSparseQueries; ++query) {
+      const int row = group_idx * kGroupedSparseQueries + query;
+      const int request_idx = __ldg(token_to_req + row);
+      if (request_idx < 0 || request_idx >= num_requests) {
+        continue;
+      }
+      const int sequence_length = __ldg(sequence_lengths + request_idx);
+      const int64_t query_visible_tokens = __ldg(query_positions + row) + 1;
+      const int visible_tokens =
+          query_visible_tokens <= 0
+              ? 0
+              : (query_visible_tokens < sequence_length
+                     ? static_cast<int>(query_visible_tokens)
+                     : max(sequence_length, 0));
+      const int row_complete_page4_count =
+          min(min(visible_tokens / 4, sequence_length / 4), full_page4_count);
+      if (selected_page >= row_complete_page4_count) {
+        continue;
+      }
+      const int* selected = logical_indices +
+                            static_cast<int64_t>(row) * logical_indices_stride +
+                            selected_page * 4;
+      const int first_token = __ldg(selected);
+      if (first_token < 0) {
+        continue;
+      }
+      const bool full_page4 = __ldg(selected + 1) == first_token + 1 &&
+                              __ldg(selected + 2) == first_token + 2 &&
+                              __ldg(selected + 3) == first_token + 3 &&
+                              (first_token & 3) == 0 &&
+                              first_token + 3 < sequence_length;
+      if (full_page4) {
+        const int physical_microblock = grouped_sparse_physical_microblock(
+            first_token, request_idx, request_block_table,
+            request_block_table_stride, block_table_width, page_size,
+            physical_page_stride, num_cache_blocks);
+        grouped_sparse_hash_insert(hash_table, logical_owners,
+                                   physical_microblock, 0xFu << (query * 4),
+                                   query, first_token);
+      } else {
+#pragma unroll
+        for (int token_offset = 0; token_offset < 4; ++token_offset) {
+          const int token = __ldg(selected + token_offset);
+          if (token >= 0 && token < sequence_length) {
+            const int physical_microblock = grouped_sparse_physical_microblock(
+                token, request_idx, request_block_table,
+                request_block_table_stride, block_table_width, page_size,
+                physical_page_stride, num_cache_blocks);
+            grouped_sparse_hash_insert(
+                hash_table, logical_owners, physical_microblock,
+                1u << (query * 4 + (token & 3)), query, token);
+          }
+        }
+      }
+    }
+  }
+  if (tid < kGroupedSparseQueries) {
+    const int query = tid;
+    const int row = group_idx * kGroupedSparseQueries + query;
+    const int request_idx = __ldg(token_to_req + row);
+    if (request_idx >= 0 && request_idx < num_requests) {
+      const int sequence_length = __ldg(sequence_lengths + request_idx);
+      const int64_t query_visible_tokens = __ldg(query_positions + row) + 1;
+      const int visible_tokens =
+          query_visible_tokens <= 0
+              ? 0
+              : (query_visible_tokens < sequence_length
+                     ? static_cast<int>(query_visible_tokens)
+                     : max(sequence_length, 0));
+      const int complete_page4_count =
+          min(min(visible_tokens / 4, sequence_length / 4), full_page4_count);
+      const int tail_count = visible_tokens & 3;
+      const int tail_index = complete_page4_count * 4;
+      const int selected_tail_token =
+          tail_index < selection_width
+              ? __ldg(logical_indices +
+                      static_cast<int64_t>(row) * logical_indices_stride +
+                      tail_index)
+              : -1;
+      const int expected_tail_token = (visible_tokens / 4) * 4;
+      if (tail_count > 0 && selected_tail_token == expected_tail_token &&
+          selected_tail_token < sequence_length) {
+        const int physical_microblock = grouped_sparse_physical_microblock(
+            selected_tail_token, request_idx, request_block_table,
+            request_block_table_stride, block_table_width, page_size,
+            physical_page_stride, num_cache_blocks);
+        const uint32_t tail_mask = ((1u << tail_count) - 1) << (query * 4);
+        grouped_sparse_hash_insert(hash_table, logical_owners,
+                                   physical_microblock, tail_mask, query,
+                                   selected_tail_token);
+      }
+    }
+  }
+  __syncthreads();
+
+  // Keep the existing physical-page union and masks, but never let physical
+  // hash slots determine the attention reduction order. Category is primary
+  // to preserve active-tile packing; the logical owner orders each category.
+  unsigned long long entries[kGroupedSparseItemsPerThread];
+  unsigned long long sort_keys[kGroupedSparseItemsPerThread];
+#pragma unroll
+  for (int item = 0; item < kGroupedSparseItemsPerThread; ++item) {
+    const int slot = tid * kGroupedSparseItemsPerThread + item;
+    const unsigned long long entry = hash_table[slot];
+    entries[item] = entry;
+    const int category =
+        grouped_sparse_active_m_tiles(static_cast<uint32_t>(entry >> 32));
+    sort_keys[item] = static_cast<uint32_t>(entry) == 0xffffffffu
+                          ? ULLONG_MAX
+                          : (static_cast<unsigned long long>(category) << 32) |
+                                logical_owners[slot];
+  }
+  __syncthreads();
+  auto& sort_storage =
+      *reinterpret_cast<GroupedSparseSort::TempStorage*>(hash_table);
+  // Three category bits, 32 owner bits, and one bit separating empty slots.
+  GroupedSparseSort(sort_storage).Sort(sort_keys, entries, 0, 36);
+  __syncthreads();
+#pragma unroll
+  for (int item = 0; item < kGroupedSparseItemsPerThread; ++item) {
+    hash_table[tid * kGroupedSparseItemsPerThread + item] = entries[item];
+  }
+  auto* category_counts = reinterpret_cast<int*>(logical_owners);
+  int* category_offsets = category_counts + 8;
+  int* category_cursors = category_offsets + 8;
+  int* warp_category_prefix = category_cursors + 8;
+  __syncthreads();
+
+  if (tid < 8) {
+    category_counts[tid] = 0;
+    category_offsets[tid] = 0;
+    category_cursors[tid] = 0;
+  }
+  __syncthreads();
+  for (int slot = tid; slot < kGroupedSparseHashCapacity;
+       slot += kGroupedSparsePlannerThreads) {
+    const unsigned long long entry = hash_table[slot];
+    if (static_cast<uint32_t>(entry) != 0xffffffffu) {
+      const int category =
+          grouped_sparse_active_m_tiles(static_cast<uint32_t>(entry >> 32));
+      atomicAdd(category_counts + category, 1);
+    }
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int padded_offset = 0;
+#pragma unroll
+    for (int category = 1; category < 8; ++category) {
+      category_offsets[category] = padded_offset;
+      padded_offset += (category_counts[category] + 7) & ~7;
+    }
+    category_offsets[0] = padded_offset;
+  }
+  __syncthreads();
+  constexpr int kPlannerWarps = kGroupedSparsePlannerThreads / kWarpSize;
+  const int lane = tid & (kWarpSize - 1);
+  const int warp = tid / kWarpSize;
+  for (int chunk_start = 0; chunk_start < kGroupedSparseHashCapacity;
+       chunk_start += kGroupedSparsePlannerThreads) {
+    const unsigned long long entry = hash_table[chunk_start + tid];
+    const uint32_t physical_microblock = static_cast<uint32_t>(entry);
+    int category = 0;
+    if (physical_microblock != 0xffffffffu) {
+      const uint32_t token_mask = static_cast<uint32_t>(entry >> 32);
+      category = grouped_sparse_active_m_tiles(token_mask);
+    }
+    unsigned category_lanes = 0;
+#pragma unroll
+    for (int scan_category = 1; scan_category < 8; ++scan_category) {
+      const unsigned lanes =
+          __ballot_sync(0xffffffffu, category == scan_category);
+      if (category == scan_category) {
+        category_lanes = lanes;
+      }
+      if (lane == 0) {
+        warp_category_prefix[warp * 8 + scan_category] = __popc(lanes);
+      }
+    }
+    __syncthreads();
+    if (tid > 0 && tid < 8) {
+      int prefix = category_cursors[tid];
+#pragma unroll
+      for (int scan_warp = 0; scan_warp < kPlannerWarps; ++scan_warp) {
+        const int count = warp_category_prefix[scan_warp * 8 + tid];
+        warp_category_prefix[scan_warp * 8 + tid] = prefix;
+        prefix += count;
+      }
+      category_cursors[tid] = prefix;
+    }
+    __syncthreads();
+    if (category != 0) {
+      const int category_rank = warp_category_prefix[warp * 8 + category] +
+                                __popc(category_lanes & ((1u << lane) - 1));
+      const int output_idx = category_offsets[category] + category_rank;
+      if (output_idx < output_width) {
+        output_blocks[static_cast<int64_t>(group_idx) * output_width +
+                      output_idx] = static_cast<int>(physical_microblock);
+        output_masks[static_cast<int64_t>(group_idx) * output_width +
+                     output_idx] = static_cast<uint32_t>(entry >> 32);
+      }
+    }
+    __syncthreads();
+  }
+  __syncthreads();
+  if (tid > 0 && tid < 8) {
+    const int category = tid;
+    const int padded_count = (category_counts[category] + 7) & ~7;
+    for (int local_idx = category_counts[category]; local_idx < padded_count;
+         ++local_idx) {
+      const int output_idx = category_offsets[category] + local_idx;
+      if (output_idx < output_width) {
+        output_blocks[static_cast<int64_t>(group_idx) * output_width +
+                      output_idx] = 0;
+        output_masks[static_cast<int64_t>(group_idx) * output_width +
+                     output_idx] = 0;
+      }
+    }
+  }
+  if (tid == 0) {
+    output_seq_lens[group_idx] = min(category_offsets[0], output_width) * 4;
+  }
+}
+
+}  // namespace
+
+at::Tensor private_grouped_e4m3_fp32_paged(
+    const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    at::Tensor& out, const at::Tensor& block_table,
+    const at::Tensor& row_lengths, at::Tensor& partial, at::Tensor& lse,
+    float scale, float k_scale, float v_scale) {
+  TORCH_CHECK(q.is_cuda() && q.scalar_type() == at::kHalf &&
+                  q.is_contiguous() && q.dim() == 3 && q.size(0) >= 2 &&
+                  q.size(0) <= 8 && q.size(1) == 6 && q.size(2) == 256,
+              "E4M3 grouped FP32 requires contiguous CUDA FP16 Q [2..8,6,256]");
+  TORCH_CHECK(
+      k.dim() == 4 && k.size(2) == 1 && k.size(3) == 256 &&
+          (k.size(1) == 800 || k.size(1) == 848 || k.size(1) == 1616 ||
+           k.size(1) == 1648 || k.size(1) == 1728 || k.size(1) == 3296 ||
+           k.size(1) == 3456) &&
+          k.scalar_type() == at::kByte && v.scalar_type() == at::kByte &&
+          v.sizes() == k.sizes(),
+      "E4M3 grouped FP32 requires supported uint8 paged KV [pages,page,1,256]");
+  TORCH_CHECK(
+      block_table.dim() == 2 && block_table.size(0) == 1 &&
+          block_table.is_contiguous() &&
+          block_table.scalar_type() == at::kInt && block_table.size(1) > 0 &&
+          block_table.size(1) * k.size(1) <= 266240 &&
+          row_lengths.sizes() == at::IntArrayRef({q.size(0)}) &&
+          row_lengths.scalar_type() == at::kInt && row_lengths.is_contiguous(),
+      "E4M3 grouped FP32 requires one KV sequence and per-query int32 lengths");
+  TORCH_CHECK(out.sizes() == q.sizes() && out.is_contiguous() &&
+                  out.scalar_type() == at::kHalf,
+              "E4M3 grouped FP32 output must be contiguous FP16 and Q-shaped");
+  TORCH_CHECK(partial.sizes() == at::IntArrayRef({80, 8, 6, 256}) &&
+                  partial.is_contiguous() &&
+                  partial.scalar_type() == at::kFloat &&
+                  lse.sizes() == at::IntArrayRef({80, 8, 6, 2}) &&
+                  lse.is_contiguous() && lse.scalar_type() == at::kFloat,
+              "E4M3 grouped FP32 requires numerator [80,8,6,256] and max/sum "
+              "[80,8,6,2]");
+  TORCH_CHECK(
+      std::isfinite(scale) && std::isfinite(k_scale) &&
+          std::isfinite(v_scale) && k_scale > 0 && v_scale > 0,
+      "E4M3 grouped FP32 requires finite scale and positive finite KV scales");
+  for (const auto* t :
+       {&k, &v, static_cast<const at::Tensor*>(&out), &block_table,
+        &row_lengths, static_cast<const at::Tensor*>(&partial),
+        static_cast<const at::Tensor*>(&lse)}) {
+    TORCH_CHECK(t->device() == q.device(),
+                "E4M3 grouped tensors must share device");
+  }
+  for (const auto* t : {&k, &v}) {
+    // Explicit-row FP32 groups retain the 8-byte loader. The dense q8
+    // verifier's paired loader requires 16-byte strides and is gated there;
+    // inheriting it here would truncate valid 8-but-not-16-byte offsets.
+    TORCH_CHECK(t->stride(3) == 1 &&
+                    reinterpret_cast<uintptr_t>(t->data_ptr()) % 16 == 0,
+                "E4M3 grouped KV requires aligned contiguous head dimension");
+    for (int i = 0; i < 3; ++i)
+      TORCH_CHECK(t->stride(i) % 8 == 0,
+                  "E4M3 grouped KV strides must be multiples of 8");
+  }
+  c10::cuda::CUDAGuard guard(q.device());
+  const auto* properties = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(properties->major == 7 && properties->minor == 0,
+              "E4M3 grouped FP32 supports SM70 only");
+  // A contiguous FP16 view can start at a half-element storage offset.
+  // The shared-Q feed uses uint4 loads; only those exceptional views need
+  // an aligned, stream-local copy. Ordinary model Q keeps the original path.
+  const at::Tensor aligned_q =
+      reinterpret_cast<uintptr_t>(q.data_ptr()) % 16 == 0 ? q : q.clone();
+  const auto stream = at::cuda::getCurrentCUDAStream().stream();
+  bool paired = true;
+  for (const auto* tensor : {&k, &v}) {
+    for (int dim = 0; dim < 3; ++dim)
+      paired = paired && tensor->stride(dim) % 16 == 0;
+  }
+  auto kernel = paired
+      ? flash_attention_grouped_verify_e5m2_partial_kernel<
+          8, false, 0, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+          false, float, true, true, true>
+      : flash_attention_grouped_verify_e5m2_partial_kernel<
+          8, false, 0, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+          false, float, true, true, false>;
+  if (k.size(1) == 1648) kernel = paired ? flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
+  if (k.size(1) == 3296) kernel = paired ? flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
+  constexpr int kCompensatedSmemBytes =
+      sizeof(GroupedVerifySmem) +
+      kGroupedVerifyRows * kGroupedVerifyProbStride * sizeof(__half) +
+      kGroupedVerifyBlockN * kGroupedVerifyKVStride * sizeof(__half);
+  static_assert(kCompensatedSmemBytes <= 96 * 1024,
+                "compensated P and prefetched V must fit the SM70 budget");
+  TORCH_CHECK(properties->sharedMemPerBlockOptin >= kCompensatedSmemBytes,
+              "V prefetch exceeds device opt-in shared memory");
+  C10_CUDA_CHECK(
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                           kCompensatedSmemBytes));
+  C10_CUDA_CHECK(cudaFuncSetAttribute(
+      kernel, cudaFuncAttributePreferredSharedMemoryCarveout, 100));
+  kernel<<<dim3(1, 80), kGroupedVerifyThreads, kCompensatedSmemBytes, stream>>>(
+      reinterpret_cast<const __half*>(aligned_q.data_ptr()), k.data_ptr(),
+      v.data_ptr(), block_table.data_ptr<int>(), row_lengths.data_ptr<int>(),
+      partial.data_ptr<float>(), lse.data_ptr<float>(), q.size(0),
+      block_table.size(1), k.size(1), k.stride(0), k.stride(1), k.stride(2),
+      v.stride(0), v.stride(1), v.stride(2), scale * k_scale, v_scale, nullptr,
+      1, row_lengths.data_ptr<int>());
+  flash_attention_grouped_verify_e5m2_combine_kernel<8, false, float, true>
+      <<<dim3(q.size(0), 6), kGroupedVerifyThreads, 0, stream>>>(
+          partial.data_ptr<float>(), lse.data_ptr<float>(),
+          row_lengths.data_ptr<int>(),
+          reinterpret_cast<__half*>(out.data_ptr()), q.size(0),
+          row_lengths.data_ptr<int>());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+
+// Registered into the shipped FA2 extension rather than a private pybind
+// module, so the long-context route is available by default instead of
+// requiring an externally built DSO selected by an environment variable.
+// TORCH_LIBRARY schemas spell float arguments as double, so the operator keeps
+// its validated float signature behind a thin adapter rather than having its
+// numeric body touched.
+namespace {
+at::Tensor sm70_grouped_long_entry(
+    const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    at::Tensor& out, const at::Tensor& block_table,
+    const at::Tensor& row_lengths, at::Tensor& partial, at::Tensor& lse,
+    double scale, double k_scale, double v_scale) {
+  return private_grouped_e4m3_fp32_paged(
+      q, k, v, out, block_table, row_lengths, partial, lse,
+      static_cast<float>(scale), static_cast<float>(k_scale),
+      static_cast<float>(v_scale));
+}
+}  // namespace
+
+TORCH_LIBRARY_FRAGMENT(_vllm_fa2_C, ops) {
+  ops.def(
+      "sm70_grouped_long_fwd(Tensor q, Tensor k, Tensor v, Tensor(a!) out, "
+      "Tensor block_table, Tensor row_lengths, Tensor(a!) partial, "
+      "Tensor(a!) lse, float scale, float k_scale, float v_scale) -> Tensor(a!)");
+}
+TORCH_LIBRARY_IMPL(_vllm_fa2_C, CUDA, ops) {
+  ops.impl("sm70_grouped_long_fwd", &sm70_grouped_long_entry);
+}

--- a/csrc/attention/sm70_grouped_long/kernel/paged_kv_utils.cuh
+++ b/csrc/attention/sm70_grouped_long/kernel/paged_kv_utils.cuh
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+__device__ __forceinline__ size_t resolve_paged_kv_offset(
+    const int token_idx, const int page_block_size,
+    const int* __restrict__ block_table, const int kv_head_offset,
+    const int num_kv_heads, const int head_dim) {
+  const int virtual_page_idx = token_idx / page_block_size;
+  const int page_offset = token_idx % page_block_size;
+
+  const int physical_block_idx = block_table[virtual_page_idx];
+
+  const size_t physical_offset =
+      (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim +
+      (size_t)page_offset * num_kv_heads * head_dim + (size_t)kv_head_offset;
+
+  return physical_offset;
+}
+
+template <int D>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int kv_head_idx,
+    const int num_kv_heads, const int head_dim, const int page_block_size,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads) {
+  constexpr int PER_UINT4 = 8;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+
+  const int kv_head_offset = kv_head_idx * head_dim;
+
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
+
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
+
+      const size_t base_offset = resolve_paged_kv_offset(
+          global_token_idx, page_block_size, block_table, kv_head_offset,
+          num_kv_heads, head_dim);
+
+      const uint4* kv_vec =
+          reinterpret_cast<const uint4*>(kv_cache + base_offset);
+      kv_val = __ldg(&kv_vec[vec_col]);
+    }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
+}
+
+#endif

--- a/vllm/v1/attention/ops/sm70_e4m3_long.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_long.py
@@ -16,15 +16,49 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-# Include generation headroom after a 128K prompt. Larger CPU upper bounds use
-# the existing full-context graph; device row lengths remain authoritative.
-MAX_CONTEXT = 132096
+# Upper bound the accelerated route admits. The operator s extended-boundary
+# screen covers 262152 physical-page and stride boundaries byte-exactly, so the
+# route covers the full 262144 service capacity plus generation headroom instead
+# of stopping at a 128K prompt. Device row lengths remain authoritative.
+MAX_CONTEXT = 262152
 MANIFEST_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST"
+DISABLE_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION"
 _WORKSPACES: dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
 
 
+# The grouped long-context route is compiled into the shipped FA2 extension, so
+# it is available without any environment variable. The manifest variable stays
+# as an explicit override for an unqualified experimental candidate.
+BUILTIN_OP = "sm70_grouped_long_fwd"
+BUILTIN_MANIFEST = {
+    "module_name": "_vllm_fa2_C",
+    "source_sha256": BUILTIN_OP,
+    "splits": 80,
+    "head_groups": 1,
+    "max_context": MAX_CONTEXT,
+    "query_rows": [8],
+}
+
+
+@lru_cache(maxsize=1)
+def builtin_long_attention():
+    try:
+        return getattr(torch.ops._vllm_fa2_C, BUILTIN_OP)
+    except AttributeError:
+        return None
+
+
+# Explicit opt-out. The accelerated route is on by default, so an operator needs
+# a way back to the full-context route without rebuilding, and the paired A/B
+# validation needs both arms from one build. An explicit off wins over a
+# manifest override.
+DISABLE_VALUES = {"0", "false", "no", "off"}
+
+
 def long_attention_enabled() -> bool:
-    return bool(os.environ.get(MANIFEST_ENV))
+    if os.environ.get(DISABLE_ENV, "").strip().lower() in DISABLE_VALUES:
+        return False
+    return bool(os.environ.get(MANIFEST_ENV)) or builtin_long_attention() is not None
 
 
 @lru_cache(maxsize=4)
@@ -77,9 +111,13 @@ def load_long_attention(manifest_name: str):
 def long_attention_contract(manifest):
     context_limit = manifest.get("max_context", MAX_CONTEXT)
     query_rows = tuple(manifest.get("query_rows", [8]))
+    # No ceiling on the declared context. A bound larger than the captured graph
+    # simply never equals a real descriptor bucket, so the route falls back on
+    # its own; the operator requirement that actually matters is the query-row
+    # range, which mirrors the native q.size(0) in [2, 8] check.
     if (
         type(context_limit) is not int
-        or not 0 < context_limit <= 262144
+        or context_limit <= 0
         or not query_rows
         or any(type(q) is not int or not 2 <= q <= 8 for q in query_rows)
     ):
@@ -87,16 +125,38 @@ def long_attention_contract(manifest):
     return context_limit, query_rows
 
 
+def resolve_long_attention():
+    """The route in effect: an explicit manifest candidate, else the shipped one."""
+    if not long_attention_enabled():
+        return None, None
+    manifest_name = os.environ.get(MANIFEST_ENV)
+    if manifest_name:
+        return load_long_attention(manifest_name)
+    operator = builtin_long_attention()
+    if operator is None:
+        return None, None
+    logger.info_once(
+        "Using the shipped SM70 E4M3 q8 long-context route (%s): max_context=%d "
+        "query_rows=%s; 80 splits, compensated FP32 state.",
+        BUILTIN_OP,
+        MAX_CONTEXT,
+        (8,),
+        scope="process",
+    )
+    return operator, BUILTIN_MANIFEST
+
+
 def long_attention_graph_contract():
-    _, manifest = load_long_attention(os.environ[MANIFEST_ENV])
+    _, manifest = resolve_long_attention()
+    if manifest is None:
+        return MAX_CONTEXT, (8,)
     return long_attention_contract(manifest)
 
 
 def wrap_long_attention(fallback):
-    manifest_name = os.environ.get(MANIFEST_ENV)
-    if not manifest_name:
+    operator, manifest = resolve_long_attention()
+    if operator is None:
         return fallback
-    operator, manifest = load_long_attention(manifest_name)
     context_limit, query_rows = long_attention_contract(manifest)
 
     def run(


### PR DESCRIPTION
## 问题 / Problem

SM70 的长文补偿 attention（E4M3 FP32 grouped）此前只以**私有 DSO** 形式存在，靠 `VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST` 指向一个外部构建的 `.so` 才能启用；而且图上界停在 132096，**覆盖不到 262144 的服务容量**。

结果是：加速路径要手工开启、要额外维护一个版本绑定的二进制产物，256K 完全用不上。#587 当初把这批优化默认关闭（正文写明 *"Targets remain unmet; all experimental defaults remain disabled"*），所以 main 上跑出来的是**未加速**的数字。

## 改动 / Changes

**1. 算子源码进仓库**

从私有 candidate 搬入 `csrc/attention/sm70_grouped_long/`，共 **5,214 行**：

```
kernel/grouped-attention.cu      4,316
include/fused_mma.h                441
include/fused_mha.h                173
kernel/flash_v100_traits.cuh       118
kernel/fp8_kv_utils.cuh            105
kernel/paged_kv_utils.cuh           61
```

**2. 接进主构建**

按 `sm70_v37` 已验证的 `target_sources` 模式编入 `_vllm_fa2_C`，带上该算子被验证时用的编译参数（`-gencode=arch=compute_70,code=sm_70 -O3 -std=c++17 --use_fast_math` 等），并保留那条关键的作用域修正（`TARGET_DIRECTORY _vllm_fa2_C`，否则 SM70 选项会被静默丢弃）。

**只改了注册方式**：`PYBIND11_MODULE` → `TORCH_LIBRARY_FRAGMENT(_vllm_fa2_C)` + 一层薄适配（`TORCH_LIBRARY` schema 的 `float` 对应 C++ `double`，故适配层做类型转换）。**数值代码一行未动。** 同时删掉因此不再需要的 `torch/extension.h`（它拉进 pybind11 需要 `Python.h`，而该 target 的 nvcc 编译不带 Python include 路径）。

**3. 默认可用**

```python
def long_attention_enabled() -> bool:
    if os.environ.get(DISABLE_ENV, "").strip().lower() in DISABLE_VALUES:
        return False
    return bool(os.environ.get(MANIFEST_ENV)) or builtin_long_attention() is not None
```

判据从「环境变量是否设置」改为「算子是否编进随包发布的扩展」。manifest 变量保留为**实验覆盖**（做 A/B 用），新增 `VLLM_SM70_E4M3_LONG_ATTENTION=0/false/no/off` 作为**显式关闭**——它使同一构建能跑出 control 臂，也给运维一个不需要重编的回退手段。

**4. 覆盖到 262144 容量**

`MAX_CONTEXT` 132096 → **262152**（容量 + 一页 generation headroom）。

同时**去掉契约里对声明上界的封顶**：该检查的默认值就等于 `MAX_CONTEXT`，所以恒为真；而声明过大只会导致 `attention_context_bucket == context_limit` 不匹配、自动回退全上下文路径，是安全降级而非故障。真正有约束力的是 query-row 范围，它对应算子 C++ 侧 `q.size(0) >= 2 && q.size(0) <= 8`，仍然保留强制。

## 实测 / Evidence

4×V100-SXM2-32GB，CUDA 12.8，Torch 2.10.0+cu128，QUASAR Qwen3.8-27B-NVFP4 + 7-draft DFlash2，TP4/B1，E4M3 target KV，FP32 state/logits。

**未设置任何环境变量**（`ENV_CHECK manifest=[<unset>]`），服务日志确认选中内置算子：

```
shipped SM70 E4M3 q8 long-context route (sm70_grouped_long_fwd): max_context=262152 query_rows=(8,)
```

官方 context-cost 客户端，`--reset-prefix-cache-before-length --require-native-prefill`：

| context | round ms | 之前 | 加速 | decode tok/s | 之前 |
|---|---|---|---|---|---|
| 32,768 | **18.42** | 25.57 | **1.39x** | 209.7 | 151.1 |
| 65,536 | **20.50** | 34.74 | **1.69x** | 236.2 | 139.4 |
| 131,072 | **24.39** | 52.91 | **2.17x** | 177.2 | 81.7 |
| 261,888 | **38.24** | 94.93 | **2.48x** | 133.4 | 53.5 |

**prefill 无回退**（4082 / 3624 / 3021 / 2233 tok/s，与改动前一致），说明该算子只影响长文 attention 路径。

## 未覆盖的部分 / Not covered

- **配对验证（三次独立启动 + seeds 0/1/2 自然输出，token ID / acceptance / EOS 必须完全一致）尚未完成。** 本次只做了单次启动的 round 与 prefill 测量，acceptance 与冻结 control 一致（5.120 @261888 等），但不构成跨启动的配对证据。#587 当初默认关闭正是因为这批验证没跑完——**我们接受把默认开启前移，但要把这个缺口明确标注出来**，验证会以独立 PR 或后续 commit 补齐。
- 回退开关、以及 `MAX_CONTEXT` 提升后在大容量下的显存开销，尚未做多配置回归。
