### PR TITLE
[Bugfix][Core] Backport upstream Mamba prefix-cache retention

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -24,11 +24,16 @@ We describe two example workloads, where APC can provide huge performance benefi
 
 ### Sparse checkpoints for aligned Mamba caches
 
-In 1Cat, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL` opts into sparse
+In 1Cat, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS` opts into sparse
 checkpoint admission for aligned Mamba prefix caches. Its default is `0`, which
-retains dense checkpoint admission. A positive value is measured in tokens and
-must be a multiple of each Mamba manager's block size; invalid values fail at
-initialization. For example, an interval of `16000` is valid for 800-token blocks.
+retains dense checkpoint admission. A positive integer selects every Nth block
+boundary in each Mamba manager; `1` admits every eligible boundary. Negative values
+fail at initialization. For example, `20` corresponds to 16000 tokens with
+800-token blocks, or 10240 tokens with 512-token blocks. The token spacing adapts
+to the model's block size; the physical block size and pool capacity do not change.
+Smaller intervals retain more recovery points, while larger intervals reduce
+checkpoint pressure but can require more replay. Compare values such as `5`,
+`10`, `20`, and `40` for the intended workload.
 
 Sparse admission applies only when the cache mode is `align` and the coordinator's
 alignment equals the manager's block size. Other geometries use dense admission.

--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -24,34 +24,49 @@ We describe two example workloads, where APC can provide huge performance benefi
 
 ### Sparse checkpoints for aligned Mamba caches
 
-In 1Cat, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS` opts into sparse
-checkpoint admission for aligned Mamba prefix caches. Its default is `0`, which
-retains dense checkpoint admission. A positive integer selects every Nth block
-boundary in each Mamba manager; `1` admits every eligible boundary. Negative values
-fail at initialization. For example, `20` corresponds to 16000 tokens with
-800-token blocks, or 10240 tokens with 512-token blocks. The token spacing adapts
-to the model's block size; the physical block size and pool capacity do not change.
-Smaller intervals retain more recovery points, while larger intervals reduce
-checkpoint pressure but can require more replay. Compare values such as `5`,
-`10`, `20`, and `40` for the intended workload.
+`--prefix-cache-retention-interval` (the `CacheConfig.prefix_cache_retention_interval`
+field) controls Mamba checkpoint retention. Its name, token unit, and value
+semantics follow upstream vLLM:
 
-Sparse admission applies only when the cache mode is `align` and the coordinator's
-alignment equals the manager's block size. Other geometries use dense admission.
-It retains periodic checkpoints and both prompt replay boundaries needed by
-ordinary and speculative lookups. It preserves the speculative one-block backoff
-and does not change state computation. Free uncached scratch blocks are recycled
-before cached blocks whenever prefix caching is enabled, including when the
-sparse interval is zero.
+| Value | Retained checkpoints |
+| --- | --- |
+| `None` | Every eligible state, preserving dense admission |
+| `0` (default) | Necessary replay boundaries and detected shared-prefix junctions |
+| Positive integer | Those boundaries plus periodic checkpoints at this token interval |
 
-This reduces checkpoint churn that can evict another request's reusable prefix
-during a long prefill. It does not pin conversation caches: finite capacity and
-changed prefixes can still cause misses. A prefix that ends between retained
-checkpoints can require additional replay. Cold-prefill contention with active
-decoders also remains possible.
+A positive interval must be a multiple of the resolved cache-hit alignment, not
+necessarily a power of two. For 800-token alignment, `16000` selects a checkpoint
+every 20 blocks. The former draft environment variables
+`VLLM_MAMBA_SPARSE_CACHE_INTERVAL` and
+`VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS` are replaced by this configuration field;
+the old value `0` maps to `None`, not to the new default `0`.
 
-Real-model validation used Flash-Next AWQ with four V100 GPUs and MTP3. Shared
-manager code does not imply that other models, including 27B variants, have
-completed real-weight validation.
+This is a Mamba-focused adaptation of upstream
+[#43447](https://github.com/vllm-project/vllm/pull/43447),
+[#45845](https://github.com/vllm-project/vllm/pull/45845),
+[#47782](https://github.com/vllm-project/vllm/pull/47782), and the replay-boundary
+fixes [#53945](https://github.com/vllm-project/vllm/pull/53945) /
+[#54713](https://github.com/vllm-project/vllm/pull/54713).
+Other cache types retain their existing 1Cat admission policy. Sparse Mamba
+admission applies in `align` mode when the manager block size matches the
+coordinator alignment; other geometries keep dense admission.
+
+Free uncached blocks are reused before cached blocks. The retention mask keeps
+both model-level MTP/EAGLE replay positions when required, without removing the
+existing speculative safety backoff. When a group has a longer cached prefix than
+the combined hit, the request records that shared junction; scheduling
+materializes its aligned state and admission keeps it for later sibling requests.
+The first newly observed fork can still require replay. This does not predict
+future forks or pin caches against eventual capacity eviction.
+
+The parameter changes retention, not state computation, block size, or allocated
+VRAM. Smaller positive intervals retain more recovery points; larger intervals
+reduce checkpoint pressure but may require more replay. Cold-prefill contention
+with active decoders remains possible.
+
+The earlier custom-policy GPU experiments used Flash-Next AWQ on four V100 GPUs
+with native FP8 MTP3. They do not constitute GPU acceptance of this revised
+upstream-aligned implementation or of other models such as 27B variants.
 
 ### Workloads without reusable prefixes
 

--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -24,7 +24,7 @@ We describe two example workloads, where APC can provide huge performance benefi
 
 ### Sparse checkpoints for aligned Mamba caches
 
-On this release branch, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL` opts into sparse
+In 1Cat, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL` opts into sparse
 checkpoint admission for aligned Mamba prefix caches. Its default is `0`, which
 retains dense checkpoint admission. A positive value is measured in tokens and
 must be a multiple of each Mamba manager's block size; invalid values fail at

--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -22,4 +22,32 @@ We describe two example workloads, where APC can provide huge performance benefi
 
 ## Limits
 
+### Sparse checkpoints for aligned Mamba caches
+
+On this release branch, `VLLM_MAMBA_SPARSE_CACHE_INTERVAL` opts into sparse
+checkpoint admission for aligned Mamba prefix caches. Its default is `0`, which
+retains dense checkpoint admission. A positive value is measured in tokens and
+must be a multiple of each Mamba manager's block size; invalid values fail at
+initialization. For example, an interval of `16000` is valid for 800-token blocks.
+
+Sparse admission applies only when the cache mode is `align` and the coordinator's
+alignment equals the manager's block size. Other geometries use dense admission.
+It retains periodic checkpoints and both prompt replay boundaries needed by
+ordinary and speculative lookups. It preserves the speculative one-block backoff
+and does not change state computation. Free uncached scratch blocks are recycled
+before cached blocks whenever prefix caching is enabled, including when the
+sparse interval is zero.
+
+This reduces checkpoint churn that can evict another request's reusable prefix
+during a long prefill. It does not pin conversation caches: finite capacity and
+changed prefixes can still cause misses. A prefix that ends between retained
+checkpoints can require additional replay. Cold-prefill contention with active
+decoders also remains possible.
+
+Real-model validation used Flash-Next AWQ with four V100 GPUs and MTP3. Shared
+manager code does not imply that other models, including 27B variants, have
+completed real-weight validation.
+
+### Workloads without reusable prefixes
+
 APC in general does not reduce the performance of vLLM. With that being said, APC only reduces the time of processing the queries (the prefilling phase) and does not reduce the time of generating new tokens (the decoding phase). So APC does not bring performance gain when vLLM spends most of the time generating answers to the queries (e.g. when the length of the answer is long), or new queries do not share the same prefix with any of existing queries (so that the computation cannot be reused).

--- a/tests/v1/core/test_mamba_sparse_retention.py
+++ b/tests/v1/core/test_mamba_sparse_retention.py
@@ -8,10 +8,18 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.config import CacheConfig
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_coordinator import KVCacheCoordinator
+from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import BlockHashListWithBlockSize
 from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, MambaManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
 
 # These tests allocate only block metadata; no device/distributed state exists.
 pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
@@ -21,6 +29,8 @@ def _request(name, length, hash_size=8):
     return SimpleNamespace(
         request_id=name,
         num_tokens=length,
+        shared_prefix_boundary=0,
+        skip_reading_prefix_cache=False,
         block_hashes=[
             hashlib.sha256(f"{name}:{i}".encode()).digest()
             for i in range(length // hash_size)
@@ -42,14 +52,26 @@ def _mamba(pool, block_size, group):
     )
 
 
-def _prefill(managers, request, block_size, alignment=None):
+def _prefill(managers, request, block_size, alignment=None, interval=None, eagle=False):
+    boundaries = KVCacheCoordinator.get_replay_boundaries(
+        SimpleNamespace(eagle_group_ids={0} if eagle else set()),
+        request,
+        alignment or block_size,
+    )
     for start in range(0, request.num_tokens, block_size):
         end = min(start + block_size, request.num_tokens)
         for manager in managers:
             manager.new_step_starts()
             manager.remove_skipped_blocks(request.request_id, start)
             manager.allocate_new_blocks(request.request_id, end, end)
-            manager.cache_blocks(request, end, alignment_tokens=alignment or block_size)
+            kwargs = (
+                {"retention_interval": interval, "replay_boundaries": boundaries}
+                if isinstance(manager, MambaManager)
+                else {}
+            )
+            manager.cache_blocks(
+                request, end, alignment_tokens=alignment or block_size, **kwargs
+            )
     for manager in managers:
         manager.free(request.request_id)
 
@@ -76,12 +98,12 @@ def _hit(manager, request, pool, block_size, eagle):
     "length", [799, 800, 801, 15999, 16000, 16001, 16799, 16800, 16801]
 )
 @pytest.mark.parametrize("eagle", [False, True])
-def test_sparse_retains_both_prompt_replay_boundaries(monkeypatch, length, eagle):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", "20")
+@pytest.mark.parametrize("interval", [0, 16000])
+def test_sparse_retains_both_prompt_replay_boundaries(length, eagle, interval):
     pool = BlockPool(80, True, 8)
     manager = _mamba(pool, 800, 1)
     request = _request("boundary", length)
-    _prefill([manager], request, 800)
+    _prefill([manager], request, 800, interval=interval, eagle=eagle)
     assert (
         _hit(manager, request, pool, 800, eagle)
         == max(0, (length - 1) // 800 - int(eagle)) * 800
@@ -89,9 +111,10 @@ def test_sparse_retains_both_prompt_replay_boundaries(monkeypatch, length, eagle
     assert pool.get_num_free_blocks() == 79
 
 
-@pytest.mark.parametrize("interval,expected", [(0, 0), (20, 169 * 16)])
-def test_long_b_does_not_flush_a_when_sparse_enabled(monkeypatch, interval, expected):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
+@pytest.mark.parametrize(
+    "interval,expected", [(None, 0), (0, 169 * 16), (320, 169 * 16)]
+)
+def test_long_b_does_not_flush_a_when_sparse_enabled(interval, expected):
     pool = BlockPool(650, True, 8)
     full = FullAttentionManager(
         FullAttentionSpec(
@@ -103,36 +126,28 @@ def test_long_b_does_not_flush_a_when_sparse_enabled(monkeypatch, interval, expe
     )
     managers = [full] + [_mamba(pool, 16, group) for group in range(1, 5)]
     a, b = _request("a", 170 * 16 + 3), _request("b", 175 * 16 + 7)
-    _prefill(managers, a, 16)
+    _prefill(managers, a, 16, interval=interval, eagle=True)
     assert min(_hit(m, a, pool, 16, True) for m in managers) == 169 * 16
-    _prefill(managers, b, 16)
+    _prefill(managers, b, 16, interval=interval, eagle=True)
     assert min(_hit(m, a, pool, 16, True) for m in managers) == expected
     assert pool.get_num_free_blocks() == 649
 
 
 @pytest.mark.parametrize("alignment", [800, 1600])
-def test_admission_falls_back_for_different_alignment(monkeypatch, alignment):
+def test_admission_falls_back_for_different_alignment(alignment):
     def retained(interval):
-        monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
         pool = BlockPool(80, True, 8)
         manager = _mamba(pool, 800, 1)
         request = _request("fallback", 16001)
-        _prefill([manager], request, 800, alignment)
+        _prefill([manager], request, 800, alignment, interval=interval)
         hashes = BlockHashListWithBlockSize(request.block_hashes, 8, 800)
         return [i for i, h in enumerate(hashes) if pool.get_cached_block(h, [1])]
 
-    dense, sparse = retained(0), retained(20)
+    dense, sparse = retained(None), retained(16000)
     if alignment == 800:
         assert len(sparse) < len(dense)
     else:
         assert sparse == dense
-
-
-@pytest.mark.parametrize("interval", [-1, -20])
-def test_invalid_interval_fails_early(monkeypatch, interval):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
-    with pytest.raises(ValueError, match="non-negative block count"):
-        _mamba(BlockPool(80, True, 8), 800, 1)
 
 
 @pytest.mark.parametrize("enable_caching", [False, True])
@@ -155,22 +170,127 @@ def test_scratch_reuse_preserves_cached_and_shared_blocks(enable_caching):
     assert pool.get_num_free_blocks() == 6
 
 
+def _cache_manager(block_size=32, interval=0, eagle=True, capacity=1000):
+    full = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float16
+    )
+    mamba = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+    config = KVCacheConfig(
+        capacity,
+        [],
+        [KVCacheGroupSpec(["full"], full), KVCacheGroupSpec(["mamba"], mamba)],
+    )
+    return KVCacheManager(
+        config, 100000, 8, use_eagle=eagle, prefix_cache_retention_interval=interval
+    )
+
+
+def _coordinated_prefill(cm, request, block_size=32):
+    for start in range(0, request.num_tokens, block_size):
+        end = min(start + block_size, request.num_tokens)
+        for manager in cm.coordinator.single_type_managers:
+            manager.new_step_starts()
+            manager.remove_skipped_blocks(request.request_id, start)
+            manager.allocate_new_blocks(request.request_id, end, end)
+        cm.coordinator.cache_blocks(request, end)
+    cm.coordinator.free(request.request_id)
+
+
+@pytest.mark.parametrize("interval", [None, 0, 32, 16000])
+def test_upstream_config_semantics(interval):
+    assert CacheConfig().prefix_cache_retention_interval == 0
+    assert (
+        CacheConfig(
+            prefix_cache_retention_interval=interval
+        ).prefix_cache_retention_interval
+        == interval
+    )
+    manager = _cache_manager(interval=interval)
+    assert manager.coordinator.retention_interval == interval
+    assert (
+        CacheConfig(prefix_cache_retention_interval=interval).compute_hash()
+        == CacheConfig().compute_hash()
+    )
+
+
+@pytest.mark.parametrize("interval", [-1, 1000])
+def test_invalid_interval_fails_after_geometry_resolution(interval):
+    with pytest.raises(ValueError, match="resolved alignment"):
+        _cache_manager(block_size=800, interval=interval)
+
+
+@pytest.mark.parametrize("length", [127, 128, 129, 160, 161])
+@pytest.mark.parametrize("eagle", [False, True])
+@pytest.mark.parametrize("interval", [0, 320])
+def test_hybrid_identical_resend_and_longer_sibling(length, eagle, interval):
+    cm = _cache_manager(interval=interval, eagle=eagle)
+    a = _request("same", length)
+    _coordinated_prefill(cm, a)
+    _, resend = cm.get_computed_blocks(a)
+    sibling = _request("same", length + 64)
+    _, extension = cm.get_computed_blocks(sibling)
+    assert resend == max(0, (length - 1) // 32 - int(eagle)) * 32
+    assert extension == (max(0, length // 32 - 1) if eagle else (length - 1) // 32) * 32
+    assert cm.block_pool.get_num_free_blocks() == 999
+
+
+@pytest.mark.parametrize("eagle", [False, True])
+@pytest.mark.parametrize("retain_junction", [False, True])
+def test_detected_junction_survives_semantic_only_retention(eagle, retain_junction):
+    cm = _cache_manager(interval=0, eagle=eagle)
+    a, b, c = [
+        _request(name, length * 32 + 3)
+        for name, length in [("a", 80), ("b", 60), ("c", 70)]
+    ]
+    shared_hashes = 30 * 32 // 8
+    b.block_hashes[:shared_hashes] = a.block_hashes[:shared_hashes]
+    c.block_hashes[:shared_hashes] = a.block_hashes[:shared_hashes]
+    _coordinated_prefill(cm, a)
+    _, first_hit = cm.get_computed_blocks(b)
+    assert first_hit == 0
+    assert b.shared_prefix_boundary == (30 - int(eagle)) * 32
+    if not retain_junction:
+        b.shared_prefix_boundary = 0
+    _coordinated_prefill(cm, b)
+    _, later_hit = cm.get_computed_blocks(c)
+    assert later_hit == ((30 - int(eagle)) * 32 if retain_junction else 0)
+    assert cm.block_pool.get_num_free_blocks() == 999
+
+
 @pytest.mark.parametrize("block_size", [16, 512, 800, 1024])
-@pytest.mark.parametrize("interval", [0, 1, 5, 10, 20, 40])
-def test_block_interval_is_independent_of_token_block_size(
-    monkeypatch, block_size, interval
-):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
+@pytest.mark.parametrize("interval_blocks", [1, 5, 10, 20, 40])
+def test_token_interval_uses_resolved_block_size(block_size, interval_blocks):
     pool = BlockPool(100, True, 8)
     manager = _mamba(pool, block_size, 1)
-    request = _request("portable", 45 * block_size + 3)
-    _prefill([manager], request, block_size)
+    request = _request("periodic", 45 * block_size + 3)
+    _prefill([manager], request, block_size, interval=interval_blocks * block_size)
     hashes = BlockHashListWithBlockSize(request.block_hashes, 8, block_size)
     retained = [i + 1 for i, h in enumerate(hashes) if pool.get_cached_block(h, [1])]
-    expected = (
-        list(range(1, 46))
-        if interval == 0
-        else sorted(set(range(interval, 46, interval)) | {44, 45})
-    )
-    assert retained == expected
+    assert retained == sorted(set(range(interval_blocks, 46, interval_blocks)) | {45})
     assert pool.get_num_free_blocks() == 99
+
+
+@pytest.mark.parametrize("eagle_groups", [{0}, {1}, {2}, {0, 2}])
+@pytest.mark.parametrize("length", [127, 128, 129])
+def test_mixed_main_and_draft_groups_retain_joint_restore_point(eagle_groups, length):
+    cm = _cache_manager()
+    config = cm.coordinator.kv_cache_config
+    config.kv_cache_groups.append(
+        KVCacheGroupSpec(["draft_mamba"], config.kv_cache_groups[1].kv_cache_spec)
+    )
+    for index, group in enumerate(config.kv_cache_groups):
+        group.is_eagle_group = index in eagle_groups
+    cm = KVCacheManager(
+        config, 100000, 8, use_eagle=True, prefix_cache_retention_interval=0
+    )
+    request = _request("mixed", length)
+    _coordinated_prefill(cm, request)
+    _, hit = cm.get_computed_blocks(request)
+    assert hit == max(0, (length - 1) // 32 - 1) * 32
+    _, extension = cm.get_computed_blocks(_request("mixed", length + 64))
+    assert extension == max(0, length // 32 - 1) * 32

--- a/tests/v1/core/test_mamba_sparse_retention.py
+++ b/tests/v1/core/test_mamba_sparse_retention.py
@@ -77,7 +77,7 @@ def _hit(manager, request, pool, block_size, eagle):
 )
 @pytest.mark.parametrize("eagle", [False, True])
 def test_sparse_retains_both_prompt_replay_boundaries(monkeypatch, length, eagle):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", "16000")
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", "20")
     pool = BlockPool(80, True, 8)
     manager = _mamba(pool, 800, 1)
     request = _request("boundary", length)
@@ -89,9 +89,9 @@ def test_sparse_retains_both_prompt_replay_boundaries(monkeypatch, length, eagle
     assert pool.get_num_free_blocks() == 79
 
 
-@pytest.mark.parametrize("interval,expected", [(0, 0), (320, 169 * 16)])
+@pytest.mark.parametrize("interval,expected", [(0, 0), (20, 169 * 16)])
 def test_long_b_does_not_flush_a_when_sparse_enabled(monkeypatch, interval, expected):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
     pool = BlockPool(650, True, 8)
     full = FullAttentionManager(
         FullAttentionSpec(
@@ -113,7 +113,7 @@ def test_long_b_does_not_flush_a_when_sparse_enabled(monkeypatch, interval, expe
 @pytest.mark.parametrize("alignment", [800, 1600])
 def test_admission_falls_back_for_different_alignment(monkeypatch, alignment):
     def retained(interval):
-        monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
+        monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
         pool = BlockPool(80, True, 8)
         manager = _mamba(pool, 800, 1)
         request = _request("fallback", 16001)
@@ -121,17 +121,17 @@ def test_admission_falls_back_for_different_alignment(monkeypatch, alignment):
         hashes = BlockHashListWithBlockSize(request.block_hashes, 8, 800)
         return [i for i, h in enumerate(hashes) if pool.get_cached_block(h, [1])]
 
-    dense, sparse = retained(0), retained(16000)
+    dense, sparse = retained(0), retained(20)
     if alignment == 800:
         assert len(sparse) < len(dense)
     else:
         assert sparse == dense
 
 
-@pytest.mark.parametrize("interval", [-1, 1000])
+@pytest.mark.parametrize("interval", [-1, -20])
 def test_invalid_interval_fails_early(monkeypatch, interval):
-    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
-    with pytest.raises(ValueError, match="block multiple"):
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
+    with pytest.raises(ValueError, match="non-negative block count"):
         _mamba(BlockPool(80, True, 8), 800, 1)
 
 
@@ -153,3 +153,24 @@ def test_scratch_reuse_preserves_cached_and_shared_blocks(enable_caching):
         assert pool.get_cached_block(request.block_hashes[0], [0]) == [cached]
     pool.free_blocks(reused + [shared])
     assert pool.get_num_free_blocks() == 6
+
+
+@pytest.mark.parametrize("block_size", [16, 512, 800, 1024])
+@pytest.mark.parametrize("interval", [0, 1, 5, 10, 20, 40])
+def test_block_interval_is_independent_of_token_block_size(
+    monkeypatch, block_size, interval
+):
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", str(interval))
+    pool = BlockPool(100, True, 8)
+    manager = _mamba(pool, block_size, 1)
+    request = _request("portable", 45 * block_size + 3)
+    _prefill([manager], request, block_size)
+    hashes = BlockHashListWithBlockSize(request.block_hashes, 8, block_size)
+    retained = [i + 1 for i, h in enumerate(hashes) if pool.get_cached_block(h, [1])]
+    expected = (
+        list(range(1, 46))
+        if interval == 0
+        else sorted(set(range(interval, 46, interval)) | {44, 45})
+    )
+    assert retained == expected
+    assert pool.get_num_free_blocks() == 99

--- a/tests/v1/core/test_mamba_sparse_retention.py
+++ b/tests/v1/core/test_mamba_sparse_retention.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU regressions for retention under interleaved long aligned prefills."""
+
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHashListWithBlockSize
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, MambaManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+# These tests allocate only block metadata; no device/distributed state exists.
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _request(name, length, hash_size=8):
+    return SimpleNamespace(
+        request_id=name,
+        num_tokens=length,
+        block_hashes=[
+            hashlib.sha256(f"{name}:{i}".encode()).digest()
+            for i in range(length // hash_size)
+        ],
+    )
+
+
+def _mamba(pool, block_size, group):
+    return MambaManager(
+        MambaSpec(
+            block_size=block_size,
+            shapes=((1,),),
+            dtypes=(torch.float16,),
+            mamba_cache_mode="align",
+        ),
+        pool,
+        enable_caching=True,
+        kv_cache_group_id=group,
+    )
+
+
+def _prefill(managers, request, block_size, alignment=None):
+    for start in range(0, request.num_tokens, block_size):
+        end = min(start + block_size, request.num_tokens)
+        for manager in managers:
+            manager.new_step_starts()
+            manager.remove_skipped_blocks(request.request_id, start)
+            manager.allocate_new_blocks(request.request_id, end, end)
+            manager.cache_blocks(request, end, alignment_tokens=alignment or block_size)
+    for manager in managers:
+        manager.free(request.request_id)
+
+
+def _hit(manager, request, pool, block_size, eagle):
+    hashes = BlockHashListWithBlockSize(request.block_hashes, 8, block_size)
+    return (
+        len(
+            manager.find_longest_cache_hit(
+                hashes,
+                request.num_tokens - 1,
+                [manager.kv_cache_group_id],
+                pool,
+                manager.kv_cache_spec,
+                eagle,
+                block_size,
+            )[0]
+        )
+        * block_size
+    )
+
+
+@pytest.mark.parametrize(
+    "length", [799, 800, 801, 15999, 16000, 16001, 16799, 16800, 16801]
+)
+@pytest.mark.parametrize("eagle", [False, True])
+def test_sparse_retains_both_prompt_replay_boundaries(monkeypatch, length, eagle):
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", "16000")
+    pool = BlockPool(80, True, 8)
+    manager = _mamba(pool, 800, 1)
+    request = _request("boundary", length)
+    _prefill([manager], request, 800)
+    assert (
+        _hit(manager, request, pool, 800, eagle)
+        == max(0, (length - 1) // 800 - int(eagle)) * 800
+    )
+    assert pool.get_num_free_blocks() == 79
+
+
+@pytest.mark.parametrize("interval,expected", [(0, 0), (320, 169 * 16)])
+def test_long_b_does_not_flush_a_when_sparse_enabled(monkeypatch, interval, expected):
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
+    pool = BlockPool(650, True, 8)
+    full = FullAttentionManager(
+        FullAttentionSpec(
+            block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float16
+        ),
+        pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+    managers = [full] + [_mamba(pool, 16, group) for group in range(1, 5)]
+    a, b = _request("a", 170 * 16 + 3), _request("b", 175 * 16 + 7)
+    _prefill(managers, a, 16)
+    assert min(_hit(m, a, pool, 16, True) for m in managers) == 169 * 16
+    _prefill(managers, b, 16)
+    assert min(_hit(m, a, pool, 16, True) for m in managers) == expected
+    assert pool.get_num_free_blocks() == 649
+
+
+@pytest.mark.parametrize("alignment", [800, 1600])
+def test_admission_falls_back_for_different_alignment(monkeypatch, alignment):
+    def retained(interval):
+        monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
+        pool = BlockPool(80, True, 8)
+        manager = _mamba(pool, 800, 1)
+        request = _request("fallback", 16001)
+        _prefill([manager], request, 800, alignment)
+        hashes = BlockHashListWithBlockSize(request.block_hashes, 8, 800)
+        return [i for i, h in enumerate(hashes) if pool.get_cached_block(h, [1])]
+
+    dense, sparse = retained(0), retained(16000)
+    if alignment == 800:
+        assert len(sparse) < len(dense)
+    else:
+        assert sparse == dense
+
+
+@pytest.mark.parametrize("interval", [-1, 1000])
+def test_invalid_interval_fails_early(monkeypatch, interval):
+    monkeypatch.setenv("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", str(interval))
+    with pytest.raises(ValueError, match="block multiple"):
+        _mamba(BlockPool(80, True, 8), 800, 1)
+
+
+@pytest.mark.parametrize("enable_caching", [False, True])
+def test_scratch_reuse_preserves_cached_and_shared_blocks(enable_caching):
+    pool = BlockPool(7, enable_caching, 8)
+    cached, first, second, shared = pool.get_new_blocks(4)
+    untouched = list(pool.free_block_queue.get_all_free_blocks())
+    request = _request("cached", 8)
+    if enable_caching:
+        pool.cache_full_blocks(request, [cached], 0, 1, 8, 0)
+    pool.touch([shared])
+    pool.free_blocks([cached])
+    pool.free_blocks([first, second, shared])
+    assert shared.ref_cnt == 1
+    reused = pool.get_new_blocks(2)
+    assert reused == ([first, second] if enable_caching else untouched)
+    if enable_caching:
+        assert pool.get_cached_block(request.block_hashes[0], [0]) == [cached]
+    pool.free_blocks(reused + [shared])
+    assert pool.get_num_free_blocks() == 6

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -275,13 +275,12 @@ def test_prefill(hash_fn):
     # All blocks should be available.
     assert free_block_queue.num_free_blocks == 10
     # The order should be
+    # [uncached unique_req1 (5), unique_req0 (4)]
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
     # [common (3, 2, 1)]
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Cache hit in the common prefix when the original block is already free.
     # Incomplete 1 block (6 tokens)
@@ -295,7 +294,7 @@ def test_prefill(hash_fn):
     blocks = manager.allocate_slots(
         req2, num_new_tokens, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([6],)
+    assert blocks is not None and blocks.get_block_ids() == ([5],)
 
     # Although we only have 6 free blocks, we have 8 blocks in
     # the free block queue due to lazy removal.
@@ -315,7 +314,7 @@ def test_prefill(hash_fn):
     )
     # This block ID order also checks the eviction order.
     assert blocks is not None and blocks.get_block_ids() == (
-        [7, 8, 9, 10, 4, 5, 6, 3, 2, 1],
+        [5, 4, 6, 7, 8, 9, 10, 3, 2, 1],
     )
 
     assert free_block_queue.num_free_blocks == 0
@@ -1180,13 +1179,12 @@ def test_prefill_plp():
     # All blocks should be available.
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     # The order should be
+    # [uncached unique_req1 (5), unique_req0 (4)]
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
     # [common (3, 2, 1)]
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Request #2 is a prompt-logprobs request:
     # NO cache hit in the common prefix; duplicates request #0 cached blocks
@@ -1319,7 +1317,7 @@ def test_evict():
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [10, 6, 5, 4, 3, 2, 1, 9, 8, 7]
+    ] == [6, 10, 5, 4, 3, 2, 1, 9, 8, 7]
 
     # Touch the first 2 blocks.
     req2 = make_request("2", list(range(2 * 16 + 3)), block_size, sha256)
@@ -1329,7 +1327,7 @@ def test_evict():
     blocks = manager.allocate_slots(
         req2, 3, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([10],)
+    assert blocks is not None and blocks.get_block_ids() == ([6],)
     assert manager.block_pool.free_block_queue.num_free_blocks == 7
 
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -94,6 +94,13 @@ class CacheConfig:
     `ModelConfig` and that value should be manually duplicated here."""
     enable_prefix_caching: bool = True
     """Whether to enable prefix caching."""
+    prefix_cache_retention_interval: int | None = Field(default=0, ge=0)
+    """Token interval between retained Mamba prefix-cache checkpoints.
+    ``None`` keeps dense admission; ``0`` keeps replay and detected shared-prefix
+    boundaries; positive values additionally keep periodic checkpoints and must
+    be a multiple of the resolved cache-hit alignment. This backport applies to
+    aligned Mamba groups; other cache types keep their existing admission policy.
+    """
     prefix_caching_hash_algo: PrefixCachingHashAlgo = "sha256"
     """Set the hash algorithm for prefix caching:
 
@@ -198,6 +205,7 @@ class CacheConfig:
             "num_gpu_blocks_override",
             "enable_prefix_caching",
             "prefix_caching_hash_algo",
+            "prefix_cache_retention_interval",
             # Prefix-caching implementation detail (doesn't affect compiled graph).
             "hash_block_size",
             "mamba_page_size_padded",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -535,6 +535,9 @@ class EngineArgs:
     )
     block_size: int | None = None
     enable_prefix_caching: bool | None = None
+    prefix_cache_retention_interval: int | None = (
+        CacheConfig.prefix_cache_retention_interval
+    )
     prefix_caching_hash_algo: PrefixCachingHashAlgo = (
         CacheConfig.prefix_caching_hash_algo
     )
@@ -1173,6 +1176,10 @@ class EngineArgs:
         )
         cache_group.add_argument(
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]
+        )
+        cache_group.add_argument(
+            "--prefix-cache-retention-interval",
+            **cache_kwargs["prefix_cache_retention_interval"],
         )
         cache_group.add_argument(
             "--calculate-kv-scales", **cache_kwargs["calculate_kv_scales"]
@@ -1995,6 +2002,7 @@ class EngineArgs:
             sliding_window=sliding_window,
             enable_prefix_caching=self.enable_prefix_caching,
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
+            prefix_cache_retention_interval=self.prefix_cache_retention_interval,
             calculate_kv_scales=self.calculate_kv_scales,
             kv_cache_dtype_skip_layers=self.kv_cache_dtype_skip_layers,
             kv_sharing_fast_prefill=self.kv_sharing_fast_prefill,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -428,9 +428,20 @@ class BlockPool:
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
             block.ref_cnt -= 1
-        self.free_block_queue.append_n(
-            [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
-        )
+        freed_blocks = [
+            block for block in blocks_list if block.ref_cnt == 0 and not block.is_null
+        ]
+        if self.enable_caching:
+            # Uncached scratch has no reusable prefix to evict. Recycle it
+            # before consuming the queue's older cached entries.
+            self.free_block_queue.prepend_n(
+                [block for block in freed_blocks if block.block_hash is None]
+            )
+            self.free_block_queue.append_n(
+                [block for block in freed_blocks if block.block_hash is not None]
+            )
+        else:
+            self.free_block_queue.append_n(freed_blocks)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -14,6 +14,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
+    MambaManager,
     SingleTypeKVCacheManager,
     get_manager_for_kv_cache_spec,
 )
@@ -46,6 +47,8 @@ class KVCacheCoordinator(ABC):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
         self.enable_caching = enable_caching
+        self.retention_interval: int | None = None
+        self.shared_prefix_boundary = 0
 
         self.block_pool = BlockPool(
             num_gpu_blocks=kv_cache_config.num_blocks,
@@ -76,6 +79,61 @@ class KVCacheCoordinator(ABC):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+
+    def configure_prefix_cache_retention(self, interval: int | None) -> None:
+        """Validate after 1Cat has resolved the heterogeneous cache geometry."""
+        self.retention_interval = interval
+        if interval is None or not self.enable_caching:
+            return
+        mamba = [m for m in self.single_type_managers if isinstance(m, MambaManager)]
+        if not mamba:
+            if interval == 0:
+                return
+            raise ValueError(
+                "prefix_cache_retention_interval requires a Mamba cache group "
+                "in this backport"
+            )
+        alignment = getattr(self, "lcm_block_size", mamba[0].block_size)
+        if interval < 0 or interval % alignment:
+            raise ValueError(
+                f"prefix_cache_retention_interval ({interval}) must be a non-negative "
+                f"multiple of the resolved alignment ({alignment})"
+            )
+
+    def get_replay_boundaries(
+        self, request: Request, alignment: int
+    ) -> tuple[int, ...]:
+        """Retain both identical resend and longer-sibling resume positions.
+
+        Adapted from upstream #53945/#54713. Use the current request length so
+        resumed output-token prefills follow 1Cat's existing scheduler behavior.
+        """
+        if not self.eagle_group_ids:
+            return (request.num_tokens - 1,)
+        resend = (request.num_tokens - 1) // alignment * alignment
+        extension = request.num_tokens // alignment * alignment
+        return tuple(
+            sorted({max(resend - alignment, 0), max(extension - alignment, 0)})
+        )
+
+    def _cache_manager_blocks(
+        self,
+        manager: SingleTypeKVCacheManager,
+        request: Request,
+        num_tokens: int,
+        alignment: int | None = None,
+    ) -> None:
+        if isinstance(manager, MambaManager):
+            alignment = alignment or manager.block_size
+            manager.cache_blocks(
+                request,
+                num_tokens,
+                alignment_tokens=alignment,
+                retention_interval=self.retention_interval,
+                replay_boundaries=self.get_replay_boundaries(request, alignment),
+            )
+        else:
+            manager.cache_blocks(request, num_tokens, alignment_tokens=alignment)
 
     def get_num_blocks_to_allocate(
         self,
@@ -206,7 +264,7 @@ class KVCacheCoordinator(ABC):
                 (including tokens that are already cached).
         """
         for manager in self.single_type_managers:
-            manager.cache_blocks(request, num_computed_tokens)
+            self._cache_manager_blocks(manager, request, num_computed_tokens)
 
     def free(self, request_id: str) -> None:
         """
@@ -514,10 +572,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             num_computed_tokens // self.lcm_block_size * self.lcm_block_size
         )
         for manager in self.single_type_managers:
-            manager.cache_blocks(
-                request,
-                num_computed_tokens,
-                alignment_tokens=self.lcm_block_size,
+            self._cache_manager_blocks(
+                manager, request, num_computed_tokens, self.lcm_block_size
             )
 
     def find_longest_cache_hit(
@@ -550,6 +606,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 block_hashes, self.hash_block_size, kv_cache_spec.block_size
             )
 
+        self.shared_prefix_boundary = 0
+        longest_hit_length = 0
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_length = max_cache_hit_length
         hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
@@ -599,6 +657,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     alignment_tokens=self.lcm_block_size,
                 )
                 _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                longest_hit_length = max(longest_hit_length, _new_hit_length)
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -613,6 +672,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             hit_length = curr_hit_length
             if is_simple_hybrid:
                 break
+
+        if longest_hit_length > hit_length:
+            self.shared_prefix_boundary = longest_hit_length
 
         # Truncate full attention blocks to final hit_length (if present)
         spec, group_ids, _ = self.attention_groups[0]

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -125,6 +125,7 @@ class KVCacheManager:
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        prefix_cache_retention_interval: int | None = None,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -153,6 +154,9 @@ class KVCacheManager:
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
+        )
+        self.coordinator.configure_prefix_cache_retention(
+            prefix_cache_retention_interval
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool
@@ -211,6 +215,7 @@ class KVCacheManager:
         # disabled or the request is marked as skipping kv cache read
         # (which happens when the request requires prompt logprobs
         # or calls a pooling model with all pooling).
+        request.shared_prefix_boundary = 0
         if not self.enable_caching or request.skip_reading_prefix_cache:
             return self.empty_kv_cache_blocks, 0
 
@@ -226,6 +231,10 @@ class KVCacheManager:
                 request.block_hashes, max_cache_hit_length
             )
         )
+
+        # Keep the existing two-value lookup API used by 1Cat connectors. The
+        # synchronous coordinator exposes the junction from this lookup only.
+        request.shared_prefix_boundary = self.coordinator.shared_prefix_boundary
 
         if self.log_stats:
             assert self.prefix_cache_stats is not None

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -328,6 +328,27 @@ class FreeKVCacheBlockQueue:
 
         self.num_free_blocks += 1
 
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, (
+            "next_free_block of fake_free_list_head should always exist"
+        )
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
     def append_n(self, blocks: list[KVCacheBlock]) -> None:
         """Put a list of blocks back into the free list
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -267,6 +267,7 @@ class Scheduler(SchedulerInterface):
             pcp_world_size=self.pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
+            prefix_cache_retention_interval=self.cache_config.prefix_cache_retention_interval,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
@@ -463,7 +464,13 @@ class Scheduler(SchedulerInterface):
         end = min(
             (
                 stop
-                for stop in (next_block_boundary, last_cache_position)
+                for stop in (
+                    next_block_boundary,
+                    last_cache_position,
+                    getattr(request, "shared_prefix_boundary", 0)
+                    // block_size
+                    * block_size,
+                )
                 if start < stop < end
             ),
             default=end,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1140,16 +1140,11 @@ class MambaManager(SingleTypeKVCacheManager):
         self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
-        self.sparse_checkpoint_interval = int(
-            os.environ.get("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", "0")
+        self.sparse_checkpoint_interval_blocks = int(
+            os.environ.get("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", "0")
         )
-        if (
-            self.sparse_checkpoint_interval < 0
-            or self.sparse_checkpoint_interval % self.block_size
-        ):
-            raise ValueError(
-                "Mamba sparse interval must be zero or a positive block multiple"
-            )
+        if self.sparse_checkpoint_interval_blocks < 0:
+            raise ValueError("Mamba sparse interval must be a non-negative block count")
         if self.mamba_cache_mode == "align":
             # Mapping from request ID to the index of the block
             # allocated in the previous step
@@ -1423,7 +1418,7 @@ class MambaManager(SingleTypeKVCacheManager):
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
         sparse_enabled = (
-            self.sparse_checkpoint_interval > 0
+            self.sparse_checkpoint_interval_blocks > 0
             and self.mamba_cache_mode == "align"
             and alignment_tokens == self.block_size
         )
@@ -1434,7 +1429,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # coordinator's per-group EAGLE classification in this manager.
             replay_block = max(0, (request.num_tokens - 1) // self.block_size)
             mask = [
-                ((i + 1) * self.block_size % self.sparse_checkpoint_interval == 0)
+                ((i + 1) % self.sparse_checkpoint_interval_blocks == 0)
                 or (i + 1 in (replay_block, replay_block - 1))
                 for i in range(num_cached_blocks_before, num_full_blocks)
             ]

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
-import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
@@ -1140,11 +1139,6 @@ class MambaManager(SingleTypeKVCacheManager):
         self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
-        self.sparse_checkpoint_interval_blocks = int(
-            os.environ.get("VLLM_MAMBA_SPARSE_CACHE_INTERVAL_BLOCKS", "0")
-        )
-        if self.sparse_checkpoint_interval_blocks < 0:
-            raise ValueError("Mamba sparse interval must be a non-negative block count")
         if self.mamba_cache_mode == "align":
             # Mapping from request ID to the index of the block
             # allocated in the previous step
@@ -1410,63 +1404,88 @@ class MambaManager(SingleTypeKVCacheManager):
         """
         return num_computed_tokens - 1
 
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        retention_interval: int | None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        """Adapt upstream #45845/#47782 retention to 1Cat's align-state layout."""
+        if retention_interval is None or alignment_tokens is None:
+            return None
+        assert isinstance(kv_cache_spec, MambaSpec)
+        block_size = kv_cache_spec.block_size
+        # Preserve the previous dense fallback for unproven mixed alignments.
+        if kv_cache_spec.mamba_cache_mode != "align" or alignment_tokens != block_size:
+            return None
+        mask = [False] * (end_block - start_block)
+        if retention_interval:
+            per_segment = retention_interval // block_size
+            if per_segment <= 1:
+                return None
+            first = (start_block + per_segment) // per_segment * per_segment - 1
+            for i in range(first - start_block, len(mask), per_segment):
+                mask[i] = True
+        for boundary in reachable_boundaries:
+            aligned = boundary // alignment_tokens * alignment_tokens
+            block = aligned // block_size - 1
+            if start_block <= block < end_block:
+                mask[block - start_block] = True
+        return mask
+
     def cache_blocks(
         self,
         request: Request,
         num_tokens: int,
         alignment_tokens: int | None = None,
+        *,
+        retention_interval: int | None = None,
+        replay_boundaries: Sequence[int] = (),
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        sparse_enabled = (
-            self.sparse_checkpoint_interval_blocks > 0
-            and self.mamba_cache_mode == "align"
-            and alignment_tokens == self.block_size
+        num_full_blocks = num_tokens // self.block_size
+        if num_cached_blocks_before >= num_full_blocks:
+            return
+        boundaries = list(replay_boundaries)
+        if boundary := getattr(request, "shared_prefix_boundary", 0):
+            boundaries.append(boundary)
+        mask = self.reachable_block_mask(
+            num_cached_blocks_before,
+            num_full_blocks,
+            alignment_tokens,
+            self.kv_cache_spec,
+            retention_interval,
+            boundaries,
         )
-        if sparse_enabled:
-            num_full_blocks = num_tokens // self.block_size
-            # Preserve both the ordinary replay boundary and its one-block
-            # speculative backoff. Keeping both avoids duplicating the
-            # coordinator's per-group EAGLE classification in this manager.
-            replay_block = max(0, (request.num_tokens - 1) // self.block_size)
-            mask = [
-                ((i + 1) % self.sparse_checkpoint_interval_blocks == 0)
-                or (i + 1 in (replay_block, replay_block - 1))
-                for i in range(num_cached_blocks_before, num_full_blocks)
-            ]
-            self.block_pool.cache_full_blocks(
-                request=request,
-                blocks=self.req_to_blocks[request.request_id],
-                num_cached_blocks=num_cached_blocks_before,
-                num_full_blocks=num_full_blocks,
-                block_size=self.block_size,
-                kv_cache_group_id=self.kv_cache_group_id,
-                block_mask=mask,
-            )
-            self.num_cached_block[request.request_id] = max(
-                num_cached_blocks_before, num_full_blocks
-            )
-        else:
-            super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
-        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
-        if num_cached_blocks_after > num_cached_blocks_before:
-            blocks = self.req_to_blocks[request.request_id]
-            for block_idx in range(num_cached_blocks_before, num_cached_blocks_after):
-                block = blocks[block_idx]
-                if block.is_null:
-                    continue
-                if sparse_enabled and block.block_hash is None:
-                    continue
-                assert block.block_hash is not None
-                self.cached_blocks_this_step.add(block.block_hash)
-                if self.mamba_cache_mode == "align":
-                    self._pending_boundary_state_offloads.append(
-                        (
-                            request.request_id,
-                            self.kv_cache_group_id,
-                            block,
-                            (block_idx + 1) * self.block_size,
-                        )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks_before,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=mask,
+        )
+        self.num_cached_block[request.request_id] = num_full_blocks
+        blocks = self.req_to_blocks[request.request_id]
+        for block_idx in range(num_cached_blocks_before, num_full_blocks):
+            block = blocks[block_idx]
+            if block.is_null or block.block_hash is None:
+                continue
+            self.cached_blocks_this_step.add(block.block_hash)
+            if self.mamba_cache_mode == "align":
+                self._pending_boundary_state_offloads.append(
+                    (
+                        request.request_id,
+                        self.kv_cache_group_id,
+                        block,
+                        (block_idx + 1) * self.block_size,
                     )
+                )
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
@@ -1139,6 +1140,16 @@ class MambaManager(SingleTypeKVCacheManager):
         self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        self.sparse_checkpoint_interval = int(
+            os.environ.get("VLLM_MAMBA_SPARSE_CACHE_INTERVAL", "0")
+        )
+        if (
+            self.sparse_checkpoint_interval < 0
+            or self.sparse_checkpoint_interval % self.block_size
+        ):
+            raise ValueError(
+                "Mamba sparse interval must be zero or a positive block multiple"
+            )
         if self.mamba_cache_mode == "align":
             # Mapping from request ID to the index of the block
             # allocated in the previous step
@@ -1411,13 +1422,44 @@ class MambaManager(SingleTypeKVCacheManager):
         alignment_tokens: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
+        sparse_enabled = (
+            self.sparse_checkpoint_interval > 0
+            and self.mamba_cache_mode == "align"
+            and alignment_tokens == self.block_size
+        )
+        if sparse_enabled:
+            num_full_blocks = num_tokens // self.block_size
+            # Preserve both the ordinary replay boundary and its one-block
+            # speculative backoff. Keeping both avoids duplicating the
+            # coordinator's per-group EAGLE classification in this manager.
+            replay_block = max(0, (request.num_tokens - 1) // self.block_size)
+            mask = [
+                ((i + 1) * self.block_size % self.sparse_checkpoint_interval == 0)
+                or (i + 1 in (replay_block, replay_block - 1))
+                for i in range(num_cached_blocks_before, num_full_blocks)
+            ]
+            self.block_pool.cache_full_blocks(
+                request=request,
+                blocks=self.req_to_blocks[request.request_id],
+                num_cached_blocks=num_cached_blocks_before,
+                num_full_blocks=num_full_blocks,
+                block_size=self.block_size,
+                kv_cache_group_id=self.kv_cache_group_id,
+                block_mask=mask,
+            )
+            self.num_cached_block[request.request_id] = max(
+                num_cached_blocks_before, num_full_blocks
+            )
+        else:
+            super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if num_cached_blocks_after > num_cached_blocks_before:
             blocks = self.req_to_blocks[request.request_id]
             for block_idx in range(num_cached_blocks_before, num_cached_blocks_after):
                 block = blocks[block_idx]
                 if block.is_null:
+                    continue
+                if sparse_enabled and block.block_hash is None:
                     continue
                 assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -167,6 +167,8 @@ class Request:
 
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
+        # Detected cross-request junction to retain for subsequent sparse reuse.
+        self.shared_prefix_boundary = 0
 
         # The number of NaNs in logits. A value greater than 0
         # indicates that the output is corrupted


### PR DESCRIPTION
### CI dependency and review fixes

Baseline CI fixes have been extracted into **#624**. This PR's final diff contains only cache-retention code, tests and documentation. Merge #624 first, then sync the baseline; until then, the known baseline typing/header/README failures can still affect this PR's CI. The green run at `fdc0ffc896` predates this split and is not the CI status of the current head.

The sparse `BlockStored` event-range fix from [PR15 review](https://github.com/Leonccaa/1Cat-vLLM/pull/15#discussion_r4000060118) and non-EAGLE completed-decode-boundary fix from [PR617 review](https://github.com/1CatAI/1Cat-vLLM/pull/617#discussion_r4000066783) remain here unchanged. All 38 new regression cases pass; the preceding source failed 34 of them. The cache suites passed 205 tests; the prior combined run including the separate QSA scale-gate suite passed 210.

Splitting the three CI files leaves all cache code and test contents byte-identical to the tested `fdc0ffc896` revision. No GPU or production changes. The 37-request GPU acceptance below remains attributed to `820516bf5a` / `5c49dbfb13`; the subsequent review fixes have CPU regression coverage, not a new GPU acceptance claim.

Dense Mamba state snapshots can consume the shared block pool and evict the Attention prefix of an older long conversation. A subsequent follow-up then reports zero usable prefix and repeats the full prefill. This PR adapts upstream Mamba retention to 1Cat's aligned state layout and preserves uncached blocks for reuse before evicting cached prefixes.

### Upstream provenance and configuration

This is a semantic backport of established upstream work, replacing the earlier custom environment-variable design:

- [vLLM #43447](https://github.com/vllm-project/vllm/pull/43447): uncached-first free queue and selective retention framework.
- [vLLM #45845](https://github.com/vllm-project/vllm/pull/45845): Mamba sparse retention to prevent recurrent snapshots from evicting Attention prefixes.
- [vLLM #47782](https://github.com/vllm-project/vllm/pull/47782): detect and retain shared-prefix junctions.
- [vLLM #53945](https://github.com/vllm-project/vllm/pull/53945) and [#54713](https://github.com/vllm-project/vllm/pull/54713): MTP/EAGLE recovery boundaries for identical resend and longer sibling requests.

Configuration follows upstream main at `fa008bdccf10f2f31f84553112a227cf1b8947d7`: `CacheConfig.prefix_cache_retention_interval`, exposed as `--prefix-cache-retention-interval`.

| Value | Meaning |
|---|---|
| `None` | Dense retention |
| `0` (default) | Retain necessary replay boundaries and detected shared-prefix junctions |
| Positive integer | Additionally retain periodic checkpoints, in **tokens**, validated as a multiple of resolved cache alignment |

For CT252's 800-token alignment, 4000/8000/16000/32000 correspond to 5/10/20/40 blocks. The former custom environment variable is removed: its `0` meant dense retention and corresponds to the new `None`, **not** the new `0`.

### 1Cat adaptation and scope

- Keep 1Cat's existing MTP safety backoff, per-group EAGLE classification, aligned state allocation, and offload bookkeeping.
- Carry the detected junction through the request and scheduler to retention; preserve the existing two-value cache-lookup API used by connectors.
- Apply sparse admission to aligned Mamba groups. Unproven mixed alignments fall back to dense retention; SWA policy remains unchanged. A positive interval without a Mamba group is rejected in this bounded backport.
- A newly observed fork can still require replay before its junction is materialized. Retained checkpoints are evictable; this does not guarantee hits under arbitrary capacity pressure.
- No model kernels, QSA operators, quantization paths, or speculative token acceptance changes.

### Validation

CPU metadata regressions cover dense-vs-sparse long A/B retention, identical resend and longer sibling boundaries, detected junction reuse, main/draft mixed EAGLE groups, reference counts and scratch reuse, and token intervals across 16/512/800/1024-token block sizes. The 105 retention tests pass. Existing prefix-cache tests pass after updating exact queue-order assertions for the intended uncached-first policy. Applicable pre-commit checks pass.

The broader five-file CPU run reports **237 passed / 16 failed**. All 16 failing node IDs also fail on the unmodified CT252 baseline (132 passed / 16 failed), from unavailable device inference and existing simplified config fixtures; there are no new failing nodes. These CPU tests do not establish CUDA/state-tensor correctness or production acceptance.

Historical GPU evidence is for the **previous custom patch**, not this final upstream-aligned implementation (TP4 V100, Flash-Next AWQ + native FP8 MTP3, 800-token state alignment):

| Earlier policy | A after long B: cached tokens / TTFT | B after short C: cached tokens / TTFT |
|---|---|---|
| Original | 0 / 73.453 s | 0 / 75.846 s |
| Queue fix, dense custom `0` | 0 / 73.538 s | 0 / 75.942 s |
| Queue fix, explicit 800 tokens | 0 / 73.279 s | 0 / 77.307 s |
| Queue fix, custom 16000 tokens | 168800 / 1.040 s | 174400 / 0.995 s |
| Queue fix, custom 5 blocks | 168800 / 1.143 s | 174400 / 1.064 s |

The custom 5-block arm also exposed a first-fork miss despite a surviving Attention prefix, motivating the junction port. The subsequent 10-block arm was stopped during initialization; 20/40 were not run. No results are claimed for those arms.

The final port has now passed the bounded Flash-Next/V100/MTP3 GPU acceptance below. Production has not been patched.


### Final-port GPU acceptance — 2026-09-13

**PASS on exact head `820516bf5a`** (identical runtime source in release-port `5c49dbfb13`). All nine changed source files were SHA-256 verified over the original b8aa release image. No diagnostic or #616 overlay. Default `prefix_cache_retention_interval=0`; TP4 V10032GB, Flash-Next AWQ + native FP8 MTP3, FP16 KV, C2, max context262144, batch8192, GMU0.984, KV capacity493491tokens.

**37 requests completed; zero preemptions; no CUDA/OOM/engine errors.**

| Final-port check | Cached tokens | TTFT |
|---|---:|---:|
| A170123 repeat |168800|1.050s|
| A after B175321 cold prefill |168800|1.029s|
| A / B after C14017 |168800 / 174400|1.031 / 0.997s|
| First119k fork (allowed replay) |0|50.757s|
| Same fork / second sibling |117600 / 117600|0.979 / 0.978s|
|15999 /16000 /16001-token repeat|14400 /14400 /15200|0.714 /0.703 /0.489s|
| A / B after600seconds with no inference |168800 /174400|2.217 /1.004s|
| A / B follow-up after warmed C2 + new third14k |168800 /174400|2.682 /1.280s|

Seven serial prompt/output token arrays match the historical accepted arm. Three boundary cases and the fork sibling also match independent, unique-cache-salt cold controls token-for-token. Both long follow-ups and post-idle outputs match their cold references. The first unknown fork requires replay, then the materialized junction is reusable.

The clean warmed mixed run records343200 combined A+B prefix hits and0hits for the new third request. Over a16.776s pure dual stream window, A/B deliver67.716/39.700tok/s (combined107.416); A after the third delivers77.392tok/s alone. Maximum token gaps A0.943s/B0.061s. Third TTFT21.332s includes C2 queueing and is **not** a pure prefill measurement. A prior mixed arm following several independent fork/control prefixes had B cold and is not used as the warmed comparison. Retention does not eliminate finite-pool capacity eviction.

Reproduction: serial A170123 repeat, B175321, A, C14017, A/B; fork at119123tokens plus instruction tail, identical and sibling retries;15999/16000/16001 boundaries with fresh-salt controls; A4096-output/B768-output concurrent streams with a third cold14023-token request under C2, followed by A/B continuations; refresh A/B, wait600seconds without inference, repeat. Sampling temperature0; long stream stress ignores EOS. All assertions pass for cached-token deltas, zero preemptions, generated-token counts and the output comparisons above. Acceptance scope is this Flash-Next/V100/MTP3 configuration, not universal model/GPU coverage.
