### PR TITLE
[Bugfix][Distributed] Pass --distributed-timeout-seconds to the NCCL subgroups

### DIFF
--- a/tests/distributed/test_group_coordinator_timeout.py
+++ b/tests/distributed/test_group_coordinator_timeout.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The NCCL subgroups of a GroupCoordinator follow --distributed-timeout-seconds.
+
+CPU-only: ``torch.distributed.new_group`` is replaced by a recorder, so no
+process group is created. Only the arguments handed to it are checked.
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+@pytest.fixture
+def new_group_calls(monkeypatch):
+    calls: list[dict] = []
+
+    def record(ranks, **kwargs):
+        calls.append({"ranks": ranks, **kwargs})
+        return MagicMock(name=f"pg[{kwargs.get('backend')}]")
+
+    monkeypatch.setattr(torch.distributed, "new_group", record)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    return calls
+
+
+def _build_coordinator() -> GroupCoordinator:
+    return GroupCoordinator(
+        group_ranks=[[0]],
+        local_rank=0,
+        torch_distributed_backend="nccl",
+        use_device_communicator=False,
+    )
+
+
+def test_device_group_follows_distributed_timeout(new_group_calls):
+    config = VllmConfig()
+    config.parallel_config.distributed_timeout_seconds = 3600
+    config.parallel_config.cpu_distributed_timeout_seconds = 120
+
+    with set_current_vllm_config(config):
+        _build_coordinator()
+
+    device_call, cpu_call = new_group_calls
+    assert device_call["backend"] == "nccl"
+    assert device_call["timeout"] == timedelta(seconds=3600)
+    assert cpu_call["backend"] == "gloo"
+    assert cpu_call["timeout"] == timedelta(seconds=120)
+
+
+def test_unset_timeout_keeps_pytorch_default(new_group_calls):
+    config = VllmConfig()
+    assert config.parallel_config.distributed_timeout_seconds is None
+
+    with set_current_vllm_config(config):
+        _build_coordinator()
+
+    device_call, cpu_call = new_group_calls
+    assert device_call["timeout"] is None
+    assert cpu_call["timeout"] is None
+
+
+def test_without_config_keeps_pytorch_default(new_group_calls):
+    _build_coordinator()
+
+    device_call, cpu_call = new_group_calls
+    assert device_call["timeout"] is None
+    assert cpu_call["timeout"] is None

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -486,13 +486,25 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
-        from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
+        from vllm.distributed.utils import (
+            get_cpu_distributed_timeout_or_none,
+            get_distributed_timeout_or_none,
+        )
 
         timeout = get_cpu_distributed_timeout_or_none()
+        # --distributed-timeout-seconds reaches init_process_group (the world
+        # group) and the gloo CPU groups, but the NCCL subgroups were created
+        # without it, so TP and PP silently kept PyTorch's 600 s default. On a
+        # cold boot under pipeline parallelism the first stage compiles Triton
+        # kernels for minutes while the next stage sits in its receive; the
+        # watchdog then kills the waiting rank and the boot dies at a timeout
+        # instead of an error. The subgroups follow the configured value;
+        # unset keeps PyTorch's default.
+        device_timeout = get_distributed_timeout_or_none()
 
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
+                ranks, backend=torch_distributed_backend, timeout=device_timeout
             )
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -516,6 +516,17 @@ def get_cpu_distributed_timeout_or_none() -> timedelta | None:
     return timedelta(seconds=timeout_seconds) if timeout_seconds is not None else None
 
 
+def get_distributed_timeout_or_none() -> timedelta | None:
+    """Timeout for the device (NCCL) subgroups, from the current vLLM config."""
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is None:
+        return None
+    timeout_seconds = vllm_config.parallel_config.distributed_timeout_seconds
+    return timedelta(seconds=timeout_seconds) if timeout_seconds is not None else None
+
+
 def init_gloo_process_group(
     prefix_store: PrefixStore,
     group_rank: int,


### PR DESCRIPTION
## Purpose

`--distributed-timeout-seconds` is documented as the timeout for the
distributed groups, and `init_distributed_environment` does hand it to
`init_process_group` (the world group) and to every gloo CPU group. The
device groups that `GroupCoordinator` creates for TP, PP and the other
subgroups were created without it, so they silently kept PyTorch's
default of 600 s no matter what was configured.

On a cold boot under pipeline parallelism that default is too short: the
first stage compiles its Triton kernels for minutes while the next stage
already sits in its first receive. The NCCL watchdog then kills the waiting
rank and the boot dies at a timeout instead of finishing the compile
(Qwen3.8 Flash-Next, TP2 × PP2, `--distributed-timeout-seconds 3600`
configured and ignored).

The change is one helper next to the existing
`get_cpu_distributed_timeout_or_none()` in `distributed/utils.py`, reading
`parallel_config.distributed_timeout_seconds` from the current vLLM config
the same way, and the device subgroups are created with that timeout.
`GroupCoordinator` is constructed inside `set_current_vllm_config` on the
worker (`worker_base.py`, `init_device`), so the value is available there.
Unset keeps `timeout=None`, i.e. PyTorch's default, exactly as before.

## Test Plan

1. `pre-commit run --files vllm/distributed/parallel_state.py vllm/distributed/utils.py tests/distributed/test_group_coordinator_timeout.py`
   and `pre-commit run mypy-3.10 --hook-stage manual --files <same>`.
2. New CPU-only `tests/distributed/test_group_coordinator_timeout.py`:
   `torch.distributed.new_group` is replaced by a recorder, a
   `GroupCoordinator` is built under `set_current_vllm_config`; the NCCL
   group receives `distributed_timeout_seconds`, the gloo group
   `cpu_distributed_timeout_seconds`, and both fall back to `None` with the
   fields unset or without a config.
3. PyTorch behaviour, checked in the installed torch 2.10.0:
   `torch.distributed.new_group(..., timeout=None)` resolves the timeout in
   `_new_group_with_tag` via `_get_default_timeout(backend)`, which returns
   the constant `default_pg_nccl_timeout` (600 s) and never the timeout the
   world group was initialised with. A configured
   `--distributed-timeout-seconds` therefore did not reach any subgroup.

## Test Result

1. All applicable hooks passed; mypy-3.10 passed.
2. 3 passed.
3. Confirmed by reading `distributed_c10d.py` (`_new_group_with_tag`,
   `_get_default_timeout`).

## Not a duplicate

Checked on 2026-09-12 against `1CatAI/1Cat-vLLM`: `gh pr list --state open
--search` for "distributed_timeout", "NCCL timeout subgroup", "new_group
timeout" and `gh issue list --search "timeout pipeline parallel boot"`
return nothing related; `gh pr diff --name-only` over every open PR shows
no PR touching `vllm/distributed/parallel_state.py`.

AI assistance (Claude) was used to trace the timeout path and prepare the
change; I reviewed every line and ran the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
