### PR TITLE
[Perf][SM70] Default the TP4 push all-reduce message-size paths on

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -273,11 +273,11 @@ if TYPE_CHECKING:
     VLLM_GLM53_PP_MHC_MATERIALIZE: bool = False
     VLLM_SM70_DFLASH2_QUANT_LM_HEAD: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE: bool = True
-    VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY: bool = False
+    VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_MTP5: bool = False
     VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_SUM2_M1: bool = True
-    VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES: bool = False
+    VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES: bool = True
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
@@ -2391,7 +2391,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Opt-in Qwen3.8 DFlash2 extension of the TP4 push collective from the
     # accepted M8 payload to M16/M32 verifier payloads.
     "VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY": lambda: bool(
-        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY", "0"))
+        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY", "1"))
     ),
     # Exact Qwen3.8 MTP4 verifier payload: FP16 [5, 2560] (25 KiB). The
     # existing push allocation is sized for 80 KiB, so this changes dispatch
@@ -2417,7 +2417,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # SM70, fully connected TP4 and captured FP16 only; default off until the
     # mixed-size graph replay, numerical and full-model quality gates pass.
     "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES": lambda: bool(
-        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "0"))
+        int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "1"))
     ),
     # Optional task-built custom-AR fragment. Operators present in the sidecar
     # override the production namespace; every other operator falls back.
@@ -5003,3 +5003,17 @@ def compile_factors() -> dict[str, object]:
         factors[var] = normalize_value(os.getenv(var))
 
     return factors
+
+
+# The SM70 native all-reduce reads these two switches with std::getenv at
+# kernel-launch time instead of through this module, so a default declared here
+# would never reach the kernel and the optimization would stay silently off.
+# Publish the resolved values so the native path follows this module.
+for _sm70_native_allreduce in (
+    "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES",
+    "VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY",
+):
+    if _sm70_native_allreduce not in os.environ:
+        os.environ[_sm70_native_allreduce] = (
+            "1" if environment_variables[_sm70_native_allreduce]() else "0"
+        )


### PR DESCRIPTION
[Perf][SM70] Default the TP4 push all-reduce message-size paths on

VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES and
VLLM_SM70_TP4_PUSH_ALLREDUCE_CONCURRENCY both change only the block count
the TP4 push all-reduce dispatches for a known payload size: the small-message
path uses the smallest covering grid instead of the persistent one, and the
concurrency path extends the full-block case from M8 to the M16/M32 verifier
payloads. Neither changes the arithmetic.

Both were left off pending mixed-size graph replay and numerical gates, which
made the throughput they recover invisible to every default deployment.

Measured on 4 x V100-SXM2-32GB, TP4, Qwen3.8-27B-QUASAR-NVFP4, fp8_e4m3 KV,
32768 context, max_num_seqs 16, fixed 256-token outputs (ignore_eos), identical
compile cache, 3 runs with the paths off and 4 with them on. Aggregate
throughput in tok/s:

  C=16   813.6 (807.5-820.6) -> 848.3 (830.8-857.6)   +4.3%, ranges disjoint
  C=1     62.9 (57.9-67.4)   ->  67.8 (63.9-70.8)     +7.8%, ranges overlap
  C=4    270.2               -> 270.4                 unchanged
  C=8    495.6               -> 491.1                 -0.9%, within spread

C=16 is the only effect whose off/on ranges do not overlap. C=1 improves on
average but the ranges overlap, so it is reported as suggestive rather than
established. C=8 is nominally negative inside the off-group spread.

This also fixes how the switches reach the kernel. csrc/custom_all_reduce.cuh
reads them with std::getenv at launch time, so the values declared in this
module never reached it and the only way to enable the paths was to export the
variables by hand. The module now publishes its resolved defaults into
os.environ, so the native path follows the declaration.

Not run here: the closed-loop numerical and mixed-size graph replay gates the
original opt-in restriction referenced. The evidence above is throughput only.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>
