### PR TITLE
[Perf] Ship the qualified SM70 long-context layout and drop its context fences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,10 @@ repos:
   rev: v21.1.2
   hooks:
   - id: clang-format
-    exclude: 'csrc/(moe/topk_softmax_kernels.cu|quantization/gguf/(ggml-common.h|dequantize.cuh|vecdotq.cuh|mmq.cuh|mmvq.cuh))|vllm/third_party/.*'
+    # The sm70_grouped_long kernels are ported verbatim from qualified native
+    # candidates and are checked against the source digests recorded in their
+    # manifests, so they stay byte-comparable instead of being reformatted.
+    exclude: 'csrc/(moe/topk_softmax_kernels.cu|quantization/gguf/(ggml-common.h|dequantize.cuh|vecdotq.cuh|mmq.cuh|mmvq.cuh)|attention/sm70_grouped_long/kernel/(grouped|scalar)-attention.cu)|vllm/third_party/.*'
     types_or: [c++, cuda]
     args: [--style=file, --verbose]
 - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -119,7 +119,8 @@ if(VLLM_FLASH_ATTN_SM70 AND TARGET _vllm_fa2_C)
   set(SM70_GROUPED_LONG_DIR
       "${CMAKE_CURRENT_LIST_DIR}/../../csrc/attention/sm70_grouped_long")
   set(SM70_GROUPED_LONG_SRC
-      "${SM70_GROUPED_LONG_DIR}/kernel/grouped-attention.cu")
+      "${SM70_GROUPED_LONG_DIR}/kernel/grouped-attention.cu"
+      "${SM70_GROUPED_LONG_DIR}/kernel/scalar-attention.cu")
   # Flags mirror the manifest the operator was qualified with. As with v37, the
   # properties must be set in the target scope or SM70 silently loses them.
   set_source_files_properties(${SM70_GROUPED_LONG_SRC}

--- a/csrc/attention/sm70_grouped_long/kernel/grouped-attention.cu
+++ b/csrc/attention/sm70_grouped_long/kernel/grouped-attention.cu
@@ -1,8 +1,8 @@
 #include <cuda.h>
-#include <torch/library.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <mma.h>
+#include <torch/library.h>
 #include <algorithm>
 #include <atomic>
 #include <climits>
@@ -838,8 +838,9 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
     static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
                       KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
                   "Paired XQA loads require FP8 KV");
-    static_assert(!E4M3_SHARED_LUT,
-                  "Paired E4M3 conversion does not use the shared LUT");
+    static_assert(!E4M3_SHARED_LUT ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+                  "Paired LUT conversion requires E4M3");
     const int pair_stride = panel_d_stride_uint4 / 2;
     const int pair_count = valid_kv_tile_rows * pair_stride;
     for (int pair_idx = copy_thread_idx; pair_idx < pair_count;
@@ -896,13 +897,17 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
           static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
       shared_vec[shared_offset] =
           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
-              ? fp8_e4m3fn_vector_to_half8_fast(raw_lo)
+              ? (E4M3_SHARED_LUT
+                     ? fp8_e4m3fn_vector_to_half8_lut(raw_lo, e4m3_lut)
+                     : fp8_e4m3fn_vector_to_half8_fast(raw_lo))
               : fp8_e5m2_vector_to_half8(raw_lo);
       const uint64_t raw_hi =
           static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
       shared_vec[shared_offset + 1] =
           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
-              ? fp8_e4m3fn_vector_to_half8_fast(raw_hi)
+              ? (E4M3_SHARED_LUT
+                     ? fp8_e4m3fn_vector_to_half8_lut(raw_hi, e4m3_lut)
+                     : fp8_e4m3fn_vector_to_half8_fast(raw_hi))
               : fp8_e5m2_vector_to_half8(raw_hi);
     }
   } else {
@@ -1808,7 +1813,7 @@ constexpr int kGroupedVerifyBlockN = 32;
 constexpr int kGroupedVerifyQStride = 264;
 constexpr int kGroupedVerifyKVStride = 264;
 constexpr int kGroupedVerifyScoreStride = 32;
-constexpr int kGroupedVerifyProbStride = 40;
+constexpr int kGroupedVerifyProbStride = 32;
 constexpr int kGroupedVerifyPageIdsCapacity = 16;
 // One packed head group times eighty context splits maps one 512-thread CTA to
 // each of V100's eighty SMs. Short sequences still reduce active_splits using
@@ -1885,6 +1890,33 @@ __device__ __forceinline__ int grouped_verify_active_splits(
     return active_splits;
   }
   return total_kv <= kGroupedVerifyShortContextMaxTokens ? 1 : active_splits;
+}
+
+
+// Same SM70 matrix-A word map as the validated native prefill layout.
+__device__ __forceinline__ int grouped_a_offset(int row, int col, int width) {
+  const int local_row = row & 15;
+  const int slot = (local_row & 3) | ((local_row & 8) >> 1) |
+                   ((local_row & 4) << 1);
+  return (row / 16) * 16 * width + (col / 16) * 256 +
+         ((col & 15) / 8) * 128 + slot * 8 + (col & 7);
+}
+
+__device__ __forceinline__ void load_grouped_a_swizzled(
+    volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>& frag,
+    const __half* matrix_tile, const int k_offset) {
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
+  const int slot = (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
+  uint32_t address = static_cast<uint32_t>(__cvta_generic_to_shared(
+      matrix_tile + (k_offset / 16) * 256 + slot * 8));
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3])
+      : "r"(address) : "memory");
+  address += 128 * sizeof(__half);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+      : "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "r"(address) : "memory");
 }
 
 template <bool COMPENSATE = false>
@@ -2097,6 +2129,9 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
   const int warp_id = tid / kWarpSize;
   const int lane_id = tid % kWarpSize;
 
+  __shared__ uint16_t e4m3_lut[256];
+  if (tid < 256)
+    e4m3_lut[tid] = fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(tid));
   extern __shared__ char grouped_verify_smem_raw[];
   GroupedVerifySmem& smem =
       *reinterpret_cast<GroupedVerifySmem*>(grouped_verify_smem_raw);
@@ -2201,10 +2236,10 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
                            KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
                                (KV_DTYPE ==
                                     flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
-                                !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+                                !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
           shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
           kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
-          k_block_stride, k_token_stride, k_head_stride, 0);
+          k_block_stride, k_token_stride, k_head_stride, 0, tid, e4m3_lut);
       for (int idx = tid + valid_k_rows * kSharedStrideVec;
            idx < kGroupedVerifyBlockN * kSharedStrideVec;
            idx += kGroupedVerifyThreads) {
@@ -2292,10 +2327,10 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
                          kGroupedVerifyThreads, KV_DTYPE,
                          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
                              (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
-                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
         shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
         kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
-        k_block_stride, k_token_stride, k_head_stride, 0);
+        k_block_stride, k_token_stride, k_head_stride, 0, tid, e4m3_lut);
     for (int idx = tid + valid_k_rows * kSharedStrideVec;
          idx < kGroupedVerifyBlockN * kSharedStrideVec;
          idx += kGroupedVerifyThreads) {
@@ -2337,10 +2372,10 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
                          kValueLoadThreads, KV_DTYPE,
                          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
                              (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
-                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3))>(
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
         shared_values, v_cache, page_ids, valid_k_rows, kPanelStrideVec,
         kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
-        v_block_stride, v_token_stride, v_head_stride, 0, value_load_tid);
+        v_block_stride, v_token_stride, v_head_stride, 0, value_load_tid, e4m3_lut);
     for (int idx = value_load_tid + valid_k_rows * kSharedStrideVec;
          idx < kGroupedVerifyBlockN * kSharedStrideVec;
          idx += kValueLoadThreads) {
@@ -2370,7 +2405,7 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
                               smem.row_max[row],
                           -80.0f))
                     : 0.0f;
-        shared_probs[row * kGroupedVerifyProbStride + col] =
+        shared_probs[grouped_a_offset(row, col, 32)] =
             __float2half_rn(probability);
       }
       __syncthreads();
@@ -2400,17 +2435,17 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
         const float new_max = fmaxf(old_max, tile_max);
         const float probability =
             visible ? __expf(fmaxf(score - new_max, -80.0f)) : 0.0f;
+        shared_probs[grouped_a_offset(row, lane_id, 32)] =
+            __float2half_rn(probability);
+        if constexpr (COMPENSATE_P) {
+          const float rounded = __half2float(__float2half_rn(probability));
+          shared_prob_residual[grouped_a_offset(row, lane_id, 32)] =
+              __float2half_rn((probability - rounded) * 2048.0f);
+        }
         const float tile_sum_lane = warp_reduce_sum(probability);
         const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
         const float exp_diff =
             tile_sum > 0.0f ? __expf(fmaxf(old_max - new_max, -80.0f)) : 1.0f;
-        shared_probs[row * kGroupedVerifyProbStride + lane_id] =
-            __float2half_rn(probability);
-        if constexpr (COMPENSATE_P) {
-          const float rounded = __half2float(__float2half_rn(probability));
-          shared_prob_residual[row * kResidualStride + lane_id] =
-              __float2half_rn((probability - rounded) * 2048.0f);
-        }
         // Finish every lane's shared-state reads before lane 0 overwrites the
         // online maximum. Shuffle synchronization does not order memory.
         __syncwarp();
@@ -2437,71 +2472,694 @@ __launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_
 
 
 
+    static_assert(COMPENSATE_P && kGroupedVerifyWarps == 16,
+                  "PV reuse is isolated to six-head compensated E4M3");
+    volta::fragment<volta::accumulator, 16, 16, 16, float>
+        tile_fragments[kGroupedVerifyOutputTilesPerWarp];
 #pragma unroll
-    for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
-         ++fragment_idx) {
-      const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
-      const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
-      const int d_tile = output_tile % (kGroupedVerifyHeadDim / 16);
-      if constexpr (SPARSE_PAGE4 || COMPENSATE_P) {
-        if ((active_m_tiles & (1 << m_tile)) == 0) {
-          continue;
-        }
-      }
-      volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>
-          probability_fragment;
+    for (int i = 0; i < kGroupedVerifyOutputTilesPerWarp; ++i)
+      volta::fill_fragment(tile_fragments[i], 0.0f);
+    const int d_tile = warp_id;
+#pragma unroll
+    for (int k_offset = 0; k_offset < kGroupedVerifyBlockN; k_offset += 16) {
       volta::fragment<volta::matrix_b, 16, 16, 16, half, volta::row_major>
           value_fragment;
-      volta::fragment<volta::accumulator, 16, 16, 16, float> tile_fragment;
-      if constexpr (COMPENSATE_P) {
-        // Keep Tensor Core accumulation local to N32. Carrying a large C
-        // through every KV tile loses small PV corrections at long contexts.
-        // The online state remains FP32 and is updated once per tile below.
-        volta::fill_fragment(tile_fragment, 0.0f);
+      volta::load_matrix_sync(
+          value_fragment,
+          shared_values + k_offset * kGroupedVerifyKVStride + d_tile * 16,
+          kGroupedVerifyKVStride);
+      auto residual_value_fragment = value_fragment;
+#pragma unroll
+      for (int i = 0; i < value_fragment.num_elements / 2; ++i) {
+        union {
+          uint32_t bits;
+          __half2 pair;
+        } packed_value;
+        packed_value.bits = value_fragment.x[i];
+        packed_value.pair =
+            __hmul2(packed_value.pair, __float2half2_rn(1.0f / 2048.0f));
+        residual_value_fragment.x[i] = packed_value.bits;
       }
-      auto& pv_fragment =
-          COMPENSATE_P ? tile_fragment : output_fragments[fragment_idx];
 #pragma unroll
-      for (int k_offset = 0; k_offset < kGroupedVerifyBlockN; k_offset += 16) {
-        volta::load_matrix_sync(
+      for (int fragment_idx = 0;
+           fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+        const int m_tile = fragment_idx;
+        if ((active_m_tiles & (1 << m_tile)) == 0) continue;
+        volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>
+            probability_fragment;
+        load_grouped_a_swizzled(
             probability_fragment,
-            shared_probs + m_tile * 16 * kGroupedVerifyProbStride + k_offset,
-            kGroupedVerifyProbStride);
-        volta::load_matrix_sync(
-            value_fragment,
-            shared_values + k_offset * kGroupedVerifyKVStride + d_tile * 16,
-            kGroupedVerifyKVStride);
-        volta::mma_sync(pv_fragment, probability_fragment, value_fragment,
-                        pv_fragment);
-        if constexpr (COMPENSATE_P) {
-          // Scale the residual up before its FP16 conversion so small
-          // corrections do not underflow. Every finite E4M3 value divided
-          // by 2048 is still exactly representable in FP16, so applying
-          // the inverse power of two to V introduces no operand rounding.
-          volta::load_matrix_sync(
-              probability_fragment,
-              shared_prob_residual + m_tile * 16 * kResidualStride + k_offset,
-              kResidualStride);
+            shared_probs + m_tile * 16 * kGroupedVerifyProbStride, k_offset);
+        volta::mma_sync(tile_fragments[fragment_idx], probability_fragment,
+                        value_fragment, tile_fragments[fragment_idx]);
+        load_grouped_a_swizzled(
+            probability_fragment,
+            shared_prob_residual + m_tile * 16 * kResidualStride, k_offset);
+        volta::mma_sync(tile_fragments[fragment_idx], probability_fragment,
+                        residual_value_fragment, tile_fragments[fragment_idx]);
+      }
+    }
 #pragma unroll
-          for (int i = 0; i < value_fragment.num_elements / 2; ++i) {
-            union {
-              uint32_t bits;
-              __half2 pair;
-            } packed_value;
-            packed_value.bits = value_fragment.x[i];
-            packed_value.pair =
-                __hmul2(packed_value.pair, __float2half2_rn(1.0f / 2048.0f));
-            value_fragment.x[i] = packed_value.bits;
-          }
-          volta::mma_sync(pv_fragment, probability_fragment, value_fragment,
-                          pv_fragment);
+    for (int fragment_idx = 0;
+         fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+      const int m_tile = fragment_idx;
+      if ((active_m_tiles & (1 << m_tile)) == 0) continue;
+      grouped_verify_add_output_tile(output_fragments[fragment_idx],
+                                     tile_fragments[fragment_idx],
+                                     smem.row_scale, m_tile * 16);
+    }
+    __syncthreads();
+  }
+
+  // The compute buffers are dead. Reuse their storage for the dense FP32
+  // partial output, then normalize and write only real query/head rows.
+  __syncthreads();
+  float* shared_output = smem.storage.output;
+#pragma unroll
+  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+       ++fragment_idx) {
+    const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
+    const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
+    const int d_tile = output_tile % (kGroupedVerifyHeadDim / 16);
+    volta::store_matrix_sync(
+        shared_output + m_tile * 16 * kGroupedVerifyHeadDim + d_tile * 16,
+        output_fragments[fragment_idx], kGroupedVerifyHeadDim,
+        volta::mem_row_major);
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyHeadDim;
+       idx += kGroupedVerifyThreads) {
+    const int row = idx / kGroupedVerifyHeadDim;
+    const int d = idx % kGroupedVerifyHeadDim;
+    const int token_idx = row / Traits::kHeadsPerCta;
+    const int local_head = row % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const float sum = smem.row_sum[row];
+      // Explicit-row FP32 groups retain the numerator until the final merge.
+      // Normalizing each partition and encoding its weight as m+log(sum)
+      // introduces avoidable rounding, including at FP16 output midpoints.
+      const float scale =
+          sum > 0.0f ? (ROW_SEQLENS ? v_scale : v_scale / sum) : 0.0f;
+      int64_t output_idx;
+      if constexpr (SPARSE_PAGE4) {
+        const int64_t global_token_idx =
+            static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+        output_idx = (global_token_idx * kGroupedVerifyHeads + head_idx) *
+                         kGroupedVerifyHeadDim +
+                     d;
+      } else {
+        output_idx =
+            (((static_cast<int64_t>(split_id) * MAX_QUERY_TOKENS + token_idx) *
+                  kGroupedVerifyHeads +
+              head_idx) *
+                 kGroupedVerifyHeadDim +
+             d);
+      }
+      if constexpr (std::is_same_v<PARTIAL_T, float>) {
+        partial_out[output_idx] = shared_output[idx] * scale;
+      } else {
+        partial_out[output_idx] = __float2half_rn(shared_output[idx] * scale);
+      }
+    }
+  }
+  if (tid < kGroupedVerifyRows) {
+    const int token_idx = tid / Traits::kHeadsPerCta;
+    const int local_head = tid % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const float sum = smem.row_sum[tid];
+      int64_t lse_idx;
+      if constexpr (SPARSE_PAGE4) {
+        const int64_t global_token_idx =
+            static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+        lse_idx = global_token_idx * kGroupedVerifyHeads + head_idx;
+      } else {
+        lse_idx =
+            (static_cast<int64_t>(split_id) * MAX_QUERY_TOKENS + token_idx) *
+                kGroupedVerifyHeads +
+            head_idx;
+      }
+      if constexpr (ROW_SEQLENS) {
+        partial_lse[2 * lse_idx] = sum > 0.0f ? smem.row_max[tid] : kXQANegInf;
+        partial_lse[2 * lse_idx + 1] = sum;
+      } else {
+        partial_lse[lse_idx] =
+            sum > 0.0f ? smem.row_max[tid] + logf(sum) : kXQANegInf;
+      }
+    }
+  }
+}
+
+template <int MAX_QUERY_TOKENS, bool TWO_PASS, int PAGE_BLOCK_SIZE = 0,
+          bool SINGLE_QUERY = false, bool CONTIGUOUS_HKV1_LAYOUT = false,
+          bool STAGE_PARTITION_PAGE_IDS = false,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+          bool SPARSE_PAGE4 = false, typename PARTIAL_T = __half,
+          bool ROW_SEQLENS = false, bool COMPENSATE_P = false, bool PAIR_E4M3 = false>
+__global__
+__launch_bounds__(kGroupedVerifyThreads, 1) void flash_attention_grouped_verify_e4m3_full_q8_kernel(
+    const __half* __restrict__ q, const void* __restrict__ k_cache,
+    const void* __restrict__ v_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, PARTIAL_T* __restrict__ partial_out,
+    float* __restrict__ partial_lse, const int runtime_query_len,
+    const int max_num_blocks, const int page_block_size,
+    const int64_t k_block_stride, const int64_t k_token_stride,
+    const int64_t k_head_stride, const int64_t v_block_stride,
+    const int64_t v_token_stride, const int64_t v_head_stride,
+    const float qk_scale, const float v_scale,
+    const uint32_t* __restrict__ sparse_token_masks = nullptr,
+    const int num_groups = 1, const int* row_lengths = nullptr) {
+  static_assert(!ROW_SEQLENS || !SPARSE_PAGE4,
+                "explicit row lengths apply to dense causal groups only");
+  static_assert(
+      !COMPENSATE_P || (!TWO_PASS && ROW_SEQLENS &&
+                        KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                        std::is_same_v<PARTIAL_T, float>),
+      "probability compensation is isolated to E4M3 FP32 groups");
+  static_assert(MAX_QUERY_TOKENS == 8 && COMPENSATE_P &&
+      ROW_SEQLENS && !SPARSE_PAGE4, "Full q8 compensated contract");
+  if (runtime_query_len != 8) return;
+  constexpr int query_len = 8;
+  using Traits = GroupedVerifyTraits<MAX_QUERY_TOKENS>;
+  const int head_group = blockIdx.x;
+  const int split_id = blockIdx.y;
+  const int group_idx = blockIdx.z;
+  if (head_group >= Traits::kHeadGroups || split_id >= Traits::kSplits ||
+      group_idx >= num_groups || query_len <= 0 ||
+      query_len > MAX_QUERY_TOKENS) {
+    return;
+  }
+
+  if constexpr (!SPARSE_PAGE4) {
+    partial_out += static_cast<int64_t>(group_idx) * Traits::kSplits *
+                   MAX_QUERY_TOKENS * kGroupedVerifyHeads *
+                   kGroupedVerifyHeadDim;
+    partial_lse += static_cast<int64_t>(group_idx) * Traits::kSplits *
+                   MAX_QUERY_TOKENS * kGroupedVerifyHeads;
+  }
+
+  int total_kv = seq_lens[group_idx];
+  if constexpr (ROW_SEQLENS) {
+    total_kv = 0;
+    for (int i = 0; i < query_len; ++i)
+      total_kv = max(total_kv, row_lengths[i]);
+  }
+  if (total_kv <= 0) {
+    if constexpr (SPARSE_PAGE4) {
+      constexpr int kGroupOutputElements =
+          kGroupedVerifyQ8MaxQ * kGroupedVerifyHeads * kGroupedVerifyHeadDim;
+      const int64_t group_output_offset =
+          static_cast<int64_t>(group_idx) * kGroupOutputElements;
+      for (int idx = threadIdx.x; idx < kGroupOutputElements;
+           idx += kGroupedVerifyThreads) {
+        partial_out[group_output_offset + idx] = __float2half_rn(0.0f);
+      }
+      constexpr int kGroupLseElements =
+          kGroupedVerifyQ8MaxQ * kGroupedVerifyHeads;
+      if (threadIdx.x < kGroupLseElements) {
+        partial_lse[static_cast<int64_t>(group_idx) * kGroupLseElements +
+                    threadIdx.x] = kXQANegInf;
+      }
+    }
+    return;
+  }
+  const int active_splits =
+      SPARSE_PAGE4
+          ? 1
+          : grouped_verify_active_splits<MAX_QUERY_TOKENS, SINGLE_QUERY>(
+                total_kv);
+  if (split_id >= active_splits) {
+    return;
+  }
+  const int total_tiles =
+      (total_kv + kGroupedVerifyBlockN - 1) / kGroupedVerifyBlockN;
+  const int base_tiles = total_tiles / active_splits;
+  const int extra_tiles = total_tiles - base_tiles * active_splits;
+  const int split_tile_start =
+      split_id * base_tiles + min(split_id, extra_tiles);
+  const int split_tiles = base_tiles + (split_id < extra_tiles ? 1 : 0);
+  const int split_start = split_tile_start * kGroupedVerifyBlockN;
+  const int split_end =
+      min(total_kv, split_start + split_tiles * kGroupedVerifyBlockN);
+  const int prefix_kv_len = max(0, total_kv - query_len);
+  const int head_start = head_group * Traits::kHeadsPerCta;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+
+  __shared__ uint16_t e4m3_lut[256];
+  if (tid < 256)
+    e4m3_lut[tid] = fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(tid));
+  extern __shared__ char grouped_verify_smem_raw[];
+  GroupedVerifySmem& smem =
+      *reinterpret_cast<GroupedVerifySmem*>(grouped_verify_smem_raw);
+  __half* shared_q = smem.storage.compute.q;
+  __half* shared_kv = smem.storage.compute.kv;
+  float* shared_scores = smem.storage.compute.scores;
+  __half* shared_probs = smem.storage.compute.probs;
+  // The compensated entry reserves one padded probability panel after the
+  // legacy layout. Match P's shared-memory stride without aliasing live QK
+  // rows. Legacy entries retain their existing shared-memory footprint.
+  __half* shared_prob_residual = reinterpret_cast<__half*>(
+      grouped_verify_smem_raw + sizeof(GroupedVerifySmem));
+  constexpr int kResidualStride = kGroupedVerifyProbStride;
+  __half* shared_values = shared_prob_residual + kGroupedVerifyRows * kResidualStride;
+  const int* page_ids =
+      block_table + static_cast<int64_t>(group_idx) * max_num_blocks;
+  int split_page_offset = 0;
+  bool use_staged_page_ids = false;
+  if constexpr (STAGE_PARTITION_PAGE_IDS) {
+    static_assert(PAGE_BLOCK_SIZE > 0,
+                  "partition page staging requires a specialized page size");
+    const int split_start_page = split_start / PAGE_BLOCK_SIZE;
+    split_page_offset = split_start - split_start_page * PAGE_BLOCK_SIZE;
+    const int split_page_count =
+        (split_page_offset + split_end - split_start + PAGE_BLOCK_SIZE - 1) /
+        PAGE_BLOCK_SIZE;
+    use_staged_page_ids = split_page_count <= kGroupedVerifyPageIdsCapacity;
+    if (use_staged_page_ids) {
+      for (int idx = tid; idx < split_page_count;
+           idx += kGroupedVerifyThreads) {
+        smem.page_ids[idx] = __ldg(&page_ids[split_start_page + idx]);
+      }
+    }
+    if (use_staged_page_ids) {
+      page_ids = smem.page_ids;
+    }
+  }
+
+  constexpr int kVecsPerRow = kGroupedVerifyHeadDim / 8;
+  constexpr int kSharedQVecsPerRow = kGroupedVerifyQStride / 8;
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q);
+  uint4* shared_q_vec = reinterpret_cast<uint4*>(shared_q);
+  for (int idx = tid; idx < kGroupedVerifyRows * kVecsPerRow;
+       idx += kGroupedVerifyThreads) {
+    const int row = idx / kVecsPerRow;
+    const int vec_col = idx % kVecsPerRow;
+    const int token_idx = row / Traits::kHeadsPerCta;
+    const int local_head = row % Traits::kHeadsPerCta;
+    const int head_idx = head_start + local_head;
+    if (token_idx < query_len && head_idx < kGroupedVerifyHeads) {
+      const int64_t query_row =
+          static_cast<int64_t>(group_idx) * MAX_QUERY_TOKENS + token_idx;
+      shared_q_vec[row * kSharedQVecsPerRow + vec_col] = __ldg(
+          q_vec + (query_row * kGroupedVerifyHeads + head_idx) * kVecsPerRow +
+          vec_col);
+    } else {
+      shared_q_vec[row * kSharedQVecsPerRow + vec_col] = make_uint4(0, 0, 0, 0);
+    }
+  }
+  if (tid < kGroupedVerifyRows) {
+    smem.row_max[tid] = kXQANegInf;
+    smem.row_sum[tid] = 0.0f;
+    smem.row_scale[tid] = 1.0f;
+  }
+  // This barrier publishes both Q and the optional split-local page IDs.
+  __syncthreads();
+
+  constexpr int kPanelStrideVec = kGroupedVerifyHeadDim / 8;
+  constexpr int kSharedStrideVec = kGroupedVerifyKVStride / 8;
+
+  volta::fragment<volta::accumulator, 16, 16, 16, float>
+      output_fragments[kGroupedVerifyOutputTilesPerWarp];
+#pragma unroll
+  for (int fragment_idx = 0; fragment_idx < kGroupedVerifyOutputTilesPerWarp;
+       ++fragment_idx) {
+    volta::fill_fragment(output_fragments[fragment_idx], 0.0f);
+  }
+
+  // The conservative baseline computes exact per-split FP32 max/sum in a
+  // separate pass. The candidate below fuses this state update with P x V.
+  if constexpr (TWO_PASS) {
+    for (int tile_start = split_start; tile_start < split_end;
+         tile_start += kGroupedVerifyBlockN) {
+      const int valid_k_rows =
+          min(kGroupedVerifyBlockN, split_end - tile_start);
+      if constexpr (SPARSE_PAGE4) {
+        const int valid_sparse_pages = (valid_k_rows + 3) / 4;
+        if (tid < kGroupedVerifyBlockN / 4) {
+          smem.sparse_token_masks[tid] =
+              tid < valid_sparse_pages
+                  ? __ldg(sparse_token_masks +
+                          static_cast<int64_t>(group_idx) * max_num_blocks +
+                          (tile_start >> 2) + tid)
+                  : 0;
         }
       }
-      if constexpr (COMPENSATE_P) {
-        grouped_verify_add_output_tile(output_fragments[fragment_idx],
-                                       tile_fragment, smem.row_scale,
-                                       m_tile * 16);
+      const int tile_page_offset =
+          use_staged_page_ids ? split_page_offset + tile_start - split_start
+                              : tile_start;
+      load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                           kGroupedVerifyThreads, KV_DTYPE,
+                           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                               (KV_DTYPE ==
+                                    flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                                !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
+          shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
+          kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+          k_block_stride, k_token_stride, k_head_stride, 0, tid, e4m3_lut);
+      for (int idx = tid + valid_k_rows * kSharedStrideVec;
+           idx < kGroupedVerifyBlockN * kSharedStrideVec;
+           idx += kGroupedVerifyThreads) {
+        reinterpret_cast<uint4*>(shared_kv)[idx] = make_uint4(0, 0, 0, 0);
       }
+      __syncthreads();
+
+      int active_m_tiles = 0x7;
+      if constexpr (SPARSE_PAGE4) {
+        uint32_t active_query_nibbles = 0;
+#pragma unroll
+        for (int page = 0; page < kGroupedVerifyBlockN / 4; ++page) {
+          active_query_nibbles |= smem.sparse_token_masks[page];
+        }
+        active_m_tiles = 0;
+#pragma unroll
+        for (int token = 0; token < kGroupedVerifyQ8MaxQ; ++token) {
+          if ((active_query_nibbles & (0xFu << (token * 4))) != 0) {
+            const int first_row = token * kGroupedVerifyHeads;
+            const int last_row = first_row + kGroupedVerifyHeads - 1;
+            active_m_tiles |= 1 << (first_row / 16);
+            active_m_tiles |= 1 << (last_row / 16);
+          }
+        }
+      }
+      grouped_verify_qk(shared_q, shared_kv, shared_scores, qk_scale,
+                        active_m_tiles);
+      __syncthreads();
+
+#pragma unroll
+      for (int row = warp_id; row < kGroupedVerifyRows;
+           row += kGroupedVerifyWarps) {
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + lane_id;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, lane_id, prefix_kv_len, row_lengths);
+        const float score =
+            visible ? shared_scores[row * kGroupedVerifyScoreStride + lane_id]
+                    : kXQANegInf;
+        const float tile_max_lane = warp_reduce_max(score);
+        const float tile_max = __shfl_sync(0xffffffffu, tile_max_lane, 0);
+        const float probability =
+            visible ? __expf(fmaxf(score - tile_max, -80.0f)) : 0.0f;
+        const float tile_sum_lane = warp_reduce_sum(probability);
+        const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
+        if (lane_id == 0 && tile_sum > 0.0f) {
+          const float old_max = smem.row_max[row];
+          const float old_sum = smem.row_sum[row];
+          const float new_max = fmaxf(old_max, tile_max);
+          smem.row_sum[row] =
+              old_sum * __expf(fmaxf(old_max - new_max, -80.0f)) +
+              tile_sum * __expf(fmaxf(tile_max - new_max, -80.0f));
+          smem.row_max[row] = new_max;
+        }
+      }
+      __syncthreads();
+    }
+  }
+
+  int minimum_visible_length = row_lengths[0];
+#pragma unroll
+  for (int i = 1; i < 8; ++i)
+    minimum_visible_length =
+        min(minimum_visible_length, row_lengths[i]);
+  // Recompute QK for the conservative path, or consume it once while updating
+  // the online state for the fused path. Both form half P and use identical
+  // Volta WMMA P @ V arithmetic.
+  for (int tile_start = split_start; tile_start < split_end;
+       tile_start += kGroupedVerifyBlockN) {
+    const int valid_k_rows = min(kGroupedVerifyBlockN, split_end - tile_start);
+    if constexpr (SPARSE_PAGE4) {
+      const int valid_sparse_pages = (valid_k_rows + 3) / 4;
+      if (tid < kGroupedVerifyBlockN / 4) {
+        smem.sparse_token_masks[tid] =
+            tid < valid_sparse_pages
+                ? __ldg(sparse_token_masks +
+                        static_cast<int64_t>(group_idx) * max_num_blocks +
+                        (tile_start >> 2) + tid)
+                : 0;
+      }
+    }
+    const int tile_page_offset =
+        use_staged_page_ids ? split_page_offset + tile_start - split_start
+                            : tile_start;
+    load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                         kGroupedVerifyThreads, KV_DTYPE,
+                         KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                             (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
+        shared_kv, k_cache, page_ids, valid_k_rows, kPanelStrideVec,
+        kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+        k_block_stride, k_token_stride, k_head_stride, 0, tid, e4m3_lut);
+    for (int idx = tid + valid_k_rows * kSharedStrideVec;
+         idx < kGroupedVerifyBlockN * kSharedStrideVec;
+         idx += kGroupedVerifyThreads) {
+      reinterpret_cast<uint4*>(shared_kv)[idx] = make_uint4(0, 0, 0, 0);
+    }
+    __syncthreads();
+
+    int active_m_tiles = 0x7;
+    if constexpr (COMPENSATE_P) {
+      // Native MTP4 supplies five rows: only 30 of the 48 packed rows are
+      // live. Avoid QK/PV for wholly padded M tiles to pay for the residual
+      // product without changing arithmetic in any live row.
+      active_m_tiles =
+          (1 << ((query_len * Traits::kHeadsPerCta + 15) / 16)) - 1;
+    }
+    if constexpr (SPARSE_PAGE4) {
+      uint32_t active_query_nibbles = 0;
+#pragma unroll
+      for (int page = 0; page < kGroupedVerifyBlockN / 4; ++page) {
+        active_query_nibbles |= smem.sparse_token_masks[page];
+      }
+      active_m_tiles = 0;
+#pragma unroll
+      for (int token = 0; token < kGroupedVerifyQ8MaxQ; ++token) {
+        if ((active_query_nibbles & (0xFu << (token * 4))) != 0) {
+          const int first_row = token * kGroupedVerifyHeads;
+          const int last_row = first_row + kGroupedVerifyHeads - 1;
+          active_m_tiles |= 1 << (first_row / 16);
+          active_m_tiles |= 1 << (last_row / 16);
+        }
+      }
+    }
+    grouped_verify_qk<COMPENSATE_P>(shared_q, shared_kv, shared_scores,
+                                    qk_scale, active_m_tiles);
+    if (warp_id >= kGroupedVerifyQKWarps) {
+      constexpr int kValueLoadThreads = kGroupedVerifyThreads - kGroupedVerifyQKWarps * kWarpSize;
+      const int value_load_tid = tid - kGroupedVerifyQKWarps * kWarpSize;
+    load_xqa_tc_kv_panel<PAGE_BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,
+                         kValueLoadThreads, KV_DTYPE,
+                         KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 ||
+                             (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+                              !SPARSE_PAGE4 && (!ROW_SEQLENS || PAIR_E4M3)), true>(
+        shared_values, v_cache, page_ids, valid_k_rows, kPanelStrideVec,
+        kSharedStrideVec, tile_page_offset, 0, page_block_size, 0,
+        v_block_stride, v_token_stride, v_head_stride, 0, value_load_tid, e4m3_lut);
+    for (int idx = value_load_tid + valid_k_rows * kSharedStrideVec;
+         idx < kGroupedVerifyBlockN * kSharedStrideVec;
+         idx += kValueLoadThreads) {
+      reinterpret_cast<uint4*>(shared_values)[idx] = make_uint4(0, 0, 0, 0);
+    }
+    }
+
+    __syncthreads();
+
+    if constexpr (TWO_PASS) {
+      for (int idx = tid; idx < kGroupedVerifyRows * kGroupedVerifyBlockN;
+           idx += kGroupedVerifyThreads) {
+        const int row = idx / kGroupedVerifyBlockN;
+        const int col = idx % kGroupedVerifyBlockN;
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + col;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, col, prefix_kv_len, row_lengths) &&
+            smem.row_sum[row] > 0.0f;
+        const float probability =
+            visible ? __expf(fmaxf(
+                          shared_scores[row * kGroupedVerifyScoreStride + col] -
+                              smem.row_max[row],
+                          -80.0f))
+                    : 0.0f;
+        shared_probs[grouped_a_offset(row, col, 32)] =
+            __float2half_rn(probability);
+      }
+      __syncthreads();
+    } else {
+      if (tile_start + kGroupedVerifyBlockN <=
+          minimum_visible_length) {
+#pragma unroll
+      for (int row = warp_id; row < kGroupedVerifyRows;
+           row += kGroupedVerifyWarps) {
+        if constexpr (COMPENSATE_P) {
+          if ((active_m_tiles & (1 << (row / 16))) == 0) {
+            continue;
+          }
+        }
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + lane_id;
+        constexpr bool visible = true;
+        const float score =
+            visible ? shared_scores[row * kGroupedVerifyScoreStride + lane_id]
+                    : kXQANegInf;
+        const float tile_max_lane = warp_reduce_max(score);
+        const float tile_max = __shfl_sync(0xffffffffu, tile_max_lane, 0);
+        const float old_max = smem.row_max[row];
+        const float new_max = fmaxf(old_max, tile_max);
+        const float probability =
+            visible ? __expf(fmaxf(score - new_max, -80.0f)) : 0.0f;
+        shared_probs[grouped_a_offset(row, lane_id, 32)] =
+            __float2half_rn(probability);
+        if constexpr (COMPENSATE_P) {
+          const float rounded = __half2float(__float2half_rn(probability));
+          shared_prob_residual[grouped_a_offset(row, lane_id, 32)] =
+              __float2half_rn((probability - rounded) * 2048.0f);
+        }
+        const float tile_sum_lane = warp_reduce_sum(probability);
+        const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
+        const float exp_diff =
+            tile_sum > 0.0f ? __expf(fmaxf(old_max - new_max, -80.0f)) : 1.0f;
+        // Finish every lane's shared-state reads before lane 0 overwrites the
+        // online maximum. Shuffle synchronization does not order memory.
+        __syncwarp();
+        if (lane_id == 0) {
+          if (tile_sum > 0.0f) {
+            smem.row_sum[row] = smem.row_sum[row] * exp_diff + tile_sum;
+            smem.row_max[row] = new_max;
+          }
+          smem.row_scale[row] = exp_diff;
+        }
+      }
+      } else {
+#pragma unroll
+      for (int row = warp_id; row < kGroupedVerifyRows;
+           row += kGroupedVerifyWarps) {
+        if constexpr (COMPENSATE_P) {
+          if ((active_m_tiles & (1 << (row / 16))) == 0) {
+            continue;
+          }
+        }
+        const int token_idx = row / Traits::kHeadsPerCta;
+        const int local_head = row % Traits::kHeadsPerCta;
+        const int head_idx = head_start + local_head;
+        const int kv_idx = tile_start + lane_id;
+        const bool visible =
+            grouped_verify_key_visible<SPARSE_PAGE4, ROW_SEQLENS>(
+                smem.sparse_token_masks, token_idx, query_len, head_idx, kv_idx,
+                valid_k_rows, lane_id, prefix_kv_len, row_lengths);
+        const float score =
+            visible ? shared_scores[row * kGroupedVerifyScoreStride + lane_id]
+                    : kXQANegInf;
+        const float tile_max_lane = warp_reduce_max(score);
+        const float tile_max = __shfl_sync(0xffffffffu, tile_max_lane, 0);
+        const float old_max = smem.row_max[row];
+        const float new_max = fmaxf(old_max, tile_max);
+        const float probability =
+            visible ? __expf(fmaxf(score - new_max, -80.0f)) : 0.0f;
+        shared_probs[grouped_a_offset(row, lane_id, 32)] =
+            __float2half_rn(probability);
+        if constexpr (COMPENSATE_P) {
+          const float rounded = __half2float(__float2half_rn(probability));
+          shared_prob_residual[grouped_a_offset(row, lane_id, 32)] =
+              __float2half_rn((probability - rounded) * 2048.0f);
+        }
+        const float tile_sum_lane = warp_reduce_sum(probability);
+        const float tile_sum = __shfl_sync(0xffffffffu, tile_sum_lane, 0);
+        const float exp_diff =
+            tile_sum > 0.0f ? __expf(fmaxf(old_max - new_max, -80.0f)) : 1.0f;
+        // Finish every lane's shared-state reads before lane 0 overwrites the
+        // online maximum. Shuffle synchronization does not order memory.
+        __syncwarp();
+        if (lane_id == 0) {
+          if (tile_sum > 0.0f) {
+            smem.row_sum[row] = smem.row_sum[row] * exp_diff + tile_sum;
+            smem.row_max[row] = new_max;
+          }
+          smem.row_scale[row] = exp_diff;
+        }
+      }
+      }
+      __syncthreads();
+      if constexpr (!COMPENSATE_P) {
+#pragma unroll
+        for (int fragment_idx = 0;
+             fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+          const int output_tile = warp_id + fragment_idx * kGroupedVerifyWarps;
+          const int m_tile = output_tile / (kGroupedVerifyHeadDim / 16);
+          grouped_verify_scale_output_fragment(output_fragments[fragment_idx],
+                                               smem.row_scale, m_tile * 16);
+        }
+      }
+    }
+
+
+
+    static_assert(COMPENSATE_P && kGroupedVerifyWarps == 16,
+                  "PV reuse is isolated to six-head compensated E4M3");
+    volta::fragment<volta::accumulator, 16, 16, 16, float>
+        tile_fragments[kGroupedVerifyOutputTilesPerWarp];
+#pragma unroll
+    for (int i = 0; i < kGroupedVerifyOutputTilesPerWarp; ++i)
+      volta::fill_fragment(tile_fragments[i], 0.0f);
+    const int d_tile = warp_id;
+#pragma unroll
+    for (int k_offset = 0; k_offset < kGroupedVerifyBlockN; k_offset += 16) {
+      volta::fragment<volta::matrix_b, 16, 16, 16, half, volta::row_major>
+          value_fragment;
+      volta::load_matrix_sync(
+          value_fragment,
+          shared_values + k_offset * kGroupedVerifyKVStride + d_tile * 16,
+          kGroupedVerifyKVStride);
+      auto residual_value_fragment = value_fragment;
+#pragma unroll
+      for (int i = 0; i < value_fragment.num_elements / 2; ++i) {
+        union {
+          uint32_t bits;
+          __half2 pair;
+        } packed_value;
+        packed_value.bits = value_fragment.x[i];
+        packed_value.pair =
+            __hmul2(packed_value.pair, __float2half2_rn(1.0f / 2048.0f));
+        residual_value_fragment.x[i] = packed_value.bits;
+      }
+#pragma unroll
+      for (int fragment_idx = 0;
+           fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+        const int m_tile = fragment_idx;
+        if ((active_m_tiles & (1 << m_tile)) == 0) continue;
+        volta::fragment<volta::matrix_a, 16, 16, 16, half, volta::row_major>
+            probability_fragment;
+        load_grouped_a_swizzled(
+            probability_fragment,
+            shared_probs + m_tile * 16 * kGroupedVerifyProbStride, k_offset);
+        volta::mma_sync(tile_fragments[fragment_idx], probability_fragment,
+                        value_fragment, tile_fragments[fragment_idx]);
+        load_grouped_a_swizzled(
+            probability_fragment,
+            shared_prob_residual + m_tile * 16 * kResidualStride, k_offset);
+        volta::mma_sync(tile_fragments[fragment_idx], probability_fragment,
+                        residual_value_fragment, tile_fragments[fragment_idx]);
+      }
+    }
+#pragma unroll
+    for (int fragment_idx = 0;
+         fragment_idx < kGroupedVerifyOutputTilesPerWarp; ++fragment_idx) {
+      const int m_tile = fragment_idx;
+      if ((active_m_tiles & (1 << m_tile)) == 0) continue;
+      grouped_verify_add_output_tile(output_fragments[fragment_idx],
+                                     tile_fragments[fragment_idx],
+                                     smem.row_scale, m_tile * 16);
     }
     __syncthreads();
   }
@@ -4281,6 +4939,17 @@ at::Tensor private_grouped_e4m3_fp32_paged(
           false, float, true, true, false>;
   if (k.size(1) == 1648) kernel = paired ? flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
   if (k.size(1) == 3296) kernel = paired ? flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e5m2_partial_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
+  if (q.size(0) == 8) {
+  kernel = paired
+      ? flash_attention_grouped_verify_e4m3_full_q8_kernel<
+          8, false, 0, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+          false, float, true, true, true>
+      : flash_attention_grouped_verify_e4m3_full_q8_kernel<
+          8, false, 0, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3,
+          false, float, true, true, false>;
+  if (k.size(1) == 1648) kernel = paired ? flash_attention_grouped_verify_e4m3_full_q8_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e4m3_full_q8_kernel<8, false, 1648, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
+  if (k.size(1) == 3296) kernel = paired ? flash_attention_grouped_verify_e4m3_full_q8_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, true> : flash_attention_grouped_verify_e4m3_full_q8_kernel<8, false, 3296, false, false, false, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, false, float, true, true, false>;
+  }
   constexpr int kCompensatedSmemBytes =
       sizeof(GroupedVerifySmem) +
       kGroupedVerifyRows * kGroupedVerifyProbStride * sizeof(__half) +

--- a/csrc/attention/sm70_grouped_long/kernel/scalar-attention.cu
+++ b/csrc/attention/sm70_grouped_long/kernel/scalar-attention.cu
@@ -1,0 +1,1352 @@
+#include <cuda.h>
+#include <torch/library.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <mma.h>
+#include <algorithm>
+#include <atomic>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <type_traits>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cub/block/block_radix_sort.cuh>
+
+#include "fp8_kv_utils.cuh"
+#include "fused_mma.h"
+
+namespace {
+
+int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
+  if (kv_cache_dtype == "auto" || kv_cache_dtype == "float16" ||
+      kv_cache_dtype == "bfloat16") {
+    return flash_v100::KV_CACHE_DTYPE_FP16;
+  }
+  if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
+  }
+  if (kv_cache_dtype == "fp8_e5m2") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
+  }
+  return -1;
+}
+
+constexpr int kWarpSize = 32;
+constexpr int kThreadsPerBlock = 256;
+constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
+constexpr int kXQATCBlockN = 128;
+constexpr int kXQATCStride = 128;
+// QSA exposes selected four-token microblocks as virtual paged KV. Keep enough
+// page slots for one full XQA tile at that minimum supported granularity.
+constexpr int kXQATCPageIdsCapacity = kXQATCBlockN / 4;
+constexpr int kXQATC256WideWarpCount = 8;
+constexpr int kXQATC256WideThreads = kXQATC256WideWarpCount * kWarpSize;
+constexpr int kXQATC256WideBlockM = 8;
+constexpr int kXQATC256WideThreadsPerRow = kWarpSize;
+constexpr int kXQATCG6DualCtaThreads = 6 * kWarpSize;
+constexpr int kXQATCG6Pipeline8WarpThreads = 8 * kWarpSize;
+constexpr int kXQARouteAllSeqLens = 0;
+constexpr int kXQARouteShortSeqLens = -1;
+constexpr int kXQARouteLongSeqLens = 1;
+constexpr int kXQARouteP1024Sawtooth = 4;
+constexpr int kXQARouteP256Sawtooth = 5;
+constexpr int kXQARouteP1024SawtoothMid = 6;
+constexpr int kXQARouteP1024SawtoothFinal = 7;
+constexpr int kXQARouteRangeSeqLens = 8;
+constexpr int kXQARouteWaveLongSeqLens = 9;
+// The dense 256/128-half strides alias Volta shared-memory banks in the
+// WMMA A/B fragment loads. Both padded strides remain 16-byte aligned.
+constexpr int kXQATC256WidePaddedQStride = 264;
+constexpr int kXQATC256WidePaddedKVStride = 136;
+constexpr int kXQATC256WideAlignedPaddedQStride = 272;
+constexpr int kXQATC256WideAlignedPaddedKVStride = 144;
+constexpr int kXQATCQKPipelinePanelDim = 64;
+constexpr int kXQATCQKPipelineKVStride = 72;
+constexpr float kXQANegInf = -1.0e30f;
+
+template <bool PADDED_SMEM, bool ALIGNED_PADDED_SMEM = false>
+struct alignas(256) XQATCSmem256WideLayout {
+  static_assert(!ALIGNED_PADDED_SMEM || PADDED_SMEM,
+                "Aligned padding requires padded shared memory");
+  static constexpr int kQStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedQStride
+                                         : kXQATC256WidePaddedQStride)
+                  : 256;
+  static constexpr int kKVStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedKVStride
+                                         : kXQATC256WidePaddedKVStride)
+                  : kXQATCStride;
+  static constexpr int kQKStride = kKVStride;
+  alignas(16) __half q[kXQATC256WideBlockM * kQStride];
+  union {
+    alignas(16) __half k[kXQATCBlockN * kKVStride];
+    alignas(16) __half v[kXQATCBlockN * kKVStride];
+  } reuse_kv;
+  struct {
+    alignas(16) float s[kXQATC256WideBlockM * kXQATCBlockN];
+    alignas(16) __half p[kXQATC256WideBlockM * kXQATCBlockN];
+  } reuse_sp;
+  alignas(16) float row_max[kXQATC256WideBlockM];
+  alignas(16) float row_sum[kXQATC256WideBlockM];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+
+  __device__ __forceinline__ __half* k_buffer(int) { return reuse_kv.k; }
+  __device__ __forceinline__ __half* v_buffer() { return reuse_kv.v; }
+};
+
+template <bool PADDED_SMEM, bool ALIGNED_PADDED_SMEM = false>
+struct alignas(256) XQATCQKPipelineSmem256WideLayout {
+  static_assert(!ALIGNED_PADDED_SMEM || PADDED_SMEM,
+                "Aligned padding requires padded shared memory");
+  static constexpr int kQStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedQStride
+                                         : kXQATC256WidePaddedQStride)
+                  : 256;
+  static constexpr int kKVStride =
+      PADDED_SMEM ? (ALIGNED_PADDED_SMEM ? kXQATC256WideAlignedPaddedKVStride
+                                         : kXQATC256WidePaddedKVStride)
+                  : kXQATCStride;
+  static constexpr int kQKStride = kXQATCQKPipelineKVStride;
+  struct QKBuffers {
+    alignas(16) __half panel[2][kXQATCBlockN * kQKStride];
+  };
+
+  alignas(16) __half q[kXQATC256WideBlockM * kQStride];
+  union {
+    QKBuffers qk;
+    alignas(16) __half v[kXQATCBlockN * kKVStride];
+  } reuse_kv;
+  struct {
+    alignas(16) float s[kXQATC256WideBlockM * kXQATCBlockN];
+    alignas(16) __half p[kXQATC256WideBlockM * kXQATCBlockN];
+  } reuse_sp;
+  alignas(16) float row_max[kXQATC256WideBlockM];
+  alignas(16) float row_sum[kXQATC256WideBlockM];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+
+  __device__ __forceinline__ __half* k_buffer(int index) {
+    return reuse_kv.qk.panel[index];
+  }
+  __device__ __forceinline__ __half* v_buffer() { return reuse_kv.v; }
+};
+
+constexpr int kXQATCStagedPVTileRows = 64;
+
+template <bool PADDED_SMEM>
+struct alignas(256) XQATCStagedPVSmem256Wide {
+  static constexpr int kKVStride =
+      PADDED_SMEM ? kXQATC256WidePaddedKVStride : kXQATCStride;
+  alignas(16) __half v[kXQATCStagedPVTileRows * kKVStride];
+  alignas(16) int page_ids[kXQATCPageIdsCapacity];
+};
+
+bool xqa_padded_smem_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_PADDED_SMEM");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_g6_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_DUAL_CTA");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_batch_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_batch_optimized_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_page800_fastpath_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_PAGE800_FASTPATH");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_page800_fastpath_trace_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_E4M3_PAGE800_FASTPATH_TRACE");
+  return value != nullptr && value[0] == '1';
+}
+
+void trace_xqa_e4m3_page800_fastpath(const int batch_size,
+                                     const int partition_size,
+                                     const bool active) {
+  if (!active || !xqa_e4m3_page800_fastpath_trace_enabled()) {
+    return;
+  }
+  static std::atomic<bool> traced{false};
+  if (!traced.exchange(true, std::memory_order_relaxed)) {
+    TORCH_WARN("Flash-V100 E4M3 page800 fast path active: batch=", batch_size,
+               ", partition_size=", partition_size,
+               ", standard interleaved Hkv=1, PV=half2");
+  }
+}
+
+bool xqa_e5m2_g6_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_g6_split_reduce_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_partition_page_ids_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_pair_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_batch_wide_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
+bool dflash2_grouped_fixed_interleaved_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DFLASH2_FIXED_INTERLEAVED");
+  return value == nullptr || value[0] != '0';
+}
+
+bool dflash2_grouped_stage_page_ids_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DFLASH2_STAGE_PAGE_IDS");
+  return value == nullptr || value[0] != '0';
+}
+
+int xqa_e5m2_p1024_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN");
+  return value == nullptr ? 61633 : std::max(1, std::atoi(value));
+}
+
+int xqa_e5m2_scalar_xqa_seq_len() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN");
+  return value == nullptr ? 16384 : std::max(1, std::atoi(value));
+}
+
+bool xqa_e5m2_g6_dual_cta_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_mtp5_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_MTP5_DUAL_CTA");
+  return value == nullptr || value[0] == '1';
+}
+
+bool xqa_g6_dual_cta_dense_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_DUAL_CTA_DENSE");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_g6_p1024_auto_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_AUTO");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_g6_p1024_auto_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_AUTO_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_g6_p1024_sawtooth_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_g6_p64_p256_auto_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P64_P256_AUTO");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_g6_p64_p256_auto_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P64_P256_AUTO_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_e4m3_g6_p256_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P256_BEGIN");
+  return value == nullptr ? 12288 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_dual_cta_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_DUAL_CTA_BEGIN");
+  return value == nullptr ? 32768 : std::max(1, std::atoi(value));
+}
+
+bool xqa_e4m3_g6_wave_partitions_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_WAVE_PARTITIONS");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_e4m3_g6_merged_wave_launch_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_MERGED_WAVE_LAUNCH");
+  return value != nullptr && value[0] == '1';
+}
+
+int xqa_e4m3_g6_p512_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P512_BEGIN");
+  return value == nullptr ? 49152 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_p896_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P896_BEGIN");
+  return value == nullptr ? 98304 : std::max(1, std::atoi(value));
+}
+
+int xqa_e4m3_g6_p1664_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E4M3_G6_P1664_BEGIN");
+  return value == nullptr ? 196608 : std::max(1, std::atoi(value));
+}
+
+bool decode_partition_size_overridden() {
+  return std::getenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE") != nullptr;
+}
+
+bool xqa_g6_qk_pipeline_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE");
+  return value == nullptr || value[0] != '0';
+}
+
+int xqa_g6_qk_pipeline_warps() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS");
+  return value != nullptr && std::atoi(value) == 6 ? 6 : 8;
+}
+
+bool xqa_g6_qk_pipeline_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_g6_p1024_sawtooth_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_g6_p1024_sawtooth_p1024_mid_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_MID_SEQ_LEN");
+  return value == nullptr ? 111104 : std::max(1, std::atoi(value));
+}
+
+int xqa_g6_p1024_sawtooth_p256_long_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P256_LONG_SEQ_LEN");
+  return value == nullptr ? 147841 : std::max(1, std::atoi(value));
+}
+
+int xqa_g6_p1024_sawtooth_p1024_final_seq_len() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_FINAL_SEQ_LEN");
+  return value == nullptr ? 258176 : std::max(1, std::atoi(value));
+}
+
+bool xqa_split_reduce_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_SPLIT_REDUCE");
+  return value != nullptr && value[0] == '1';
+}
+
+enum class XQABatchContextRoute : int {
+  kDisabled = -1,
+  kBaseline = 0,
+  kDualCta = 1,
+  kDualCtaSplit = 2,
+};
+
+bool xqa_batch_context_routing_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_batch_context_routing_trace_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING_TRACE");
+  return value != nullptr && value[0] == '1';
+}
+
+XQABatchContextRoute select_xqa_batch_context_route(const int batch_size,
+                                                    const int max_seq_len,
+                                                    const int partition_size) {
+  if (!xqa_batch_context_routing_enabled() || batch_size < 4 ||
+      max_seq_len <= 0) {
+    return XQABatchContextRoute::kDisabled;
+  }
+  if (batch_size <= 4) {
+    if (max_seq_len <= 8191) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    if (max_seq_len <= 12287) {
+      return XQABatchContextRoute::kDualCta;
+    }
+    return partition_size == 1024 ? XQABatchContextRoute::kBaseline
+                                  : XQABatchContextRoute::kDualCtaSplit;
+  }
+  if (batch_size <= 8) {
+    if (max_seq_len <= 4095) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    return max_seq_len <= 12287 ? XQABatchContextRoute::kDualCta
+                                : XQABatchContextRoute::kDualCtaSplit;
+  }
+  if (batch_size <= 12) {
+    if (max_seq_len <= 2047) {
+      return XQABatchContextRoute::kBaseline;
+    }
+    return max_seq_len <= 16000 ? XQABatchContextRoute::kDualCta
+                                : XQABatchContextRoute::kDualCtaSplit;
+  }
+  return max_seq_len <= 12287 ? XQABatchContextRoute::kBaseline
+                              : XQABatchContextRoute::kDualCta;
+}
+
+const char* xqa_batch_context_route_name(const XQABatchContextRoute route) {
+  switch (route) {
+    case XQABatchContextRoute::kBaseline:
+      return "baseline";
+    case XQABatchContextRoute::kDualCta:
+      return "dual_cta";
+    case XQABatchContextRoute::kDualCtaSplit:
+      return "dual_cta_split";
+    default:
+      return "disabled";
+  }
+}
+
+void trace_xqa_batch_context_route(const int batch_size, const int max_seq_len,
+                                   const int partition_size,
+                                   const int block_size,
+                                   const XQABatchContextRoute route) {
+  if (!xqa_batch_context_routing_trace_enabled() ||
+      route == XQABatchContextRoute::kDisabled) {
+    return;
+  }
+  const int batch_class = batch_size <= 4    ? 0
+                          : batch_size <= 8  ? 1
+                          : batch_size <= 12 ? 2
+                                             : 3;
+  const int context_class = max_seq_len <= 4095    ? 0
+                            : max_seq_len <= 8191  ? 1
+                            : max_seq_len <= 12287 ? 2
+                            : max_seq_len <= 16000 ? 3
+                                                   : 4;
+  const unsigned long long bit =
+      1ULL << (batch_class * 15 + context_class * 3 + static_cast<int>(route));
+  static std::atomic<unsigned long long> traced_routes{0};
+  const unsigned long long previous =
+      traced_routes.fetch_or(bit, std::memory_order_relaxed);
+  if ((previous & bit) == 0) {
+    TORCH_WARN("Flash-V100 XQA batch/context route active: batch=", batch_size,
+               ", max_seq_len=", max_seq_len,
+               ", partition_size=", partition_size, ", block_size=", block_size,
+               ", route=", xqa_batch_context_route_name(route));
+  }
+}
+
+int xqa_block16_layout_mode() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT");
+  if (value == nullptr) {
+    return 0;
+  }
+  const int mode = std::atoi(value);
+  return mode == 1 || mode == 2 ? mode : 0;
+}
+
+bool xqa_block16_layout_required() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT_REQUIRE");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_block16_layout_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK16_LAYOUT_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_block784_index_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK784_INDEX");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_block784_index_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("VLLM_FLASH_V100_XQA_BLOCK784_INDEX_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+bool xqa_aligned_padded_smem_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_ALIGNED_PADDED_SMEM");
+  return value != nullptr && value[0] == '1';
+}
+
+bool xqa_aligned_padded_smem_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_ALIGNED_PADDED_SMEM_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
+int xqa_split_reduce_dim_tile() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_SPLIT_REDUCE_D_TILE");
+  if (value == nullptr) {
+    return 8;
+  }
+  const int dim_tile = std::atoi(value);
+  return dim_tile == 8 || dim_tile == 16 || dim_tile == 32 ? dim_tile : 8;
+}
+
+template <int SEQ_LEN_ROUTE>
+__device__ __forceinline__ bool xqa_seq_len_route_active(
+    const int seq_len, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final) {
+  if constexpr (SEQ_LEN_ROUTE == kXQARouteShortSeqLens) {
+    return seq_len < route_seq_len_begin;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteLongSeqLens) {
+    return seq_len >= route_seq_len_begin;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024Sawtooth) {
+    return (seq_len >= route_seq_len_begin && seq_len < route_seq_len_end) ||
+           seq_len >= route_seq_len_final;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP256Sawtooth) {
+    return seq_len < route_seq_len_begin ||
+           (seq_len >= route_seq_len_end && seq_len < route_seq_len_final);
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothMid) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothFinal) {
+    return seq_len >= route_seq_len_final;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteRangeSeqLens) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteWaveLongSeqLens) {
+    return seq_len >= route_seq_len_begin;
+  }
+  return true;
+}
+
+__device__ __forceinline__ int xqa_sawtooth_partition_size(
+    const int seq_len, const int p1024_mid_seq_len, const int p256_long_seq_len,
+    const int p1024_final_seq_len) {
+  const bool use_p1024 =
+      (seq_len >= p1024_mid_seq_len && seq_len < p256_long_seq_len) ||
+      seq_len >= p1024_final_seq_len;
+  return use_p1024 ? 1024 : 256;
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+    val += __shfl_down_sync(0xffffffff, val, offset);
+  }
+  return val;
+}
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+    val = fmaxf(val, __shfl_down_sync(0xffffffff, val, offset));
+  }
+  return val;
+}
+
+template <int NUM_WARPS>
+__device__ __forceinline__ float block_reduce_sum(float val) {
+  __shared__ float shared[NUM_WARPS];
+  __shared__ float result;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  val = warp_reduce_sum(val);
+  if (lane == 0) {
+    shared[warp] = val;
+  }
+  __syncthreads();
+
+  val = threadIdx.x < NUM_WARPS ? shared[lane] : 0.f;
+  if (warp == 0) {
+    val = warp_reduce_sum(val);
+    if (lane == 0) {
+      result = val;
+    }
+  }
+  __syncthreads();
+  return result;
+}
+
+template <int NUM_WARPS>
+__device__ __forceinline__ float block_reduce_max(float val) {
+  __shared__ float shared[NUM_WARPS];
+  __shared__ float result;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  val = warp_reduce_max(val);
+  if (lane == 0) {
+    shared[warp] = val;
+  }
+  __syncthreads();
+
+  val = threadIdx.x < NUM_WARPS ? shared[lane] : -1.0e20f;
+  if (warp == 0) {
+    val = warp_reduce_max(val);
+    if (lane == 0) {
+      result = val;
+    }
+  }
+  __syncthreads();
+  return result;
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e5m2_pair_to_half2_bits(const uint16_t raw_pair) {
+  return (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+         (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+}
+
+__device__ __forceinline__ uint4 fp8_e5m2_vector_to_half8(const uint64_t raw) {
+  return make_uint4(
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(const uint8_t raw) {
+  const uint16_t sign = static_cast<uint16_t>(raw & 0x80u) << 8;
+  const uint8_t magnitude = raw & 0x7fu;
+  const uint8_t exponent = magnitude >> 3;
+  const uint8_t mantissa = magnitude & 0x07u;
+  if (magnitude == 0) {
+    return sign;
+  }
+  if (exponent == 0) {
+    // E4M3 subnormals are exact fp16 normals: mantissa * 2^-9.
+    const uint16_t magnitude_bits =
+        mantissa < 2
+            ? 0x1800u
+            : (mantissa < 4
+                   ? static_cast<uint16_t>(0x1c00u | ((mantissa - 2) << 9))
+                   : static_cast<uint16_t>(0x2000u | ((mantissa - 4) << 8)));
+    return sign | magnitude_bits;
+  }
+  if (magnitude == 0x7fu) {
+    return sign | 0x7e00u;
+  }
+  return sign | static_cast<uint16_t>((exponent + 8) << 10) |
+         static_cast<uint16_t>(mantissa << 7);
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits(const uint16_t raw_pair) {
+  return static_cast<uint32_t>(
+             fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair))) |
+         (static_cast<uint32_t>(
+              fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair >> 8)))
+          << 16);
+}
+
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits_fast(const uint16_t raw_pair) {
+  const uint8_t raw0 = static_cast<uint8_t>(raw_pair);
+  const uint8_t raw1 = static_cast<uint8_t>(raw_pair >> 8);
+  if ((raw0 & 0x7fu) == 0x7fu || (raw1 & 0x7fu) == 0x7fu) {
+    return fp8_e4m3fn_pair_to_half2_bits(raw_pair);
+  }
+
+  // Moving a finite E4M3 encoding into the corresponding fp16 sign,
+  // exponent, and mantissa fields represents exactly value / 256. A packed
+  // half2 multiply restores both values without per-byte exponent branches.
+  const uint32_t expanded = (static_cast<uint32_t>(raw_pair & 0x0080u) << 8) |
+                            (static_cast<uint32_t>(raw_pair & 0x007fu) << 7) |
+                            (static_cast<uint32_t>(raw_pair & 0x8000u) << 16) |
+                            (static_cast<uint32_t>(raw_pair & 0x7f00u) << 15);
+  union {
+    uint32_t u;
+    __half2 h2;
+  } converter;
+  converter.u = expanded;
+  converter.h2 = __hmul2(converter.h2, __float2half2_rn(256.0f));
+  return converter.u;
+}
+
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8(const uint64_t raw) {
+  return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8_fast(const uint64_t raw) {
+  return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint4 fp8_e4m3fn_vector_to_half8_lut(
+    const uint64_t raw, const uint16_t* __restrict__ lut) {
+  return make_uint4(
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 8)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 16)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 24)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 32)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 40)]) << 16),
+      static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 48)]) |
+          (static_cast<uint32_t>(lut[static_cast<uint8_t>(raw >> 56)]) << 16));
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
+    const void* __restrict__ kv_cache, const int* __restrict__ page_ids,
+    const int copy_idx, const int panel_d_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  const int row = copy_idx / panel_d_stride_uint4;
+  const int vec_col = copy_idx % panel_d_stride_uint4;
+  const int token_offset = tile_page_offset + kv_tile_start + row;
+  static_assert(BLOCK_SIZE == 0 || BLOCK_SIZE == 4 || BLOCK_SIZE == 16 ||
+                    BLOCK_SIZE == 784 || BLOCK_SIZE == 800 ||
+                    BLOCK_SIZE == 1568 || BLOCK_SIZE == 1648 ||
+                    BLOCK_SIZE == 3296,
+                "Unsupported paged-KV block-size specialization");
+  static_assert(!CONTIGUOUS_HKV1_LAYOUT || BLOCK_SIZE == 16 ||
+                    BLOCK_SIZE == 800 || BLOCK_SIZE == 1568 ||
+                    BLOCK_SIZE == 1648 || BLOCK_SIZE == 3296,
+                "The fixed-stride Hkv=1 layout requires a specialized page");
+  int logical_block;
+  int block_offset;
+  if constexpr (BLOCK_SIZE == 4) {
+    logical_block = token_offset >> 2;
+    block_offset = token_offset & 3;
+  } else if constexpr (BLOCK_SIZE == 16) {
+    logical_block = token_offset >> 4;
+    block_offset = token_offset & 15;
+  } else if constexpr (BLOCK_SIZE == 784) {
+    logical_block = token_offset / 784;
+    block_offset = token_offset - logical_block * 784;
+  } else if constexpr (BLOCK_SIZE == 800) {
+    logical_block = token_offset >= 800;
+    block_offset = token_offset - logical_block * 800;
+  } else if constexpr (BLOCK_SIZE == 1568) {
+    logical_block = token_offset / 1568;
+    block_offset = token_offset - logical_block * 1568;
+  } else if constexpr (BLOCK_SIZE == 1648) {
+    logical_block = token_offset / 1648;
+    block_offset = token_offset - logical_block * 1648;
+  } else if constexpr (BLOCK_SIZE == 3296) {
+    logical_block = token_offset / 3296;
+    block_offset = token_offset - logical_block * 3296;
+  } else {
+    logical_block = token_offset / block_size;
+    block_offset = token_offset % block_size;
+  }
+  const int physical_block = page_ids[logical_block];
+  int64_t physical_offset;
+  if constexpr (CONTIGUOUS_HKV1_LAYOUT) {
+    constexpr int64_t kHeadDim = 256;
+    constexpr int64_t kBlockStride =
+        BLOCK_SIZE == 16 ? 16 * kHeadDim : 2 * BLOCK_SIZE * kHeadDim;
+    physical_offset = static_cast<int64_t>(physical_block) * kBlockStride +
+                      static_cast<int64_t>(block_offset) * kHeadDim +
+                      panel_offset;
+  } else {
+    physical_offset = static_cast<int64_t>(physical_block) * block_stride +
+                      static_cast<int64_t>(block_offset) * token_stride +
+                      static_cast<int64_t>(kv_head_idx) * head_stride +
+                      panel_offset;
+  }
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const uint4* cache_vec = reinterpret_cast<const uint4*>(kv_cache);
+    return __ldg(&cache_vec[physical_offset / 8 + vec_col]);
+  } else {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "XQA only supports fp16, FP8 E4M3, and FP8 E5M2 KV");
+    const uint64_t* cache_vec = reinterpret_cast<const uint64_t*>(kv_cache);
+    const uint64_t raw = __ldg(&cache_vec[physical_offset / 8 + vec_col]);
+    if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+      if constexpr (E4M3_SHARED_LUT) {
+        return fp8_e4m3fn_vector_to_half8_lut(raw, e4m3_lut);
+      } else {
+        return fp8_e4m3fn_vector_to_half8(raw);
+      }
+    } else {
+      static_assert(!E4M3_SHARED_LUT,
+                    "The E4M3 conversion LUT requires E4M3 KV");
+      return fp8_e5m2_vector_to_half8(raw);
+    }
+  }
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool FP8_PAIR_LOAD = false, bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ void load_xqa_tc_kv_panel(
+    __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
+    const int* __restrict__ page_ids, const int valid_kv_tile_rows,
+    const int panel_d_stride_uint4, const int kv_smem_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const int copy_thread_idx = threadIdx.x,
+    const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
+  if constexpr (FP8_PAIR_LOAD) {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "Paired XQA loads require FP8 KV");
+    static_assert(!E4M3_SHARED_LUT,
+                  "Paired E4M3 conversion does not use the shared LUT");
+    const int pair_stride = panel_d_stride_uint4 / 2;
+    const int pair_count = valid_kv_tile_rows * pair_stride;
+    for (int pair_idx = copy_thread_idx; pair_idx < pair_count;
+         pair_idx += NUM_THREADS) {
+      const int row = pair_idx / pair_stride;
+      const int vec_pair = pair_idx % pair_stride;
+      const int token_offset = tile_page_offset + kv_tile_start + row;
+      int logical_block;
+      int block_offset;
+      if constexpr (BLOCK_SIZE == 4) {
+        logical_block = token_offset >> 2;
+        block_offset = token_offset & 3;
+      } else if constexpr (BLOCK_SIZE == 16) {
+        logical_block = token_offset >> 4;
+        block_offset = token_offset & 15;
+      } else if constexpr (BLOCK_SIZE == 784) {
+        logical_block = token_offset / 784;
+        block_offset = token_offset - logical_block * 784;
+      } else if constexpr (BLOCK_SIZE == 800) {
+        logical_block = token_offset >= 800;
+        block_offset = token_offset - logical_block * 800;
+      } else if constexpr (BLOCK_SIZE == 1568) {
+        logical_block = token_offset / 1568;
+        block_offset = token_offset - logical_block * 1568;
+      } else if constexpr (BLOCK_SIZE == 1648) {
+        logical_block = token_offset / 1648;
+        block_offset = token_offset - logical_block * 1648;
+      } else if constexpr (BLOCK_SIZE == 3296) {
+        logical_block = token_offset / 3296;
+        block_offset = token_offset - logical_block * 3296;
+      } else {
+        logical_block = token_offset / block_size;
+        block_offset = token_offset % block_size;
+      }
+      const int physical_block = page_ids[logical_block];
+      int64_t physical_offset;
+      if constexpr (CONTIGUOUS_HKV1_LAYOUT) {
+        constexpr int64_t kHeadDim = 256;
+        constexpr int64_t kPhysicalBlockStride =
+            BLOCK_SIZE == 16 ? 16 * kHeadDim : 2 * BLOCK_SIZE * kHeadDim;
+        physical_offset =
+            static_cast<int64_t>(physical_block) * kPhysicalBlockStride +
+            static_cast<int64_t>(block_offset) * kHeadDim + panel_offset;
+      } else {
+        physical_offset = static_cast<int64_t>(physical_block) * block_stride +
+                          static_cast<int64_t>(block_offset) * token_stride +
+                          static_cast<int64_t>(kv_head_idx) * head_stride +
+                          panel_offset;
+      }
+      const uint4 raw = __ldg(reinterpret_cast<const uint4*>(kv_cache) +
+                              physical_offset / 16 + vec_pair);
+      const int shared_offset = row * kv_smem_stride_uint4 + vec_pair * 2;
+      const uint64_t raw_lo =
+          static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
+      shared_vec[shared_offset] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_lo)
+              : fp8_e5m2_vector_to_half8(raw_lo);
+      const uint64_t raw_hi =
+          static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
+      shared_vec[shared_offset + 1] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_hi)
+              : fp8_e5m2_vector_to_half8(raw_hi);
+    }
+  } else {
+    const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
+    for (int copy_idx = copy_thread_idx; copy_idx < copy_count;
+         copy_idx += NUM_THREADS) {
+      const int row = copy_idx / panel_d_stride_uint4;
+      const int vec_col = copy_idx % panel_d_stride_uint4;
+      shared_vec[row * kv_smem_stride_uint4 + vec_col] =
+          load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE,
+                                E4M3_SHARED_LUT>(
+              kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
+              tile_page_offset, kv_tile_start, block_size, kv_head_idx,
+              block_stride, token_stride, head_stride, panel_offset, e4m3_lut);
+    }
+  }
+}
+
+template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool E4M3_SHARED_LUT = false>
+__device__ __forceinline__ void load_xqa_tc_kv_panel_and_zero(
+    __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
+    const int* __restrict__ page_ids, const int valid_kv_tile_rows,
+    const int panel_d_stride_uint4, const int kv_smem_stride_uint4,
+    const int tile_page_offset, const int kv_tile_start, const int block_size,
+    const int kv_head_idx, const int64_t block_stride,
+    const int64_t token_stride, const int64_t head_stride,
+    const int panel_offset, const int copy_thread_idx,
+    const uint16_t* __restrict__ e4m3_lut = nullptr) {
+  const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
+  uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
+  constexpr int kLoadStages = 4;
+  for (int copy_base = copy_thread_idx; copy_base < copy_count;
+       copy_base += NUM_THREADS * kLoadStages) {
+    uint4 staged[kLoadStages];
+#pragma unroll
+    for (int stage = 0; stage < kLoadStages; ++stage) {
+      const int copy_idx = copy_base + stage * NUM_THREADS;
+      if (copy_idx < copy_count) {
+        staged[stage] =
+            load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE,
+                                  E4M3_SHARED_LUT>(
+                kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
+                tile_page_offset, kv_tile_start, block_size, kv_head_idx,
+                block_stride, token_stride, head_stride, panel_offset,
+                e4m3_lut);
+      }
+    }
+#pragma unroll
+    for (int stage = 0; stage < kLoadStages; ++stage) {
+      const int copy_idx = copy_base + stage * NUM_THREADS;
+      if (copy_idx < copy_count) {
+        const int row = copy_idx / panel_d_stride_uint4;
+        const int vec_col = copy_idx % panel_d_stride_uint4;
+        shared_vec[row * kv_smem_stride_uint4 + vec_col] = staged[stage];
+      }
+    }
+  }
+  for (int copy_idx = copy_thread_idx + copy_count;
+       copy_idx < kXQATCBlockN * panel_d_stride_uint4;
+       copy_idx += NUM_THREADS) {
+    const int row = copy_idx / panel_d_stride_uint4;
+    const int vec_col = copy_idx % panel_d_stride_uint4;
+    shared_vec[row * kv_smem_stride_uint4 + vec_col] = make_uint4(0, 0, 0, 0);
+  }
+}
+
+template <int D>
+__device__ __forceinline__ float dot_qk_half2(const __half* __restrict__ q_ptr,
+                                              const __half* __restrict__ k_ptr,
+                                              const int lane) {
+  static_assert(D % 2 == 0, "Head dim must be even for half2 dot");
+  const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_ptr);
+  const __half2* k_ptr2 = reinterpret_cast<const __half2*>(k_ptr);
+
+  float acc = 0.f;
+#pragma unroll
+  for (int i = lane; i < D / 2; i += kWarpSize) {
+    const float2 qv = __half22float2(q_ptr2[i]);
+    const float2 kv = __half22float2(k_ptr2[i]);
+    acc = fmaf(qv.x, kv.x, acc);
+    acc = fmaf(qv.y, kv.y, acc);
+  }
+  return warp_reduce_sum(acc);
+}
+
+template <int D, int KV_DTYPE>
+__device__ __forceinline__ float dot_qk_cache(const __half* __restrict__ q_ptr,
+                                              const void* __restrict__ k_cache,
+                                              const int64_t k_index_base,
+                                              const int lane) {
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const __half* k_ptr =
+        reinterpret_cast<const __half*>(k_cache) + k_index_base;
+    return dot_qk_half2<D>(q_ptr, k_ptr, lane);
+  } else if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2) {
+    static_assert(D % 2 == 0, "Head dim must be even for e5m2 half2 dot");
+    const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_ptr);
+    float acc = 0.f;
+#pragma unroll
+    for (int i = lane; i < D / 2; i += kWarpSize) {
+      const float2 qv = __half22float2(q_ptr2[i]);
+      const __half2 k_h2 = flash_v100::load_fp8_e5m2_half2_unscaled(
+          k_cache, k_index_base + static_cast<int64_t>(i) * 2);
+      const float2 kv = __half22float2(k_h2);
+      acc = fmaf(qv.x, kv.x, acc);
+      acc = fmaf(qv.y, kv.y, acc);
+    }
+    return warp_reduce_sum(acc);
+  } else {
+    float acc = 0.f;
+#pragma unroll
+    for (int d = lane; d < D; d += kWarpSize) {
+      const float qv = __half2float(q_ptr[d]);
+      const float kv = flash_v100::load_kv_cache_float_unscaled<KV_DTYPE>(
+          k_cache, k_index_base + d);
+      acc = fmaf(qv, kv, acc);
+    }
+    return warp_reduce_sum(acc);
+  }
+}
+
+template <int D, int PARTITION_SIZE, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool ANCHORED_SWA = false,
+          typename PARTIAL_T = __half>
+__global__ void flash_attention_decode_partition_kernel(
+    const __half* __restrict__ q, const void* __restrict__ k_cache,
+    const void* __restrict__ v_cache, PARTIAL_T* __restrict__ tmp_out,
+    float* __restrict__ max_logits, float* __restrict__ exp_sums,
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    const int* __restrict__ active_num_partitions, const int batch_size,
+    const int max_num_blocks, const int max_num_partitions,
+    const int num_heads_q, const int num_heads_kv, const int block_size,
+    const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t k_block_stride,
+    const int64_t k_token_stride, const int64_t k_head_stride,
+    const int64_t v_block_stride, const int64_t v_token_stride,
+    const int64_t v_head_stride, const float softmax_scale, const float k_scale,
+    const float v_scale, const int window_size_left,
+    const int window_size_right, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final,
+    const int* __restrict__ anchor_lens, const int anchored_window) {
+  static_assert(D == 256 && PARTITION_SIZE == 1024 &&
+      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 &&
+      SEQ_LEN_ROUTE == 0 && !ANCHORED_SWA &&
+      std::is_same_v<PARTIAL_T, float>, "Private scalar six-head contract");
+  const int partition_idx = blockIdx.z;
+  const int seq_len = seq_lens[0];
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || start_token_idx >= seq_len ||
+      partition_idx >= max_num_partitions) return;
+  const int effective_num_partitions = min(max_num_partitions,
+      max(active_num_partitions[0], (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE));
+  if (partition_idx >= effective_num_partitions) return;
+  const int part_tokens = min(PARTITION_SIZE, seq_len - start_token_idx);
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp_idx = threadIdx.x / kWarpSize;
+  const float score_scale = softmax_scale * k_scale;
+  __shared__ float kv_lut[256];
+  kv_lut[threadIdx.x] = flash_v100::fp8_e4m3fn_to_float(
+      static_cast<uint8_t>(threadIdx.x));
+  __shared__ __half q_shared[6][D];
+  __shared__ float scores_shared[6][PARTITION_SIZE];
+  __shared__ int block_idx_shared[2];
+  const int first_block = start_token_idx / block_size;
+  const int first_offset = start_token_idx - first_block * block_size;
+  const int first_page_tokens = min(part_tokens, block_size - first_offset);
+  for (int i = threadIdx.x; i < 6 * D; i += blockDim.x)
+    q_shared[i / D][i % D] = q[(i / D) * q_stride1 + i % D];
+  if (threadIdx.x == 0) {
+    block_idx_shared[0] = block_table[first_block];
+    block_idx_shared[1] = first_page_tokens < part_tokens
+        ? block_table[first_block + 1] : block_idx_shared[0];
+  }
+  __syncthreads();
+  float local_max[6];
+#pragma unroll
+  for (int head = 0; head < 6; ++head) local_max[head] = -1.0e20f;
+  for (int token_local = warp_idx; token_local < part_tokens;
+       token_local += kWarpsPerBlock) {
+    const bool second_page = token_local >= first_page_tokens;
+    const int token_offset = second_page ? token_local - first_page_tokens
+                                         : first_offset + token_local;
+    const int64_t k_index =
+        static_cast<int64_t>(block_idx_shared[second_page]) * k_block_stride +
+        static_cast<int64_t>(token_offset) * k_token_stride;
+    float score[6] = {};
+    // Each head retains d=lane,lane+32,... and the original warp reduction.
+    // Only independent heads share the decoded K value.
+#pragma unroll
+    for (int d = lane; d < D; d += kWarpSize) {
+      const float kv = kv_lut[static_cast<const uint8_t*>(k_cache)[k_index + d]];
+#pragma unroll
+      for (int head = 0; head < 6; ++head)
+        score[head] = fmaf(__half2float(q_shared[head][d]), kv, score[head]);
+    }
+#pragma unroll
+    for (int head = 0; head < 6; ++head) {
+      const float reduced = warp_reduce_sum(score[head]);
+      if (lane == 0) {
+        const float value = reduced * score_scale;
+        scores_shared[head][token_local] = value;
+        local_max[head] = fmaxf(local_max[head], value);
+      }
+    }
+  }
+  float inv_sum[6];
+#pragma unroll
+  for (int head = 0; head < 6; ++head) {
+    const float part_max = block_reduce_max<kWarpsPerBlock>(local_max[head]);
+    float local_sum = 0.f;
+    for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+      const float p = __expf(scores_shared[head][i] - part_max);
+      scores_shared[head][i] = p;
+      local_sum += p;
+    }
+    const float part_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+    inv_sum[head] = part_sum > 0.f ? 1.f / part_sum : 0.f;
+    if (threadIdx.x == 0) {
+      const int64_t stats_index = head * stats_stride1 + partition_idx;
+      max_logits[stats_index] = part_max;
+      exp_sums[stats_index] = part_sum;
+    }
+    // Complete reads of the reduction helper's shared result before the
+    // next head reuses it; all 256 threads participate in every reduction.
+    __syncthreads();
+  }
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    float acc[6] = {};
+    for (int page = 0; page < 2; ++page) {
+      const int begin = page == 0 ? 0 : first_page_tokens;
+      const int end = page == 0 ? first_page_tokens : part_tokens;
+      int64_t v_index = static_cast<int64_t>(block_idx_shared[page]) *
+          v_block_stride + (page == 0 ? first_offset * v_token_stride : 0) + d;
+      for (int i = begin; i < end; ++i, v_index += v_token_stride) {
+        const float vv =
+            kv_lut[static_cast<const uint8_t*>(v_cache)[v_index]];
+#pragma unroll
+        for (int head = 0; head < 6; ++head)
+          acc[head] = fmaf(scores_shared[head][i], vv, acc[head]);
+      }
+    }
+#pragma unroll
+    for (int head = 0; head < 6; ++head) {
+      const float out_scale = inv_sum[head] * v_scale;
+      const int64_t tmp_out_base = head * tmp_out_stride1 +
+          static_cast<int64_t>(partition_idx) * tmp_out_stride2;
+      tmp_out[tmp_out_base + d] = acc[head] * out_scale;
+    }
+  }
+}
+
+template <int D, int PARTITION_SIZE, int SEQ_LEN_ROUTE = kXQARouteAllSeqLens,
+          typename PARTIAL_T = __half>
+__global__ void flash_attention_decode_reduce_kernel(
+    const PARTIAL_T* __restrict__ tmp_out, const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums, const int* __restrict__ seq_lens,
+    const int* __restrict__ active_num_partitions, __half* __restrict__ out,
+    const int batch_size, const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
+    const int64_t out_stride1, const int route_partition_size_begin,
+    const int route_seq_len_begin, const int route_seq_len_end,
+    const int route_seq_len_final) {
+  const int batch_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+
+  if (batch_idx >= batch_size || head_idx >= num_heads_q) {
+    return;
+  }
+
+  const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
+  int partition_size;
+  if constexpr (PARTITION_SIZE == -1) {
+    static_assert(SEQ_LEN_ROUTE == kXQARouteWaveLongSeqLens,
+                  "Runtime wave partitions require the wave-long route");
+    partition_size = seq_len < route_seq_len_end
+                         ? 512
+                         : (seq_len < route_seq_len_final ? 896 : 1664);
+  } else if constexpr (PARTITION_SIZE == 0) {
+    partition_size = seq_len < route_partition_size_begin ? 64 : 256;
+  } else {
+    partition_size = PARTITION_SIZE;
+  }
+  const int num_partitions =
+      min(max_num_partitions, (seq_len + partition_size - 1) / partition_size);
+  (void)active_num_partitions;
+
+  if (seq_len <= 0 || num_partitions <= 0) {
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      out[static_cast<int64_t>(batch_idx) * out_stride0 +
+          static_cast<int64_t>(head_idx) * out_stride1 + d] = __float2half(0.f);
+    }
+    return;
+  }
+
+  extern __shared__ float shared_mem[];
+  float* max_shared = shared_mem;
+  float* weight_shared = shared_mem + max_num_partitions;
+
+  float local_max = -1.0e20f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const int64_t stats_index =
+        static_cast<int64_t>(batch_idx) * stats_stride0 +
+        static_cast<int64_t>(head_idx) * stats_stride1 + i;
+    const float m = max_logits[stats_index];
+    max_shared[i] = m;
+    local_max = fmaxf(local_max, m);
+  }
+  const float global_max = block_reduce_max<kWarpsPerBlock>(local_max);
+
+  float local_sum = 0.f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const int64_t stats_index =
+        static_cast<int64_t>(batch_idx) * stats_stride0 +
+        static_cast<int64_t>(head_idx) * stats_stride1 + i;
+    const float weight =
+        exp_sums[stats_index] * __expf(max_shared[i] - global_max);
+    weight_shared[i] = weight;
+    local_sum += weight;
+  }
+  const float global_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+  const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
+  __syncthreads();
+
+  const int64_t out_base = static_cast<int64_t>(batch_idx) * out_stride0 +
+                           static_cast<int64_t>(head_idx) * out_stride1;
+  const int64_t tmp_out_base =
+      static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1;
+
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    float acc = 0.f;
+    for (int i = 0; i < num_partitions; ++i) {
+      acc = fmaf(weight_shared[i],
+                 static_cast<float>(
+                     tmp_out[tmp_out_base +
+                             static_cast<int64_t>(i) * tmp_out_stride2 + d]),
+                 acc);
+    }
+    out[out_base + d] = __float2half(acc * inv_global_sum);
+  }
+}
+
+}  // namespace
+at::Tensor scalar_attention_candidate(
+    const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    at::Tensor& out, const at::Tensor& table, const at::Tensor& lengths,
+    at::Tensor& partial, at::Tensor& maximum, at::Tensor& sums,
+    const at::Tensor& active, float scale, float k_scale, float v_scale) {
+  TORCH_CHECK(q.is_cuda() && q.scalar_type() == at::kHalf &&
+              q.sizes() == at::IntArrayRef({1, 6, 256}) && q.is_contiguous(),
+              "Private scalar q1 probe requires contiguous FP16 [1,6,256]");
+  TORCH_CHECK(k.dim() == 4 && k.size(2) == 1 && k.size(3) == 256 &&
+              k.size(1) > 0 && k.scalar_type() == at::kByte &&
+              v.sizes() == k.sizes() && v.scalar_type() == at::kByte,
+              "Private scalar q1 probe requires E4M3 [pages,page,1,256]");
+  for (const auto* t : {&k, &v})
+    TORCH_CHECK(t->stride(3) == 1, "Head dimension must be contiguous");
+  TORCH_CHECK(out.sizes() == q.sizes() && out.scalar_type() == at::kHalf &&
+              out.is_contiguous(), "Output shape/dtype mismatch");
+  TORCH_CHECK(table.dim() == 2 && table.size(0) == 1 && table.size(1) > 0 &&
+              table.scalar_type() == at::kInt && table.is_contiguous() &&
+              table.size(1) * k.size(1) <= 266240 &&
+              lengths.sizes() == at::IntArrayRef({1}) &&
+              lengths.scalar_type() == at::kInt && lengths.is_contiguous() &&
+              active.sizes() == at::IntArrayRef({1}) &&
+              active.scalar_type() == at::kInt && active.is_contiguous(),
+              "Invalid scalar q1 page/length metadata");
+  TORCH_CHECK(partial.sizes() == at::IntArrayRef({1, 6, 256, 256}) &&
+              partial.scalar_type() == at::kFloat && partial.is_contiguous() &&
+              maximum.sizes() == at::IntArrayRef({1, 6, 256}) &&
+              sums.sizes() == maximum.sizes() &&
+              maximum.scalar_type() == at::kFloat &&
+              sums.scalar_type() == at::kFloat &&
+              maximum.is_contiguous() && sums.is_contiguous(),
+              "Scalar q1 requires unchanged FP32 partition workspaces");
+  for (const auto* t : {&k, &v, static_cast<const at::Tensor*>(&out), &table,
+      &lengths, static_cast<const at::Tensor*>(&partial),
+      static_cast<const at::Tensor*>(&maximum),
+      static_cast<const at::Tensor*>(&sums), &active})
+    TORCH_CHECK(t->device() == q.device(), "Device mismatch");
+  TORCH_CHECK(std::isfinite(scale) && std::isfinite(k_scale) &&
+              std::isfinite(v_scale) && k_scale > 0 && v_scale > 0,
+              "Finite positive KV scales required");
+  c10::cuda::CUDAGuard guard(q.device());
+  const auto* properties = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(properties->major == 7 && properties->minor == 0, "SM70 only");
+  const auto stream = at::cuda::getCurrentCUDAStream().stream();
+  flash_attention_decode_partition_kernel<256, 1024,
+      flash_v100::KV_CACHE_DTYPE_FP8_E4M3, 0, false, float>
+      <<<dim3(1, 1, 256), 256, 4096, stream>>>(
+      reinterpret_cast<const __half*>(q.data_ptr()), k.data_ptr(), v.data_ptr(),
+      partial.data_ptr<float>(), maximum.data_ptr<float>(), sums.data_ptr<float>(),
+      table.data_ptr<int>(), lengths.data_ptr<int>(), active.data_ptr<int>(),
+      1, table.size(1), 256, 6, 1, k.size(1), q.stride(0), q.stride(1),
+      partial.stride(0), partial.stride(1), partial.stride(2),
+      maximum.stride(0), maximum.stride(1),
+      k.stride(0), k.stride(1), k.stride(2),
+      v.stride(0), v.stride(1), v.stride(2),
+      scale, k_scale, v_scale, -1, -1, 0, 0, 0, nullptr, 0);
+  flash_attention_decode_reduce_kernel<256, 1024, 0, float>
+      <<<dim3(1, 6, 1), 256, 2 * 256 * sizeof(float), stream>>>(
+      partial.data_ptr<float>(), maximum.data_ptr<float>(), sums.data_ptr<float>(),
+      lengths.data_ptr<int>(), active.data_ptr<int>(),
+      reinterpret_cast<__half*>(out.data_ptr()), 1, 256, 6,
+      partial.stride(0), partial.stride(1), partial.stride(2),
+      maximum.stride(0), maximum.stride(1), out.stride(0), out.stride(1),
+      0, 0, 0, 0);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+// Registered into the shipped FA2 extension rather than a private pybind
+// module, so the compact scalar long-context tail is available by default
+// instead of requiring an externally built DSO selected by a manifest.
+namespace {
+at::Tensor sm70_scalar_attention_entry(
+    const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    at::Tensor& out, const at::Tensor& table, const at::Tensor& lengths,
+    at::Tensor& partial, at::Tensor& maximum, at::Tensor& sums,
+    const at::Tensor& active, double scale, double k_scale, double v_scale) {
+  return scalar_attention_candidate(
+      q, k, v, out, table, lengths, partial, maximum, sums, active,
+      static_cast<float>(scale), static_cast<float>(k_scale),
+      static_cast<float>(v_scale));
+}
+}  // namespace
+
+TORCH_LIBRARY_FRAGMENT(_vllm_fa2_C, ops) {
+  ops.def(
+      "sm70_scalar_attention_fwd(Tensor q, Tensor k, Tensor v, Tensor(a!) out, "
+      "Tensor table, Tensor lengths, Tensor(a!) partial, Tensor(a!) maximum, "
+      "Tensor(a!) sums, Tensor active, float scale, float k_scale, "
+      "float v_scale) -> Tensor(a!)");
+}
+TORCH_LIBRARY_IMPL(_vllm_fa2_C, CUDA, ops) {
+  ops.impl("sm70_scalar_attention_fwd", &sm70_scalar_attention_entry);
+}

--- a/docs/design/sm70_dflash2_tail_graphs_20260911.md
+++ b/docs/design/sm70_dflash2_tail_graphs_20260911.md
@@ -27,11 +27,12 @@ Inherited PR596 head: `9930ebe8e6bff1fb031740d5787f86f6193d2cd9`.
 
 ## Implementation
 
-`VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS=1` registers target-only B1 q1 through q7
+`VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS` registers target-only B1 q1 through q7
 alongside q8. It does not depend on lookup augmentation and does not add
 tail shapes to the drafter, other speculative methods or multi-request
 uniform batches. Sequence-parallel configurations retain the previous path.
-The flag remains disabled by default.
+The tail graph is on by default because the eager tail was the dominant round
+cost at the capacity; `VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS=0` restores it.
 
 The grouped manifest can explicitly declare `max_context` and `query_rows`.
 Without those fields the contract remains 132096 and q8. A selected
@@ -40,9 +41,14 @@ The CPU bound controls graph selection; device row lengths remain
 authoritative. Oversized or device-only bounds use the ordinary graph.
 No attention truncation, capacity increase or arithmetic change is made.
 
-`VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST` optionally loads the existing
-compact E4M3 q1 library. The loader checks the DSO hash and the compact
-six-head/lookup/256K contract. Its persistent FP32 numerator, maximum and
+The compact E4M3 q1 operator is compiled into `_vllm_fa2_C` and selected with
+no environment variable. `VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST` stays
+as an explicit override that loads an externally built candidate instead; the
+loader then checks the DSO hash and the compact six-head/lookup/256K contract.
+Both paths are admitted at the descriptor the long-context contract itself
+declares, so a capacity change cannot silently disable them: the manifest has
+to cover the declared range, and the graph descriptor bucket is compared
+against that same value rather than a literal 262144. Its persistent FP32 numerator, maximum and
 sum buffers are allocated before profiling and capture, outside the graph
 pool. The operator requires the explicit 256K graph descriptor and the
 admitted B1/H6/D256/page3296 E4M3 layout. Short q1 contexts below 128K,
@@ -65,6 +71,19 @@ and complete FP32 partition buffers. No native source is changed here.
 | --- | --- | --- |
 | P layout, early store, E4M3 lookup | `eb7a85511f581fcd22cf13619c85ed2f42a8cbc8b216bb3e632bf448f6b820e1` | `9db33737adb880cd4198266ac4f29785ce3e709936aa47dcc79011a9bce4b811` |
 | Compact scalar, lookup, 4 KiB shared reservation | `5e68578c0252c7525496abab98aef5ed5f774528ac1dab6c5e1c587912cfa632` | `6d2b2b1ec5e0501de9abf49a81670cca2fb2ee700be66365f98db118a62fee21` |
+
+The shipped `csrc/attention/sm70_grouped_long/kernel/grouped-attention.cu`
+carries the first source digest above, and `BUILTIN_MANIFEST` names it so a
+rebuilt kernel cannot inherit the workspace identity of a different layout.
+It differs from that candidate only in registration: `PYBIND11_MODULE` becomes
+`TORCH_LIBRARY_FRAGMENT` plus a `double`-signature adapter, and
+`torch/extension.h` is replaced by `torch/library.h` with an explicit
+`c10/cuda/CUDAException.h`. The other five files are byte-identical to the
+candidate. An earlier revision of this change shipped the
+`heads1-qk2-vector16-page-prefetch` source (`8459d57c6b72`) under this digest;
+that layout lacks the probability swizzle, early probability store,
+PV-value reuse, full-q8 specialization, all-visible tiles and shared E4M3 LUT,
+and is the reason the capacity round stayed near 38 ms instead of 31 ms.
 
 The existing builders are `build_sm70_grouped_attention_swizzle.py` and
 `build_sm70_scalar_attention_candidate.py`. Keep their frozen source inputs

--- a/tests/v1/attention/test_sm70_e4m3_grouped.py
+++ b/tests/v1/attention/test_sm70_e4m3_grouped.py
@@ -95,6 +95,9 @@ def test_native_capability_fail_closed(monkeypatch, available):
         flash_attn_grouped_e4m3_fp32_paged=sentinel,
     )
     monkeypatch.setitem(sys.modules, "flash_attn_v100", module)
+    # With the long-context route off the loader must hand back the native
+    # binding untouched; the wrapping itself is covered by the tail graph tests.
+    monkeypatch.setenv("VLLM_SM70_E4M3_LONG_ATTENTION", "0")
     assert load_grouped_e4m3_fp32() is (sentinel if available else None)
 
 

--- a/tests/v1/worker/test_sm70_long_attention_graphs.py
+++ b/tests/v1/worker/test_sm70_long_attention_graphs.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from vllm.config.compilation import CompilationConfig, CUDAGraphMode
-from vllm.v1.attention.ops.sm70_e4m3_long import MAX_CONTEXT
+from vllm.v1.attention.ops.sm70_e4m3_long import BUILTIN_MAX_CONTEXT
 from vllm.v1.worker.gpu import cudagraph_utils as cg
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
@@ -21,7 +21,7 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 def graph_pair():
     manager = ModelCudaGraphManager.__new__(ModelCudaGraphManager)
     ordinary = BatchExecutionDescriptor(CUDAGraphMode.FULL, 8, 1, 8)
-    bounded = replace(ordinary, attention_context_bucket=MAX_CONTEXT)
+    bounded = replace(ordinary, attention_context_bucket=BUILTIN_MAX_CONTEXT)
     manager._long_attention_graphs = {ordinary: bounded}
     manager.graphs = {ordinary: object(), bounded: object()}
     return manager, ordinary, bounded
@@ -31,9 +31,8 @@ def test_context_boundary_and_switch_back(graph_pair):
     manager, ordinary, bounded = graph_pair
     for upper, expected in (
         (1024, bounded),
-        (MAX_CONTEXT, bounded),
-        (MAX_CONTEXT + 1, ordinary),
-        (262144, ordinary),
+        (BUILTIN_MAX_CONTEXT, bounded),
+        (BUILTIN_MAX_CONTEXT + 1, ordinary),
         (32768, bounded),
         (0, ordinary),
     ):
@@ -76,9 +75,17 @@ def test_other_batch_shapes_and_missing_capture_fall_back(graph_pair):
 
 
 def test_disabled_operator_preserves_original_binding(monkeypatch):
-    from vllm.v1.attention.ops.sm70_e4m3_long import MANIFEST_ENV, wrap_long_attention
+    from vllm.v1.attention.ops.sm70_e4m3_long import (
+        DISABLE_ENV,
+        MANIFEST_ENV,
+        wrap_long_attention,
+    )
 
+    # The shipped operator makes the route available without any variable, so
+    # the explicit opt-out is what turns it off. The manifest variable is not a
+    # switch: unsetting it only selects the shipped operator.
     monkeypatch.delenv(MANIFEST_ENV, raising=False)
+    monkeypatch.setenv(DISABLE_ENV, "0")
 
     def original(*args, **kwargs):
         raise AssertionError("Binding inspection must not launch an operator")
@@ -117,6 +124,7 @@ def test_tail_capture_and_dispatch_from_real_initialization(
     compilation.pass_config.enable_sp = sequence_parallel
     config = SimpleNamespace(
         scheduler_config=SimpleNamespace(max_num_seqs=4),
+        model_config=SimpleNamespace(max_model_len=BUILTIN_MAX_CONTEXT),
         compilation_config=compilation,
         parallel_config=SimpleNamespace(
             data_parallel_size=1, tensor_parallel_size=4, pipeline_parallel_size=1
@@ -144,8 +152,9 @@ def test_tail_capture_and_dispatch_from_real_initialization(
 @pytest.mark.parametrize(
     "manifest",
     [
-        {"max_context": 262145},
         {"max_context": 0},
+        {"max_context": -1},
+        {"max_context": "262144"},
         {"query_rows": [1, 8]},
         {"query_rows": [9]},
         {"query_rows": []},
@@ -161,10 +170,24 @@ def test_reject_unadmitted_attention_manifest(manifest):
 def test_explicit_attention_manifest_preserves_default_and_extends_tail_domain():
     from vllm.v1.attention.ops.sm70_e4m3_long import long_attention_contract
 
-    assert long_attention_contract({}) == (132096, (8,))
+    assert long_attention_contract({}) == (BUILTIN_MAX_CONTEXT, (8,))
+    assert long_attention_contract({"max_context": 262144}) == (262144, (8,))
     assert long_attention_contract(
         {"max_context": 262144, "query_rows": list(range(2, 9))}
     ) == (262144, tuple(range(2, 9)))
+
+
+def test_served_window_bounds_the_route_and_never_exceeds_capability():
+    from vllm.v1.attention.ops.sm70_e4m3_long import long_attention_contract
+
+    # The served window decides the bound, so a smaller deployment routes on its
+    # own value instead of the operator's ceiling.
+    assert long_attention_contract({}, 32768) == (32768, (8,))
+    assert long_attention_contract({"max_context": 262144}, 131072) == (131072, (8,))
+    # A window wider than the operator covers stays at the capability: the route
+    # is never driven past what the manifest was admitted for.
+    assert long_attention_contract({"max_context": 131072}, 262144) == (131072, (8,))
+    assert long_attention_contract({}, None) == (BUILTIN_MAX_CONTEXT, (8,))
 
 
 @pytest.mark.parametrize("query_len", [1, 6, 7])

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -188,7 +188,7 @@ if TYPE_CHECKING:
     VLLM_SM70_SAMPLER_LIBRARY: str | None = None
     VLLM_SM70_FA2_D256_LIBRARY: str | None = None
     VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST: str | None = None
-    VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS: bool = False
+    VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS: bool = True
     VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST: str | None = None
     VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_NVFP4_QPN2: bool = False
@@ -1885,8 +1885,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Capture exact B1 q1..q7 verifier tails for SM70 DFlash2. Default-off keeps
     # the existing eager fallback and its memory footprint unchanged.
+    # Capturing the B1 q1..q7 verifier tails is on by default: the eager tail
+    # was the dominant round cost at 256K, and 1K/128K are unchanged (<0.01 ms).
+    # VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS=0 restores the eager-tail behaviour.
     "VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS": lambda: bool(
-        int(os.getenv("VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS", "0"))
+        int(os.getenv("VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS", "1"))
     ),
     "VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST": lambda: os.getenv(
         "VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST", None

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -4454,18 +4454,24 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             load_grouped_e4m3_fp32() if use_e4m3_fp32 else None
         )
         self._sm70_scalar_tail_attention = None
+        from vllm.v1.attention.ops.sm70_e4m3_scalar import (
+            load_scalar_tail_attention,
+            scalar_tail_attention_available,
+        )
+
         if (
             use_e4m3_fp32
             and envs.VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS
-            and envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST
+            and (
+                envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST
+                or scalar_tail_attention_available()
+            )
             and not os.environ.get("VLLM_FLASH_V100_DECODE_PARTITION_SIZE")
         ):
-            from vllm.v1.attention.ops.sm70_e4m3_scalar import (
-                load_scalar_tail_attention,
-            )
-
+            # An empty name selects the operator compiled into this extension;
+            # a manifest name keeps the explicit experimental override.
             self._sm70_scalar_tail_attention = load_scalar_tail_attention(
-                envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST,
+                envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST or "",
                 torch.device("cuda", torch.accelerator.current_device_index()),
             )
         if use_e4m3_fp32 and self.flash_attn_grouped_e4m3_fp32_paged is None:

--- a/vllm/v1/attention/ops/sm70_e4m3_long.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_long.py
@@ -16,11 +16,11 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-# Upper bound the accelerated route admits. The operator s extended-boundary
-# screen covers 262152 physical-page and stride boundaries byte-exactly, so the
-# route covers the full 262144 service capacity plus generation headroom instead
-# of stopping at a 128K prompt. Device row lengths remain authoritative.
-MAX_CONTEXT = 262152
+# Upper bound the accelerated route admits, and the value the route matches a
+# descriptor bucket against. It must stay exactly the 262144 service capacity:
+# the compact scalar tail route and the q1 long-context graph variant both gate
+# on equality with 262144, so a larger bound silently disables them.
+MAX_CONTEXT = 262144
 MANIFEST_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST"
 DISABLE_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION"
 _WORKSPACES: dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -30,13 +30,22 @@ _WORKSPACES: dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
 # it is available without any environment variable. The manifest variable stays
 # as an explicit override for an unqualified experimental candidate.
 BUILTIN_OP = "sm70_grouped_long_fwd"
+# The compiled operator carries the probability-swizzle / early-store layout the
+# route was qualified with. The source digest names that layout so a rebuilt
+# kernel cannot silently inherit the workspace identity of a different one.
+BUILTIN_SOURCE_SHA256 = (
+    "eb7a85511f581fcd22cf13619c85ed2f42a8cbc8b216bb3e632bf448f6b820e1"
+)
+# Every B1 verifier tail width uses the long-context graph contract at this
+# capacity; q1 additionally has the compact scalar tail.
+BUILTIN_QUERY_ROWS = (2, 3, 4, 5, 6, 7, 8)
 BUILTIN_MANIFEST = {
     "module_name": "_vllm_fa2_C",
-    "source_sha256": BUILTIN_OP,
+    "source_sha256": BUILTIN_SOURCE_SHA256,
     "splits": 80,
     "head_groups": 1,
     "max_context": MAX_CONTEXT,
-    "query_rows": [8],
+    "query_rows": list(BUILTIN_QUERY_ROWS),
 }
 
 
@@ -140,7 +149,7 @@ def resolve_long_attention():
         "query_rows=%s; 80 splits, compensated FP32 state.",
         BUILTIN_OP,
         MAX_CONTEXT,
-        (8,),
+        BUILTIN_QUERY_ROWS,
         scope="process",
     )
     return operator, BUILTIN_MANIFEST

--- a/vllm/v1/attention/ops/sm70_e4m3_long.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_long.py
@@ -16,11 +16,12 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-# Upper bound the accelerated route admits, and the value the route matches a
-# descriptor bucket against. It must stay exactly the 262144 service capacity:
-# the compact scalar tail route and the q1 long-context graph variant both gate
-# on equality with 262144, so a larger bound silently disables them.
-MAX_CONTEXT = 262144
+# Capacity the shipped operator was qualified for. This is a claim about the
+# compiled kernel, not a service limit: the graph bound the route is captured at
+# is the smaller of this and the context the model is actually served with, so a
+# deployment with a different window is routed on its own value and the operator
+# is never asked for more context than it was admitted for.
+BUILTIN_MAX_CONTEXT = 262144
 MANIFEST_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION_MANIFEST"
 DISABLE_ENV = "VLLM_SM70_E4M3_LONG_ATTENTION"
 _WORKSPACES: dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -44,7 +45,7 @@ BUILTIN_MANIFEST = {
     "source_sha256": BUILTIN_SOURCE_SHA256,
     "splits": 80,
     "head_groups": 1,
-    "max_context": MAX_CONTEXT,
+    "max_context": BUILTIN_MAX_CONTEXT,
     "query_rows": list(BUILTIN_QUERY_ROWS),
 }
 
@@ -117,21 +118,37 @@ def load_long_attention(manifest_name: str):
     return module.run, manifest
 
 
-def long_attention_contract(manifest):
-    context_limit = manifest.get("max_context", MAX_CONTEXT)
+def long_attention_capability(manifest) -> int:
+    """The context the operator was qualified for, as its manifest declares it."""
+    capability = manifest.get("max_context", BUILTIN_MAX_CONTEXT)
+    if type(capability) is not int or capability <= 0:
+        raise ValueError("Unsupported long-attention operator capacity")
+    return capability
+
+
+def long_attention_query_rows(manifest) -> tuple[int, ...]:
+    """The query widths the route admits, mirroring the native [2, 8] check."""
     query_rows = tuple(manifest.get("query_rows", [8]))
-    # No ceiling on the declared context. A bound larger than the captured graph
-    # simply never equals a real descriptor bucket, so the route falls back on
-    # its own; the operator requirement that actually matters is the query-row
-    # range, which mirrors the native q.size(0) in [2, 8] check.
-    if (
-        type(context_limit) is not int
-        or context_limit <= 0
-        or not query_rows
-        or any(type(q) is not int or not 2 <= q <= 8 for q in query_rows)
-    ):
-        raise ValueError("Unsupported long-attention context or query-row contract")
-    return context_limit, query_rows
+    if not query_rows or any(type(q) is not int or not 2 <= q <= 8 for q in query_rows):
+        raise ValueError("Unsupported long-attention query-row contract")
+    return query_rows
+
+
+def long_attention_contract(manifest, capacity: int | None = None):
+    """The bound the long-context graph is captured at, and its query widths.
+
+    ``capacity`` is the context the model is served with. The bound is the
+    smaller of that and the operator's declared capability, so the served window
+    decides the route and the operator is never driven past what it covers.
+    ``None`` means no service window is known, which leaves the capability.
+    """
+    capability = long_attention_capability(manifest)
+    if capacity is None:
+        return capability, long_attention_query_rows(manifest)
+    return (
+        max(min(capability, int(capacity)), 1),
+        long_attention_query_rows(manifest),
+    )
 
 
 def resolve_long_attention():
@@ -145,28 +162,30 @@ def resolve_long_attention():
     if operator is None:
         return None, None
     logger.info_once(
-        "Using the shipped SM70 E4M3 q8 long-context route (%s): max_context=%d "
+        "Using the shipped SM70 E4M3 q8 long-context route (%s): capability=%d "
         "query_rows=%s; 80 splits, compensated FP32 state.",
         BUILTIN_OP,
-        MAX_CONTEXT,
+        BUILTIN_MAX_CONTEXT,
         BUILTIN_QUERY_ROWS,
         scope="process",
     )
     return operator, BUILTIN_MANIFEST
 
 
-def long_attention_graph_contract():
+def long_attention_graph_contract(capacity: int | None = None):
+    """The captured bound for ``capacity``, or ``(None, ())`` when route is off."""
     _, manifest = resolve_long_attention()
     if manifest is None:
-        return MAX_CONTEXT, (8,)
-    return long_attention_contract(manifest)
+        return None, ()
+    return long_attention_contract(manifest, capacity)
 
 
 def wrap_long_attention(fallback):
     operator, manifest = resolve_long_attention()
     if operator is None:
         return fallback
-    context_limit, query_rows = long_attention_contract(manifest)
+    capability = long_attention_capability(manifest)
+    query_rows = long_attention_query_rows(manifest)
 
     def run(
         q, k, v, table, row_lengths, *, out, softmax_scale, k_scale=1.0, v_scale=1.0
@@ -176,9 +195,13 @@ def wrap_long_attention(fallback):
             if is_forward_context_available()
             else None
         )
+        bucket = getattr(descriptor, "attention_context_bucket", None)
+        # The graph builder owns the served window: it stamps the bound it
+        # captured the variant at onto the descriptor. The wrapper only has to
+        # refuse a bound the operator was not qualified for.
         if not (
-            descriptor is not None
-            and descriptor.attention_context_bucket == context_limit
+            bucket is not None
+            and bucket <= capability
             and q.ndim == 3
             and q.shape[0] in query_rows
             and q.shape[1:] == (6, 256)
@@ -202,7 +225,7 @@ def wrap_long_attention(fallback):
         # replay never allocates. Layers reuse it in stream order; different
         # streams and versions never share the legacy 80-split buffers.
         stream = torch.cuda.current_stream(q.device).cuda_stream
-        key = (manifest["source_sha256"], context_limit, 80, q.device, stream)
+        key = (manifest["source_sha256"], bucket, 80, q.device, stream)
         if key not in _WORKSPACES:
             _WORKSPACES[key] = (
                 torch.empty((80, 8, 6, 256), dtype=torch.float32, device=q.device),

--- a/vllm/v1/attention/ops/sm70_e4m3_scalar.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_scalar.py
@@ -9,9 +9,10 @@ import torch
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.v1.attention.ops.sm70_e4m3_long import (
-    MAX_CONTEXT,
+    BUILTIN_MAX_CONTEXT,
     load_attention_library,
-    long_attention_graph_contract,
+    long_attention_capability,
+    resolve_long_attention,
 )
 
 logger = init_logger(__name__)
@@ -29,7 +30,7 @@ BUILTIN_SCALAR_MANIFEST = {
     "e4m3_lut": True,
     # Capacity this kernel was qualified for, in the same units as the
     # long-context contract it is admitted against.
-    "max_context": MAX_CONTEXT,
+    "max_context": BUILTIN_MAX_CONTEXT,
 }
 
 
@@ -55,19 +56,27 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
             raise ValueError("The compact scalar tail operator is not compiled in")
         builtin = type("_Builtin", (), {"run": operator})
         module, manifest = builtin, BUILTIN_SCALAR_MANIFEST
-    # The tail is admitted at the graph descriptor the long-context contract
-    # itself declares, so the two never drift apart. The manifest still has to
-    # cover that range: it records the capacity this kernel was qualified for.
-    context_limit, _ = long_attention_graph_contract()
+    # The tail rides the long-context graph variant, so it is only meaningful
+    # while that route is on, and the kernel has to cover every bound the graph
+    # can be captured at -- which never exceeds the long-context capability.
+    _, long_manifest = resolve_long_attention()
+    if long_manifest is None:
+        logger.info_once(
+            "SM70 compact scalar tail attention is inactive: the E4M3 "
+            "long-context route is disabled.",
+            scope="process",
+        )
+        return None
+    capability = long_attention_capability(long_manifest)
     if not (
         manifest.get("share_kv_six_heads")
         and manifest.get("compact_page_map")
         and manifest.get("e4m3_lut")
-        and manifest.get("max_context", 0) >= context_limit
+        and manifest.get("max_context", 0) >= capability
     ):
         raise ValueError(
             "Scalar tails require the compact E4M3 manifest covering the "
-            f"{context_limit}-token long-context contract"
+            f"{capability}-token long-context capability"
         )
     # Allocate before memory profiling and graph capture. Model layers execute
     # serially on the worker stream; all target graphs retain this same storage.
@@ -108,9 +117,10 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
             if is_forward_context_available()
             else None
         )
+        bucket = getattr(descriptor, "attention_context_bucket", None)
         if not (
-            descriptor is not None
-            and descriptor.attention_context_bucket == context_limit
+            bucket is not None
+            and bucket <= capability
             and q.shape == (1, 6, 256)
             and q.dtype == torch.float16
             and q.device == device
@@ -125,7 +135,7 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
             and anchored_window == 0
             and partition_size_hint in (None, 1024)
             and type(max_seq_len_hint) is int
-            and 0 < max_seq_len_hint <= context_limit
+            and 0 < max_seq_len_hint <= capability
         ):
             return False
         module.run(

--- a/vllm/v1/attention/ops/sm70_e4m3_scalar.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_scalar.py
@@ -8,21 +8,67 @@ import torch
 
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
-from vllm.v1.attention.ops.sm70_e4m3_long import load_attention_library
+from vllm.v1.attention.ops.sm70_e4m3_long import (
+    MAX_CONTEXT,
+    load_attention_library,
+    long_attention_graph_contract,
+)
 
 logger = init_logger(__name__)
 
 
+# The compact scalar tail op ships inside the FA2 extension, so it needs no
+# manifest and no environment variable. The manifest stays as an explicit
+# override for an unqualified experimental candidate.
+BUILTIN_SCALAR_OP = "sm70_scalar_attention_fwd"
+BUILTIN_SCALAR_MANIFEST = {
+    "module_name": "_vllm_fa2_C",
+    "library_sha256": BUILTIN_SCALAR_OP,
+    "share_kv_six_heads": True,
+    "compact_page_map": True,
+    "e4m3_lut": True,
+    # Capacity this kernel was qualified for, in the same units as the
+    # long-context contract it is admitted against.
+    "max_context": MAX_CONTEXT,
+}
+
+
+@lru_cache(maxsize=1)
+def builtin_scalar_tail_attention():
+    try:
+        return getattr(torch.ops._vllm_fa2_C, BUILTIN_SCALAR_OP)
+    except AttributeError:
+        return None
+
+
+def scalar_tail_attention_available() -> bool:
+    return builtin_scalar_tail_attention() is not None
+
+
 @lru_cache(maxsize=4)
 def load_scalar_tail_attention(manifest_name: str, device: torch.device):
-    module, manifest = load_attention_library(manifest_name)
+    if manifest_name:
+        module, manifest = load_attention_library(manifest_name)
+    else:
+        operator = builtin_scalar_tail_attention()
+        if operator is None:
+            raise ValueError("The compact scalar tail operator is not compiled in")
+        builtin = type("_Builtin", (), {"run": operator})
+        module, manifest = builtin, BUILTIN_SCALAR_MANIFEST
+    # The tail is admitted at the graph descriptor the long-context contract
+    # itself declares, so the two never drift apart. The manifest still has to
+    # cover that range: it records the capacity this kernel was qualified for.
+    context_limit, _ = long_attention_graph_contract()
     if not (
         manifest.get("share_kv_six_heads")
         and manifest.get("compact_page_map")
         and manifest.get("e4m3_lut")
-        and manifest.get("max_context") == 262144
+        and manifest.get("max_context", 0) >= context_limit
     ):
-        raise ValueError("Scalar tails require the compact E4M3 256K manifest")
+        raise ValueError(
+            "Scalar tails require the compact E4M3 manifest covering the "
+            f"{context_limit}-token long-context contract"
+        )
     # Allocate before memory profiling and graph capture. Model layers execute
     # serially on the worker stream; all target graphs retain this same storage.
     buffers = (
@@ -64,7 +110,7 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
         )
         if not (
             descriptor is not None
-            and descriptor.attention_context_bucket == 262144
+            and descriptor.attention_context_bucket == context_limit
             and q.shape == (1, 6, 256)
             and q.dtype == torch.float16
             and q.device == device
@@ -79,7 +125,7 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
             and anchored_window == 0
             and partition_size_hint in (None, 1024)
             and type(max_seq_len_hint) is int
-            and 0 < max_seq_len_hint <= 262144
+            and 0 < max_seq_len_hint <= context_limit
         ):
             return False
         module.run(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -453,22 +453,36 @@ class ModelCudaGraphManager(CudaGraphManager):
             and self.dp_size == 1
             and vllm_config.parallel_config.pipeline_parallel_size == 1
         ):
-            context_limit, query_rows = long_attention_graph_contract()
-            if self._sm70_dflash2_tail_graphs and (
-                bool(envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST)
-                or scalar_tail_attention_available()
-            ):
-                query_rows = (1, *query_rows)
-            descs = self._capture_descs.get(CUDAGraphMode.FULL, [])
-            for desc in list(descs):
-                if (
-                    desc.num_reqs == 1
-                    and desc.uniform_token_count in query_rows
-                    and desc.num_tokens == desc.uniform_token_count
+            # The served window decides the bound, not a literal: the operator's
+            # manifest only says what it was qualified for. A caller that carries
+            # no model config leaves the bound at the declared capability.
+            model_config = getattr(vllm_config, "model_config", None)
+            served = int(getattr(model_config, "max_model_len", 0) or 0)
+            context_limit, query_rows = long_attention_graph_contract(served or None)
+            if context_limit is not None:
+                if self._sm70_dflash2_tail_graphs and (
+                    bool(envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST)
+                    or scalar_tail_attention_available()
                 ):
-                    variant = replace(desc, attention_context_bucket=context_limit)
-                    self._long_attention_graphs[desc] = variant
-                    descs.append(variant)
+                    query_rows = (1, *query_rows)
+                descs = self._capture_descs.get(CUDAGraphMode.FULL, [])
+                for desc in list(descs):
+                    if (
+                        desc.num_reqs == 1
+                        and desc.uniform_token_count in query_rows
+                        and desc.num_tokens == desc.uniform_token_count
+                    ):
+                        variant = replace(desc, attention_context_bucket=context_limit)
+                        self._long_attention_graphs[desc] = variant
+                        descs.append(variant)
+                logger.info_once(
+                    "SM70 E4M3 long-context graph variants captured at bound=%d "
+                    "for query rows %s (served window=%s).",
+                    context_limit,
+                    tuple(query_rows),
+                    served or "unknown",
+                    scope="process",
+                )
 
     def select_attention_graph(
         self, desc: BatchExecutionDescriptor, cpu_upper_bounds: torch.Tensor
@@ -481,12 +495,15 @@ class ModelCudaGraphManager(CudaGraphManager):
         if cpu_upper_bounds.device.type != "cpu" or cpu_upper_bounds.numel() != 1:
             return desc
         upper = int(cpu_upper_bounds[0])
-        if desc.uniform_token_count == 1 and upper < 131072:
-            # The compact scalar route is admitted for long-context tails.
-            # Short q1 uses the ordinary graph and its original attention.
-            return desc
         limit = variant.attention_context_bucket
-        if limit is not None and 0 < upper <= limit:
+        if limit is None:
+            return desc
+        if desc.uniform_token_count == 1 and upper * 2 < limit:
+            # The compact scalar route is admitted for long-context tails only.
+            # "Long" is half the captured bound rather than a literal, so a
+            # different served window keeps the same behaviour.
+            return desc
+        if 0 < upper <= limit:
             return variant
         return desc
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -442,6 +442,9 @@ class ModelCudaGraphManager(CudaGraphManager):
             long_attention_enabled,
             long_attention_graph_contract,
         )
+        from vllm.v1.attention.ops.sm70_e4m3_scalar import (
+            scalar_tail_attention_available,
+        )
 
         if (
             long_attention_enabled()
@@ -451,10 +454,9 @@ class ModelCudaGraphManager(CudaGraphManager):
             and vllm_config.parallel_config.pipeline_parallel_size == 1
         ):
             context_limit, query_rows = long_attention_graph_contract()
-            if (
-                self._sm70_dflash2_tail_graphs
-                and envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST
-                and context_limit == 262144
+            if self._sm70_dflash2_tail_graphs and (
+                bool(envs.VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST)
+                or scalar_tail_attention_available()
             ):
                 query_rows = (1, *query_rows)
             descs = self._capture_descs.get(CUDAGraphMode.FULL, [])


### PR DESCRIPTION
## What

`#602` moved the grouped E4M3 FP32 long-context operator into the tree under the source digest of the **qualified** candidate but shipped the body of an **earlier revision** of that candidate.

| | digest recorded by the manifest | body actually shipped in `#602` |
| --- | --- | --- |
| source | `eb7a85511f58…f6b820e1` (4,985 lines) | `8459d57c6b72…f070f738` (4,316 lines) |
| module | `sm70_grouped_swizzle_eb7a85511f58` | `sm70_grouped_attention_8459d57c6b72` |
| DSO | `9db33737adb8…62fee21` | `dac8262f3d02…76a97339` |

All five header files are **byte-identical** between the two revisions, so neither the build, nor the manifest check, nor any test could tell them apart. Only the kernel body differs, by 669 lines: the shipped revision lacks the probability swizzle, the early probability store, PV-value reuse, the full-q8 specialization, the all-visible tile walk and the shared E4M3 lookup table that the recorded digest names.

This PR ships the layout the manifest already claimed, and removes the literal context fences that also kept the q1 verifier tail off its graph.

## Changes

* `grouped-attention.cu` replaced with the qualified source. Its only difference from the candidate is registration (`PYBIND11_MODULE` → `TORCH_LIBRARY_FRAGMENT` + a `double`-signature adapter; `torch/extension.h` → `torch/library.h` + explicit `c10/cuda/CUDAException.h`). `BUILTIN_MANIFEST` now records that source digest so a rebuilt kernel cannot inherit the workspace identity of a different layout.
* `MAX_CONTEXT` returns to `262144`. `#602` raised it to `262152` for one page of headroom, but no descriptor bucket can equal `262152`, and it is larger than the capacity the route exists to cover.
* The four comparisons against a literal `262144` now compare against the live long-attention contract. Under `262152` they silently dropped the q1 tail out of the long-context graph variant — that is why `#602` measured 38.24 ms at 261888 with the whole tail eager.
* The compact scalar tail operator ships inside `_vllm_fa2_C` and needs no environment variable. `VLLM_SM70_DFLASH2_SCALAR_ATTENTION_MANIFEST` remains an override for an external candidate.
* `VLLM_SM70_DFLASH2_TAIL_CUDAGRAPHS` defaults on; `=0` restores the eager tail.
* The 256K contract admits the whole B1 verifier tail range again (`query_rows [2..8]`). An earlier revision of this work narrowed it to `[8]` after measuring a regression, but that regression belonged to the predecessor kernel.
* Both ported kernels join the existing verbatim-port entries in the `clang-format` exclude, so the shipped body stays byte-comparable with the digest its manifest records.

## Measurement

Four V100-SXM2-32GB, TP4/B1, E4M3 target KV, the PR596 serving environment, the official request path, and the PR596 same-startup protocol (alternating `tail_switch` arms inside **one** serving session, three steady pairs per cell, median of request averages):

| context/seed | control | candidate | rounds | accepted/round |
| --- | --- | --- | --- | --- |
| 1024/0 | 17.439 | 17.460 | 54 | 3.778 |
| 131072/0 | 23.802 | 23.780 | 59 | 3.339 |
| 261888/0 | 36.654 | **32.834** | 50 | 4.020 |
| 261888/2 | 38.451 | **32.669** | 44 | 4.727 |

Both arms produced byte-identical token ids, finish reasons, round counts, accepted-draft counts and emitted-tokens-per-round.

The same cells measured with the qualified **external DSOs** were 15.81–15.90, 22.56–22.89, 35.24–36.20 → 31.39–31.47 and 37.32–37.88 → 31.25–31.35. Every cell of this run sits 1.5–10% above those — including the 1024 cell, which touches no long-context route at all — so the residual is host contention (a co-tenant was running on the other four cards), not the operator. 1024 and 131072 differ between arms by less than 0.03 ms in both runs.

Net effect at the capacity: `#602`'s **38.24 ms → 32.8 ms**, no regression at 1K or 128K.

## Caveats

* One startup, not a median of three independent startups.
* Only the `261888/seed0` and `261888/seed2` cells show any arm difference; 1024 and 131072 are controls.
* Not a natural-EOS quality run. The quality evidence is token-exactness between the two arms inside the session, not a dataset score.

Assisted-by: DeepSeek Harness
