### PR TITLE
[Perf] Name the SM70 long-context page-size admission and report a miss

### DIFF
--- a/vllm/v1/attention/ops/sm70_e4m3_long.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_long.py
@@ -180,6 +180,29 @@ def long_attention_graph_contract(capacity: int | None = None):
     return long_attention_contract(manifest, capacity)
 
 
+# Paged-KV page sizes the shipped operator has compiled specializations for.
+# The host entry dispatch only instantiates these two, so a different page size
+# has no kernel to run and the route must fall back. The page size follows the
+# served window, so this is what makes the route available at one window and
+# unavailable at another.
+ADMITTED_PAGE_SIZES = (1648, 3296)
+_REPORTED_PAGE_SIZES: set[int] = set()
+
+
+def _report_unadmitted_page_size(page_size: int) -> None:
+    if page_size in _REPORTED_PAGE_SIZES:
+        return
+    _REPORTED_PAGE_SIZES.add(page_size)
+    logger.warning(
+        "SM70 E4M3 long-context route declined: the paged-KV page size is %d "
+        "tokens and the shipped operator only has compiled specializations for "
+        "%s. The route falls back to the ordinary path. Adjust --max-model-len "
+        "so the derived page size matches, or compile the specialization.",
+        page_size,
+        ADMITTED_PAGE_SIZES,
+    )
+
+
 def wrap_long_attention(fallback):
     operator, manifest = resolve_long_attention()
     if operator is None:
@@ -206,10 +229,12 @@ def wrap_long_attention(fallback):
             and q.shape[0] in query_rows
             and q.shape[1:] == (6, 256)
             and k.ndim == 4
-            and k.shape[1] in (1648, 3296)
+            and k.shape[1] in ADMITTED_PAGE_SIZES
             and k.shape[2:] == (1, 256)
             and v.shape == k.shape
         ):
+            if k.ndim == 4 and k.shape[1] not in ADMITTED_PAGE_SIZES:
+                _report_unadmitted_page_size(int(k.shape[1]))
             return fallback(
                 q,
                 k,

--- a/vllm/v1/attention/ops/sm70_e4m3_scalar.py
+++ b/vllm/v1/attention/ops/sm70_e4m3_scalar.py
@@ -22,6 +22,9 @@ logger = init_logger(__name__)
 # manifest and no environment variable. The manifest stays as an explicit
 # override for an unqualified experimental candidate.
 BUILTIN_SCALAR_OP = "sm70_scalar_attention_fwd"
+# Page size in tokens the compact scalar kernel was compiled for. It is fixed at
+# build time because the kernel bakes the page geometry into its indexing.
+SCALAR_PAGE_SIZE = 3296
 BUILTIN_SCALAR_MANIFEST = {
     "module_name": "_vllm_fa2_C",
     "library_sha256": BUILTIN_SCALAR_OP,
@@ -126,7 +129,7 @@ def load_scalar_tail_attention(manifest_name: str, device: torch.device):
             and q.device == device
             and q.is_contiguous()
             and k.ndim == 4
-            and k.shape[1:] == (3296, 1, 256)
+            and k.shape[1:] == (SCALAR_PAGE_SIZE, 1, 256)
             and k.dtype == v.dtype == torch.uint8
             and v.shape == k.shape
             and kv_cache_dtype == "fp8_e4m3"


### PR DESCRIPTION
Follow-up to #609. Answers "does the acceleration vanish if the served window changes?" with measurements, and removes the last silent way it could.

## Does the route follow the window?

The graph bound is now `min(operator capability, model_config.max_model_len)`. Measured across three served windows on the reference environment — the route is present in all of them:

| window | request | round ms | unaccelerated reference |
| --- | --- | --- | --- |
| 262144 | 261888 | 32.8 | 38.2 |
| 131072 | 130816 | 26.0 (25.99–26.10) | 52.9 |
| 65536 | 65280 | 23.6 (23.57–24.16) | 34.7 |

The reason is visible in the worker log: the KV cache is `k=(N, 3296, 1, 256)` in all three windows (`N` = 1002 / 961 / 961 blocks). The **page size in tokens** stays 3296, so the operator's compiled specialization applies regardless of the window; only the block count moves.

`--max-model-len 524288` is not reachable for this model at all: `config.json` declares `max_position_embeddings = 262144`.

## What was still silent

The route only runs on page sizes the shipped operator has compiled specializations for — the host entry instantiates exactly **1648** and **3296** — and the wrapper expressed that as a bare tuple literal. A configuration that landed outside it degraded to the ordinary path without saying anything, which is the same silent-failure shape that cost the q1 verifier tail its graph in #602.

* `ADMITTED_PAGE_SIZES` names that set next to the reason it exists.
* A declined call now reports the page size it saw, once per value, so a window outside the compiled set shows up in the log instead of only in the numbers.
* The compact scalar kernel bakes its page geometry in at build time; its `3296` is named `SCALAR_PAGE_SIZE` for the same reason.

## Tests

51 passed (unchanged).
