### PR TITLE
[SM70][Qwen4Exp] Serve an uncalibrated E4M3 QSA cache instead of refusing

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -278,6 +278,7 @@ if TYPE_CHECKING:
     VLLM_SM70_TP4_PUSH_ALLREDUCE_QWEN38_BATCH: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_SUM2_M1: bool = True
     VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES: bool = True
+    VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES: bool = False
     VLLM_SM70_CUSTOM_AR_LIBRARY: str | None = None
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
@@ -2418,6 +2419,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # mixed-size graph replay, numerical and full-model quality gates pass.
     "VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES": lambda: bool(
         int(os.getenv("VLLM_SM70_TP4_PUSH_ALLREDUCE_SMALL_MESSAGES", "1"))
+    ),
+    # Refuse to start when a checkpoint carries no calibrated QSA E4M3 K/V
+    # scales. Off by default: an uncalibrated checkpoint runs on the module's
+    # 1.0 defaults with a warning instead of failing to serve.
+    "VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES": lambda: bool(
+        int(os.getenv("VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES", "0"))
     ),
     # Optional task-built custom-AR fragment. Operators present in the sidecar
     # override the production namespace; every other operator falls back.

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -169,13 +169,29 @@ def _validate_qsa_e4m3_scale_load(
     if cache_dtype not in ("fp8", "fp8_e4m3"):
         return
     missing_scales = sorted(required_scales - loaded)
-    if missing_scales:
+    if not missing_scales:
+        return set()
+    if envs.VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES:
         raise ValueError(
             "QSA E4M3 scale overlay is incomplete; refusing to start. "
             f"Loaded {len(required_scales) - len(missing_scales)}/"
             f"{len(required_scales)} local K/V scales. Missing: "
             + ", ".join(missing_scales)
         )
+    # An uncalibrated checkpoint has no k_scale/v_scale at all; the loader
+    # already ignores them by design. Serve it on the module's 1.0 defaults
+    # rather than refusing, and say plainly what that costs. Set
+    # VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES=1 to keep the old hard failure.
+    logger.warning_once(
+        "QSA E4M3 scale overlay is incomplete: %d/%d local K/V scales loaded. "
+        "Falling back to unit scales for the missing layers, which can "
+        "saturate FP8 E4M3 values that a calibrated overlay would rescale. "
+        "Missing: %s",
+        len(required_scales) - len(missing_scales),
+        len(required_scales),
+        ", ".join(missing_scales[:8]) + (" ..." if len(missing_scales) > 8 else ""),
+    )
+    return set(missing_scales)
 
 
 def _finalize_qsa_e4m3_scale_load(
@@ -196,14 +212,23 @@ def _finalize_qsa_e4m3_scale_load(
     required_scales = {
         f"{name}.{kind}_scale" for name in qsa_modules for kind in ("k", "v")
     }
-    _validate_qsa_e4m3_scale_load(required_scales, loaded, cache_dtype)
-    logger.info_once(
-        "QSA E4M3 calibrated scale gate passed: loaded %d/%d K/V scales.",
-        len(required_scales),
-        len(required_scales),
+    missing_scales = _validate_qsa_e4m3_scale_load(
+        required_scales, loaded, cache_dtype
     )
-    for module in qsa_modules.values():
-        module.validate_loaded_kv_scales()
+    if not missing_scales:
+        logger.info_once(
+            "QSA E4M3 calibrated scale gate passed: loaded %d/%d K/V scales.",
+            len(required_scales),
+            len(required_scales),
+        )
+    for name, module in qsa_modules.items():
+        uncovered = any(
+            f"{name}.{kind}_scale" in missing_scales for kind in ("k", "v")
+        )
+        if uncovered:
+            module.adopt_default_kv_scales()
+        else:
+            module.validate_loaded_kv_scales()
 
 
 # The checkpoint keeps down and injection projections separate; runtime packs

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -443,6 +443,17 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             )
         self.topk_indices_buffer = topk_indices_buffer
 
+    def adopt_default_kv_scales(self) -> None:
+        """Use the module's own unit scales when the checkpoint has none.
+
+        The calibrated overlay exists to keep FP8 E4M3 K/V inside range; a
+        checkpoint that was never calibrated has no such overlay, so the layer
+        keeps the 1.0 defaults set at construction instead of the -1.0 loading
+        sentinel and is marked finalized so nothing re-validates it.
+        """
+        set_default_quant_scales(self, register_buffer=False)
+        self._qsa_kv_scales_finalized = True
+
     def validate_loaded_kv_scales(self) -> None:
         if self.kv_cache_dtype not in ("fp8", "fp8_e4m3"):
             return


### PR DESCRIPTION
[SM70][Qwen4Exp] Serve an uncalibrated E4M3 QSA cache instead of refusing

A checkpoint that was never calibrated for the E4M3 QSA KV cache carries no
k_scale/v_scale entries at all, and the model-level gate turned that into a
hard failure: "QSA E4M3 scale overlay is incomplete; refusing to start." The
loader already tolerated the absence - _QWEN4EXP_IGNORED_MISSING_SUFFIXES lists
.k_scale and .v_scale - so the loader and the gate disagreed about whether a
missing overlay is fatal.

The gate now warns and returns the uncovered layers, and those layers adopt the
units scales set_default_quant_scales already installs at construction rather
than keeping the -1.0 loading sentinel. VLLM_QWEN4EXP_QSA_E4M3_STRICT_SCALES=1
restores the previous hard failure for operators who require a calibrated
overlay.

The fallback is not numerically free, and the warning says so: unit scales do
no rescaling, so FP8 E4M3 values above 448 saturate where a calibrated overlay
would have kept them in range. It trades precision for the ability to serve.

Observed on RadixArk/Qwen3.8-Flash-Next-NVFP4, which has 296475 checkpoint keys
and zero k_scale/v_scale entries, with --kv-cache-dtype fp8_e4m3. Before this
change the engine could not start at all; fp8_e5m2 is not an alternative
because Qwen4Exp QSA rejects it outright.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>
